### PR TITLE
feat(host): chat-native agent host v1 — runtime + contracts

### DIFF
--- a/apps/sigil/CLAUDE.md
+++ b/apps/sigil/CLAUDE.md
@@ -98,16 +98,37 @@ Special tool_use renderers: `AskUserQuestion` (option buttons), `TodoWrite` (che
 
 ### Receiving from canvas
 
-Messages arrive via the canvas `onMessage` callback (Swift side). All messages have a `type` field:
+Messages arrive via the canvas `onMessage` callback (Swift side). Every emitted
+event is wrapped as `{type: '<name>', payload: <body>}` — the outer `type` is
+the event name, the `payload` carries only the event-specific fields (no
+redundant inner `type`).
 
-| Type | Payload | When |
-|------|---------|------|
-| `response` | `{type, value: string, tool_use_id: string}` | User answered an AskUserQuestion |
-| `user_message` | `{type, text: string}` | User sent a free-form message |
-| `stop` | `{type}` | User requested interrupt |
-| `ready` | `{type, ...manifest}` | Canvas loaded |
-| `avatar_toggle` | `{type}` | User clicked the avatar dot |
+| Type | `payload` | When |
+|------|-----------|------|
+| `response` | `{value: string, tool_use_id: string}` | User answered an AskUserQuestion |
+| `user_message` | `{text: string}` | User sent a free-form message |
+| `stop` | _(no payload)_ | User requested interrupt |
+| `ready` | `{name, accepts, emits}` (the canvas manifest) | Canvas loaded |
+| `avatar_toggle` | _(no payload)_ | User clicked the avatar dot |
 | `drag_start` / `move_abs` / `drag_end` | position data | Window drag |
+
+### Focus on show
+
+By default, clicking into an `.accessory` app's window to type is debounced by
+macOS and takes several seconds. Pass `--focus` to `aos show create` or
+`aos show update` to eliminate the delay:
+
+- The daemon activates the aos process (`NSApp.activate`) and marks the canvas
+  window key, so the next keystroke lands there.
+- On create, the daemon arms a one-shot that evals `focusInput()` when the page
+  emits `ready`. On update, it evals `focusInput()` immediately (the page is
+  already loaded).
+
+`--focus` is a no-op on non-interactive canvases.
+
+The chat page exposes `focusInput()` as a top-level function that focuses its
+`<input>`; other canvases can expose their own `focusInput()` if they want to
+opt into the same behavior.
 
 ### Active state
 

--- a/apps/sigil/CLAUDE.md
+++ b/apps/sigil/CLAUDE.md
@@ -76,3 +76,39 @@ Canvases load via `aos://sigil/studio/index.html` or `aos://sigil/renderer/index
 - **Three.js r128** — 3D rendering engine (loaded from CDN)
 - **xray_target.py** (`tools/dogfood/xray_target.py`) — element resolution for spatial behaviors
 - **agent_helpers.sh** (`tools/dogfood/agent_helpers.sh`) — channel events that drive avatar behaviors
+
+## Chat Canvas Protocol
+
+The chat canvas (`chat/index.html`) is a bidirectional conversational surface. Agents project into it — the canvas does not run its own Claude API client.
+
+### Sending to canvas
+
+Push messages via `evalCanvas('chat', 'headsup.receive("' + btoa(json) + '")')` or the coordination channel. Payload must be base64-encoded JSON.
+
+| Message | Payload | Effect |
+|---------|---------|--------|
+| Assistant message | `{type: 'assistant', content: [<Anthropic content blocks>]}` | Renders text, thinking, tool use, images |
+| Echo user message | `{type: 'user', content: string}` | Shows user bubble |
+| Status line | `{type: 'status', text: string}` | Replaces status indicator |
+| Clear | `{type: 'clear'}` | Resets conversation display |
+
+Supported content block types: `text`, `thinking`, `redacted_thinking`, `tool_use`, `tool_result`, `image`, `server_tool_use`, `web_search_tool_result`, `web_fetch_tool_result`, `code_execution_tool_result`, `bash_code_execution_tool_result`.
+
+Special tool_use renderers: `AskUserQuestion` (option buttons), `TodoWrite` (checklist), `ExitPlanMode` (plan card).
+
+### Receiving from canvas
+
+Messages arrive via the canvas `onMessage` callback (Swift side). All messages have a `type` field:
+
+| Type | Payload | When |
+|------|---------|------|
+| `response` | `{type, value: string, tool_use_id: string}` | User answered an AskUserQuestion |
+| `user_message` | `{type, text: string}` | User sent a free-form message |
+| `stop` | `{type}` | User requested interrupt |
+| `ready` | `{type, ...manifest}` | Canvas loaded |
+| `avatar_toggle` | `{type}` | User clicked the avatar dot |
+| `drag_start` / `move_abs` / `drag_end` | position data | Window drag |
+
+### Active state
+
+Call `setActive()` (via eval) when the agent is generating. This pulses the status dot and shows the stop button. Call `setIdle()` when done. Input is always enabled regardless of state.

--- a/apps/sigil/avatar-sub.swift
+++ b/apps/sigil/avatar-sub.swift
@@ -339,9 +339,120 @@ func handleChatCanvasEvent(payload: [String: Any]) {
             break
         }
 
+    case "user_message":
+        if let payload = payload["payload"] as? [String: Any],
+           let text = payload["text"] as? String {
+            hostBridgeSend(["type": "user_message", "payload": ["text": text]])
+        }
+
+    case "stop":
+        hostBridgeSend(["type": "stop"])
+
+    case "response":
+        if let payload = payload["payload"] as? [String: Any] {
+            hostBridgeSend(["type": "response", "payload": payload])
+        }
+
     default:
         break
     }
+}
+
+// ============================================================================
+// MARK: - Host Bridge (Node.js agent host subprocess)
+// ============================================================================
+
+/// Long-running Node.js bridge process connecting chat canvas ↔ agent host.
+/// Spawned lazily on first user_message. Reads canvas events from stdin (JSON
+/// lines), writes canvas update messages to stdout (JSON lines) which we eval
+/// into the chat canvas.
+
+private var hostBridgeProcess: Process?
+private var hostBridgeStdin: FileHandle?
+private let hostBridgeLock = NSLock()
+
+func hostBridgeSend(_ msg: [String: Any]) {
+    hostBridgeLock.lock()
+    defer { hostBridgeLock.unlock() }
+
+    // Lazy-start bridge on first message
+    if hostBridgeProcess == nil || !(hostBridgeProcess?.isRunning ?? false) {
+        startHostBridge()
+    }
+
+    guard let stdin = hostBridgeStdin,
+          let data = try? JSONSerialization.data(withJSONObject: msg),
+          let line = String(data: data, encoding: .utf8) else { return }
+    stdin.write(Data((line + "\n").utf8))
+}
+
+private func startHostBridge() {
+    let mode = ProcessInfo.processInfo.environment["AOS_MODE"] ?? "repo"
+    let bridgePath = sigilRepoPath("packages/host/src/sigil-bridge.ts")
+
+    let proc = Process()
+    proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    proc.arguments = ["node", "--experimental-strip-types", bridgePath]
+    proc.environment = ProcessInfo.processInfo.environment
+    proc.environment?["AOS_MODE"] = mode
+
+    let stdinPipe = Pipe()
+    let stdoutPipe = Pipe()
+    proc.standardInput = stdinPipe
+    proc.standardOutput = stdoutPipe
+    proc.standardError = FileHandle.nullDevice
+
+    do {
+        try proc.run()
+    } catch {
+        fputs("HOST-BRIDGE: failed to start: \(error)\n", stderr)
+        return
+    }
+
+    hostBridgeProcess = proc
+    hostBridgeStdin = stdinPipe.fileHandleForWriting
+
+    fputs("HOST-BRIDGE: started pid=\(proc.processIdentifier)\n", stderr)
+
+    // Read stdout in background — each line is a canvas message
+    DispatchQueue.global(qos: .userInitiated).async {
+        let handle = stdoutPipe.fileHandleForReading
+        var buffer = Data()
+
+        while proc.isRunning {
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                usleep(10_000) // 10ms
+                continue
+            }
+            buffer.append(chunk)
+
+            // Split on newlines
+            while let range = buffer.range(of: Data("\n".utf8)) {
+                let lineData = buffer[buffer.startIndex..<range.lowerBound]
+                buffer.removeSubrange(buffer.startIndex...range.lowerBound)
+
+                guard let lineStr = String(data: lineData, encoding: .utf8),
+                      !lineStr.isEmpty,
+                      let json = try? JSONSerialization.jsonObject(with: Data(lineStr.utf8)) as? [String: Any] else {
+                    continue
+                }
+
+                // Eval into chat canvas via daemon
+                evalChatCanvas(json)
+            }
+        }
+        fputs("HOST-BRIDGE: process exited\n", stderr)
+    }
+}
+
+/// Send a message to the chat canvas by eval'ing headsup.receive(base64)
+private func evalChatCanvas(_ msg: [String: Any]) {
+    guard let jsonData = try? JSONSerialization.data(withJSONObject: msg),
+          let jsonStr = String(data: jsonData, encoding: .utf8) else { return }
+    let b64 = Data(jsonStr.utf8).base64EncodedString()
+    let js = "headsup.receive('\(b64)')"
+    daemonOneShot(["action": "eval", "id": chatID, "js": js])
 }
 
 // ============================================================================

--- a/apps/sigil/chat/index.html
+++ b/apps/sigil/chat/index.html
@@ -552,7 +552,7 @@ function renderMarkdown(text) {
 // headsup message convention
 // ============================================================
 window.headsup = {
-  manifest: { name: 'chat', accepts: ['assistant', 'user', 'status', 'clear'], emits: ['response', 'tts', 'ready', 'avatar_toggle'] },
+  manifest: { name: 'chat', accepts: ['assistant', 'user', 'status', 'clear'], emits: ['response', 'user_message', 'stop', 'tts', 'ready', 'avatar_toggle'] },
   receive: function(b64) {
     try {
       // atob() returns Latin-1, not UTF-8. Decode properly for emoji/accented text.
@@ -841,21 +841,17 @@ function appendMessage(el) {
 // ============================================================
 function respondOption(btn) {
   var value = btn.getAttribute('data-value');
-  respond(value);
+  respondToToolUse(value);
 }
 
-function respond(value) {
+function respondToToolUse(value) {
   if (!value || value.trim() === '') return;
   value = value.trim();
 
   addUserMessage(value);
 
-  var payload = { type: 'response', value: value };
-  if (pendingToolUseId) {
-    payload.tool_use_id = pendingToolUseId;
-    pendingToolUseId = null;
-  }
-  emit('response', payload);
+  emit('response', { type: 'response', value: value, tool_use_id: pendingToolUseId });
+  pendingToolUseId = null;
 
   // Disable option buttons in the last assistant message
   var btns = document.querySelectorAll('.opt-btn');
@@ -865,12 +861,22 @@ function respond(value) {
   }
 
   setIdle();
-  document.getElementById('userInput').value = '';
 }
 
 function sendUserInput() {
   var input = document.getElementById('userInput');
-  respond(input.value);
+  var value = (input.value || '').trim();
+  if (!value) return;
+
+  input.value = '';
+  input.style.height = 'auto';
+
+  if (pendingToolUseId) {
+    respondToToolUse(value);
+  } else {
+    addUserMessage(value);
+    emit('user_message', { type: 'user_message', text: value });
+  }
 }
 
 // ============================================================

--- a/apps/sigil/chat/index.html
+++ b/apps/sigil/chat/index.html
@@ -867,7 +867,7 @@ function respondToToolUse(value) {
 
   addUserMessage(value);
 
-  emit('response', { type: 'response', value: value, tool_use_id: pendingToolUseId });
+  emit('response', { value: value, tool_use_id: pendingToolUseId });
   pendingToolUseId = null;
 
   // Disable option buttons in the last assistant message
@@ -892,7 +892,7 @@ function sendUserInput() {
     respondToToolUse(value);
   } else {
     addUserMessage(value);
-    emit('user_message', { type: 'user_message', text: value });
+    emit('user_message', { text: value });
   }
 }
 
@@ -900,7 +900,7 @@ function sendUserInput() {
 // State indicators
 // ============================================================
 function emitStop() {
-  emit('stop', { type: 'stop' });
+  emit('stop');
   setIdle();
 }
 
@@ -1052,6 +1052,13 @@ document.addEventListener('keydown', function(e) {
     }
   }
 });
+
+// Exposed to the host: called via evaluateJavaScript when the canvas was
+// created/updated with --focus, so keystrokes land in the input immediately.
+function focusInput() {
+  var el = document.getElementById('userInput');
+  if (el) el.focus();
+}
 
 // Start dismissed -- overlay appears when first message arrives
 emit('ready', window.headsup.manifest);

--- a/apps/sigil/chat/index.html
+++ b/apps/sigil/chat/index.html
@@ -432,6 +432,22 @@ body {
 .btn-send:hover { background: rgba(100,210,255,0.3); }
 .btn-send:active { transform: scale(0.96); }
 
+.btn-stop {
+  padding: 8px 16px;
+  border-radius: 8px;
+  background: rgba(255,69,58,0.2);
+  color: #ff453a;
+  border: 1px solid rgba(255,69,58,0.3);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+  transition: all 0.15s ease;
+  display: none;
+}
+.btn-stop:hover { background: rgba(255,69,58,0.3); }
+.btn-stop:active { transform: scale(0.96); }
+
 /* --- Log panel --- */
 .log-viewer {
   flex: 1;
@@ -479,6 +495,7 @@ body {
     <div class="input-bar">
       <textarea class="text-input" id="userInput" placeholder="Type a message..." rows="1" onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();sendUserInput()}" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,80)+'px'"></textarea>
       <button class="btn-send" onclick="sendUserInput()">Send</button>
+      <button class="btn-stop" id="btnStop" onclick="emitStop()">Stop</button>
     </div>
   </div>
 
@@ -882,14 +899,21 @@ function sendUserInput() {
 // ============================================================
 // State indicators
 // ============================================================
+function emitStop() {
+  emit('stop', { type: 'stop' });
+  setIdle();
+}
+
 function setActive() {
   var dot = document.getElementById('dot');
   dot.classList.add('active');
+  document.getElementById('btnStop').style.display = '';
 }
 
 function setIdle() {
   var dot = document.getElementById('dot');
   dot.classList.remove('active');
+  document.getElementById('btnStop').style.display = 'none';
 }
 
 // -- Avatar dock/undock (called from avatar-follower via eval) --

--- a/apps/sigil/chat/index.html
+++ b/apps/sigil/chat/index.html
@@ -477,8 +477,8 @@ body {
   <div class="panel active" id="panel-chat">
     <div class="messages" id="messages"></div>
     <div class="input-bar">
-      <textarea class="text-input" id="userInput" placeholder="Type a message..." rows="1" onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();sendUserInput()}" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,80)+'px'" disabled></textarea>
-      <button class="btn-send" onclick="sendUserInput()" disabled>Send</button>
+      <textarea class="text-input" id="userInput" placeholder="Type a message..." rows="1" onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();sendUserInput()}" oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,80)+'px'"></textarea>
+      <button class="btn-send" onclick="sendUserInput()">Send</button>
     </div>
   </div>
 
@@ -879,19 +879,11 @@ function sendUserInput() {
 function setActive() {
   var dot = document.getElementById('dot');
   dot.classList.add('active');
-  // Enable input when agent is asking a question
-  document.getElementById('userInput').disabled = false;
-  document.querySelector('.btn-send').disabled = false;
 }
 
 function setIdle() {
   var dot = document.getElementById('dot');
   dot.classList.remove('active');
-  // Disable input when no pending question — events would be lost
-  if (!pendingToolUseId) {
-    document.getElementById('userInput').disabled = true;
-    document.querySelector('.btn-send').disabled = true;
-  }
 }
 
 // -- Avatar dock/undock (called from avatar-follower via eval) --

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ echo "Compiling aos..."
 SOURCES=$(find src -name '*.swift' -type f)
 SHARED_IPC=$(find shared/swift/ipc -name '*.swift' -type f 2>/dev/null)
 
-swiftc -parse-as-library -O -o aos $SOURCES $SHARED_IPC
+swiftc -parse-as-library -O -o aos -lsqlite3 $SOURCES $SHARED_IPC
 
 echo "Done: ./aos ($(du -h aos | cut -f1 | xargs))"
 

--- a/docs/superpowers/plans/2026-04-09-sigil-wiki.md
+++ b/docs/superpowers/plans/2026-04-09-sigil-wiki.md
@@ -285,6 +285,8 @@ git commit -m "feat(wiki): add frontmatter parser for wiki markdown pages"
 **Files:**
 - Create: `src/commands/wiki-index.swift`
 
+> **Note (post-review):** The snippet below was updated after code review. The canonical form is the committed file at `src/commands/wiki-index.swift`. The review pass added: parameterized read-path queries via a new `queryBind<T>` helper (SQL injection / quote-break fix), `Int64`/`sqlite3_bind_int64` for `modified_at` (2038 trap fix), step-error handling in `query<T>`, a file-scope `SQLITE_TRANSIENT` constant, `ORDER BY` on `linksTo`/`linksFrom`, and `idx_links_source` / `idx_links_target` indices. Public method signatures on `WikiIndex` did not change, so Tasks 4-12 are unaffected.
+
 - [ ] **Step 1: Create the SQLite index module**
 
 Create `src/commands/wiki-index.swift`:
@@ -2421,7 +2423,7 @@ aos wiki create-plugin <name>
 Then write the SKILL.md and any reference files. Follow these guidelines:
 
 **SKILL.md structure:**
-- Frontmatter with name, description (pushy — include trigger phrases), version, tags
+- Frontmatter with name, description (assertive — include trigger phrases), version, tags
 - Clear purpose statement
 - Step-by-step instructions
 - Decision trees for branching logic
@@ -2434,7 +2436,7 @@ Then write the SKILL.md and any reference files. Follow these guidelines:
 - If all test runs would write a similar helper script, bundle it in `scripts/`
 
 **Description field:**
-The description is the primary trigger mechanism. Make it pushy:
+The description is the primary trigger mechanism. Make it clear and explicit:
 - Include what the skill does AND specific contexts for activation
 - List natural language phrases that should trigger it
 - Err on the side of over-matching — undertriggering is worse
@@ -2504,7 +2506,7 @@ plugin-name/
 
 Required fields:
 - `name` — plugin identifier (kebab-case)
-- `description` — when to trigger, what it does (be pushy)
+- `description` — when to trigger, what it does (be highly specific)
 
 Optional fields:
 - `version` — semver string

--- a/docs/superpowers/plans/2026-04-09-sigil-wiki.md
+++ b/docs/superpowers/plans/2026-04-09-sigil-wiki.md
@@ -1,0 +1,2661 @@
+# Sigil Wiki Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `aos wiki` CLI subcommands that manage a user-owned, interlinked markdown knowledge base with executable workflow plugins, stored at `~/.config/aos/{mode}/wiki/` with a SQLite index.
+
+**Architecture:** Files are canonical — markdown pages with YAML frontmatter organized into `plugins/`, `entities/`, and `concepts/` directories. A SQLite index (`wiki.db`) is a materialized view for fast queries. All operations are `aos wiki` subcommands. Plugins follow the Claude Code/Cowork SKILL.md format for compatibility.
+
+**Tech Stack:** Swift (macOS system SDK), SQLite3 (system library via `import SQLite3`), markdown with YAML-like frontmatter (custom parser — no external YAML dependency).
+
+**Spec:** `docs/superpowers/specs/2026-04-09-sigil-wiki-design.md`
+
+---
+
+### Task 1: Build System + SQLite Smoke Test
+
+**Files:**
+- Modify: `build.sh:10`
+- Create: `src/commands/wiki.swift`
+
+This task verifies that SQLite3 links and imports correctly, and wires `aos wiki` into the command router.
+
+- [ ] **Step 1: Add `-lsqlite3` to build.sh**
+
+```bash
+# In build.sh, change line 10 from:
+swiftc -parse-as-library -O -o aos $SOURCES $SHARED_IPC
+# to:
+swiftc -parse-as-library -O -o aos -lsqlite3 $SOURCES $SHARED_IPC
+```
+
+- [ ] **Step 2: Create minimal wiki command router**
+
+Create `src/commands/wiki.swift`:
+
+```swift
+// wiki.swift — aos wiki subcommands: knowledge base + workflow plugins
+
+import Foundation
+import SQLite3
+
+// MARK: - Path Helpers
+
+func aosWikiDir(for mode: AOSRuntimeMode? = nil) -> String {
+    "\(aosStateDir(for: mode))/wiki"
+}
+
+func aosWikiDbPath(for mode: AOSRuntimeMode? = nil) -> String {
+    "\(aosWikiDir(for: mode))/wiki.db"
+}
+
+// MARK: - Command Router
+
+func wikiCommand(args: [String]) {
+    guard let sub = args.first else {
+        exitError("Usage: aos wiki <create-plugin|add|rm|link|list|search|show|invoke|reindex|lint|seed>", code: "MISSING_SUBCOMMAND")
+    }
+    let subArgs = Array(args.dropFirst())
+    switch sub {
+    case "reindex":
+        wikiReindexCommand(args: subArgs)
+    default:
+        exitError("Unknown wiki subcommand: \(sub)", code: "UNKNOWN_SUBCOMMAND")
+    }
+}
+
+// MARK: - Placeholder: reindex
+
+func wikiReindexCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    let wikiDir = aosWikiDir()
+
+    // Verify SQLite3 works
+    var db: OpaquePointer?
+    let dbPath = aosWikiDbPath()
+
+    // Ensure wiki directory exists
+    try? FileManager.default.createDirectory(atPath: wikiDir, withIntermediateDirectories: true)
+
+    guard sqlite3_open(dbPath, &db) == SQLITE_OK else {
+        exitError("Failed to open wiki database at \(dbPath)", code: "WIKI_DB_ERROR")
+    }
+    sqlite3_close(db)
+
+    if asJSON {
+        print(jsonString(["status": "ok", "wiki_dir": wikiDir, "db": dbPath]))
+    } else {
+        print("Wiki database OK at \(dbPath)")
+    }
+}
+```
+
+- [ ] **Step 3: Wire wiki into main.swift command router**
+
+Add to the switch in `main.swift`, before the `default` case:
+
+```swift
+        case "wiki":
+            wikiCommand(args: Array(args.dropFirst()))
+```
+
+Add to `printUsage()` — in the Commands section:
+
+```
+      wiki <subcommand>  Knowledge base — browse, search, invoke workflow plugins
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `bash build.sh`
+Expected: Compiles without errors.
+
+Run: `./aos wiki reindex --json`
+Expected: JSON output with `"status": "ok"` and paths to wiki dir and db.
+
+Run: `ls ~/.config/aos/repo/wiki/`
+Expected: `wiki.db` exists.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add build.sh src/commands/wiki.swift src/main.swift
+git commit -m "feat(wiki): wire aos wiki command with SQLite3 integration"
+```
+
+---
+
+### Task 2: Frontmatter Parser
+
+**Files:**
+- Create: `src/commands/wiki-frontmatter.swift`
+
+The wiki needs to parse YAML-like frontmatter from markdown files. This is a minimal parser for the subset we use — not a full YAML parser.
+
+- [ ] **Step 1: Create the frontmatter parser**
+
+Create `src/commands/wiki-frontmatter.swift`:
+
+```swift
+// wiki-frontmatter.swift — Parse YAML-like frontmatter from markdown files
+
+import Foundation
+
+struct WikiFrontmatter {
+    let type: String?           // "workflow", "entity", "concept"
+    let name: String?
+    let description: String?
+    let tags: [String]
+    let version: String?
+    let author: String?
+    let triggers: [String]
+    let requires: [String]
+    let plugin: String?         // set by indexer, not parsed from file
+    let raw: [String: String]   // all key-value pairs as strings
+}
+
+struct WikiPage {
+    let frontmatter: WikiFrontmatter
+    let body: String            // markdown body after frontmatter
+    let rawContent: String      // full file content including frontmatter
+}
+
+/// Parse a markdown file with optional YAML frontmatter delimited by `---`.
+/// Returns the frontmatter fields and the body separately.
+func parseWikiPage(content: String) -> WikiPage {
+    let lines = content.components(separatedBy: "\n")
+
+    // Must start with ---
+    guard lines.first?.trimmingCharacters(in: .whitespaces) == "---" else {
+        return WikiPage(
+            frontmatter: WikiFrontmatter(type: nil, name: nil, description: nil, tags: [], version: nil, author: nil, triggers: [], requires: [], plugin: nil, raw: [:]),
+            body: content,
+            rawContent: content
+        )
+    }
+
+    // Find closing ---
+    var closingIndex: Int?
+    for i in 1..<lines.count {
+        if lines[i].trimmingCharacters(in: .whitespaces) == "---" {
+            closingIndex = i
+            break
+        }
+    }
+
+    guard let endIdx = closingIndex else {
+        return WikiPage(
+            frontmatter: WikiFrontmatter(type: nil, name: nil, description: nil, tags: [], version: nil, author: nil, triggers: [], requires: [], plugin: nil, raw: [:]),
+            body: content,
+            rawContent: content
+        )
+    }
+
+    // Parse frontmatter lines (between the two ---)
+    let fmLines = Array(lines[1..<endIdx])
+    var raw: [String: String] = [:]
+    var currentKey: String?
+    var currentValue: String = ""
+
+    for line in fmLines {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty { continue }
+
+        // Check if this is a continuation line (starts with whitespace, for multi-line description)
+        if line.first?.isWhitespace == true, let key = currentKey {
+            currentValue += " " + trimmed
+            raw[key] = currentValue
+            continue
+        }
+
+        // key: value
+        if let colonRange = trimmed.range(of: ":") {
+            let key = String(trimmed[trimmed.startIndex..<colonRange.lowerBound]).trimmingCharacters(in: .whitespaces)
+            let value = String(trimmed[colonRange.upperBound...]).trimmingCharacters(in: .whitespaces)
+            // Strip surrounding quotes
+            let cleaned = value.trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+            raw[key] = cleaned
+            currentKey = key
+            currentValue = cleaned
+        }
+    }
+
+    // Extract typed fields
+    let fm = WikiFrontmatter(
+        type: raw["type"],
+        name: raw["name"],
+        description: raw["description"],
+        tags: parseYAMLArray(raw["tags"]),
+        version: raw["version"],
+        author: raw["author"],
+        triggers: parseYAMLArray(raw["triggers"]),
+        requires: parseYAMLArray(raw["requires"]),
+        plugin: nil,
+        raw: raw
+    )
+
+    // Body is everything after the closing ---
+    let bodyLines = Array(lines[(endIdx + 1)...])
+    let body = bodyLines.joined(separator: "\n").trimmingCharacters(in: .newlines)
+
+    return WikiPage(frontmatter: fm, body: body, rawContent: content)
+}
+
+/// Parse a YAML-style inline array: [item1, item2, item3]
+func parseYAMLArray(_ value: String?) -> [String] {
+    guard let value = value, !value.isEmpty else { return [] }
+    let trimmed = value.trimmingCharacters(in: .whitespaces)
+    guard trimmed.hasPrefix("["), trimmed.hasSuffix("]") else {
+        // Single value, not an array
+        return trimmed.isEmpty ? [] : [trimmed]
+    }
+    let inner = String(trimmed.dropFirst().dropLast())
+    return inner.components(separatedBy: ",")
+        .map { $0.trimmingCharacters(in: .whitespaces).trimmingCharacters(in: CharacterSet(charactersIn: "\"'")) }
+        .filter { !$0.isEmpty }
+}
+
+/// Parse a multi-line YAML description (handles `>` block scalar indicator)
+/// Strips the `>` prefix if present and joins continuation lines.
+private func cleanDescription(_ raw: String) -> String {
+    var s = raw
+    if s.hasPrefix(">") {
+        s = String(s.dropFirst()).trimmingCharacters(in: .whitespaces)
+    }
+    return s
+}
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `bash build.sh`
+Expected: Compiles without errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/commands/wiki-frontmatter.swift
+git commit -m "feat(wiki): add frontmatter parser for wiki markdown pages"
+```
+
+---
+
+### Task 3: SQLite Index — Schema + Core Operations
+
+**Files:**
+- Create: `src/commands/wiki-index.swift`
+
+- [ ] **Step 1: Create the SQLite index module**
+
+Create `src/commands/wiki-index.swift`:
+
+```swift
+// wiki-index.swift — SQLite index for the wiki knowledge base
+
+import Foundation
+import SQLite3
+
+// MARK: - Database Lifecycle
+
+class WikiIndex {
+    private var db: OpaquePointer?
+    let dbPath: String
+
+    init(dbPath: String) {
+        self.dbPath = dbPath
+    }
+
+    func open() {
+        guard sqlite3_open(dbPath, &db) == SQLITE_OK else {
+            exitError("Failed to open wiki database at \(dbPath): \(dbError())", code: "WIKI_DB_ERROR")
+        }
+        exec("PRAGMA journal_mode=WAL")
+        exec("PRAGMA foreign_keys=ON")
+    }
+
+    func close() {
+        if db != nil {
+            sqlite3_close(db)
+            db = nil
+        }
+    }
+
+    // MARK: - Schema
+
+    func createTables() {
+        exec("""
+            CREATE TABLE IF NOT EXISTS pages (
+                path        TEXT PRIMARY KEY,
+                type        TEXT NOT NULL,
+                name        TEXT NOT NULL,
+                description TEXT,
+                tags        TEXT,
+                plugin      TEXT,
+                modified_at INTEGER NOT NULL
+            )
+        """)
+        exec("""
+            CREATE TABLE IF NOT EXISTS links (
+                source_path TEXT NOT NULL,
+                target_path TEXT NOT NULL,
+                UNIQUE(source_path, target_path)
+            )
+        """)
+        exec("""
+            CREATE TABLE IF NOT EXISTS plugins (
+                name        TEXT PRIMARY KEY,
+                version     TEXT,
+                author      TEXT,
+                description TEXT,
+                triggers    TEXT,
+                requires    TEXT,
+                modified_at INTEGER NOT NULL
+            )
+        """)
+    }
+
+    func dropTables() {
+        exec("DROP TABLE IF EXISTS links")
+        exec("DROP TABLE IF EXISTS pages")
+        exec("DROP TABLE IF EXISTS plugins")
+    }
+
+    // MARK: - Page Operations
+
+    func upsertPage(path: String, type: String, name: String, description: String?, tags: [String], plugin: String?, modifiedAt: Int) {
+        let tagsJSON = tags.isEmpty ? nil : (try? JSONSerialization.data(withJSONObject: tags))
+            .flatMap { String(data: $0, encoding: .utf8) }
+
+        let sql = """
+            INSERT INTO pages (path, type, name, description, tags, plugin, modified_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(path) DO UPDATE SET
+                type=excluded.type, name=excluded.name, description=excluded.description,
+                tags=excluded.tags, plugin=excluded.plugin, modified_at=excluded.modified_at
+        """
+        execBind(sql) { stmt in
+            sqlite3_bind_text(stmt, 1, path, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            sqlite3_bind_text(stmt, 2, type, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            sqlite3_bind_text(stmt, 3, name, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            if let d = description {
+                sqlite3_bind_text(stmt, 4, d, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            } else { sqlite3_bind_null(stmt, 4) }
+            if let t = tagsJSON {
+                sqlite3_bind_text(stmt, 5, t, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            } else { sqlite3_bind_null(stmt, 5) }
+            if let p = plugin {
+                sqlite3_bind_text(stmt, 6, p, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            } else { sqlite3_bind_null(stmt, 6) }
+            sqlite3_bind_int(stmt, 7, Int32(modifiedAt))
+        }
+    }
+
+    func deletePage(path: String) {
+        execBind("DELETE FROM pages WHERE path = ?") { stmt in
+            sqlite3_bind_text(stmt, 1, path, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        }
+        execBind("DELETE FROM links WHERE source_path = ? OR target_path = ?") { stmt in
+            sqlite3_bind_text(stmt, 1, path, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            sqlite3_bind_text(stmt, 2, path, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        }
+    }
+
+    // MARK: - Link Operations
+
+    func upsertLink(source: String, target: String) {
+        execBind("INSERT OR IGNORE INTO links (source_path, target_path) VALUES (?, ?)") { stmt in
+            sqlite3_bind_text(stmt, 1, source, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            sqlite3_bind_text(stmt, 2, target, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        }
+    }
+
+    func deleteLinksFrom(source: String) {
+        execBind("DELETE FROM links WHERE source_path = ?") { stmt in
+            sqlite3_bind_text(stmt, 1, source, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        }
+    }
+
+    // MARK: - Plugin Operations
+
+    func upsertPlugin(name: String, version: String?, author: String?, description: String?, triggers: [String], requires: [String], modifiedAt: Int) {
+        let triggersJSON = triggers.isEmpty ? nil : (try? JSONSerialization.data(withJSONObject: triggers))
+            .flatMap { String(data: $0, encoding: .utf8) }
+        let requiresJSON = requires.isEmpty ? nil : (try? JSONSerialization.data(withJSONObject: requires))
+            .flatMap { String(data: $0, encoding: .utf8) }
+
+        let sql = """
+            INSERT INTO plugins (name, version, author, description, triggers, requires, modified_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(name) DO UPDATE SET
+                version=excluded.version, author=excluded.author, description=excluded.description,
+                triggers=excluded.triggers, requires=excluded.requires, modified_at=excluded.modified_at
+        """
+        execBind(sql) { stmt in
+            sqlite3_bind_text(stmt, 1, name, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            if let v = version { sqlite3_bind_text(stmt, 2, v, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self)) } else { sqlite3_bind_null(stmt, 2) }
+            if let a = author { sqlite3_bind_text(stmt, 3, a, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self)) } else { sqlite3_bind_null(stmt, 3) }
+            if let d = description { sqlite3_bind_text(stmt, 4, d, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self)) } else { sqlite3_bind_null(stmt, 4) }
+            if let t = triggersJSON { sqlite3_bind_text(stmt, 5, t, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self)) } else { sqlite3_bind_null(stmt, 5) }
+            if let r = requiresJSON { sqlite3_bind_text(stmt, 6, r, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self)) } else { sqlite3_bind_null(stmt, 6) }
+            sqlite3_bind_int(stmt, 7, Int32(modifiedAt))
+        }
+    }
+
+    // MARK: - Queries
+
+    struct PageRow: Encodable {
+        let path: String
+        let type: String
+        let name: String
+        let description: String?
+        let tags: [String]
+        let plugin: String?
+        let modified_at: Int
+    }
+
+    struct PluginRow: Encodable {
+        let name: String
+        let version: String?
+        let author: String?
+        let description: String?
+        let triggers: [String]
+        let requires: [String]
+        let modified_at: Int
+    }
+
+    struct LinkRow: Encodable {
+        let source_path: String
+        let target_path: String
+    }
+
+    func listPages(type: String? = nil, plugin: String? = nil) -> [PageRow] {
+        var sql = "SELECT path, type, name, description, tags, plugin, modified_at FROM pages"
+        var conditions: [String] = []
+        if let t = type { conditions.append("type = '\(t)'") }
+        if let p = plugin { conditions.append("plugin = '\(p)'") }
+        if !conditions.isEmpty { sql += " WHERE " + conditions.joined(separator: " AND ") }
+        sql += " ORDER BY name"
+        return query(sql) { stmt in
+            PageRow(
+                path: col(stmt, 0),
+                type: col(stmt, 1),
+                name: col(stmt, 2),
+                description: colOpt(stmt, 3),
+                tags: decodeJSONArray(colOpt(stmt, 4)),
+                plugin: colOpt(stmt, 5),
+                modified_at: Int(sqlite3_column_int(stmt, 6))
+            )
+        }
+    }
+
+    func linksTo(path: String) -> [LinkRow] {
+        query("SELECT source_path, target_path FROM links WHERE target_path = '\(path)'") { stmt in
+            LinkRow(source_path: col(stmt, 0), target_path: col(stmt, 1))
+        }
+    }
+
+    func linksFrom(path: String) -> [LinkRow] {
+        query("SELECT source_path, target_path FROM links WHERE source_path = '\(path)'") { stmt in
+            LinkRow(source_path: col(stmt, 0), target_path: col(stmt, 1))
+        }
+    }
+
+    func orphanPages() -> [PageRow] {
+        query("""
+            SELECT p.path, p.type, p.name, p.description, p.tags, p.plugin, p.modified_at
+            FROM pages p
+            LEFT JOIN links l ON l.target_path = p.path
+            WHERE l.source_path IS NULL
+            ORDER BY p.name
+        """) { stmt in
+            PageRow(
+                path: col(stmt, 0), type: col(stmt, 1), name: col(stmt, 2),
+                description: colOpt(stmt, 3), tags: decodeJSONArray(colOpt(stmt, 4)),
+                plugin: colOpt(stmt, 5), modified_at: Int(sqlite3_column_int(stmt, 6))
+            )
+        }
+    }
+
+    func searchPages(query q: String, type: String? = nil) -> [PageRow] {
+        // Simple LIKE search across name, description
+        let pattern = "%\(q)%"
+        var sql = """
+            SELECT path, type, name, description, tags, plugin, modified_at FROM pages
+            WHERE (name LIKE '\(pattern)' OR description LIKE '\(pattern)')
+        """
+        if let t = type { sql += " AND type = '\(t)'" }
+        sql += " ORDER BY CASE WHEN name LIKE '\(pattern)' THEN 0 ELSE 1 END, name"
+        return query(sql) { stmt in
+            PageRow(
+                path: col(stmt, 0), type: col(stmt, 1), name: col(stmt, 2),
+                description: colOpt(stmt, 3), tags: decodeJSONArray(colOpt(stmt, 4)),
+                plugin: colOpt(stmt, 5), modified_at: Int(sqlite3_column_int(stmt, 6))
+            )
+        }
+    }
+
+    func listPlugins() -> [PluginRow] {
+        query("SELECT name, version, author, description, triggers, requires, modified_at FROM plugins ORDER BY name") { stmt in
+            PluginRow(
+                name: col(stmt, 0), version: colOpt(stmt, 1), author: colOpt(stmt, 2),
+                description: colOpt(stmt, 3), triggers: decodeJSONArray(colOpt(stmt, 4)),
+                requires: decodeJSONArray(colOpt(stmt, 5)), modified_at: Int(sqlite3_column_int(stmt, 6))
+            )
+        }
+    }
+
+    func pageCount() -> Int {
+        let rows: [Int] = query("SELECT COUNT(*) FROM pages") { stmt in Int(sqlite3_column_int(stmt, 0)) }
+        return rows.first ?? 0
+    }
+
+    func linkCount() -> Int {
+        let rows: [Int] = query("SELECT COUNT(*) FROM links") { stmt in Int(sqlite3_column_int(stmt, 0)) }
+        return rows.first ?? 0
+    }
+
+    func pluginCount() -> Int {
+        let rows: [Int] = query("SELECT COUNT(*) FROM plugins") { stmt in Int(sqlite3_column_int(stmt, 0)) }
+        return rows.first ?? 0
+    }
+
+    // MARK: - SQLite Helpers
+
+    private func dbError() -> String {
+        if let err = sqlite3_errmsg(db) { return String(cString: err) }
+        return "unknown error"
+    }
+
+    private func exec(_ sql: String) {
+        var errMsg: UnsafeMutablePointer<CChar>?
+        if sqlite3_exec(db, sql, nil, nil, &errMsg) != SQLITE_OK {
+            let msg = errMsg.map { String(cString: $0) } ?? "unknown error"
+            sqlite3_free(errMsg)
+            exitError("SQLite error: \(msg)\nSQL: \(sql)", code: "WIKI_DB_ERROR")
+        }
+    }
+
+    private func execBind(_ sql: String, bind: (OpaquePointer) -> Void) {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            exitError("SQLite prepare error: \(dbError())\nSQL: \(sql)", code: "WIKI_DB_ERROR")
+            return
+        }
+        bind(stmt!)
+        let result = sqlite3_step(stmt)
+        if result != SQLITE_DONE && result != SQLITE_ROW {
+            let msg = dbError()
+            sqlite3_finalize(stmt)
+            exitError("SQLite step error: \(msg)\nSQL: \(sql)", code: "WIKI_DB_ERROR")
+        }
+        sqlite3_finalize(stmt)
+    }
+
+    private func query<T>(_ sql: String, map: (OpaquePointer) -> T) -> [T] {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            exitError("SQLite query error: \(dbError())\nSQL: \(sql)", code: "WIKI_DB_ERROR")
+            return []
+        }
+        var results: [T] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            results.append(map(stmt!))
+        }
+        sqlite3_finalize(stmt)
+        return results
+    }
+
+    private func col(_ stmt: OpaquePointer?, _ idx: Int32) -> String {
+        if let cStr = sqlite3_column_text(stmt, idx) { return String(cString: cStr) }
+        return ""
+    }
+
+    private func colOpt(_ stmt: OpaquePointer?, _ idx: Int32) -> String? {
+        if sqlite3_column_type(stmt, idx) == SQLITE_NULL { return nil }
+        if let cStr = sqlite3_column_text(stmt, idx) { return String(cString: cStr) }
+        return nil
+    }
+
+    private func decodeJSONArray(_ json: String?) -> [String] {
+        guard let json = json, let data = json.data(using: .utf8),
+              let arr = try? JSONSerialization.jsonObject(with: data) as? [String] else { return [] }
+        return arr
+    }
+}
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `bash build.sh`
+Expected: Compiles without errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/commands/wiki-index.swift
+git commit -m "feat(wiki): SQLite index with pages, links, plugins tables"
+```
+
+---
+
+### Task 4: Reindex Command — Full Filesystem Scan
+
+**Files:**
+- Modify: `src/commands/wiki.swift`
+
+Replace the placeholder `wikiReindexCommand` with a real implementation that scans the wiki directory, parses frontmatter, extracts markdown links, and populates the index.
+
+- [ ] **Step 1: Implement reindex**
+
+Replace the `wikiReindexCommand` function in `src/commands/wiki.swift` with:
+
+```swift
+// MARK: - Reindex
+
+func wikiReindexCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    let wikiDir = aosWikiDir()
+
+    // Ensure directory structure exists
+    for sub in ["plugins", "entities", "concepts"] {
+        try? FileManager.default.createDirectory(
+            atPath: "\(wikiDir)/\(sub)",
+            withIntermediateDirectories: true
+        )
+    }
+
+    let index = WikiIndex(dbPath: aosWikiDbPath())
+    index.open()
+    index.dropTables()
+    index.createTables()
+
+    let fm = FileManager.default
+    var pageCount = 0
+    var linkCount = 0
+    var pluginCount = 0
+
+    // Scan plugins/
+    let pluginsDir = "\(wikiDir)/plugins"
+    if let pluginDirs = try? fm.contentsOfDirectory(atPath: pluginsDir) {
+        for pluginName in pluginDirs {
+            let pluginPath = "\(pluginsDir)/\(pluginName)"
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: pluginPath, isDirectory: &isDir), isDir.boolValue else { continue }
+
+            let skillPath = "\(pluginPath)/SKILL.md"
+            guard let skillContent = try? String(contentsOfFile: skillPath, encoding: .utf8) else { continue }
+
+            let page = parseWikiPage(content: skillContent)
+            let relativePath = "plugins/\(pluginName)/SKILL.md"
+            let mtime = fileModTime(skillPath)
+
+            // Index the plugin itself
+            index.upsertPlugin(
+                name: pluginName,
+                version: page.frontmatter.version,
+                author: page.frontmatter.author,
+                description: page.frontmatter.description,
+                triggers: page.frontmatter.triggers,
+                requires: page.frontmatter.requires,
+                modifiedAt: mtime
+            )
+            pluginCount += 1
+
+            // Index SKILL.md as a workflow page
+            index.upsertPage(
+                path: relativePath,
+                type: "workflow",
+                name: page.frontmatter.name ?? pluginName,
+                description: page.frontmatter.description,
+                tags: page.frontmatter.tags,
+                plugin: pluginName,
+                modifiedAt: mtime
+            )
+            pageCount += 1
+
+            // Extract and index links
+            let links = extractMarkdownLinks(from: page.body, relativeTo: "plugins/\(pluginName)")
+            for target in links {
+                index.upsertLink(source: relativePath, target: target)
+                linkCount += 1
+            }
+
+            // Scan references/ within the plugin
+            let refsDir = "\(pluginPath)/references"
+            if let refFiles = try? fm.contentsOfDirectory(atPath: refsDir) {
+                for refFile in refFiles where refFile.hasSuffix(".md") {
+                    let refPath = "\(refsDir)/\(refFile)"
+                    guard let refContent = try? String(contentsOfFile: refPath, encoding: .utf8) else { continue }
+                    let refPage = parseWikiPage(content: refContent)
+                    let refRelPath = "plugins/\(pluginName)/references/\(refFile)"
+                    let refMtime = fileModTime(refPath)
+
+                    index.upsertPage(
+                        path: refRelPath,
+                        type: refPage.frontmatter.type ?? "concept",
+                        name: refPage.frontmatter.name ?? refFile.replacingOccurrences(of: ".md", with: ""),
+                        description: refPage.frontmatter.description,
+                        tags: refPage.frontmatter.tags,
+                        plugin: pluginName,
+                        modifiedAt: refMtime
+                    )
+                    pageCount += 1
+
+                    let refLinks = extractMarkdownLinks(from: refPage.body, relativeTo: "plugins/\(pluginName)/references")
+                    for target in refLinks {
+                        index.upsertLink(source: refRelPath, target: target)
+                        linkCount += 1
+                    }
+                }
+            }
+        }
+    }
+
+    // Scan entities/ and concepts/
+    for dirType in ["entities", "concepts"] {
+        let typeDir = "\(wikiDir)/\(dirType)"
+        guard let files = try? fm.contentsOfDirectory(atPath: typeDir) else { continue }
+        for file in files where file.hasSuffix(".md") {
+            let filePath = "\(typeDir)/\(file)"
+            guard let content = try? String(contentsOfFile: filePath, encoding: .utf8) else { continue }
+            let page = parseWikiPage(content: content)
+            let relativePath = "\(dirType)/\(file)"
+            let mtime = fileModTime(filePath)
+            let inferredType = dirType == "entities" ? "entity" : "concept"
+
+            index.upsertPage(
+                path: relativePath,
+                type: page.frontmatter.type ?? inferredType,
+                name: page.frontmatter.name ?? file.replacingOccurrences(of: ".md", with: ""),
+                description: page.frontmatter.description,
+                tags: page.frontmatter.tags,
+                plugin: nil,
+                modifiedAt: mtime
+            )
+            pageCount += 1
+
+            let links = extractMarkdownLinks(from: page.body, relativeTo: dirType)
+            for target in links {
+                index.upsertLink(source: relativePath, target: target)
+                linkCount += 1
+            }
+        }
+    }
+
+    index.close()
+
+    if asJSON {
+        let result: [String: Any] = [
+            "status": "ok",
+            "pages": pageCount,
+            "links": linkCount,
+            "plugins": pluginCount
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: result, options: [.prettyPrinted, .sortedKeys]),
+           let s = String(data: data, encoding: .utf8) { print(s) }
+    } else {
+        print("Reindexed: \(pageCount) pages, \(linkCount) links, \(pluginCount) plugins")
+    }
+}
+
+// MARK: - Helpers
+
+/// Extract markdown links like [text](../path/to/file.md) and return resolved relative paths.
+func extractMarkdownLinks(from body: String, relativeTo dir: String) -> [String] {
+    var results: [String] = []
+    // Match [text](path) where path ends in .md
+    let pattern = "\\[([^\\]]+)\\]\\(([^)]+\\.md)\\)"
+    guard let regex = try? NSRegularExpression(pattern: pattern) else { return results }
+    let nsBody = body as NSString
+    let matches = regex.matches(in: body, range: NSRange(location: 0, length: nsBody.length))
+    for match in matches {
+        let pathRange = match.range(at: 2)
+        let linkPath = nsBody.substring(with: pathRange)
+        // Skip external URLs
+        if linkPath.hasPrefix("http://") || linkPath.hasPrefix("https://") { continue }
+        // Resolve relative path
+        let resolved = resolveRelativePath(linkPath, from: dir)
+        results.append(resolved)
+    }
+    return results
+}
+
+/// Resolve a relative path like "../concepts/ipc-protocol.md" from a base directory
+func resolveRelativePath(_ link: String, from baseDir: String) -> String {
+    let baseParts = baseDir.components(separatedBy: "/")
+    let linkParts = link.components(separatedBy: "/")
+    var result = baseParts
+    for part in linkParts {
+        if part == ".." {
+            if !result.isEmpty { result.removeLast() }
+        } else if part != "." {
+            result.append(part)
+        }
+    }
+    return result.joined(separator: "/")
+}
+
+/// Get file modification time as unix epoch
+func fileModTime(_ path: String) -> Int {
+    guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+          let date = attrs[.modificationDate] as? Date else { return 0 }
+    return Int(date.timeIntervalSince1970)
+}
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `bash build.sh`
+Expected: Compiles without errors.
+
+Run: `./aos wiki reindex --json`
+Expected: `{"links":0,"pages":0,"plugins":0,"status":"ok"}` (empty wiki)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/commands/wiki.swift
+git commit -m "feat(wiki): implement reindex — full filesystem scan with link extraction"
+```
+
+---
+
+### Task 5: create-plugin, add, rm Commands
+
+**Files:**
+- Modify: `src/commands/wiki.swift`
+
+- [ ] **Step 1: Add template helpers and scaffold commands**
+
+Add to `src/commands/wiki.swift`, in the command router switch:
+
+```swift
+    case "create-plugin":
+        wikiCreatePluginCommand(args: subArgs)
+    case "add":
+        wikiAddCommand(args: subArgs)
+    case "rm":
+        wikiRmCommand(args: subArgs)
+```
+
+Then add the implementations:
+
+```swift
+// MARK: - Create Plugin
+
+func wikiCreatePluginCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    guard let name = args.first(where: { !$0.hasPrefix("-") }) else {
+        exitError("Usage: aos wiki create-plugin <name> [--json]", code: "MISSING_ARG")
+    }
+
+    let wikiDir = aosWikiDir()
+    let pluginDir = "\(wikiDir)/plugins/\(name)"
+    let skillPath = "\(pluginDir)/SKILL.md"
+
+    if FileManager.default.fileExists(atPath: skillPath) {
+        exitError("Plugin '\(name)' already exists at \(pluginDir)", code: "WIKI_PLUGIN_EXISTS")
+    }
+
+    // Create directory structure
+    try? FileManager.default.createDirectory(atPath: "\(pluginDir)/references", withIntermediateDirectories: true)
+
+    // Write SKILL.md template
+    let template = """
+    ---
+    name: \(name)
+    description: >
+      Describe when this plugin should be used. Include trigger phrases
+      and contexts where it should activate.
+    version: "0.1.0"
+    author: ""
+    tags: []
+    triggers: []
+    requires: []
+    ---
+
+    # \(name.replacingOccurrences(of: "-", with: " ").capitalized)
+
+    ## Purpose
+
+    Describe what this workflow does and why.
+
+    ## Steps
+
+    1. First step
+    2. Second step
+
+    ## Related
+
+    """
+    try? template.write(toFile: skillPath, atomically: true, encoding: .utf8)
+
+    // Update index
+    let index = openWikiIndex()
+    let page = parseWikiPage(content: template)
+    let relativePath = "plugins/\(name)/SKILL.md"
+    index.upsertPage(
+        path: relativePath, type: "workflow", name: name,
+        description: page.frontmatter.description, tags: [],
+        plugin: name, modifiedAt: Int(Date().timeIntervalSince1970)
+    )
+    index.upsertPlugin(
+        name: name, version: "0.1.0", author: nil, description: page.frontmatter.description,
+        triggers: [], requires: [], modifiedAt: Int(Date().timeIntervalSince1970)
+    )
+    index.close()
+
+    if asJSON {
+        print(jsonString(["status": "ok", "plugin": name, "path": pluginDir]))
+    } else {
+        print("Created plugin '\(name)' at \(pluginDir)")
+        print("Edit: \(skillPath)")
+    }
+}
+
+// MARK: - Add Page
+
+func wikiAddCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    let nonFlags = args.filter { !$0.hasPrefix("-") }
+    guard nonFlags.count >= 2 else {
+        exitError("Usage: aos wiki add <entity|concept> <name> [--json]", code: "MISSING_ARG")
+    }
+    let typeArg = nonFlags[0]
+    let name = nonFlags[1]
+
+    guard typeArg == "entity" || typeArg == "concept" else {
+        exitError("Type must be 'entity' or 'concept', got '\(typeArg)'", code: "WIKI_INVALID_TYPE")
+    }
+
+    let wikiDir = aosWikiDir()
+    let dirName = typeArg == "entity" ? "entities" : "concepts"
+    let filePath = "\(wikiDir)/\(dirName)/\(name).md"
+
+    if FileManager.default.fileExists(atPath: filePath) {
+        exitError("Page '\(name)' already exists at \(filePath)", code: "WIKI_PAGE_EXISTS")
+    }
+
+    try? FileManager.default.createDirectory(
+        atPath: "\(wikiDir)/\(dirName)", withIntermediateDirectories: true
+    )
+
+    let displayName = name.replacingOccurrences(of: "-", with: " ").capitalized
+    let template = """
+    ---
+    type: \(typeArg)
+    name: \(displayName)
+    description: ""
+    tags: []
+    ---
+
+    # \(displayName)
+
+    ## Overview
+
+    ## Related
+
+    """
+    try? template.write(toFile: filePath, atomically: true, encoding: .utf8)
+
+    // Update index
+    let index = openWikiIndex()
+    let relativePath = "\(dirName)/\(name).md"
+    index.upsertPage(
+        path: relativePath, type: typeArg, name: displayName,
+        description: nil, tags: [], plugin: nil,
+        modifiedAt: Int(Date().timeIntervalSince1970)
+    )
+    index.close()
+
+    if asJSON {
+        print(jsonString(["status": "ok", "type": typeArg, "name": name, "path": filePath]))
+    } else {
+        print("Created \(typeArg) '\(name)' at \(filePath)")
+    }
+}
+
+// MARK: - Remove Page
+
+func wikiRmCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    guard let pathArg = args.first(where: { !$0.hasPrefix("-") }) else {
+        exitError("Usage: aos wiki rm <relative-path-or-name> [--json]", code: "MISSING_ARG")
+    }
+
+    let wikiDir = aosWikiDir()
+    let fullPath: String
+    let relativePath: String
+
+    // Resolve: could be a relative path or a bare name
+    if pathArg.contains("/") {
+        relativePath = pathArg
+        fullPath = "\(wikiDir)/\(pathArg)"
+    } else {
+        // Search for it
+        let candidates = ["entities/\(pathArg).md", "concepts/\(pathArg).md"]
+        if let found = candidates.first(where: { FileManager.default.fileExists(atPath: "\(wikiDir)/\($0)") }) {
+            relativePath = found
+            fullPath = "\(wikiDir)/\(found)"
+        } else {
+            exitError("Page '\(pathArg)' not found", code: "WIKI_NOT_FOUND")
+        }
+    }
+
+    guard FileManager.default.fileExists(atPath: fullPath) else {
+        exitError("File not found: \(fullPath)", code: "WIKI_NOT_FOUND")
+    }
+
+    // Check for incoming links
+    let index = openWikiIndex()
+    let incoming = index.linksTo(path: relativePath)
+    if !incoming.isEmpty && !asJSON {
+        print("Warning: \(incoming.count) page(s) link to this page:")
+        for link in incoming { print("  \(link.source_path)") }
+    }
+
+    try? FileManager.default.removeItem(atPath: fullPath)
+    index.deletePage(path: relativePath)
+    index.close()
+
+    if asJSON {
+        print(jsonString(["status": "ok", "removed": relativePath, "broken_links": incoming.count]))
+    } else {
+        print("Removed \(relativePath)")
+    }
+}
+
+// MARK: - Index Helper
+
+/// Open the wiki index, creating tables if needed
+func openWikiIndex() -> WikiIndex {
+    let wikiDir = aosWikiDir()
+    try? FileManager.default.createDirectory(atPath: wikiDir, withIntermediateDirectories: true)
+    let index = WikiIndex(dbPath: aosWikiDbPath())
+    index.open()
+    index.createTables()
+    return index
+}
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `bash build.sh`
+Expected: Compiles without errors.
+
+Run: `./aos wiki create-plugin test-workflow --json`
+Expected: JSON with `"status": "ok"` and plugin path.
+
+Run: `./aos wiki add entity test-entity --json`
+Expected: JSON with `"status": "ok"`.
+
+Run: `./aos wiki reindex --json`
+Expected: Pages count > 0.
+
+Run: `./aos wiki rm test-entity --json`
+Expected: JSON with `"status": "ok"`.
+
+Clean up: `rm -rf ~/.config/aos/repo/wiki/plugins/test-workflow`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/commands/wiki.swift
+git commit -m "feat(wiki): add create-plugin, add, rm commands"
+```
+
+---
+
+### Task 6: list, search, show Commands
+
+**Files:**
+- Modify: `src/commands/wiki.swift`
+
+- [ ] **Step 1: Add to command router**
+
+Add cases to the switch in `wikiCommand`:
+
+```swift
+    case "list":
+        wikiListCommand(args: subArgs)
+    case "search":
+        wikiSearchCommand(args: subArgs)
+    case "show":
+        wikiShowCommand(args: subArgs)
+```
+
+- [ ] **Step 2: Implement list command**
+
+```swift
+// MARK: - List
+
+func wikiListCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    let typeFilter = getArg(args, "--type")
+    let pluginFilter = getArg(args, "--plugin")
+    let linksTo = getArg(args, "--links-to")
+    let linksFrom = getArg(args, "--links-from")
+    let orphans = hasFlag(args, "--orphans")
+
+    let index = openWikiIndex()
+
+    if orphans {
+        let pages = index.orphanPages()
+        index.close()
+        if asJSON {
+            print(jsonString(pages))
+        } else {
+            if pages.isEmpty { print("No orphan pages."); return }
+            for p in pages { print("\(p.type.padding(toLength: 10, withPad: " ", startingAt: 0)) \(p.path)  — \(p.name)") }
+        }
+        return
+    }
+
+    if let target = linksTo {
+        let links = index.linksTo(path: target)
+        index.close()
+        if asJSON {
+            print(jsonString(links))
+        } else {
+            if links.isEmpty { print("No pages link to \(target)."); return }
+            for l in links { print("  \(l.source_path)") }
+        }
+        return
+    }
+
+    if let source = linksFrom {
+        let links = index.linksFrom(path: source)
+        index.close()
+        if asJSON {
+            print(jsonString(links))
+        } else {
+            if links.isEmpty { print("No outgoing links from \(source)."); return }
+            for l in links { print("  \(l.target_path)") }
+        }
+        return
+    }
+
+    let pages = index.listPages(type: typeFilter, plugin: pluginFilter)
+    index.close()
+
+    if asJSON {
+        print(jsonString(pages))
+    } else {
+        if pages.isEmpty { print("Wiki is empty. Run 'aos wiki seed' to get started."); return }
+        for p in pages {
+            let desc = p.description.map { " — \($0.prefix(60))" } ?? ""
+            print("\(p.type.padding(toLength: 10, withPad: " ", startingAt: 0)) \(p.path)\(desc)")
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Implement search command**
+
+```swift
+// MARK: - Search
+
+func wikiSearchCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    let typeFilter = getArg(args, "--type")
+    let nonFlags = args.filter { !$0.hasPrefix("-") && $0 != getArg(args, "--type") }
+
+    guard let query = nonFlags.first else {
+        exitError("Usage: aos wiki search <query> [--type <type>] [--json]", code: "MISSING_ARG")
+    }
+
+    let index = openWikiIndex()
+    var results = index.searchPages(query: query, type: typeFilter)
+
+    // Also search file content for matches not caught by index
+    let wikiDir = aosWikiDir()
+    let indexPaths = Set(results.map { $0.path })
+    let contentMatches = searchFileContent(wikiDir: wikiDir, query: query, excluding: indexPaths)
+    results.append(contentsOf: contentMatches)
+
+    index.close()
+
+    if asJSON {
+        print(jsonString(results))
+    } else {
+        if results.isEmpty { print("No results for '\(query)'."); return }
+        for r in results {
+            let desc = r.description.map { " — \($0.prefix(60))" } ?? ""
+            print("\(r.type.padding(toLength: 10, withPad: " ", startingAt: 0)) \(r.path)\(desc)")
+        }
+    }
+}
+
+/// Search file content for a query string, returning pages not already in index results
+func searchFileContent(wikiDir: String, query: String, excluding: Set<String>) -> [WikiIndex.PageRow] {
+    var results: [WikiIndex.PageRow] = []
+    let fm = FileManager.default
+    let lowerQuery = query.lowercased()
+
+    for dirType in ["plugins", "entities", "concepts"] {
+        let dirPath = "\(wikiDir)/\(dirType)"
+        guard let enumerator = fm.enumerator(atPath: dirPath) else { continue }
+        while let relativePath = enumerator.nextObject() as? String {
+            guard relativePath.hasSuffix(".md") else { continue }
+            let fullRelative = "\(dirType)/\(relativePath)"
+            guard !excluding.contains(fullRelative) else { continue }
+            let fullPath = "\(dirPath)/\(relativePath)"
+            guard let content = try? String(contentsOfFile: fullPath, encoding: .utf8) else { continue }
+            if content.lowercased().contains(lowerQuery) {
+                let page = parseWikiPage(content: content)
+                results.append(WikiIndex.PageRow(
+                    path: fullRelative,
+                    type: page.frontmatter.type ?? dirType.dropLast().description,
+                    name: page.frontmatter.name ?? relativePath.replacingOccurrences(of: ".md", with: ""),
+                    description: page.frontmatter.description,
+                    tags: page.frontmatter.tags,
+                    plugin: nil,
+                    modified_at: fileModTime(fullPath)
+                ))
+            }
+        }
+    }
+    return results
+}
+```
+
+- [ ] **Step 4: Implement show command**
+
+```swift
+// MARK: - Show
+
+struct WikiShowResponse: Encodable {
+    let path: String
+    let frontmatter: [String: String]
+    let body: String
+    let raw: String
+}
+
+func wikiShowCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    let rawMode = hasFlag(args, "--raw")
+    guard let pathArg = args.first(where: { !$0.hasPrefix("-") }) else {
+        exitError("Usage: aos wiki show <path-or-name> [--raw] [--json]", code: "MISSING_ARG")
+    }
+
+    let wikiDir = aosWikiDir()
+    let fullPath: String
+    let relativePath: String
+
+    if pathArg.contains("/") || pathArg.contains(".md") {
+        relativePath = pathArg
+        fullPath = "\(wikiDir)/\(pathArg)"
+    } else {
+        // Search by name across all directories
+        let candidates = [
+            "entities/\(pathArg).md",
+            "concepts/\(pathArg).md",
+            "plugins/\(pathArg)/SKILL.md"
+        ]
+        if let found = candidates.first(where: { FileManager.default.fileExists(atPath: "\(wikiDir)/\($0)") }) {
+            relativePath = found
+            fullPath = "\(wikiDir)/\(found)"
+        } else {
+            exitError("Page '\(pathArg)' not found. Try 'aos wiki list' to see available pages.", code: "WIKI_NOT_FOUND")
+        }
+    }
+
+    guard let content = try? String(contentsOfFile: fullPath, encoding: .utf8) else {
+        exitError("Could not read \(fullPath)", code: "WIKI_READ_ERROR")
+    }
+
+    if rawMode {
+        print(content)
+        return
+    }
+
+    let page = parseWikiPage(content: content)
+
+    if asJSON {
+        let response = WikiShowResponse(
+            path: relativePath,
+            frontmatter: page.frontmatter.raw,
+            body: page.body,
+            raw: content
+        )
+        print(jsonString(response))
+    } else {
+        // Print formatted: metadata header then body
+        if let name = page.frontmatter.name { print("# \(name)") }
+        if let type = page.frontmatter.type { print("Type: \(type)") }
+        if let desc = page.frontmatter.description { print("Description: \(desc)") }
+        if !page.frontmatter.tags.isEmpty { print("Tags: \(page.frontmatter.tags.joined(separator: ", "))") }
+        print("---")
+        print(page.body)
+    }
+}
+```
+
+- [ ] **Step 5: Build and verify**
+
+Run: `bash build.sh`
+Expected: Compiles without errors.
+
+Run: `./aos wiki create-plugin demo && ./aos wiki reindex && ./aos wiki list --json`
+Expected: JSON array with the demo plugin's SKILL.md entry.
+
+Run: `./aos wiki show demo --json`
+Expected: JSON with frontmatter, body, raw fields.
+
+Run: `./aos wiki search demo`
+Expected: Shows the demo plugin in results.
+
+Clean up: `rm -rf ~/.config/aos/repo/wiki/plugins/demo`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/commands/wiki.swift
+git commit -m "feat(wiki): add list, search, show commands with --json support"
+```
+
+---
+
+### Task 7: link + lint Commands
+
+**Files:**
+- Modify: `src/commands/wiki.swift`
+
+- [ ] **Step 1: Add to command router**
+
+```swift
+    case "link":
+        wikiLinkCommand(args: subArgs)
+    case "lint":
+        wikiLintCommand(args: subArgs)
+```
+
+- [ ] **Step 2: Implement link command**
+
+```swift
+// MARK: - Link
+
+func wikiLinkCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    let nonFlags = args.filter { !$0.hasPrefix("-") }
+    guard nonFlags.count >= 2 else {
+        exitError("Usage: aos wiki link <from-path> <to-path> [--json]", code: "MISSING_ARG")
+    }
+    let fromPath = nonFlags[0]
+    let toPath = nonFlags[1]
+
+    let wikiDir = aosWikiDir()
+
+    // Resolve from path
+    let fromFull = resolveWikiPath(wikiDir: wikiDir, arg: fromPath)
+    guard let fromFull = fromFull else {
+        exitError("Source page '\(fromPath)' not found", code: "WIKI_NOT_FOUND")
+    }
+
+    // Resolve to path
+    let toFull = resolveWikiPath(wikiDir: wikiDir, arg: toPath)
+    guard let toFull = toFull else {
+        exitError("Target page '\(toPath)' not found", code: "WIKI_NOT_FOUND")
+    }
+
+    // Add link to index
+    let index = openWikiIndex()
+    index.upsertLink(source: fromFull.relative, target: toFull.relative)
+    index.close()
+
+    // Append to Related section in source file
+    let relativeLink = makeRelativeLink(from: fromFull.relative, to: toFull.relative)
+    if var content = try? String(contentsOfFile: fromFull.absolute, encoding: .utf8) {
+        let toPage = parseWikiPage(content: (try? String(contentsOfFile: toFull.absolute, encoding: .utf8)) ?? "")
+        let linkName = toPage.frontmatter.name ?? toPath
+        let linkLine = "- [\(linkName)](\(relativeLink))"
+
+        if content.contains("## Related") {
+            content = content.replacingOccurrences(of: "## Related\n", with: "## Related\n\(linkLine)\n")
+        } else {
+            content += "\n## Related\n\(linkLine)\n"
+        }
+        try? content.write(toFile: fromFull.absolute, atomically: true, encoding: .utf8)
+    }
+
+    if asJSON {
+        print(jsonString(["status": "ok", "from": fromFull.relative, "to": toFull.relative]))
+    } else {
+        print("Linked \(fromFull.relative) → \(toFull.relative)")
+    }
+}
+
+struct ResolvedPath {
+    let relative: String
+    let absolute: String
+}
+
+func resolveWikiPath(wikiDir: String, arg: String) -> ResolvedPath? {
+    if arg.contains("/") || arg.contains(".md") {
+        let abs = "\(wikiDir)/\(arg)"
+        if FileManager.default.fileExists(atPath: abs) { return ResolvedPath(relative: arg, absolute: abs) }
+        return nil
+    }
+    let candidates = [
+        ("entities/\(arg).md", "\(wikiDir)/entities/\(arg).md"),
+        ("concepts/\(arg).md", "\(wikiDir)/concepts/\(arg).md"),
+        ("plugins/\(arg)/SKILL.md", "\(wikiDir)/plugins/\(arg)/SKILL.md")
+    ]
+    for (rel, abs) in candidates {
+        if FileManager.default.fileExists(atPath: abs) { return ResolvedPath(relative: rel, absolute: abs) }
+    }
+    return nil
+}
+
+/// Compute a relative path from one wiki page to another
+func makeRelativeLink(from: String, to: String) -> String {
+    let fromParts = from.components(separatedBy: "/").dropLast() // directory of source
+    let toParts = to.components(separatedBy: "/")
+
+    // Find common prefix length
+    var common = 0
+    for i in 0..<min(fromParts.count, toParts.count) {
+        if Array(fromParts)[i] == toParts[i] { common += 1 } else { break }
+    }
+
+    let ups = Array(repeating: "..", count: fromParts.count - common)
+    let downs = Array(toParts[common...])
+    return (ups + downs).joined(separator: "/")
+}
+```
+
+- [ ] **Step 3: Implement lint command**
+
+```swift
+// MARK: - Lint
+
+struct LintIssue: Encodable {
+    let severity: String  // "error", "warning"
+    let category: String  // "broken_link", "orphan", "missing_frontmatter", "malformed_plugin", "index_drift"
+    let path: String
+    let message: String
+}
+
+func wikiLintCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    let fix = hasFlag(args, "--fix")
+    let wikiDir = aosWikiDir()
+    var issues: [LintIssue] = []
+
+    // If --fix, reindex first
+    if fix {
+        wikiReindexCommand(args: ["--json"])
+    }
+
+    let index = openWikiIndex()
+    let allPages = index.listPages()
+    let allPagePaths = Set(allPages.map { $0.path })
+
+    // 1. Broken links: links pointing to paths that don't exist
+    for page in allPages {
+        let outgoing = index.linksFrom(path: page.path)
+        for link in outgoing {
+            if !allPagePaths.contains(link.target_path) {
+                // Also check if file exists on disk but just not indexed
+                let diskPath = "\(wikiDir)/\(link.target_path)"
+                if !FileManager.default.fileExists(atPath: diskPath) {
+                    issues.append(LintIssue(
+                        severity: "error", category: "broken_link",
+                        path: page.path, message: "Links to '\(link.target_path)' which does not exist"
+                    ))
+                }
+            }
+        }
+    }
+
+    // 2. Orphan pages
+    let orphans = index.orphanPages()
+    for page in orphans {
+        // SKILL.md pages are entry points, not orphans
+        if page.path.hasSuffix("SKILL.md") { continue }
+        issues.append(LintIssue(
+            severity: "warning", category: "orphan",
+            path: page.path, message: "No incoming links (orphan page)"
+        ))
+    }
+
+    // 3. Missing frontmatter
+    for page in allPages {
+        if page.name.isEmpty {
+            issues.append(LintIssue(
+                severity: "error", category: "missing_frontmatter",
+                path: page.path, message: "Missing 'name' in frontmatter"
+            ))
+        }
+    }
+
+    // 4. Malformed plugins
+    let plugins = index.listPlugins()
+    for plugin in plugins {
+        let skillPath = "\(wikiDir)/plugins/\(plugin.name)/SKILL.md"
+        if !FileManager.default.fileExists(atPath: skillPath) {
+            issues.append(LintIssue(
+                severity: "error", category: "malformed_plugin",
+                path: "plugins/\(plugin.name)", message: "Plugin directory exists but SKILL.md is missing"
+            ))
+        }
+        if plugin.description == nil || plugin.description?.isEmpty == true {
+            issues.append(LintIssue(
+                severity: "warning", category: "malformed_plugin",
+                path: "plugins/\(plugin.name)/SKILL.md", message: "Plugin has no description (will not trigger reliably)"
+            ))
+        }
+    }
+
+    // 5. Index drift: files on disk not in the index
+    let fm = FileManager.default
+    for dirType in ["entities", "concepts"] {
+        let dirPath = "\(wikiDir)/\(dirType)"
+        guard let files = try? fm.contentsOfDirectory(atPath: dirPath) else { continue }
+        for file in files where file.hasSuffix(".md") {
+            let relative = "\(dirType)/\(file)"
+            if !allPagePaths.contains(relative) {
+                issues.append(LintIssue(
+                    severity: "warning", category: "index_drift",
+                    path: relative, message: "File exists on disk but not in index (run 'aos wiki reindex')"
+                ))
+            }
+        }
+    }
+
+    index.close()
+
+    // Fix: remove broken link entries from index
+    if fix {
+        let brokenLinks = issues.filter { $0.category == "broken_link" }
+        if !brokenLinks.isEmpty {
+            let idx = openWikiIndex()
+            // Reindex already handled this via dropTables + rebuild
+            idx.close()
+        }
+    }
+
+    if asJSON {
+        print(jsonString(issues))
+    } else {
+        if issues.isEmpty {
+            print("Wiki is clean. No issues found.")
+        } else {
+            let errors = issues.filter { $0.severity == "error" }
+            let warnings = issues.filter { $0.severity == "warning" }
+            for issue in issues {
+                let icon = issue.severity == "error" ? "ERROR" : "WARN "
+                print("\(icon)  [\(issue.category)] \(issue.path): \(issue.message)")
+            }
+            print("\n\(errors.count) error(s), \(warnings.count) warning(s)")
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `bash build.sh`
+Expected: Compiles without errors.
+
+Run: `./aos wiki lint --json`
+Expected: JSON array (possibly empty or with warnings for existing state).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commands/wiki.swift
+git commit -m "feat(wiki): add link and lint commands"
+```
+
+---
+
+### Task 8: invoke Command
+
+**Files:**
+- Modify: `src/commands/wiki.swift`
+
+- [ ] **Step 1: Add to command router**
+
+```swift
+    case "invoke":
+        wikiInvokeCommand(args: subArgs)
+```
+
+- [ ] **Step 2: Implement invoke**
+
+```swift
+// MARK: - Invoke
+
+func wikiInvokeCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    guard let name = args.first(where: { !$0.hasPrefix("-") }) else {
+        exitError("Usage: aos wiki invoke <plugin-name> [--json]", code: "MISSING_ARG")
+    }
+
+    let wikiDir = aosWikiDir()
+    let pluginDir = "\(wikiDir)/plugins/\(name)"
+    let skillPath = "\(pluginDir)/SKILL.md"
+
+    guard let skillContent = try? String(contentsOfFile: skillPath, encoding: .utf8) else {
+        exitError("Plugin '\(name)' not found at \(pluginDir)", code: "WIKI_NOT_FOUND")
+    }
+
+    var bundle = skillContent
+
+    // Bundle references
+    let refsDir = "\(pluginDir)/references"
+    if let refFiles = try? FileManager.default.contentsOfDirectory(atPath: refsDir)?.sorted() ?? [] {
+        for refFile in refFiles where refFile.hasSuffix(".md") {
+            let refPath = "\(refsDir)/\(refFile)"
+            if let refContent = try? String(contentsOfFile: refPath, encoding: .utf8) {
+                bundle += "\n\n--- BEGIN reference: \(refFile) ---\n\n"
+                bundle += refContent
+                bundle += "\n\n--- END reference: \(refFile) ---"
+            }
+        }
+    }
+
+    // Bundle scripts (show content so agent knows what's available)
+    let scriptsDir = "\(pluginDir)/scripts"
+    if let scriptFiles = try? FileManager.default.contentsOfDirectory(atPath: scriptsDir)?.sorted() ?? [] {
+        for scriptFile in scriptFiles {
+            let scriptPath = "\(scriptsDir)/\(scriptFile)"
+            if let scriptContent = try? String(contentsOfFile: scriptPath, encoding: .utf8) {
+                bundle += "\n\n--- BEGIN script: \(scriptFile) ---\n\n"
+                bundle += scriptContent
+                bundle += "\n\n--- END script: \(scriptFile) ---"
+            }
+        }
+    }
+
+    if asJSON {
+        let response: [String: String] = [
+            "plugin": name,
+            "bundle": bundle
+        ]
+        print(jsonString(response))
+    } else {
+        print(bundle)
+    }
+}
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `bash build.sh`
+Expected: Compiles without errors.
+
+Run: `./aos wiki create-plugin test-invoke && ./aos wiki invoke test-invoke`
+Expected: Prints the SKILL.md template content.
+
+Clean up: `rm -rf ~/.config/aos/repo/wiki/plugins/test-invoke`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/commands/wiki.swift
+git commit -m "feat(wiki): add invoke command — bundles plugin into prompt payload"
+```
+
+---
+
+### Task 9: seed Command + Starter Pack
+
+**Files:**
+- Modify: `src/commands/wiki.swift`
+- Create: `wiki-seed/entities/gateway.md`
+- Create: `wiki-seed/entities/sigil.md`
+- Create: `wiki-seed/entities/canvas-system.md`
+- Create: `wiki-seed/entities/daemon.md`
+- Create: `wiki-seed/entities/studio.md`
+- Create: `wiki-seed/concepts/ipc-protocol.md`
+- Create: `wiki-seed/concepts/daemon-lifecycle.md`
+- Create: `wiki-seed/concepts/content-server.md`
+- Create: `wiki-seed/concepts/runtime-modes.md`
+- Create: `wiki-seed/plugins/self-check/SKILL.md`
+
+- [ ] **Step 1: Add seed to command router**
+
+```swift
+    case "seed":
+        wikiSeedCommand(args: subArgs)
+```
+
+- [ ] **Step 2: Implement seed command**
+
+```swift
+// MARK: - Seed
+
+func wikiSeedCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    let force = hasFlag(args, "--force")
+    let fromPath = getArg(args, "--from")
+
+    let wikiDir = aosWikiDir()
+
+    // Check if wiki already has content
+    let fm = FileManager.default
+    let hasContent = ["plugins", "entities", "concepts"].contains { dir in
+        let dirPath = "\(wikiDir)/\(dir)"
+        return (try? fm.contentsOfDirectory(atPath: dirPath))?.contains(where: { $0.hasSuffix(".md") || !$0.hasPrefix(".") }) ?? false
+    }
+
+    if hasContent && !force {
+        if asJSON {
+            print(jsonString(["status": "skipped", "reason": "Wiki already has content. Use --force to overwrite."]))
+        } else {
+            print("Wiki already has content. Use --force to seed anyway.")
+        }
+        return
+    }
+
+    // Determine source directory
+    let sourceDir: String
+    if let from = fromPath {
+        sourceDir = from
+    } else if let repoRoot = aosCurrentRepoRoot() {
+        sourceDir = "\(repoRoot)/wiki-seed"
+    } else {
+        exitError("No seed source found. Use --from <path> or run from the repo.", code: "WIKI_SEED_NOT_FOUND")
+    }
+
+    guard fm.fileExists(atPath: sourceDir) else {
+        exitError("Seed directory not found at \(sourceDir)", code: "WIKI_SEED_NOT_FOUND")
+    }
+
+    // Copy seed files without overwriting existing
+    var copied = 0
+    for subDir in ["plugins", "entities", "concepts"] {
+        let srcDir = "\(sourceDir)/\(subDir)"
+        let dstDir = "\(wikiDir)/\(subDir)"
+        guard let enumerator = fm.enumerator(atPath: srcDir) else { continue }
+        while let relativePath = enumerator.nextObject() as? String {
+            let srcPath = "\(srcDir)/\(relativePath)"
+            let dstPath = "\(dstDir)/\(relativePath)"
+
+            var isDir: ObjCBool = false
+            fm.fileExists(atPath: srcPath, isDirectory: &isDir)
+
+            if isDir.boolValue {
+                try? fm.createDirectory(atPath: dstPath, withIntermediateDirectories: true)
+            } else {
+                if !force && fm.fileExists(atPath: dstPath) { continue }
+                let dstParent = (dstPath as NSString).deletingLastPathComponent
+                try? fm.createDirectory(atPath: dstParent, withIntermediateDirectories: true)
+                try? fm.copyItem(atPath: srcPath, toPath: dstPath)
+                copied += 1
+            }
+        }
+    }
+
+    // Reindex after seeding
+    wikiReindexCommand(args: asJSON ? ["--json"] : [])
+
+    if asJSON {
+        print(jsonString(["status": "ok", "files_copied": copied]))
+    } else {
+        print("Seeded \(copied) files. Wiki is ready.")
+    }
+}
+```
+
+- [ ] **Step 3: Create seed entity pages**
+
+Create `wiki-seed/entities/gateway.md`:
+
+```markdown
+---
+type: entity
+name: Gateway
+description: MCP server for typed script execution and cross-harness coordination
+tags: [infrastructure, mcp, tools]
+---
+
+# Gateway
+
+The gateway is an MCP (Model Context Protocol) server that provides typed tool access to the agent-os runtime. It exposes coordination tools (session management, state, messaging) and execution tools (OS script running, script registry).
+
+## Location
+
+`packages/gateway/` in the agent-os repo. Runs as a Node.js process, typically started via MCP configuration in `.mcp.json`.
+
+## Tools
+
+### Coordination
+- `register_session` — register a named session with metadata
+- `set_state` / `get_state` — per-session key-value state
+- `post_message` / `read_stream` — cross-session messaging
+- `who_is_online` — list active sessions
+
+### Execution
+- `run_os_script` — execute TypeScript scripts with SDK access
+- `save_script` / `list_scripts` — persistent script registry
+- `discover_capabilities` — runtime capability detection
+
+## Related
+- [IPC Protocol](../concepts/ipc-protocol.md)
+- [Daemon](./daemon.md)
+```
+
+Create `wiki-seed/entities/sigil.md`:
+
+```markdown
+---
+type: entity
+name: Sigil
+description: Avatar presence system — the visual face of agent-os
+tags: [display, avatar, presence]
+---
+
+# Sigil
+
+Sigil is the avatar presence system for agent-os. It renders a Three.js celestial animation on full-screen transparent canvases, tracks cursor position across displays, and provides visual feedback for agent activity.
+
+## Components
+
+- **avatar-sub** — Swift binary, Sigil's entry point. Manages state machine, IPC, and animation loop.
+- **renderer/** — Three.js live renderer (bundled single HTML for WKWebView compatibility)
+- **studio/** — Customization UI for avatar appearance and behavior
+- **chat/** — Chat surface for agent conversations (in development)
+
+## Architecture
+
+Sigil runs as a separate process from the daemon. It connects via Unix socket IPC, receives cursor position and event updates, and sends scene-position commands to its canvases.
+
+## Related
+- [Canvas System](./canvas-system.md)
+- [Daemon](./daemon.md)
+- [Studio](./studio.md)
+```
+
+Create `wiki-seed/entities/canvas-system.md`:
+
+```markdown
+---
+type: entity
+name: Canvas System
+description: Daemon-managed transparent overlay windows for HTML content
+tags: [display, canvas, overlay]
+---
+
+# Canvas System
+
+Canvases are transparent NSWindow overlays managed by the aos daemon. Each canvas loads HTML content via WKWebView and communicates bidirectionally with the daemon through JavaScript evaluation.
+
+## Operations
+
+- `create` — create a canvas with ID, position, and URL
+- `update` — modify canvas content, position, or style
+- `remove` — destroy a canvas
+- `eval` — run JavaScript in a canvas context
+- `list` — enumerate active canvases
+
+## Canvas Types
+
+- **Interactive** (`.floating` level) — receive clicks. Used for studio, chat, inspector.
+- **Overlay** (`.statusBar` level) — click-through. Used for display overlays, annotations.
+
+## Content Loading
+
+Canvases load content from the daemon's content server via `aos://` URLs, which resolve to `http://127.0.0.1:PORT/...`. This allows multi-file web apps (ES modules, CSS) without bundling.
+
+## Related
+- [Content Server](../concepts/content-server.md)
+- [Daemon](./daemon.md)
+- [Sigil](./sigil.md)
+```
+
+Create `wiki-seed/entities/daemon.md`:
+
+```markdown
+---
+type: entity
+name: Daemon
+description: Unified aos daemon — socket server, canvas manager, autonomic behaviors
+tags: [infrastructure, daemon, service]
+---
+
+# Daemon
+
+The aos daemon (`aos serve`) is the central process that manages canvases, routes IPC messages, runs the content server, and provides autonomic behaviors (voice, visual feedback).
+
+## Communication
+
+Unix socket at `~/.config/aos/{mode}/sock`. Messages are newline-delimited JSON (ndjson) using the daemon event envelope format.
+
+## Responsibilities
+
+- Canvas lifecycle (create, update, remove, eval)
+- Content server (HTTP file serving for WKWebView)
+- IPC routing between connected clients
+- Autonomic voice announcements
+- Configuration watching and live reload
+
+## Service Management
+
+The daemon can run as a launchd service:
+```
+aos service install --mode repo
+aos service start
+aos service status --json
+```
+
+## Related
+- [IPC Protocol](../concepts/ipc-protocol.md)
+- [Canvas System](./canvas-system.md)
+- [Daemon Lifecycle](../concepts/daemon-lifecycle.md)
+- [Runtime Modes](../concepts/runtime-modes.md)
+```
+
+Create `wiki-seed/entities/studio.md`:
+
+```markdown
+---
+type: entity
+name: Studio
+description: Sigil customization UI — avatar appearance, surfaces, settings
+tags: [display, ui, configuration]
+---
+
+# Studio
+
+Studio is Sigil's customization interface, rendered as an interactive canvas. It provides controls for avatar appearance, companion surface management, and settings.
+
+## Panels
+
+- **Avatar** — visual appearance controls, animation parameters
+- **Surfaces** — launch companion canvases (chat, inspector)
+- **Settings** — voice, visual feedback toggles
+
+## Runtime
+
+Studio runs as a WKWebView canvas loaded via the content server. It communicates with the daemon through IPC — sends config changes, receives state updates.
+
+## Location
+
+`apps/sigil/studio/` — HTML, CSS, JavaScript files served by the content server.
+
+## Related
+- [Sigil](./sigil.md)
+- [Canvas System](./canvas-system.md)
+```
+
+- [ ] **Step 4: Create seed concept pages**
+
+Create `wiki-seed/concepts/ipc-protocol.md`:
+
+```markdown
+---
+type: concept
+name: IPC Protocol
+description: Newline-delimited JSON messaging over Unix socket between daemon and clients
+tags: [protocol, ipc, messaging]
+---
+
+# IPC Protocol
+
+All communication between the aos daemon and its clients (CLI commands, Sigil, gateway) uses newline-delimited JSON (ndjson) over a Unix socket.
+
+## Envelope Format
+
+```json
+{"v":1,"service":"display","event":"canvas_created","ts":1712345678,"data":{...},"ref":"optional-correlation-id"}
+```
+
+| Field | Description |
+|-------|-------------|
+| v | Protocol version (always 1) |
+| service | Originating subsystem |
+| event | Event type (snake_case) |
+| ts | Unix timestamp |
+| data | Event payload |
+| ref | Optional correlation ID for request/response |
+
+## Request/Response
+
+CLI commands use a request/response pattern: send a command, receive a response with the same `ref`. The `DaemonSession` class handles this via `sendAndReceive()`.
+
+## Streaming
+
+Long-lived connections (Sigil, observe) receive continuous events. The daemon broadcasts relevant events to all connected clients.
+
+## Related
+- [Daemon](../entities/daemon.md)
+- [Gateway](../entities/gateway.md)
+```
+
+Create `wiki-seed/concepts/daemon-lifecycle.md`:
+
+```markdown
+---
+type: concept
+name: Daemon Lifecycle
+description: How the aos daemon starts, runs, and stops across runtime modes
+tags: [daemon, lifecycle, service]
+---
+
+# Daemon Lifecycle
+
+## Startup
+
+1. Parse config from `~/.config/aos/{mode}/config.json`
+2. Create Unix socket at `~/.config/aos/{mode}/sock`
+3. Start content server (HTTP) on an OS-assigned port
+4. Start configuration file watcher for live reload
+5. Begin accepting client connections
+
+## Connection Handling
+
+Each client gets an independent ndjson stream. Canvas operations, eval calls, and queries are routed through the daemon's central state.
+
+## Shutdown
+
+- `aos service stop` — sends SIGTERM via launchctl
+- `aos reset` — stops service, removes socket, cleans state directory
+- The daemon cleans up canvases and closes connections on exit
+
+## Auto-Start
+
+CLI commands that need the daemon (canvas operations, eval, listen) attempt to auto-start it via `DaemonSession.connect()`, which launches `aos serve` as a background process if no socket exists.
+
+## Related
+- [Daemon](../entities/daemon.md)
+- [Runtime Modes](./runtime-modes.md)
+```
+
+Create `wiki-seed/concepts/content-server.md`:
+
+```markdown
+---
+type: concept
+name: Content Server
+description: Local HTTP server for serving HTML assets to WKWebView canvases
+tags: [infrastructure, http, content]
+---
+
+# Content Server
+
+The daemon runs a local HTTP file server that serves HTML, CSS, and JavaScript files to WKWebView canvases. This eliminates the need to bundle multi-file web apps into single HTML files.
+
+## URL Scheme
+
+Canvases use `aos://` URLs which the daemon rewrites to `http://127.0.0.1:PORT/...` at canvas creation time.
+
+Example: `aos://sigil/studio/index.html` resolves to the studio interface.
+
+## Configuration
+
+Content roots map URL prefixes to filesystem directories:
+
+```bash
+aos set content.roots.sigil apps/sigil
+```
+
+## Why
+
+WKWebView in file:// mode blocks ES module imports and cross-origin CSS. The HTTP server bypasses these restrictions while keeping everything local.
+
+## Related
+- [Canvas System](../entities/canvas-system.md)
+- [Daemon](../entities/daemon.md)
+```
+
+Create `wiki-seed/concepts/runtime-modes.md`:
+
+```markdown
+---
+type: concept
+name: Runtime Modes
+description: Repo vs installed mode — separate state directories prevent cross-contamination
+tags: [infrastructure, runtime, configuration]
+---
+
+# Runtime Modes
+
+AOS has two explicit runtime modes that determine where state is stored and which binaries are used.
+
+## Modes
+
+| Mode | Binary | State Dir | When |
+|------|--------|-----------|------|
+| repo | `./aos` | `~/.config/aos/repo/` | Building/testing from source |
+| installed | `~/Applications/AOS.app/.../aos` | `~/.config/aos/installed/` | Packaged runtime |
+
+## Detection
+
+Automatic: if the executable path contains `.app/Contents/MacOS/`, it's installed mode. Otherwise, repo mode. Can be overridden via `AOS_RUNTIME_MODE` environment variable.
+
+## Isolation
+
+Each mode gets its own socket, config, logs, and launchd labels. This prevents development builds from interfering with the installed runtime.
+
+## Related
+- [Daemon](../entities/daemon.md)
+- [Daemon Lifecycle](./daemon-lifecycle.md)
+```
+
+- [ ] **Step 5: Create seed example plugin**
+
+Create `wiki-seed/plugins/self-check/SKILL.md`:
+
+```markdown
+---
+name: self-check
+description: >
+  Run a health check on the aos runtime. Use when the user asks
+  to check system status, verify the runtime is healthy, diagnose
+  issues, or troubleshoot aos problems.
+version: "1.0.0"
+author: agent-os
+tags: [diagnostics, health, runtime]
+triggers: ["check system health", "is aos working", "diagnose issues", "run health check"]
+requires: [aos-daemon]
+---
+
+# Self-Check — Runtime Health Verification
+
+Run a comprehensive health check of the aos runtime and report status.
+
+## Steps
+
+1. Run `aos doctor --json` and parse the output
+2. Check each section:
+   - **Permissions**: accessibility and screen recording granted?
+   - **Daemon**: running? Socket exists?
+   - **Service**: launch agent installed and loaded?
+3. If issues found, suggest specific fix commands
+4. Report summary to the user
+
+## Decision Tree
+
+- If permissions missing → suggest `aos permissions setup --once`
+- If daemon not running → suggest `aos service start`
+- If service not installed → suggest `aos service install --mode repo`
+- If everything healthy → confirm all systems operational
+
+## Related
+- [Daemon](../../entities/daemon.md)
+- [Runtime Modes](../../concepts/runtime-modes.md)
+```
+
+- [ ] **Step 6: Build and verify**
+
+Run: `bash build.sh`
+Expected: Compiles without errors.
+
+Run: `./aos wiki seed --json`
+Expected: JSON with `"status": "ok"` and files_copied count > 0.
+
+Run: `./aos wiki reindex --json`
+Expected: Pages, links, and plugins counts all > 0.
+
+Run: `./aos wiki list`
+Expected: Lists all seeded entities, concepts, and the self-check workflow.
+
+Run: `./aos wiki show gateway`
+Expected: Formatted output of the gateway entity page.
+
+Run: `./aos wiki invoke self-check`
+Expected: Prints the self-check SKILL.md content.
+
+Run: `./aos wiki lint`
+Expected: Clean or only minor warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/commands/wiki.swift wiki-seed/
+git commit -m "feat(wiki): add seed command with starter pack — 9 entities/concepts + self-check plugin"
+```
+
+---
+
+### Task 10: Integration Test Script
+
+**Files:**
+- Create: `tests/wiki-integration.sh`
+
+- [ ] **Step 1: Write the integration test**
+
+Create `tests/wiki-integration.sh`:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# wiki-integration.sh — end-to-end test of aos wiki commands
+# Requires: ./aos built, no existing wiki (or will be reset)
+
+AOS="./aos"
+WIKI_DIR=$(${AOS} wiki reindex --json 2>/dev/null | grep -o '"wiki_dir":"[^"]*"' | cut -d'"' -f4 || echo "$HOME/.config/aos/repo/wiki")
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== aos wiki integration tests ==="
+echo "Wiki dir: $WIKI_DIR"
+
+# Clean slate
+rm -rf "$WIKI_DIR"
+
+# Test: reindex on empty wiki
+echo ""
+echo "--- reindex (empty) ---"
+OUTPUT=$($AOS wiki reindex --json)
+echo "$OUTPUT" | grep -q '"pages" : 0' && pass "reindex empty" || fail "reindex empty"
+
+# Test: seed
+echo ""
+echo "--- seed ---"
+OUTPUT=$($AOS wiki seed --json)
+echo "$OUTPUT" | grep -q '"status" : "ok"' && pass "seed" || fail "seed"
+
+# Test: reindex after seed
+echo ""
+echo "--- reindex (after seed) ---"
+OUTPUT=$($AOS wiki reindex --json)
+PAGES=$(echo "$OUTPUT" | grep -o '"pages" : [0-9]*' | grep -o '[0-9]*')
+[ "$PAGES" -gt 0 ] && pass "reindex found $PAGES pages" || fail "reindex found 0 pages"
+
+# Test: list
+echo ""
+echo "--- list ---"
+OUTPUT=$($AOS wiki list --json)
+echo "$OUTPUT" | grep -q "gateway" && pass "list contains gateway" || fail "list missing gateway"
+
+# Test: list --type
+OUTPUT=$($AOS wiki list --type workflow --json)
+echo "$OUTPUT" | grep -q "self-check" && pass "list --type workflow" || fail "list --type workflow"
+
+# Test: show
+echo ""
+echo "--- show ---"
+OUTPUT=$($AOS wiki show gateway --json)
+echo "$OUTPUT" | grep -q '"name" : "Gateway"' && pass "show gateway" || fail "show gateway"
+
+# Test: show --raw
+OUTPUT=$($AOS wiki show gateway --raw)
+echo "$OUTPUT" | grep -q "^---" && pass "show --raw has frontmatter" || fail "show --raw"
+
+# Test: search
+echo ""
+echo "--- search ---"
+OUTPUT=$($AOS wiki search "MCP server" --json)
+echo "$OUTPUT" | grep -q "gateway" && pass "search finds gateway" || fail "search"
+
+# Test: create-plugin
+echo ""
+echo "--- create-plugin ---"
+OUTPUT=$($AOS wiki create-plugin test-workflow --json)
+echo "$OUTPUT" | grep -q '"status" : "ok"' && pass "create-plugin" || fail "create-plugin"
+
+# Test: add entity
+OUTPUT=$($AOS wiki add entity test-entity --json)
+echo "$OUTPUT" | grep -q '"status" : "ok"' && pass "add entity" || fail "add entity"
+
+# Test: link
+echo ""
+echo "--- link ---"
+OUTPUT=$($AOS wiki link test-entity gateway --json)
+echo "$OUTPUT" | grep -q '"status" : "ok"' && pass "link" || fail "link"
+
+# Test: list --links-to
+OUTPUT=$($AOS wiki list --links-to entities/gateway.md --json)
+echo "$OUTPUT" | grep -q "test-entity" && pass "list --links-to" || fail "list --links-to"
+
+# Test: invoke
+echo ""
+echo "--- invoke ---"
+OUTPUT=$($AOS wiki invoke self-check)
+echo "$OUTPUT" | grep -q "Self-Check" && pass "invoke self-check" || fail "invoke self-check"
+
+# Test: lint
+echo ""
+echo "--- lint ---"
+OUTPUT=$($AOS wiki lint --json)
+# Should run without error
+[ $? -eq 0 ] && pass "lint runs" || fail "lint runs"
+
+# Test: rm
+echo ""
+echo "--- rm ---"
+OUTPUT=$($AOS wiki rm test-entity --json)
+echo "$OUTPUT" | grep -q '"status" : "ok"' && pass "rm" || fail "rm"
+
+# Cleanup test plugin
+rm -rf "$WIKI_DIR/plugins/test-workflow"
+$AOS wiki reindex > /dev/null 2>&1
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ $FAIL -eq 0 ] && exit 0 || exit 1
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `bash build.sh && bash tests/wiki-integration.sh`
+Expected: All tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/wiki-integration.sh
+git commit -m "test(wiki): add integration test script covering all wiki commands"
+```
+
+---
+
+### Task 11: "Customize with Agent" Skill
+
+**Files:**
+- Create: `wiki-seed/plugins/customize-with-agent/SKILL.md`
+- Create: `wiki-seed/plugins/customize-with-agent/references/skill-writing-guide.md`
+
+This is the agent skill for creating and editing wiki plugins. Derived from Anthropic's skill-creator (`docs/reference/anthropic-skill-creator.md`), adapted for the wiki environment.
+
+- [ ] **Step 1: Write the skill**
+
+Create `wiki-seed/plugins/customize-with-agent/SKILL.md`:
+
+```markdown
+---
+name: customize-with-agent
+description: >
+  Create new wiki plugins or edit existing ones through guided conversation.
+  Use when the user asks to create a plugin, build a workflow, make a new
+  skill, automate a task, or says "customize with agent". Also use when
+  the user wants to turn a conversation or process into a reusable workflow.
+version: "1.0.0"
+author: agent-os
+tags: [meta, authoring, plugin-creation]
+triggers: ["create a plugin", "build a workflow", "make a skill", "customize with agent", "turn this into a plugin"]
+requires: []
+---
+
+# Customize with Agent — Plugin Creator
+
+Create new wiki plugins or improve existing ones through collaborative dialogue.
+
+## Overview
+
+A plugin is a reusable workflow stored in the wiki. It consists of:
+- `SKILL.md` — instructions the agent follows when the plugin is invoked
+- `references/` — supporting knowledge documents loaded on demand
+- `scripts/` — optional executable code for deterministic tasks
+- `assets/` — optional templates, icons, or other files
+
+Your job is to help the user define what the plugin should do, then create it using wiki tools.
+
+## Process
+
+### 1. Capture Intent
+
+Understand what the user wants to automate or codify. Ask:
+
+1. What should this plugin enable an agent to do?
+2. When should it trigger? (what user phrases or contexts)
+3. What's the expected output?
+4. Are there existing tools, commands, or APIs it should use?
+
+If the current conversation already contains a workflow the user wants to capture, extract answers from context first. The user may need to fill gaps.
+
+### 2. Interview for Details
+
+Ask one question at a time about:
+- Edge cases and error handling
+- Input/output formats
+- Dependencies (does it need the daemon running? gateway? specific tools?)
+- Success criteria — how do you know it worked?
+
+### 3. Create the Plugin
+
+Use wiki tools to scaffold:
+
+```bash
+aos wiki create-plugin <name>
+```
+
+Then write the SKILL.md and any reference files. Follow these guidelines:
+
+**SKILL.md structure:**
+- Frontmatter with name, description (pushy — include trigger phrases), version, tags
+- Clear purpose statement
+- Step-by-step instructions
+- Decision trees for branching logic
+- Related links to wiki pages
+
+**Writing principles:**
+- Explain the *why* behind instructions, not just the *what*
+- Keep SKILL.md under 500 lines — move domain knowledge to `references/`
+- Use concrete examples over abstract descriptions
+- If all test runs would write a similar helper script, bundle it in `scripts/`
+
+**Description field:**
+The description is the primary trigger mechanism. Make it pushy:
+- Include what the skill does AND specific contexts for activation
+- List natural language phrases that should trigger it
+- Err on the side of over-matching — undertriggering is worse
+
+### 4. Test
+
+Offer to test the plugin:
+> "Want me to try running this plugin to see how it works?"
+
+If yes, invoke it: `aos wiki invoke <name>` — read the output and follow the instructions as if you were a fresh agent receiving them. Note any confusion, missing context, or unclear steps.
+
+### 5. Iterate
+
+Based on testing or user feedback:
+- Revise SKILL.md for clarity
+- Add missing reference files
+- Improve the description for better triggering
+- Update the index: `aos wiki reindex`
+
+### 6. Finalize
+
+After the user approves:
+- Verify with `aos wiki lint` — fix any issues
+- Confirm the plugin appears in `aos wiki list --type workflow`
+- Tell the user how to invoke it: from chat compose menu or by asking the agent
+
+## Editing Existing Plugins
+
+If the user wants to modify an existing plugin:
+
+1. Read it: `aos wiki show <name> --raw`
+2. Understand what needs to change
+3. Edit the files directly
+4. Reindex: `aos wiki reindex`
+5. Test the changes
+
+## Reference
+
+See [Skill Writing Guide](references/skill-writing-guide.md) for detailed authoring conventions.
+```
+
+- [ ] **Step 2: Write the reference guide**
+
+Create `wiki-seed/plugins/customize-with-agent/references/skill-writing-guide.md`:
+
+```markdown
+---
+type: concept
+name: Skill Writing Guide
+description: Conventions and best practices for writing wiki plugin SKILL.md files
+tags: [meta, authoring, conventions]
+---
+
+# Skill Writing Guide
+
+## Anatomy of a Plugin
+
+```
+plugin-name/
+├── SKILL.md          # Required: frontmatter + instructions
+├── references/       # Optional: domain knowledge loaded on demand
+├── scripts/          # Optional: executable code
+└── assets/           # Optional: templates, icons, files
+```
+
+## SKILL.md Frontmatter
+
+Required fields:
+- `name` — plugin identifier (kebab-case)
+- `description` — when to trigger, what it does (be pushy)
+
+Optional fields:
+- `version` — semver string
+- `author` — who created this
+- `tags` — categorization keywords
+- `triggers` — natural language phrases that should activate this plugin
+- `requires` — runtime dependencies (e.g., gateway, aos-daemon)
+
+## Progressive Disclosure
+
+1. **Metadata** (~100 words) — name + description, always in agent context
+2. **SKILL.md body** (<500 lines) — loaded when plugin triggers
+3. **References** (unlimited) — loaded on demand when the agent needs deeper context
+
+Keep SKILL.md focused on the workflow. Move domain knowledge, schemas, and frameworks to `references/`.
+
+## Writing Style
+
+- Use imperative form: "Run the build" not "You should run the build"
+- Explain *why* things matter, not just *what* to do
+- Prefer concrete examples over abstract descriptions
+- Use decision trees for branching logic
+- Include exact commands with expected output where applicable
+
+## Description as Trigger
+
+The description field determines whether an agent invokes the plugin. Write it to over-match rather than under-match:
+
+**Weak:** "Audit competitor employer brands"
+**Strong:** "Run employer brand competitor audits using the KILOS framework. Use when the user asks to research competitors, audit employer brands, analyze careers sites, do a KILOS audit, or build a competitor analysis. Trigger whenever a user provides a client name and a list of companies to research."
+
+## Cross-Linking
+
+Link to wiki entity and concept pages from your SKILL.md and references:
+```markdown
+See [Gateway](../../entities/gateway.md) for tool documentation.
+```
+
+This connects the plugin to the broader knowledge graph and helps agents find relevant context during execution.
+
+## Common Patterns
+
+**Mode detection:** If a plugin operates differently based on input, use a mode table at the top:
+```markdown
+| Mode | When |
+|------|------|
+| Plan | User provides requirements, no artifacts yet |
+| Execute | User provides plan + data |
+| Resume | Partial output, continue from last point |
+```
+
+**Decision trees:** For branching logic, use explicit if/then:
+```markdown
+- If build fails → check [Build Troubleshooting](references/build-troubleshooting.md)
+- If tests pass → proceed to deployment step
+```
+
+**Reference loading:** Tell the agent when to read references:
+```markdown
+For the full KILOS framework details, read `references/kilos-framework.md` before beginning analysis.
+```
+```
+
+- [ ] **Step 3: Build and verify seed includes new plugin**
+
+Run: `rm -rf ~/.config/aos/repo/wiki && bash build.sh && ./aos wiki seed && ./aos wiki list`
+Expected: Lists the `customize-with-agent` and `self-check` plugins along with all entity/concept pages.
+
+Run: `./aos wiki invoke customize-with-agent | head -20`
+Expected: Shows the SKILL.md content starting with the frontmatter.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add wiki-seed/plugins/customize-with-agent/
+git commit -m "feat(wiki): add 'Customize with Agent' plugin — guided plugin creation skill"
+```
+
+---
+
+### Task 12: Final Wiring + Usage Help
+
+**Files:**
+- Modify: `src/main.swift` (update printUsage)
+
+- [ ] **Step 1: Add wiki section to printUsage**
+
+Add to the usage string in `printUsage()`, after the Tools section:
+
+```
+    Wiki (aos wiki):
+      create-plugin <name>   Scaffold a new workflow plugin
+      add <type> <name>      Create an entity or concept page
+      rm <path>              Remove a page (warns about broken links)
+      link <from> <to>       Add a cross-reference between pages
+      list                   List pages (--type, --plugin, --links-to, --links-from, --orphans)
+      search <query>         Search pages (--type filter)
+      show <name>            Display a page (--raw for markdown, --json for structured)
+      invoke <plugin>        Bundle a plugin into a prompt payload
+      reindex                Rebuild the index from filesystem
+      lint                   Check for broken links, orphans, missing frontmatter
+      seed                   Populate wiki with starter content
+```
+
+Also add wiki examples:
+
+```
+      aos wiki seed                     # Populate with starter content
+      aos wiki list                     # List all wiki pages
+      aos wiki list --type workflow     # List workflow plugins
+      aos wiki show gateway --json      # View a page as JSON
+      aos wiki search "IPC protocol"    # Search the wiki
+      aos wiki create-plugin my-flow    # Create a new plugin
+      aos wiki invoke self-check        # Bundle a plugin for chat injection
+      aos wiki lint                     # Check wiki health
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `bash build.sh && ./aos --help`
+Expected: Wiki section appears in help output.
+
+- [ ] **Step 3: Run full integration test**
+
+Run: `bash tests/wiki-integration.sh`
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main.swift
+git commit -m "feat(wiki): add wiki section to aos --help"
+```
+
+---
+
+## Summary
+
+| Task | What it delivers | Files |
+|------|-----------------|-------|
+| 1 | SQLite link + command router | build.sh, wiki.swift, main.swift |
+| 2 | Frontmatter parser | wiki-frontmatter.swift |
+| 3 | SQLite index class | wiki-index.swift |
+| 4 | reindex (filesystem scan) | wiki.swift |
+| 5 | create-plugin, add, rm | wiki.swift |
+| 6 | list, search, show | wiki.swift |
+| 7 | link, lint | wiki.swift |
+| 8 | invoke | wiki.swift |
+| 9 | seed + starter pack (10 pages) | wiki.swift, wiki-seed/ |
+| 10 | Integration tests | tests/wiki-integration.sh |
+| 11 | "Customize with Agent" skill | wiki-seed/plugins/customize-with-agent/ |
+| 12 | Help text + final verification | main.swift |
+
+12 tasks, ~12 commits. Each task is independently buildable and testable. The wiki is fully functional after Task 10, with the agent skill and polish added in Tasks 11-12.

--- a/docs/superpowers/plans/2026-04-10-chat-native-agent-host.md
+++ b/docs/superpowers/plans/2026-04-10-chat-native-agent-host.md
@@ -1,0 +1,2293 @@
+# Chat-Native Agent Host — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a Node.js agent host sidecar (`packages/host/`) that runs Anthropic-powered agent loops with tool execution, streaming, and session persistence — wired into Sigil's chat canvas as the first consumer.
+
+**Architecture:** Hybrid topology — Swift daemon handles canvases/OS, Node.js host handles agent loops/tools/sessions. Two Unix sockets, unified SDK surface. See `docs/superpowers/specs/2026-04-10-chat-native-agent-host-design.md`.
+
+**Tech Stack:** TypeScript (ESM), Vercel AI SDK (`ai` + `@ai-sdk/anthropic`), `better-sqlite3`, `ulid`, Unix domain sockets (line-delimited JSON protocol, matching gateway pattern).
+
+**Spec:** `docs/superpowers/specs/2026-04-10-chat-native-agent-host-design.md`
+
+---
+
+## File Structure
+
+```
+packages/host/
+├── package.json
+├── tsconfig.json
+├── src/
+│   ├── index.ts                  # Entry point: starts socket server, initializes DB + registry
+│   ├── server.ts                 # Unix socket server (line-delimited JSON, same pattern as gateway)
+│   ├── types.ts                  # All shared types: StreamEvent, ToolDefinition, Session, etc.
+│   ├── agent-loop.ts             # Core agent loop: receive → provider → tool exec → loop
+│   ├── session-store.ts          # SQLite session + message persistence
+│   ├── tool-registry.ts          # In-memory tool registry: register, resolve, permission check
+│   ├── provider/
+│   │   ├── adapter.ts            # ProviderAdapter interface + factory
+│   │   └── anthropic.ts          # Anthropic adapter wrapping Vercel AI SDK
+│   └── tools/
+│       ├── read-file.ts          # read_file tool
+│       ├── list-files.ts         # list_files tool
+│       └── shell-exec.ts         # shell_exec tool (deny by default)
+└── test/
+    ├── agent-loop.test.ts
+    ├── session-store.test.ts
+    ├── tool-registry.test.ts
+    ├── provider/
+    │   └── anthropic.test.ts
+    └── tools/
+        ├── read-file.test.ts
+        ├── list-files.test.ts
+        └── shell-exec.test.ts
+```
+
+---
+
+### Task 1: Package Scaffolding
+
+**Build/Adapt/Borrow:** BORROW PATTERN from `packages/gateway/` (package.json shape, tsconfig, ESM config)
+
+**Files:**
+- Create: `packages/host/package.json`
+- Create: `packages/host/tsconfig.json`
+- Create: `packages/host/src/types.ts`
+
+- [ ] **Step 1: Create package.json**
+
+```json
+{
+  "name": "@agent-os/host",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "start": "node dist/index.js",
+    "test": "node --test --experimental-strip-types 'test/**/*.test.ts'"
+  },
+  "dependencies": {
+    "ai": "^4.3.0",
+    "@ai-sdk/anthropic": "^1.2.0",
+    "better-sqlite3": "^11.0.0",
+    "ulid": "^2.3.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.0",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}
+```
+
+- [ ] **Step 2: Create tsconfig.json**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}
+```
+
+- [ ] **Step 3: Create src/types.ts with all shared interfaces**
+
+This is the single source of truth for all types referenced across the host.
+
+```typescript
+// packages/host/src/types.ts
+
+// --- JSON primitives ---
+
+export type JSONValue = string | number | boolean | null | JSONValue[] | { [key: string]: JSONValue };
+export type JSONSchema = Record<string, unknown>;
+
+// --- Tool interfaces (BORROW PATTERN: MCP tool shape, extended) ---
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: JSONSchema;
+  permissions?: PermissionSpec;
+  timeout?: number; // ms, default 30_000
+  metadata?: {
+    type: 'simple' | 'provider-backed' | 'agent-backed';
+    source?: string;
+  };
+}
+
+export interface ToolContext {
+  sessionId: string;
+  signal: AbortSignal;
+  emit: (event: StreamEvent) => void;
+}
+
+export type ToolExecutor = (input: JSONValue, context: ToolContext) => Promise<ToolResult>;
+
+export interface ToolResult {
+  content: string | Record<string, unknown>;
+  isError?: boolean;
+}
+
+export interface RegisteredTool {
+  definition: ToolDefinition;
+  executor: ToolExecutor;
+}
+
+// --- Permission model (BUILD, borrow pattern from Claude Code) ---
+
+export interface PermissionSpec {
+  default: 'allow' | 'deny' | 'ask';
+  dangerous?: boolean;
+}
+
+export interface PermissionOverride {
+  tool: string; // glob pattern
+  decision: 'allow' | 'deny';
+  scope: 'session' | 'persistent';
+}
+
+// --- Stream events (ADAPT: Vercel AI SDK stream types, extended) ---
+
+export type StreamEvent =
+  | { type: 'text-delta'; text: string }
+  | { type: 'tool-call'; toolCallId: string; toolName: string; args: JSONValue }
+  | { type: 'tool-result'; toolCallId: string; result: ToolResult }
+  | { type: 'tool-progress'; toolCallId: string; message: string }
+  | { type: 'finish'; reason: 'end_turn' | 'stop' | 'max_tokens' | 'max_iterations' }
+  | { type: 'error'; error: string; code?: string }
+  | { type: 'status'; message: string };
+
+// --- Session & messages (BUILD on better-sqlite3) ---
+
+export interface Session {
+  id: string;
+  provider: string;
+  model: string;
+  system?: string;
+  toolProfile?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SessionConfig {
+  provider?: string;  // default: 'anthropic'
+  model?: string;     // default: 'claude-sonnet-4-20250514'
+  system?: string;
+  toolProfile?: string;
+}
+
+export interface StoredMessage {
+  id: string;
+  sessionId: string;
+  role: 'user' | 'assistant';
+  content: string; // JSON-serialized content blocks
+  createdAt: string;
+  tokenCount?: number;
+}
+
+// --- Provider adapter (ADAPT: wraps Vercel AI SDK) ---
+
+export interface ProviderConfig {
+  model: string;
+  temperature?: number;
+  maxTokens?: number;
+}
+
+export interface ProviderMessage {
+  role: 'user' | 'assistant';
+  content: ProviderContentBlock[];
+}
+
+export type ProviderContentBlock =
+  | { type: 'text'; text: string }
+  | { type: 'tool_use'; id: string; name: string; input: JSONValue }
+  | { type: 'tool_result'; tool_use_id: string; content: string };
+
+export interface ProviderAdapter {
+  id: string;
+  stream(params: {
+    messages: ProviderMessage[];
+    tools: ToolDefinition[];
+    system?: string;
+    config: ProviderConfig;
+  }): AsyncIterable<StreamEvent>;
+}
+
+// --- Agent loop config ---
+
+export interface AgentLoopConfig {
+  maxIterations: number; // default: 25
+}
+
+// --- Socket protocol (BORROW PATTERN: gateway line-delimited JSON) ---
+
+export interface SocketRequest {
+  id: string;
+  method: string;
+  params: Record<string, unknown>;
+}
+
+export interface SocketResponse {
+  id: string;
+  result?: unknown;
+  error?: { message: string; code?: string };
+}
+```
+
+- [ ] **Step 4: Install dependencies**
+
+Run: `cd packages/host && npm install`
+Expected: node_modules created, package-lock.json generated
+
+- [ ] **Step 5: Verify TypeScript compiles**
+
+Run: `cd packages/host && npx tsc --noEmit`
+Expected: No errors (types.ts compiles cleanly)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/host/
+git commit -m "feat(host): scaffold package with types"
+```
+
+---
+
+### Task 2: Session Store
+
+**Build/Adapt/Borrow:** BUILD on `better-sqlite3`. Schema modeled after gateway's SQLite patterns (WAL mode, ulid IDs).
+
+**Files:**
+- Create: `packages/host/src/session-store.ts`
+- Create: `packages/host/test/session-store.test.ts`
+
+- [ ] **Step 1: Write failing tests for session store**
+
+```typescript
+// packages/host/test/session-store.test.ts
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { SessionStore } from '../src/session-store.ts';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+describe('SessionStore', () => {
+  let store: SessionStore;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = path.join(os.tmpdir(), `host-test-${Date.now()}.db`);
+    store = new SessionStore(dbPath);
+  });
+
+  afterEach(() => {
+    store.close();
+    try { fs.unlinkSync(dbPath); } catch {}
+    try { fs.unlinkSync(dbPath + '-wal'); } catch {}
+    try { fs.unlinkSync(dbPath + '-shm'); } catch {}
+  });
+
+  describe('sessions', () => {
+    it('creates a session with defaults', () => {
+      const session = store.createSession({});
+      assert.ok(session.id);
+      assert.equal(session.provider, 'anthropic');
+      assert.equal(session.model, 'claude-sonnet-4-20250514');
+      assert.ok(session.createdAt);
+      assert.ok(session.updatedAt);
+    });
+
+    it('creates a session with custom config', () => {
+      const session = store.createSession({
+        provider: 'anthropic',
+        model: 'claude-opus-4-20250514',
+        system: 'You are a helpful assistant.',
+        toolProfile: 'devtools',
+      });
+      assert.equal(session.model, 'claude-opus-4-20250514');
+      assert.equal(session.system, 'You are a helpful assistant.');
+      assert.equal(session.toolProfile, 'devtools');
+    });
+
+    it('gets a session by id', () => {
+      const created = store.createSession({});
+      const fetched = store.getSession(created.id);
+      assert.deepEqual(fetched, created);
+    });
+
+    it('returns undefined for unknown session', () => {
+      const fetched = store.getSession('nonexistent');
+      assert.equal(fetched, undefined);
+    });
+
+    it('lists sessions', () => {
+      store.createSession({});
+      store.createSession({});
+      const sessions = store.listSessions();
+      assert.equal(sessions.length, 2);
+    });
+  });
+
+  describe('messages', () => {
+    it('appends and retrieves messages', () => {
+      const session = store.createSession({});
+      store.appendMessage(session.id, 'user', [{ type: 'text', text: 'hello' }]);
+      store.appendMessage(session.id, 'assistant', [{ type: 'text', text: 'hi there' }]);
+
+      const messages = store.getMessages(session.id);
+      assert.equal(messages.length, 2);
+      assert.equal(messages[0].role, 'user');
+      assert.equal(messages[1].role, 'assistant');
+    });
+
+    it('stores token count when provided', () => {
+      const session = store.createSession({});
+      store.appendMessage(session.id, 'user', [{ type: 'text', text: 'hello' }], 10);
+      const messages = store.getMessages(session.id);
+      assert.equal(messages[0].tokenCount, 10);
+    });
+
+    it('returns empty array for session with no messages', () => {
+      const session = store.createSession({});
+      const messages = store.getMessages(session.id);
+      assert.deepEqual(messages, []);
+    });
+
+    it('updates session updatedAt on message append', () => {
+      const session = store.createSession({});
+      const originalUpdatedAt = session.updatedAt;
+      // Small delay to ensure different timestamp
+      store.appendMessage(session.id, 'user', [{ type: 'text', text: 'hello' }]);
+      const updated = store.getSession(session.id)!;
+      assert.ok(updated.updatedAt >= originalUpdatedAt);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/host && npm test`
+Expected: FAIL — cannot find module `../src/session-store.ts`
+
+- [ ] **Step 3: Implement session store**
+
+```typescript
+// packages/host/src/session-store.ts
+import Database from 'better-sqlite3';
+import { ulid } from 'ulid';
+import type { Session, SessionConfig, StoredMessage } from './types.ts';
+
+export class SessionStore {
+  private db: Database.Database;
+
+  constructor(dbPath: string) {
+    this.db = new Database(dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('foreign_keys = ON');
+    this.migrate();
+  }
+
+  private migrate(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS sessions (
+        id TEXT PRIMARY KEY,
+        provider TEXT NOT NULL DEFAULT 'anthropic',
+        model TEXT NOT NULL DEFAULT 'claude-sonnet-4-20250514',
+        system TEXT,
+        tool_profile TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS messages (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL REFERENCES sessions(id),
+        role TEXT NOT NULL CHECK(role IN ('user', 'assistant')),
+        content TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        token_count INTEGER
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_messages_session
+        ON messages(session_id, created_at);
+    `);
+  }
+
+  createSession(config: SessionConfig): Session {
+    const now = new Date().toISOString();
+    const session: Session = {
+      id: ulid(),
+      provider: config.provider ?? 'anthropic',
+      model: config.model ?? 'claude-sonnet-4-20250514',
+      system: config.system,
+      toolProfile: config.toolProfile,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.db.prepare(`
+      INSERT INTO sessions (id, provider, model, system, tool_profile, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(session.id, session.provider, session.model, session.system ?? null,
+           session.toolProfile ?? null, session.createdAt, session.updatedAt);
+
+    return session;
+  }
+
+  getSession(id: string): Session | undefined {
+    const row = this.db.prepare('SELECT * FROM sessions WHERE id = ?').get(id) as any;
+    if (!row) return undefined;
+    return {
+      id: row.id,
+      provider: row.provider,
+      model: row.model,
+      system: row.system ?? undefined,
+      toolProfile: row.tool_profile ?? undefined,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  listSessions(): Session[] {
+    const rows = this.db.prepare('SELECT * FROM sessions ORDER BY updated_at DESC').all() as any[];
+    return rows.map(row => ({
+      id: row.id,
+      provider: row.provider,
+      model: row.model,
+      system: row.system ?? undefined,
+      toolProfile: row.tool_profile ?? undefined,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
+  }
+
+  appendMessage(
+    sessionId: string,
+    role: 'user' | 'assistant',
+    content: unknown[],
+    tokenCount?: number
+  ): StoredMessage {
+    const now = new Date().toISOString();
+    const msg: StoredMessage = {
+      id: ulid(),
+      sessionId,
+      role,
+      content: JSON.stringify(content),
+      createdAt: now,
+      tokenCount,
+    };
+
+    const txn = this.db.transaction(() => {
+      this.db.prepare(`
+        INSERT INTO messages (id, session_id, role, content, created_at, token_count)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `).run(msg.id, msg.sessionId, msg.role, msg.content, msg.createdAt,
+             msg.tokenCount ?? null);
+
+      this.db.prepare('UPDATE sessions SET updated_at = ? WHERE id = ?')
+        .run(now, sessionId);
+    });
+    txn();
+
+    return msg;
+  }
+
+  getMessages(sessionId: string): StoredMessage[] {
+    const rows = this.db.prepare(
+      'SELECT * FROM messages WHERE session_id = ? ORDER BY created_at'
+    ).all(sessionId) as any[];
+    return rows.map(row => ({
+      id: row.id,
+      sessionId: row.session_id,
+      role: row.role,
+      content: row.content,
+      createdAt: row.created_at,
+      tokenCount: row.token_count ?? undefined,
+    }));
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/host && npm test`
+Expected: All 7 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/host/src/session-store.ts packages/host/test/session-store.test.ts
+git commit -m "feat(host): session store with SQLite persistence"
+```
+
+---
+
+### Task 3: Tool Registry
+
+**Build/Adapt/Borrow:** BUILD. In-memory registry with permission checking.
+
+**Files:**
+- Create: `packages/host/src/tool-registry.ts`
+- Create: `packages/host/test/tool-registry.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// packages/host/test/tool-registry.test.ts
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { ToolRegistry } from '../src/tool-registry.ts';
+import type { ToolDefinition, ToolExecutor } from '../src/types.ts';
+
+const echoTool: ToolDefinition = {
+  name: 'echo',
+  description: 'Echoes input back',
+  inputSchema: { type: 'object', properties: { text: { type: 'string' } } },
+  permissions: { default: 'allow' },
+};
+
+const dangerousTool: ToolDefinition = {
+  name: 'danger',
+  description: 'A dangerous tool',
+  inputSchema: { type: 'object', properties: {} },
+  permissions: { default: 'deny', dangerous: true },
+};
+
+const echoExecutor: ToolExecutor = async (input) => {
+  const { text } = input as { text: string };
+  return { content: text };
+};
+
+describe('ToolRegistry', () => {
+  let registry: ToolRegistry;
+
+  beforeEach(() => {
+    registry = new ToolRegistry();
+  });
+
+  it('registers and retrieves a tool', () => {
+    registry.register(echoTool, echoExecutor);
+    const tool = registry.get('echo');
+    assert.ok(tool);
+    assert.equal(tool.definition.name, 'echo');
+  });
+
+  it('lists all registered tools', () => {
+    registry.register(echoTool, echoExecutor);
+    registry.register(dangerousTool, echoExecutor);
+    const tools = registry.list();
+    assert.equal(tools.length, 2);
+  });
+
+  it('returns definitions for provider (tool list for API call)', () => {
+    registry.register(echoTool, echoExecutor);
+    registry.register(dangerousTool, echoExecutor);
+    const defs = registry.getDefinitions();
+    assert.equal(defs.length, 2);
+    assert.ok(defs.every(d => 'name' in d && 'inputSchema' in d));
+  });
+
+  it('rejects duplicate registration', () => {
+    registry.register(echoTool, echoExecutor);
+    assert.throws(() => registry.register(echoTool, echoExecutor), /already registered/);
+  });
+
+  it('checks permission — allow', () => {
+    registry.register(echoTool, echoExecutor);
+    const decision = registry.checkPermission('echo');
+    assert.equal(decision, 'allow');
+  });
+
+  it('checks permission — deny', () => {
+    registry.register(dangerousTool, echoExecutor);
+    const decision = registry.checkPermission('danger');
+    assert.equal(decision, 'deny');
+  });
+
+  it('checks permission — unknown tool returns deny', () => {
+    const decision = registry.checkPermission('nonexistent');
+    assert.equal(decision, 'deny');
+  });
+
+  it('applies overrides', () => {
+    registry.register(dangerousTool, echoExecutor);
+    registry.addOverride({ tool: 'danger', decision: 'allow', scope: 'session' });
+    const decision = registry.checkPermission('danger');
+    assert.equal(decision, 'allow');
+  });
+
+  it('override with glob pattern', () => {
+    registry.register({ ...dangerousTool, name: 'fs.read' }, echoExecutor);
+    registry.register({ ...dangerousTool, name: 'fs.write' }, echoExecutor);
+    registry.addOverride({ tool: 'fs.*', decision: 'allow', scope: 'session' });
+    assert.equal(registry.checkPermission('fs.read'), 'allow');
+    assert.equal(registry.checkPermission('fs.write'), 'allow');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/host && npm test`
+Expected: FAIL — cannot find module `../src/tool-registry.ts`
+
+- [ ] **Step 3: Implement tool registry**
+
+```typescript
+// packages/host/src/tool-registry.ts
+import type {
+  ToolDefinition, ToolExecutor, RegisteredTool, PermissionOverride,
+} from './types.ts';
+
+export class ToolRegistry {
+  private tools = new Map<string, RegisteredTool>();
+  private overrides: PermissionOverride[] = [];
+
+  register(definition: ToolDefinition, executor: ToolExecutor): void {
+    if (this.tools.has(definition.name)) {
+      throw new Error(`Tool '${definition.name}' already registered`);
+    }
+    this.tools.set(definition.name, { definition, executor });
+  }
+
+  get(name: string): RegisteredTool | undefined {
+    return this.tools.get(name);
+  }
+
+  list(): RegisteredTool[] {
+    return Array.from(this.tools.values());
+  }
+
+  getDefinitions(): ToolDefinition[] {
+    return this.list().map(t => t.definition);
+  }
+
+  checkPermission(toolName: string): 'allow' | 'deny' | 'ask' {
+    // Check overrides first (last match wins)
+    for (let i = this.overrides.length - 1; i >= 0; i--) {
+      const override = this.overrides[i];
+      if (this.matchGlob(override.tool, toolName)) {
+        return override.decision;
+      }
+    }
+
+    // Fall back to tool's default permission
+    const tool = this.tools.get(toolName);
+    if (!tool) return 'deny';
+    return tool.definition.permissions?.default ?? 'allow';
+  }
+
+  addOverride(override: PermissionOverride): void {
+    this.overrides.push(override);
+  }
+
+  clearSessionOverrides(): void {
+    this.overrides = this.overrides.filter(o => o.scope !== 'session');
+  }
+
+  private matchGlob(pattern: string, name: string): boolean {
+    if (pattern === name) return true;
+    if (!pattern.includes('*')) return false;
+    const regex = new RegExp(
+      '^' + pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$'
+    );
+    return regex.test(name);
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/host && npm test`
+Expected: All tests PASS (session-store + tool-registry)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/host/src/tool-registry.ts packages/host/test/tool-registry.test.ts
+git commit -m "feat(host): in-memory tool registry with permission checking"
+```
+
+---
+
+### Task 4: Simple Tools
+
+**Build/Adapt/Borrow:** BUILD. Three simple tool implementations.
+
+**Files:**
+- Create: `packages/host/src/tools/read-file.ts`
+- Create: `packages/host/src/tools/list-files.ts`
+- Create: `packages/host/src/tools/shell-exec.ts`
+- Create: `packages/host/test/tools/read-file.test.ts`
+- Create: `packages/host/test/tools/list-files.test.ts`
+- Create: `packages/host/test/tools/shell-exec.test.ts`
+
+- [ ] **Step 1: Write failing tests for read_file**
+
+```typescript
+// packages/host/test/tools/read-file.test.ts
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileTool } from '../../src/tools/read-file.ts';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+describe('read_file tool', () => {
+  const tmpDir = path.join(os.tmpdir(), `host-test-${Date.now()}`);
+  const ctx = {
+    sessionId: 'test',
+    signal: AbortSignal.timeout(5000),
+    emit: () => {},
+  };
+
+  beforeEach(() => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('has correct definition', () => {
+    assert.equal(readFileTool.definition.name, 'read_file');
+    assert.equal(readFileTool.definition.permissions?.default, 'allow');
+  });
+
+  it('reads a file', async () => {
+    const filePath = path.join(tmpDir, 'test.txt');
+    fs.writeFileSync(filePath, 'hello world');
+    const result = await readFileTool.executor({ path: filePath }, ctx);
+    assert.equal(result.content, 'hello world');
+  });
+
+  it('returns error for missing file', async () => {
+    const result = await readFileTool.executor({ path: '/nonexistent/file.txt' }, ctx);
+    assert.equal(result.isError, true);
+    assert.ok((result.content as string).includes('ENOENT'));
+  });
+});
+```
+
+- [ ] **Step 2: Write failing tests for list_files**
+
+```typescript
+// packages/host/test/tools/list-files.test.ts
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { listFilesTool } from '../../src/tools/list-files.ts';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+describe('list_files tool', () => {
+  const tmpDir = path.join(os.tmpdir(), `host-test-list-${Date.now()}`);
+  const ctx = {
+    sessionId: 'test',
+    signal: AbortSignal.timeout(5000),
+    emit: () => {},
+  };
+
+  beforeEach(() => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'a.txt'), '');
+    fs.writeFileSync(path.join(tmpDir, 'b.ts'), '');
+    fs.mkdirSync(path.join(tmpDir, 'subdir'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('has correct definition', () => {
+    assert.equal(listFilesTool.definition.name, 'list_files');
+    assert.equal(listFilesTool.definition.permissions?.default, 'allow');
+  });
+
+  it('lists directory contents', async () => {
+    const result = await listFilesTool.executor({ path: tmpDir }, ctx);
+    const entries = result.content as Array<{ name: string; type: string }>;
+    assert.equal(entries.length, 3);
+    const names = entries.map(e => e.name).sort();
+    assert.deepEqual(names, ['a.txt', 'b.ts', 'subdir']);
+  });
+
+  it('marks directories vs files', async () => {
+    const result = await listFilesTool.executor({ path: tmpDir }, ctx);
+    const entries = result.content as Array<{ name: string; type: string }>;
+    const subdir = entries.find(e => e.name === 'subdir');
+    assert.equal(subdir?.type, 'directory');
+    const file = entries.find(e => e.name === 'a.txt');
+    assert.equal(file?.type, 'file');
+  });
+
+  it('returns error for missing directory', async () => {
+    const result = await listFilesTool.executor({ path: '/nonexistent/dir' }, ctx);
+    assert.equal(result.isError, true);
+  });
+});
+```
+
+- [ ] **Step 3: Write failing tests for shell_exec**
+
+```typescript
+// packages/host/test/tools/shell-exec.test.ts
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { shellExecTool } from '../../src/tools/shell-exec.ts';
+
+describe('shell_exec tool', () => {
+  const ctx = {
+    sessionId: 'test',
+    signal: AbortSignal.timeout(5000),
+    emit: () => {},
+  };
+
+  it('has correct definition', () => {
+    assert.equal(shellExecTool.definition.name, 'shell_exec');
+    assert.equal(shellExecTool.definition.permissions?.default, 'deny');
+    assert.equal(shellExecTool.definition.permissions?.dangerous, true);
+  });
+
+  it('executes a command', async () => {
+    const result = await shellExecTool.executor({ command: 'echo hello' }, ctx);
+    const output = result.content as { stdout: string; stderr: string; exitCode: number };
+    assert.equal(output.stdout.trim(), 'hello');
+    assert.equal(output.exitCode, 0);
+  });
+
+  it('captures stderr', async () => {
+    const result = await shellExecTool.executor({ command: 'echo err >&2' }, ctx);
+    const output = result.content as { stdout: string; stderr: string; exitCode: number };
+    assert.equal(output.stderr.trim(), 'err');
+  });
+
+  it('captures non-zero exit code', async () => {
+    const result = await shellExecTool.executor({ command: 'exit 42' }, ctx);
+    const output = result.content as { stdout: string; stderr: string; exitCode: number };
+    assert.equal(output.exitCode, 42);
+    assert.equal(result.isError, true);
+  });
+
+  it('respects timeout from tool definition', async () => {
+    const result = await shellExecTool.executor(
+      { command: 'sleep 10' },
+      { ...ctx, signal: AbortSignal.timeout(500) }
+    );
+    assert.equal(result.isError, true);
+  });
+});
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `cd packages/host && npm test`
+Expected: FAIL — cannot find tool modules
+
+- [ ] **Step 5: Implement read_file**
+
+```typescript
+// packages/host/src/tools/read-file.ts
+import fs from 'node:fs/promises';
+import type { ToolDefinition, ToolExecutor, RegisteredTool } from '../types.ts';
+
+const definition: ToolDefinition = {
+  name: 'read_file',
+  description: 'Read the contents of a file at the given path.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      path: { type: 'string', description: 'Absolute path to the file to read' },
+    },
+    required: ['path'],
+  },
+  permissions: { default: 'allow' },
+  metadata: { type: 'simple', source: 'builtin' },
+};
+
+const executor: ToolExecutor = async (input, context) => {
+  const { path: filePath } = input as { path: string };
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    return { content };
+  } catch (err: any) {
+    return { content: err.message, isError: true };
+  }
+};
+
+export const readFileTool: RegisteredTool = { definition, executor };
+```
+
+- [ ] **Step 6: Implement list_files**
+
+```typescript
+// packages/host/src/tools/list-files.ts
+import fs from 'node:fs/promises';
+import type { ToolDefinition, ToolExecutor, RegisteredTool } from '../types.ts';
+
+const definition: ToolDefinition = {
+  name: 'list_files',
+  description: 'List files and directories at the given path.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      path: { type: 'string', description: 'Absolute path to the directory to list' },
+    },
+    required: ['path'],
+  },
+  permissions: { default: 'allow' },
+  metadata: { type: 'simple', source: 'builtin' },
+};
+
+const executor: ToolExecutor = async (input, context) => {
+  const { path: dirPath } = input as { path: string };
+  try {
+    const entries = await fs.readdir(dirPath, { withFileTypes: true });
+    const result = entries.map(entry => ({
+      name: entry.name,
+      type: entry.isDirectory() ? 'directory' : 'file',
+    }));
+    return { content: result };
+  } catch (err: any) {
+    return { content: err.message, isError: true };
+  }
+};
+
+export const listFilesTool: RegisteredTool = { definition, executor };
+```
+
+- [ ] **Step 7: Implement shell_exec**
+
+```typescript
+// packages/host/src/tools/shell-exec.ts
+import { execFile } from 'node:child_process';
+import type { ToolDefinition, ToolExecutor, RegisteredTool } from '../types.ts';
+
+const definition: ToolDefinition = {
+  name: 'shell_exec',
+  description: 'Execute a shell command. Use with caution.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      command: { type: 'string', description: 'The shell command to execute' },
+    },
+    required: ['command'],
+  },
+  permissions: { default: 'deny', dangerous: true },
+  timeout: 30_000,
+  metadata: { type: 'simple', source: 'builtin' },
+};
+
+const executor: ToolExecutor = async (input, context) => {
+  const { command } = input as { command: string };
+
+  return new Promise((resolve) => {
+    const child = execFile('/bin/sh', ['-c', command], {
+      timeout: 30_000,
+      maxBuffer: 1024 * 1024, // 1MB
+      signal: context.signal,
+    }, (error, stdout, stderr) => {
+      const exitCode = error ? (error as any).code ?? 1 : 0;
+
+      if (error && error.name === 'AbortError') {
+        resolve({ content: 'Command aborted', isError: true });
+        return;
+      }
+
+      resolve({
+        content: { stdout, stderr, exitCode },
+        isError: exitCode !== 0,
+      });
+    });
+  });
+};
+
+export const shellExecTool: RegisteredTool = { definition, executor };
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `cd packages/host && npm test`
+Expected: All tests PASS (session-store + tool-registry + 3 tools)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/host/src/tools/ packages/host/test/tools/
+git commit -m "feat(host): builtin tools — read_file, list_files, shell_exec"
+```
+
+---
+
+### Task 5: Anthropic Provider Adapter
+
+**Build/Adapt/Borrow:** ADAPT Vercel AI SDK. Wraps `@ai-sdk/anthropic` + `ai` streamText into our `ProviderAdapter` interface.
+
+**Files:**
+- Create: `packages/host/src/provider/adapter.ts`
+- Create: `packages/host/src/provider/anthropic.ts`
+- Create: `packages/host/test/provider/anthropic.test.ts`
+
+- [ ] **Step 1: Write adapter interface file**
+
+```typescript
+// packages/host/src/provider/adapter.ts
+import type { ProviderAdapter } from '../types.ts';
+
+const adapters = new Map<string, ProviderAdapter>();
+
+export function registerAdapter(adapter: ProviderAdapter): void {
+  adapters.set(adapter.id, adapter);
+}
+
+export function getAdapter(id: string): ProviderAdapter {
+  const adapter = adapters.get(id);
+  if (!adapter) throw new Error(`Unknown provider: ${id}`);
+  return adapter;
+}
+```
+
+- [ ] **Step 2: Write failing test for Anthropic adapter**
+
+This test verifies the adapter transforms Vercel AI SDK output into our StreamEvent format. We test against the real Anthropic API to catch shape mismatches early — this is an integration test that requires `ANTHROPIC_API_KEY`.
+
+```typescript
+// packages/host/test/provider/anthropic.test.ts
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { AnthropicAdapter } from '../../src/provider/anthropic.ts';
+import type { StreamEvent } from '../../src/types.ts';
+
+describe('AnthropicAdapter', () => {
+  let adapter: AnthropicAdapter;
+
+  before(() => {
+    if (!process.env.ANTHROPIC_API_KEY) {
+      console.log('Skipping Anthropic tests — no API key');
+      return;
+    }
+    adapter = new AnthropicAdapter();
+  });
+
+  it('has correct id', () => {
+    const a = new AnthropicAdapter();
+    assert.equal(a.id, 'anthropic');
+  });
+
+  it('streams a simple text response', async () => {
+    if (!process.env.ANTHROPIC_API_KEY) return;
+
+    const events: StreamEvent[] = [];
+    const stream = adapter.stream({
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'Say "hello" and nothing else.' }] }],
+      tools: [],
+      system: 'You are a test assistant. Be extremely brief.',
+      config: { model: 'claude-sonnet-4-20250514', maxTokens: 50 },
+    });
+
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    const textEvents = events.filter(e => e.type === 'text-delta');
+    assert.ok(textEvents.length > 0, 'Should have text deltas');
+
+    const finishEvents = events.filter(e => e.type === 'finish');
+    assert.equal(finishEvents.length, 1, 'Should have exactly one finish event');
+  });
+
+  it('streams a tool call when tools are provided', async () => {
+    if (!process.env.ANTHROPIC_API_KEY) return;
+
+    const events: StreamEvent[] = [];
+    const stream = adapter.stream({
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'Read the file at /tmp/test.txt' }] }],
+      tools: [{
+        name: 'read_file',
+        description: 'Read a file',
+        inputSchema: {
+          type: 'object',
+          properties: { path: { type: 'string' } },
+          required: ['path'],
+        },
+      }],
+      system: 'Use tools when appropriate.',
+      config: { model: 'claude-sonnet-4-20250514', maxTokens: 200 },
+    });
+
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    const toolCalls = events.filter(e => e.type === 'tool-call');
+    assert.ok(toolCalls.length > 0, 'Should have at least one tool call');
+    const tc = toolCalls[0] as Extract<StreamEvent, { type: 'tool-call' }>;
+    assert.equal(tc.toolName, 'read_file');
+    assert.ok(tc.toolCallId);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd packages/host && npm test`
+Expected: FAIL — cannot find module `../../src/provider/anthropic.ts`
+
+- [ ] **Step 4: Implement Anthropic adapter**
+
+```typescript
+// packages/host/src/provider/anthropic.ts
+import { streamText } from 'ai';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import type {
+  ProviderAdapter, ProviderMessage, ProviderConfig,
+  ToolDefinition, StreamEvent, JSONValue,
+} from '../types.ts';
+
+export class AnthropicAdapter implements ProviderAdapter {
+  readonly id = 'anthropic';
+  private provider = createAnthropic();
+
+  async *stream(params: {
+    messages: ProviderMessage[];
+    tools: ToolDefinition[];
+    system?: string;
+    config: ProviderConfig;
+  }): AsyncIterable<StreamEvent> {
+    const { messages, tools, system, config } = params;
+
+    // Convert our message format to Vercel AI SDK format
+    const aiMessages = messages.map(msg => ({
+      role: msg.role as 'user' | 'assistant',
+      content: msg.content.map(block => {
+        if (block.type === 'text') return { type: 'text' as const, text: block.text };
+        if (block.type === 'tool_use') return {
+          type: 'tool-call' as const,
+          toolCallId: block.id,
+          toolName: block.name,
+          args: block.input as Record<string, unknown>,
+        };
+        if (block.type === 'tool_result') return {
+          type: 'tool-result' as const,
+          toolCallId: block.tool_use_id,
+          result: block.content,
+        };
+        return { type: 'text' as const, text: '' };
+      }),
+    }));
+
+    // Convert tool definitions to Vercel AI SDK format
+    const aiTools: Record<string, any> = {};
+    for (const tool of tools) {
+      aiTools[tool.name] = {
+        description: tool.description,
+        parameters: tool.inputSchema,
+      };
+    }
+
+    const result = streamText({
+      model: this.provider(config.model),
+      messages: aiMessages,
+      tools: Object.keys(aiTools).length > 0 ? aiTools : undefined,
+      system,
+      maxTokens: config.maxTokens,
+      temperature: config.temperature,
+    });
+
+    for await (const part of result.fullStream) {
+      switch (part.type) {
+        case 'text-delta':
+          yield { type: 'text-delta', text: part.textDelta };
+          break;
+        case 'tool-call':
+          yield {
+            type: 'tool-call',
+            toolCallId: part.toolCallId,
+            toolName: part.toolName,
+            args: part.args as JSONValue,
+          };
+          break;
+        case 'finish':
+          yield {
+            type: 'finish',
+            reason: part.finishReason === 'stop' ? 'end_turn'
+              : part.finishReason === 'length' ? 'max_tokens'
+              : part.finishReason === 'tool-calls' ? 'end_turn'
+              : 'end_turn',
+          };
+          break;
+        case 'error':
+          yield { type: 'error', error: String(part.error) };
+          break;
+        // Ignore other part types (step-start, step-finish, etc.)
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY cd packages/host && npm test`
+Expected: All tests PASS (adapter tests pass if API key present, skip cleanly if not)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/host/src/provider/ packages/host/test/provider/
+git commit -m "feat(host): Anthropic provider adapter wrapping Vercel AI SDK"
+```
+
+---
+
+### Task 6: Agent Loop
+
+**Build/Adapt/Borrow:** BUILD. Core agent loop — the main thing that doesn't exist today.
+
+**Files:**
+- Create: `packages/host/src/agent-loop.ts`
+- Create: `packages/host/test/agent-loop.test.ts`
+
+- [ ] **Step 1: Write failing tests for agent loop**
+
+We test the loop with a mock provider adapter to avoid API calls. The mock simulates text responses and tool-call/tool-result cycles.
+
+```typescript
+// packages/host/test/agent-loop.test.ts
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { AgentLoop } from '../src/agent-loop.ts';
+import { SessionStore } from '../src/session-store.ts';
+import { ToolRegistry } from '../src/tool-registry.ts';
+import type { ProviderAdapter, StreamEvent, ToolExecutor } from '../src/types.ts';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+// Mock provider that returns predetermined responses
+function createMockAdapter(responses: StreamEvent[][]): ProviderAdapter {
+  let callIndex = 0;
+  return {
+    id: 'mock',
+    async *stream() {
+      const events = responses[callIndex++] ?? [{ type: 'finish', reason: 'end_turn' }];
+      for (const event of events) {
+        yield event;
+      }
+    },
+  };
+}
+
+describe('AgentLoop', () => {
+  let store: SessionStore;
+  let registry: ToolRegistry;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = path.join(os.tmpdir(), `host-loop-test-${Date.now()}.db`);
+    store = new SessionStore(dbPath);
+    registry = new ToolRegistry();
+  });
+
+  afterEach(() => {
+    store.close();
+    try { fs.unlinkSync(dbPath); } catch {}
+    try { fs.unlinkSync(dbPath + '-wal'); } catch {}
+    try { fs.unlinkSync(dbPath + '-shm'); } catch {}
+  });
+
+  it('streams a text-only response', async () => {
+    const adapter = createMockAdapter([
+      [
+        { type: 'text-delta', text: 'Hello' },
+        { type: 'text-delta', text: ' world' },
+        { type: 'finish', reason: 'end_turn' },
+      ],
+    ]);
+
+    const loop = new AgentLoop(store, registry, adapter, { maxIterations: 25 });
+    const session = store.createSession({});
+    const events: StreamEvent[] = [];
+
+    for await (const event of loop.send(session.id, 'hi')) {
+      events.push(event);
+    }
+
+    assert.equal(events.filter(e => e.type === 'text-delta').length, 2);
+    assert.equal(events.filter(e => e.type === 'finish').length, 1);
+
+    // Message persisted
+    const messages = store.getMessages(session.id);
+    assert.equal(messages.length, 2); // user + assistant
+    assert.equal(messages[0].role, 'user');
+    assert.equal(messages[1].role, 'assistant');
+  });
+
+  it('executes tool calls and loops', async () => {
+    const echoExec: ToolExecutor = async (input) => {
+      return { content: `echoed: ${(input as any).text}` };
+    };
+    registry.register({
+      name: 'echo',
+      description: 'Echo',
+      inputSchema: { type: 'object', properties: { text: { type: 'string' } } },
+      permissions: { default: 'allow' },
+    }, echoExec);
+
+    // Turn 1: model calls echo tool
+    // Turn 2: model responds with text after seeing tool result
+    const adapter = createMockAdapter([
+      [
+        { type: 'tool-call', toolCallId: 'tc1', toolName: 'echo', args: { text: 'test' } },
+        { type: 'finish', reason: 'end_turn' },
+      ],
+      [
+        { type: 'text-delta', text: 'Got it' },
+        { type: 'finish', reason: 'end_turn' },
+      ],
+    ]);
+
+    const loop = new AgentLoop(store, registry, adapter, { maxIterations: 25 });
+    const session = store.createSession({});
+    const events: StreamEvent[] = [];
+
+    for await (const event of loop.send(session.id, 'echo test')) {
+      events.push(event);
+    }
+
+    const toolCalls = events.filter(e => e.type === 'tool-call');
+    assert.equal(toolCalls.length, 1);
+
+    const toolResults = events.filter(e => e.type === 'tool-result');
+    assert.equal(toolResults.length, 1);
+    const tr = toolResults[0] as Extract<StreamEvent, { type: 'tool-result' }>;
+    assert.equal(tr.result.content, 'echoed: test');
+
+    const textDeltas = events.filter(e => e.type === 'text-delta');
+    assert.ok(textDeltas.length > 0);
+  });
+
+  it('denies tool calls without permission', async () => {
+    registry.register({
+      name: 'danger',
+      description: 'Dangerous',
+      inputSchema: { type: 'object', properties: {} },
+      permissions: { default: 'deny' },
+    }, async () => ({ content: 'should not run' }));
+
+    const adapter = createMockAdapter([
+      [
+        { type: 'tool-call', toolCallId: 'tc1', toolName: 'danger', args: {} },
+        { type: 'finish', reason: 'end_turn' },
+      ],
+      [
+        { type: 'text-delta', text: 'ok denied' },
+        { type: 'finish', reason: 'end_turn' },
+      ],
+    ]);
+
+    const loop = new AgentLoop(store, registry, adapter, { maxIterations: 25 });
+    const session = store.createSession({});
+    const events: StreamEvent[] = [];
+
+    for await (const event of loop.send(session.id, 'do danger')) {
+      events.push(event);
+    }
+
+    const toolResults = events.filter(e => e.type === 'tool-result');
+    assert.equal(toolResults.length, 1);
+    const tr = toolResults[0] as Extract<StreamEvent, { type: 'tool-result' }>;
+    assert.equal(tr.result.isError, true);
+    assert.ok((tr.result.content as string).includes('denied'));
+  });
+
+  it('enforces max iteration limit', async () => {
+    registry.register({
+      name: 'echo',
+      description: 'Echo',
+      inputSchema: { type: 'object', properties: { text: { type: 'string' } } },
+      permissions: { default: 'allow' },
+    }, async (input) => ({ content: 'echoed' }));
+
+    // Adapter always returns a tool call — should be stopped by max iterations
+    const adapter = createMockAdapter(
+      Array(10).fill([
+        { type: 'tool-call', toolCallId: 'tc', toolName: 'echo', args: { text: 'x' } },
+        { type: 'finish', reason: 'end_turn' },
+      ])
+    );
+
+    const loop = new AgentLoop(store, registry, adapter, { maxIterations: 3 });
+    const session = store.createSession({});
+    const events: StreamEvent[] = [];
+
+    for await (const event of loop.send(session.id, 'loop forever')) {
+      events.push(event);
+    }
+
+    const finishEvents = events.filter(e => e.type === 'finish');
+    const lastFinish = finishEvents[finishEvents.length - 1] as Extract<StreamEvent, { type: 'finish' }>;
+    assert.equal(lastFinish.reason, 'max_iterations');
+  });
+
+  it('handles stop via AbortSignal', async () => {
+    const controller = new AbortController();
+
+    const adapter: ProviderAdapter = {
+      id: 'mock',
+      async *stream() {
+        yield { type: 'text-delta' as const, text: 'start' };
+        // Simulate slow streaming
+        await new Promise(r => setTimeout(r, 100));
+        yield { type: 'text-delta' as const, text: ' more' };
+        yield { type: 'finish' as const, reason: 'end_turn' as const };
+      },
+    };
+
+    const loop = new AgentLoop(store, registry, adapter, { maxIterations: 25 });
+    const session = store.createSession({});
+    const events: StreamEvent[] = [];
+
+    // Abort after first event
+    setTimeout(() => controller.abort(), 50);
+
+    for await (const event of loop.send(session.id, 'hello', controller.signal)) {
+      events.push(event);
+    }
+
+    // Should have gotten at least the first delta and a finish with reason 'stop'
+    const finishEvents = events.filter(e => e.type === 'finish');
+    assert.ok(finishEvents.length > 0);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/host && npm test`
+Expected: FAIL — cannot find module `../src/agent-loop.ts`
+
+- [ ] **Step 3: Implement agent loop**
+
+```typescript
+// packages/host/src/agent-loop.ts
+import type {
+  ProviderAdapter, StreamEvent, ToolResult, ProviderMessage,
+  ProviderContentBlock, AgentLoopConfig, JSONValue,
+} from './types.ts';
+import type { SessionStore } from './session-store.ts';
+import type { ToolRegistry } from './tool-registry.ts';
+
+export class AgentLoop {
+  constructor(
+    private store: SessionStore,
+    private registry: ToolRegistry,
+    private adapter: ProviderAdapter,
+    private config: AgentLoopConfig,
+  ) {}
+
+  async *send(
+    sessionId: string,
+    text: string,
+    signal?: AbortSignal,
+  ): AsyncIterable<StreamEvent> {
+    const session = this.store.getSession(sessionId);
+    if (!session) throw new Error(`Session not found: ${sessionId}`);
+
+    // Append user message
+    this.store.appendMessage(sessionId, 'user', [{ type: 'text', text }]);
+
+    // Build message history
+    let messages = this.buildMessages(sessionId);
+    let iterations = 0;
+
+    while (iterations < this.config.maxIterations) {
+      iterations++;
+
+      if (signal?.aborted) {
+        yield { type: 'finish', reason: 'stop' };
+        return;
+      }
+
+      // Collect tool calls and text blocks from this turn
+      const toolCalls: Array<{ toolCallId: string; toolName: string; args: JSONValue }> = [];
+      const textParts: string[] = [];
+      let finishReason: string | undefined;
+
+      try {
+        const stream = this.adapter.stream({
+          messages,
+          tools: this.registry.getDefinitions(),
+          system: session.system,
+          config: { model: session.model },
+        });
+
+        for await (const event of stream) {
+          if (signal?.aborted) {
+            // Persist what we have and stop
+            if (textParts.length > 0) {
+              this.store.appendMessage(sessionId, 'assistant',
+                [{ type: 'text', text: textParts.join('') }]);
+            }
+            yield { type: 'finish', reason: 'stop' };
+            return;
+          }
+
+          switch (event.type) {
+            case 'text-delta':
+              textParts.push(event.text);
+              yield event;
+              break;
+            case 'tool-call':
+              toolCalls.push(event);
+              yield event;
+              break;
+            case 'finish':
+              finishReason = event.reason;
+              break;
+            case 'error':
+              yield event;
+              break;
+          }
+        }
+      } catch (err: any) {
+        if (signal?.aborted) {
+          yield { type: 'finish', reason: 'stop' };
+          return;
+        }
+        yield { type: 'error', error: err.message };
+        return;
+      }
+
+      // No tool calls — conversation turn complete
+      if (toolCalls.length === 0) {
+        // Persist assistant message
+        const assistantBlocks: ProviderContentBlock[] = [];
+        if (textParts.length > 0) {
+          assistantBlocks.push({ type: 'text', text: textParts.join('') });
+        }
+        this.store.appendMessage(sessionId, 'assistant', assistantBlocks);
+        yield { type: 'finish', reason: 'end_turn' };
+        return;
+      }
+
+      // Has tool calls — execute them and loop
+      const assistantBlocks: ProviderContentBlock[] = [];
+      if (textParts.length > 0) {
+        assistantBlocks.push({ type: 'text', text: textParts.join('') });
+      }
+      for (const tc of toolCalls) {
+        assistantBlocks.push({
+          type: 'tool_use',
+          id: tc.toolCallId,
+          name: tc.toolName,
+          input: tc.args,
+        });
+      }
+      this.store.appendMessage(sessionId, 'assistant', assistantBlocks);
+
+      // Execute each tool call
+      const toolResultBlocks: ProviderContentBlock[] = [];
+      for (const tc of toolCalls) {
+        const result = await this.executeTool(tc, sessionId, signal);
+        toolResultBlocks.push({
+          type: 'tool_result',
+          tool_use_id: tc.toolCallId,
+          content: typeof result.content === 'string'
+            ? result.content
+            : JSON.stringify(result.content),
+        });
+        yield {
+          type: 'tool-result',
+          toolCallId: tc.toolCallId,
+          result,
+        };
+      }
+
+      // Persist tool results as a user message (Anthropic expects tool_result in user turn)
+      this.store.appendMessage(sessionId, 'user', toolResultBlocks);
+
+      // Rebuild messages for next iteration
+      messages = this.buildMessages(sessionId);
+    }
+
+    // Hit max iterations
+    yield { type: 'finish', reason: 'max_iterations' };
+  }
+
+  private async executeTool(
+    toolCall: { toolCallId: string; toolName: string; args: JSONValue },
+    sessionId: string,
+    signal?: AbortSignal,
+  ): Promise<ToolResult> {
+    const permission = this.registry.checkPermission(toolCall.toolName);
+
+    if (permission === 'deny') {
+      return {
+        content: `Tool '${toolCall.toolName}' denied by permission policy`,
+        isError: true,
+      };
+    }
+
+    // 'ask' falls through to deny in v1 (no approval UI yet)
+    if (permission === 'ask') {
+      return {
+        content: `Tool '${toolCall.toolName}' requires approval (not yet implemented)`,
+        isError: true,
+      };
+    }
+
+    const tool = this.registry.get(toolCall.toolName);
+    if (!tool) {
+      return { content: `Unknown tool: ${toolCall.toolName}`, isError: true };
+    }
+
+    try {
+      const context = {
+        sessionId,
+        signal: signal ?? AbortSignal.timeout(tool.definition.timeout ?? 30_000),
+        emit: () => {}, // tool-progress not wired to consumer in v1
+      };
+      return await tool.executor(toolCall.args, context);
+    } catch (err: any) {
+      return { content: `Tool execution error: ${err.message}`, isError: true };
+    }
+  }
+
+  private buildMessages(sessionId: string): ProviderMessage[] {
+    const stored = this.store.getMessages(sessionId);
+    return stored.map(msg => ({
+      role: msg.role,
+      content: JSON.parse(msg.content) as ProviderContentBlock[],
+    }));
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/host && npm test`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/host/src/agent-loop.ts packages/host/test/agent-loop.test.ts
+git commit -m "feat(host): core agent loop with tool execution and iteration limit"
+```
+
+---
+
+### Task 7: Socket Server
+
+**Build/Adapt/Borrow:** BORROW PATTERN from `packages/gateway/src/sdk-socket.ts` (line-delimited JSON over Unix socket).
+
+**Files:**
+- Create: `packages/host/src/server.ts`
+- Create: `packages/host/src/index.ts`
+
+- [ ] **Step 1: Implement socket server**
+
+```typescript
+// packages/host/src/server.ts
+import net from 'node:net';
+import type { SocketRequest, SocketResponse, StreamEvent } from './types.ts';
+
+type RequestHandler = (
+  method: string,
+  params: Record<string, unknown>,
+  streamCallback: (event: StreamEvent) => void,
+) => Promise<unknown>;
+
+export class HostServer {
+  private server: net.Server;
+  private connections = new Set<net.Socket>();
+
+  constructor(private handler: RequestHandler) {
+    this.server = net.createServer(socket => this.handleConnection(socket));
+  }
+
+  listen(socketPath: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      // Clean up stale socket file
+      try {
+        const fs = require('node:fs');
+        fs.unlinkSync(socketPath);
+      } catch {}
+
+      this.server.listen(socketPath, () => resolve());
+      this.server.once('error', reject);
+    });
+  }
+
+  close(): Promise<void> {
+    for (const conn of this.connections) {
+      conn.destroy();
+    }
+    return new Promise(resolve => this.server.close(() => resolve()));
+  }
+
+  private handleConnection(socket: net.Socket): void {
+    this.connections.add(socket);
+    let buffer = '';
+
+    socket.on('data', (data) => {
+      buffer += data.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        this.handleLine(socket, line.trim());
+      }
+    });
+
+    socket.on('close', () => {
+      this.connections.delete(socket);
+    });
+
+    socket.on('error', () => {
+      this.connections.delete(socket);
+    });
+  }
+
+  private async handleLine(socket: net.Socket, line: string): Promise<void> {
+    let req: SocketRequest;
+    try {
+      req = JSON.parse(line);
+    } catch {
+      return; // Ignore malformed messages
+    }
+
+    const streamCallback = (event: StreamEvent) => {
+      if (!socket.destroyed) {
+        const streamMsg = JSON.stringify({ id: req.id, stream: event });
+        socket.write(streamMsg + '\n');
+      }
+    };
+
+    try {
+      const result = await this.handler(req.method, req.params, streamCallback);
+      const response: SocketResponse = { id: req.id, result };
+      socket.write(JSON.stringify(response) + '\n');
+    } catch (err: any) {
+      const response: SocketResponse = {
+        id: req.id,
+        error: { message: err.message, code: err.code },
+      };
+      socket.write(JSON.stringify(response) + '\n');
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Implement entry point**
+
+```typescript
+// packages/host/src/index.ts
+import path from 'node:path';
+import fs from 'node:fs';
+import { HostServer } from './server.ts';
+import { SessionStore } from './session-store.ts';
+import { ToolRegistry } from './tool-registry.ts';
+import { AgentLoop } from './agent-loop.ts';
+import { AnthropicAdapter } from './provider/anthropic.ts';
+import { registerAdapter, getAdapter } from './provider/adapter.ts';
+import { readFileTool } from './tools/read-file.ts';
+import { listFilesTool } from './tools/list-files.ts';
+import { shellExecTool } from './tools/shell-exec.ts';
+import type { StreamEvent } from './types.ts';
+
+// Determine mode and state directory
+function getStateDir(): string {
+  const mode = process.env.AOS_MODE ?? 'repo';
+  const dir = path.join(
+    process.env.HOME ?? '/tmp',
+    '.config', 'aos', mode,
+  );
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+async function main() {
+  const stateDir = getStateDir();
+  const dbPath = path.join(stateDir, 'host.db');
+  const socketPath = path.join(stateDir, 'host.sock');
+
+  // Initialize components
+  const store = new SessionStore(dbPath);
+  const registry = new ToolRegistry();
+  const anthropic = new AnthropicAdapter();
+  registerAdapter(anthropic);
+
+  // Register builtin tools
+  registry.register(readFileTool.definition, readFileTool.executor);
+  registry.register(listFilesTool.definition, listFilesTool.executor);
+  registry.register(shellExecTool.definition, shellExecTool.executor);
+
+  // Active abort controllers per session (for stop)
+  const activeStreams = new Map<string, AbortController>();
+
+  // Socket request handler
+  const handler = async (
+    method: string,
+    params: Record<string, unknown>,
+    streamCallback: (event: StreamEvent) => void,
+  ): Promise<unknown> => {
+    switch (method) {
+      case 'chat.create': {
+        const session = store.createSession(params as any);
+        return session;
+      }
+
+      case 'chat.send': {
+        const { sessionId, text } = params as { sessionId: string; text: string };
+        const session = store.getSession(sessionId);
+        if (!session) throw new Error(`Session not found: ${sessionId}`);
+
+        const adapter = getAdapter(session.provider);
+        const loop = new AgentLoop(store, registry, adapter, {
+          maxIterations: (params.maxIterations as number) ?? 25,
+        });
+
+        const controller = new AbortController();
+        activeStreams.set(sessionId, controller);
+
+        try {
+          for await (const event of loop.send(sessionId, text, controller.signal)) {
+            streamCallback(event);
+          }
+        } finally {
+          activeStreams.delete(sessionId);
+        }
+        return { ok: true };
+      }
+
+      case 'chat.stop': {
+        const { sessionId } = params as { sessionId: string };
+        const controller = activeStreams.get(sessionId);
+        if (controller) controller.abort();
+        return { ok: true };
+      }
+
+      case 'chat.list': {
+        return store.listSessions();
+      }
+
+      case 'tools.list': {
+        return registry.getDefinitions();
+      }
+
+      default:
+        throw new Error(`Unknown method: ${method}`);
+    }
+  };
+
+  const server = new HostServer(handler);
+  await server.listen(socketPath);
+  console.log(`aos-host listening on ${socketPath}`);
+
+  // Graceful shutdown
+  const shutdown = async () => {
+    console.log('Shutting down...');
+    for (const controller of activeStreams.values()) {
+      controller.abort();
+    }
+    await server.close();
+    store.close();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 3: Verify the host starts**
+
+Run: `cd packages/host && npx tsc && AOS_MODE=repo node dist/index.js`
+Expected: Prints `aos-host listening on /Users/<you>/.config/aos/repo/host.sock`
+Kill with Ctrl+C — should print `Shutting down...` and exit cleanly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/host/src/server.ts packages/host/src/index.ts
+git commit -m "feat(host): socket server and entry point"
+```
+
+---
+
+### Task 8: Sigil Chat Integration
+
+**Build/Adapt/Borrow:** BUILD. Wires Sigil's existing chat canvas events through a thin SDK client to the host socket.
+
+**Files:**
+- Create: `packages/host/src/sdk-client.ts` (minimal SDK client for Sigil to use)
+- Modify: `apps/sigil/avatar-sub.swift` (wire chat canvas events to host)
+
+**Note:** This task bridges the Node.js host and the Swift Sigil client. The SDK client is a Node.js module that Sigil's event handler calls (via the gateway's script execution engine or a small bridge process). For v1, we take the simplest path: a standalone Node.js script that connects to `host.sock`, sends messages, and pipes streamed events back through the daemon's `evalCanvas` to update the chat canvas.
+
+- [ ] **Step 1: Create SDK client**
+
+```typescript
+// packages/host/src/sdk-client.ts
+import net from 'node:net';
+import { ulid } from 'ulid';
+import type { SocketRequest, SocketResponse, StreamEvent, Session, SessionConfig, ToolDefinition } from './types.ts';
+
+export class HostClient {
+  private socket: net.Socket | null = null;
+  private pending = new Map<string, {
+    resolve: (value: unknown) => void;
+    reject: (err: Error) => void;
+    onStream?: (event: StreamEvent) => void;
+  }>();
+
+  constructor(private socketPath: string) {}
+
+  connect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.socket = net.createConnection(this.socketPath);
+      let buffer = '';
+
+      this.socket.on('connect', resolve);
+      this.socket.once('error', reject);
+
+      this.socket.on('data', (data) => {
+        buffer += data.toString();
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const msg = JSON.parse(line);
+            const handler = this.pending.get(msg.id);
+            if (!handler) continue;
+
+            if ('stream' in msg) {
+              handler.onStream?.(msg.stream as StreamEvent);
+            } else if ('error' in msg) {
+              this.pending.delete(msg.id);
+              handler.reject(new Error(msg.error.message));
+            } else {
+              this.pending.delete(msg.id);
+              handler.resolve(msg.result);
+            }
+          } catch {}
+        }
+      });
+    });
+  }
+
+  disconnect(): void {
+    this.socket?.destroy();
+    this.socket = null;
+  }
+
+  async createSession(config: SessionConfig = {}): Promise<Session> {
+    return this.call('chat.create', config) as Promise<Session>;
+  }
+
+  async sendMessage(
+    sessionId: string,
+    text: string,
+    onStream: (event: StreamEvent) => void,
+  ): Promise<void> {
+    await this.callWithStream('chat.send', { sessionId, text }, onStream);
+  }
+
+  async stop(sessionId: string): Promise<void> {
+    await this.call('chat.stop', { sessionId });
+  }
+
+  async listSessions(): Promise<Session[]> {
+    return this.call('chat.list', {}) as Promise<Session[]>;
+  }
+
+  async listTools(): Promise<ToolDefinition[]> {
+    return this.call('tools.list', {}) as Promise<ToolDefinition[]>;
+  }
+
+  private call(method: string, params: Record<string, unknown>): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const id = ulid();
+      this.pending.set(id, { resolve, reject });
+      const req: SocketRequest = { id, method, params };
+      this.socket!.write(JSON.stringify(req) + '\n');
+    });
+  }
+
+  private callWithStream(
+    method: string,
+    params: Record<string, unknown>,
+    onStream: (event: StreamEvent) => void,
+  ): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const id = ulid();
+      this.pending.set(id, { resolve, reject, onStream });
+      const req: SocketRequest = { id, method, params };
+      this.socket!.write(JSON.stringify(req) + '\n');
+    });
+  }
+}
+```
+
+- [ ] **Step 2: Create Sigil bridge script**
+
+This is a standalone Node.js script that Sigil's Swift event handler spawns. It connects to `host.sock`, manages a session, and translates between the chat canvas protocol (base64 JSON via `evalCanvas`) and the host protocol.
+
+```typescript
+// packages/host/src/sigil-bridge.ts
+import { HostClient } from './sdk-client.ts';
+import type { StreamEvent, ProviderContentBlock } from './types.ts';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+// Reads from stdin (JSON lines from Sigil), writes to stdout (canvas eval commands)
+const mode = process.env.AOS_MODE ?? 'repo';
+const stateDir = path.join(process.env.HOME ?? '/tmp', '.config', 'aos', mode);
+const socketPath = path.join(stateDir, 'host.sock');
+
+const client = new HostClient(socketPath);
+let sessionId: string | null = null;
+
+function sendToCanvas(msg: { type: string; content?: unknown[]; text?: string }): void {
+  // Output as JSON line — the Swift caller will evalCanvas with this
+  process.stdout.write(JSON.stringify(msg) + '\n');
+}
+
+function streamEventToCanvasContent(event: StreamEvent): void {
+  switch (event.type) {
+    case 'text-delta':
+      sendToCanvas({ type: 'assistant', content: [{ type: 'text', text: event.text }] });
+      break;
+    case 'tool-call':
+      sendToCanvas({
+        type: 'status',
+        text: `Using ${event.toolName}...`,
+      });
+      break;
+    case 'tool-result':
+      if (event.result.isError) {
+        sendToCanvas({
+          type: 'status',
+          text: `Tool error: ${typeof event.result.content === 'string' ? event.result.content : JSON.stringify(event.result.content)}`,
+        });
+      }
+      break;
+    case 'finish':
+      sendToCanvas({ type: 'status', text: '' }); // Clear status
+      break;
+    case 'error':
+      sendToCanvas({ type: 'status', text: `Error: ${event.error}` });
+      break;
+  }
+}
+
+async function handleMessage(text: string): Promise<void> {
+  if (!sessionId) {
+    const session = await client.createSession({
+      system: 'You are a helpful assistant with access to file system tools. Be concise.',
+    });
+    sessionId = session.id;
+  }
+
+  sendToCanvas({ type: 'user', content: [{ type: 'text', text }] });
+
+  await client.sendMessage(sessionId, text, (event) => {
+    streamEventToCanvasContent(event);
+  });
+}
+
+async function main() {
+  await client.connect();
+
+  // Read JSON lines from stdin
+  let buffer = '';
+  process.stdin.setEncoding('utf-8');
+  process.stdin.on('data', (chunk) => {
+    buffer += chunk;
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const msg = JSON.parse(line);
+        if (msg.type === 'user_message') {
+          handleMessage(msg.payload.text).catch(err => {
+            sendToCanvas({ type: 'status', text: `Error: ${err.message}` });
+          });
+        } else if (msg.type === 'stop') {
+          if (sessionId) client.stop(sessionId);
+        }
+      } catch {}
+    }
+  });
+}
+
+main().catch(err => {
+  console.error('Bridge error:', err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 3: Manual integration test**
+
+Start the host in one terminal:
+```bash
+cd packages/host && npx tsc && AOS_MODE=repo node dist/index.js
+```
+
+In another terminal, test the SDK client directly:
+```bash
+cd packages/host && node -e "
+import { HostClient } from './dist/sdk-client.js';
+import path from 'node:path';
+
+const client = new HostClient(path.join(process.env.HOME, '.config/aos/repo/host.sock'));
+await client.connect();
+const session = await client.createSession({ system: 'Be very brief.' });
+console.log('Session:', session.id);
+await client.sendMessage(session.id, 'What is 2+2?', (event) => {
+  if (event.type === 'text-delta') process.stdout.write(event.text);
+  if (event.type === 'finish') console.log('\n[done]');
+});
+client.disconnect();
+"
+```
+
+Expected: Prints a streaming response from Claude, then `[done]`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/host/src/sdk-client.ts packages/host/src/sigil-bridge.ts
+git commit -m "feat(host): SDK client and Sigil bridge script"
+```
+
+---
+
+### Task 9: End-to-End Verification
+
+**Files:** No new files. This task verifies all success criteria from the spec.
+
+- [ ] **Step 1: Start the host**
+
+Run: `cd packages/host && npx tsc && AOS_MODE=repo node dist/index.js`
+Expected: `aos-host listening on ~/.config/aos/repo/host.sock`
+
+- [ ] **Step 2: Verify text streaming (success criterion 2+3)**
+
+In another terminal:
+```bash
+cd packages/host && node -e "
+import { HostClient } from './dist/sdk-client.js';
+import path from 'node:path';
+const client = new HostClient(path.join(process.env.HOME, '.config/aos/repo/host.sock'));
+await client.connect();
+const session = await client.createSession({});
+await client.sendMessage(session.id, 'Say hello in exactly 3 words.', (e) => {
+  if (e.type === 'text-delta') process.stdout.write(e.text);
+  if (e.type === 'finish') console.log('\n[finish: ' + e.reason + ']');
+});
+client.disconnect();
+"
+```
+Expected: Streamed text response, then `[finish: end_turn]`
+
+- [ ] **Step 3: Verify tool execution (success criterion 4)**
+
+```bash
+cd packages/host && node -e "
+import { HostClient } from './dist/sdk-client.js';
+import path from 'node:path';
+const client = new HostClient(path.join(process.env.HOME, '.config/aos/repo/host.sock'));
+await client.connect();
+const session = await client.createSession({ system: 'Use tools when helpful. Be brief.' });
+await client.sendMessage(session.id, 'Read the file at /tmp/host-test.txt and tell me what it says.', (e) => {
+  console.log(e.type, JSON.stringify(e).slice(0, 100));
+});
+client.disconnect();
+"
+```
+Pre-setup: `echo 'agent-os test content' > /tmp/host-test.txt`
+
+Expected: See `tool-call` event for `read_file`, then `tool-result`, then `text-delta` events with the file content summarized.
+
+- [ ] **Step 4: Verify session persistence (success criterion 5)**
+
+```bash
+# Check SQLite directly
+sqlite3 ~/.config/aos/repo/host.db "SELECT id, provider, model FROM sessions; SELECT session_id, role, substr(content, 1, 80) FROM messages;"
+```
+Expected: Session row exists. Multiple message rows (user + assistant + potentially tool results).
+
+- [ ] **Step 5: Verify stop (success criterion 6)**
+
+```bash
+cd packages/host && node -e "
+import { HostClient } from './dist/sdk-client.js';
+import path from 'node:path';
+const client = new HostClient(path.join(process.env.HOME, '.config/aos/repo/host.sock'));
+await client.connect();
+const session = await client.createSession({});
+let count = 0;
+await client.sendMessage(session.id, 'Write a very long essay about the history of computing.', (e) => {
+  if (e.type === 'text-delta') {
+    count++;
+    process.stdout.write(e.text);
+    if (count === 5) {
+      console.log('\n[stopping...]');
+      client.stop(session.id);
+    }
+  }
+  if (e.type === 'finish') console.log('[finish: ' + e.reason + ']');
+});
+client.disconnect();
+"
+```
+Expected: Some text deltas, then `[stopping...]`, then `[finish: stop]`.
+
+- [ ] **Step 6: Commit any fixes from verification**
+
+If any issues surfaced during testing, fix them and commit:
+```bash
+git add -u packages/host/
+git commit -m "fix(host): adjustments from end-to-end verification"
+```
+
+- [ ] **Step 7: Final commit — mark thin slice complete**
+
+```bash
+git add -A packages/host/
+git commit -m "feat(host): v1 thin slice complete — agent loop, tools, persistence, streaming"
+```

--- a/docs/superpowers/specs/2026-04-09-sigil-wiki-design.md
+++ b/docs/superpowers/specs/2026-04-09-sigil-wiki-design.md
@@ -1,0 +1,365 @@
+# Sigil Wiki — Design Spec
+
+**Date:** 2026-04-09
+**Session:** sigil-wiki
+**Status:** Draft
+
+## Overview
+
+A persistent, interlinked markdown knowledge base with executable workflows, maintained by agents and humans, browsable and invocable through Sigil. Inspired by Karpathy's "LLM Wiki" concept, extended with first-class workflow support compatible with the Claude Code/Cowork plugin format.
+
+The wiki serves two audiences equally:
+- **Agents** read and write wiki pages to maintain shared knowledge across sessions. They invoke workflows by reading bundled plugin content as context.
+- **Humans** browse the knowledge graph in Sigil, discover and invoke workflows, and curate content through direct editing or agent-assisted authoring ("Customize with Agent").
+
+### Design Principles
+
+- **Files are canonical.** The wiki is a directory of markdown files. Everything else (index, tools, UI) is derived from them.
+- **Plugin-compatible.** Plugins use the Claude Code/Cowork SKILL.md format. Existing plugins can be dropped in and work.
+- **CLI-first.** All operations are `aos wiki` subcommands. Any agent that can run bash can use the wiki. MCP/SDK wrapping is additive, not required.
+- **User-owned.** The wiki lives in the user's config directory, not the repo. The repo may ship a starter pack, but the user's wiki is theirs.
+
+---
+
+## 1. Data Model
+
+### Storage Location
+
+```
+~/.config/aos/{mode}/wiki/
+├── plugins/
+│   └── <plugin-name>/
+│       ├── SKILL.md
+│       ├── references/
+│       ├── scripts/
+│       └── assets/
+├── entities/
+│   └── <name>.md
+├── concepts/
+│   └── <name>.md
+└── wiki.db
+```
+
+Auto-created on first `aos wiki` usage.
+
+### Page Types
+
+**Workflow (plugin):** An executable set of instructions with supporting knowledge. Lives in `plugins/<name>/`. The `SKILL.md` is the entry point.
+
+**Entity:** A thing — a tool, system, API, person. Lives in `entities/<name>.md`.
+
+**Concept:** An idea, pattern, or principle. Lives in `concepts/<name>.md`.
+
+### Page Format
+
+All pages are markdown with YAML frontmatter:
+
+```markdown
+---
+type: entity
+name: Gateway
+description: MCP server for typed script execution and cross-harness coordination
+tags: [infrastructure, mcp, tools]
+---
+
+# Gateway
+
+The gateway is the MCP server at `packages/gateway/`...
+
+## Related
+- [IPC Protocol](../concepts/ipc-protocol.md)
+- [Canvas System](./canvas-system.md)
+```
+
+### Plugin Format
+
+Compatible with Claude Code/Cowork plugin structure:
+
+```
+plugins/<plugin-name>/
+├── SKILL.md              # Required: frontmatter + instructions
+├── references/           # Optional: knowledge pages loaded on demand
+│   ├── some-framework.md
+│   └── output-schema.md
+├── scripts/              # Optional: executable code for deterministic tasks
+└── assets/               # Optional: templates, icons, other files
+```
+
+**SKILL.md frontmatter** (superset of Cowork format):
+
+```yaml
+---
+name: plugin-name
+description: >
+  When to trigger, what it does. Include contexts where this
+  should activate even if not explicitly asked for.
+version: "1.0.0"             # optional
+author: "user or agent name"  # optional
+tags: [domain, capability]    # optional
+triggers: ["natural language phrases that invoke this"]  # optional
+requires: [gateway, aos-daemon]  # optional runtime deps
+---
+```
+
+Minimum viable plugin: a `SKILL.md` with `name` and `description` in the frontmatter.
+
+Reference files within a plugin are also wiki pages. They have their own frontmatter (`type: entity` or `type: concept`) and can be linked to/from pages outside the plugin. This bridges the plugin model and the knowledge graph. They live only in the plugin directory (not duplicated to `entities/` or `concepts/`) but are indexed as wiki pages with their `plugin` field set, making them reachable via search and graph queries.
+
+### Progressive Disclosure
+
+Skills use a three-level loading system (from Anthropic's skill-creator guide):
+
+1. **Metadata** (name + description) — always available for trigger matching (~100 words)
+2. **SKILL.md body** — loaded when skill triggers (<500 lines ideal)
+3. **Bundled resources** — loaded on demand (unlimited, scripts can execute without loading)
+
+### Index
+
+`wiki.db` is a SQLite database — a materialized view of the filesystem, not the source of truth. If deleted, `aos wiki reindex` regenerates it fully.
+
+```sql
+CREATE TABLE pages (
+    path        TEXT PRIMARY KEY,  -- relative to wiki root
+    type        TEXT NOT NULL,     -- 'workflow', 'entity', 'concept'
+    name        TEXT NOT NULL,
+    description TEXT,
+    tags        TEXT,              -- JSON array
+    plugin      TEXT,              -- plugin name if part of one, NULL otherwise
+    modified_at INTEGER NOT NULL   -- file mtime epoch
+);
+
+CREATE TABLE links (
+    source_path TEXT NOT NULL REFERENCES pages(path),
+    target_path TEXT NOT NULL,
+    UNIQUE(source_path, target_path)
+);
+
+CREATE TABLE plugins (
+    name        TEXT PRIMARY KEY,
+    version     TEXT,
+    author      TEXT,
+    description TEXT,
+    triggers    TEXT,              -- JSON array
+    requires    TEXT,              -- JSON array
+    modified_at INTEGER NOT NULL
+);
+```
+
+---
+
+## 2. CLI Tools (`aos wiki`)
+
+### Plugin Authoring
+
+| Command | Description |
+|---------|-------------|
+| `aos wiki create-plugin <name>` | Scaffold `plugins/<name>/` with SKILL.md template + references/ dir, update index |
+| `aos wiki edit-plugin <name>` | Open SKILL.md in `$EDITOR` (or return path for agent writes) |
+
+### Page Management
+
+| Command | Description |
+|---------|-------------|
+| `aos wiki add <type> <name>` | Create entity/concept page from template, update index |
+| `aos wiki rm <path>` | Remove page, clean up index, warn about broken incoming links |
+| `aos wiki link <from> <to>` | Add cross-reference (append to Related section + update index) |
+
+### Discovery
+
+| Command | Description |
+|---------|-------------|
+| `aos wiki search <query>` | Text search across name, description, body. `--type`, `--plugin` filters. Ranking: name > description > body |
+| `aos wiki list [--type <type>]` | List pages. Filters: `--type`, `--plugin <name>`, `--links-to <path>`, `--links-from <path>`, `--orphans` |
+| `aos wiki show <path-or-name>` | Display a page. Default: formatted for terminal. `--raw`: raw markdown source for editing. `--json`: structured output with separated frontmatter, body, and raw content |
+
+**`show --json` output:**
+
+```json
+{
+  "path": "plugins/competitor-audit/SKILL.md",
+  "frontmatter": {
+    "name": "competitor-audit",
+    "description": "...",
+    "version": "0.4.0",
+    "author": "Symphony Talent"
+  },
+  "body": "# Employer Brand Competitor Audit...",
+  "raw": "---\nname: competitor-audit\n..."
+}
+```
+
+The UI uses `frontmatter` for the metadata header, `body` for rendered preview, and `raw` for the edit view (markdown/preview toggle).
+
+### Invocation
+
+| Command | Description |
+|---------|-------------|
+| `aos wiki invoke <plugin-name> [--json]` | Bundle SKILL.md + all references + scripts into a single prompt payload, output to stdout |
+
+The bundle concatenates:
+- SKILL.md (full content)
+- All files in `references/` (delimited: `--- BEGIN reference: <filename> ---`)
+- Any `scripts/` file contents
+
+The chat surface takes this bundle and injects it into the active agent session as context. The agent reads the instructions and follows them. No orchestration engine, no step tracking — the agent drives.
+
+### Maintenance
+
+| Command | Description |
+|---------|-------------|
+| `aos wiki reindex` | Drop and rebuild wiki.db from filesystem. Idempotent. |
+| `aos wiki lint` | Report broken links, orphan pages, missing frontmatter, malformed plugins, index drift |
+| `aos wiki lint --fix` | Auto-fix what's safe: rebuild index, remove broken link entries. Does NOT delete pages or rewrite frontmatter. |
+| `aos wiki seed [--from <path>]` | Copy starter pack into wiki. No-ops if content exists (unless `--force`). Runs reindex after. |
+
+All commands producing structured data support `--json`.
+
+---
+
+## 3. "Customize with Agent"
+
+A built-in Sigil skill for agent-assisted plugin creation and editing. Derived from Anthropic's skill-creator (captured at `docs/reference/anthropic-skill-creator.md`), adapted for the wiki environment.
+
+### Authoring Flow
+
+1. **Capture intent** — what should this plugin do, when should it trigger. If the current conversation already contains a workflow worth capturing, extract from context first.
+2. **Interview** — edge cases, input/output formats, dependencies, success criteria. One question at a time.
+3. **Scaffold** — `aos wiki create-plugin <name>`
+4. **Write** — author SKILL.md + reference pages following the skill-writing guide:
+   - Description should be "pushy" — include trigger contexts even when not explicitly asked for
+   - Explain the *why* behind instructions, not just the *what*
+   - Keep SKILL.md under 500 lines; move domain knowledge to `references/`
+   - Use progressive disclosure — SKILL.md for the workflow, references for deep context
+5. **Test** — offer to run the plugin: "want me to try this?"
+6. **Iterate** — refine based on feedback, generalize from specific examples
+
+### What We Strip from Anthropic's Skill-Creator for v1
+
+- Eval viewer / benchmark machinery (requires subagent infrastructure we don't have)
+- Blind comparison system
+- Description optimization loop (`run_loop.py`)
+- Packaging (`.skill` file format — we use the wiki directory directly)
+
+### What We Keep
+
+- Intent capture and interview flow
+- Skill anatomy and writing guide (SKILL.md + references/ + scripts/ + assets/)
+- Progressive disclosure principles
+- "Explain the why" writing philosophy
+- Test-and-iterate loop (manual, not automated)
+
+---
+
+## 4. Invocation & Chat Integration
+
+### From Chat Compose Menu
+
+The chat UI calls `aos wiki list --type workflow --json` to populate a plugin menu. Each entry shows `name`, `description`, and `triggers` for the tooltip. Selecting one calls `aos wiki invoke <name>`, and the result is injected into the agent session.
+
+### From Browse View ("Try in Chat")
+
+The browse UI shows a "Try in chat" button on each plugin. Clicking it calls `aos wiki invoke <name>` and hands the payload to the chat canvas — same mechanism.
+
+### During Execution
+
+The agent can call `aos wiki show <path>` to pull additional wiki pages on demand if cross-links lead somewhere useful. The initial bundle is the plugin directory contents; the broader wiki is available for on-demand reads.
+
+---
+
+## 5. Seeding & Starter Pack
+
+### First Run
+
+When `aos wiki` is first used and the wiki directory doesn't exist, it auto-creates:
+
+```
+~/.config/aos/{mode}/wiki/
+├── plugins/
+├── entities/
+├── concepts/
+└── wiki.db
+```
+
+### Seed Command
+
+`aos wiki seed [--from <path>]`
+
+- Default source: `wiki-seed/` directory bundled in the repo (or shipped in AOS.app)
+- Copies starter pages into the user's wiki without overwriting existing files
+- Runs `reindex` after copying
+- No-ops if wiki already has content (unless `--force`)
+
+### Starter Pack Contents
+
+Sigil's own knowledge — a bounded domain to validate the system:
+
+**Entities:** gateway, sigil, canvas-system, daemon, studio
+
+**Concepts:** ipc-protocol, daemon-lifecycle, content-server, runtime-modes
+
+**Plugins:** One example workflow (e.g., `self-check` — the existing saved script wrapped as a plugin)
+
+Enough to browse entities, see cross-links, invoke a workflow, and create a new plugin via "Customize with Agent."
+
+### Sharing (Future)
+
+Not v1. The format supports it naturally — a shared wiki is a synced directory (git, Dropbox, etc.). `aos wiki seed --from /path/to/shared/wiki` imports another wiki's content.
+
+---
+
+## 6. Lint & Maintenance
+
+### `aos wiki lint`
+
+Reports issues without auto-fixing:
+
+| Check | Description |
+|-------|-------------|
+| Broken links | Page references a path that doesn't exist |
+| Orphan pages | Pages with zero incoming links (flagged, not necessarily wrong) |
+| Missing frontmatter | Pages without required fields (`type`, `name`) |
+| Malformed plugins | Plugin directory missing SKILL.md, or SKILL.md missing `description` |
+| Index drift | Files on disk not in the index |
+
+### `aos wiki lint --fix`
+
+Auto-fixes safe issues:
+- Rebuilds index (same as `reindex`)
+- Removes broken link entries from index
+
+Does NOT delete orphan pages or rewrite frontmatter — those require human judgment.
+
+---
+
+## 7. UI Surface
+
+The wiki's browse/edit/invoke UI will be integrated into Sigil's consolidated interface (alongside studio, settings, chat). The exact UI layout is a future design session's concern. This spec defines what the UI needs from the tools layer:
+
+### Browse View
+- `aos wiki list --json` — page listing with type, name, description, tags
+- `aos wiki list --links-to/--links-from --json` — graph edges for visualization
+
+### Detail View
+- `aos wiki show <path> --json` — frontmatter (metadata header), body (rendered preview), raw (edit view)
+- Markdown/preview toggle powered by `body` vs `raw` fields
+
+### Plugin View
+- Plugin metadata: version, author, triggers, requires
+- File tree: SKILL.md + references/ + scripts/
+- "Try in chat" button → `aos wiki invoke`
+- "Edit" button → opens raw markdown editor
+- "Customize with Agent" → injects the plugin-creator skill into chat with the current plugin as context
+
+### Search
+- `aos wiki search <query> --json` — results with snippets for a search UI
+
+---
+
+## Non-Goals for v1
+
+- **MCP tool exposure** — CLI is the primitive. Gateway wrapping is additive later.
+- **Semantic search** — text search with ranking is sufficient. Embeddings/vector search is future work.
+- **Automated eval/benchmarking** — manual test-and-iterate for plugin authoring.
+- **Shared/collaborative wikis** — format supports it, but no sync infrastructure in v1.
+- **Orchestrated execution** — context injection only. Progress tracking/step reporting is future work.
+- **Knowledge graph visualization** — the data supports it (links table), but rendering a visual graph is a UI concern for a later session.

--- a/docs/superpowers/specs/2026-04-10-chat-native-agent-host-design.md
+++ b/docs/superpowers/specs/2026-04-10-chat-native-agent-host-design.md
@@ -1,0 +1,322 @@
+# Chat-Native Agent Host — Design Spec
+
+**Date:** 2026-04-10
+**Status:** Approved
+**Package:** `packages/host/`
+
+## Overview
+
+A chat-native agent host inside agent-os that runs model-backed agent loops with tool execution, streaming, and session persistence. Sigil is the first consumer; any app can use it via the agent-os SDK.
+
+This is **not** a Claude Code clone or a drain-on-bridge. It's a platform primitive: model-agnostic by architecture, Anthropic-first by implementation.
+
+## Architecture Decisions (Locked)
+
+### Runtime Topology: Hybrid (Decision C)
+
+| Process | Language | Socket | Responsibility |
+|---------|----------|--------|----------------|
+| `aos` daemon | Swift | `~/.config/aos/{mode}/sock` | Canvases, display, OS primitives, content server, events |
+| `aos-host` | Node.js | `~/.config/aos/{mode}/host.sock` | Agent loop, provider adapters, tool registry, session store |
+| Gateway | Node.js | `~/.config/aos-gateway/sdk.sock` | Coordination, script exec, MCP bridge — tool source for host |
+
+**Why hybrid:** Swift daemon stays focused on what it's good at (canvases, IPC, OS). Node.js host gets the Anthropic TS SDK and broader ecosystem for tools/HTTP. Neither becomes a bottleneck or relay for the other's traffic.
+
+### Communication Topology: Direct Sockets + Unified SDK (Decision A)
+
+- SDK talks to Node host directly via `host.sock` for chat/session/tools
+- SDK talks to Swift daemon directly via `sock` for canvas/OS primitives
+- SDK abstracts both internally — apps see one coherent surface
+- SDK owns connection lifecycle, retries, reconnection for both
+- SDK presents one consistent event/streaming model regardless of backend
+- Topology can be collapsed later without breaking SDK surface
+
+### Package Location: `packages/host/`
+
+Standalone Node.js service. Distinct from gateway (which stays focused on coordination + script/MCP). They share infra patterns (SQLite, TypeScript) but not concerns. Gateway becomes a tool source the host discovers.
+
+### Process Lifecycle
+
+Mode-scoped launchd label: `com.agent-os.host.{mode}` (alongside `com.agent-os.aos.{mode}` for daemon). Started/stopped alongside the daemon.
+
+## Build / Adapt / Borrow Decisions
+
+| Component | Decision | Source | Rationale |
+|-----------|----------|--------|-----------|
+| Provider adapters | **ADAPT** | Vercel AI SDK (`ai`) | Handles SSE parsing, streaming normalization for 3+ providers. We wrap thinly. |
+| Tool definition shape | **BORROW PATTERN** | MCP `{name, description, inputSchema}` | Emerging standard; gateway already speaks MCP. We extend with `permissions`, `timeout`, `metadata`. |
+| Tool execution | **BUILD** | — | MCP's model is RPC-to-server; we need in-process + provider-backed + future agent-backed. |
+| Stream events | **ADAPT** | Vercel AI SDK stream types | Comes free with provider adapters. Mirror internally with extensions: `tool-progress`, `status`. |
+| Session persistence | **BUILD** on `better-sqlite3` | — | ~50-line schema: `sessions`, `messages`, `tool_calls`. Queryable, resumable. |
+| Permission model | **BUILD**, borrow pattern | Claude Code | Three states: `allow` / `deny` / `ask`. ~100 lines of logic; the UX matters more than the code. |
+| Wiki integration | **BUILD** | SQLite FTS5 + `gray-matter` | Novel; markdown source of truth, FTS5 index, exposed as tools. Platform primitive, not app feature. |
+
+## Core Interfaces
+
+### ToolDefinition
+
+Borrowed from MCP, extended with permissions and metadata.
+
+```typescript
+interface ToolDefinition {
+  name: string                    // unique within registry
+  description: string             // shown to model
+  inputSchema: JSONSchema         // MCP-compatible
+  permissions?: PermissionSpec    // our extension
+  timeout?: number                // ms, default 30s
+  metadata?: {
+    type: 'simple' | 'provider-backed' | 'agent-backed'
+    source?: string               // e.g., 'gateway', 'wiki', 'builtin'
+  }
+}
+```
+
+### ToolExecutor
+
+```typescript
+interface ToolExecutor {
+  (input: JSONValue, context: ToolContext): Promise<ToolResult>
+}
+
+interface ToolContext {
+  sessionId: string
+  permissions: ResolvedPermissions
+  signal: AbortSignal              // for cancellation
+  emit: (event: StreamEvent) => void  // tool can stream progress
+}
+
+interface ToolResult {
+  content: string | object         // serialized as tool_result block for the model
+  isError?: boolean
+}
+```
+
+`ToolResult.content` is intentionally constrained — it's what gets sent back to the model as the tool_result block, so it must be small and serializable.
+
+### ProviderAdapter
+
+Thin wrapper around Vercel AI SDK. Consumers never see Vercel types.
+
+```typescript
+interface ProviderAdapter {
+  id: string                       // 'anthropic', 'openai', 'google'
+
+  stream(params: {
+    messages: Message[]
+    tools: ToolDefinition[]
+    system?: string
+    config: ProviderConfig         // model, temperature, maxTokens
+  }): AsyncIterable<StreamEvent>
+}
+```
+
+### StreamEvent
+
+Adapted from Vercel AI SDK, with two extensions.
+
+```typescript
+type StreamEvent =
+  | { type: 'text-delta';    text: string }
+  | { type: 'tool-call';     toolCallId: string; toolName: string; args: JSONValue }
+  | { type: 'tool-result';   toolCallId: string; result: ToolResult }
+  | { type: 'tool-progress'; toolCallId: string; message: string }  // extension: long-running tools
+  | { type: 'finish';        reason: 'end_turn' | 'stop' | 'max_tokens' }
+  | { type: 'error';         error: string; code?: string }
+  | { type: 'status';        message: string }  // extension: host lifecycle events
+```
+
+### Session & Messages
+
+Persisted in SQLite.
+
+```typescript
+interface Session {
+  id: string
+  provider: string                 // 'anthropic'
+  model: string                    // 'claude-sonnet-4-20250514'
+  system?: string
+  toolProfile?: string            // named toolset, e.g., 'default', 'devtools'
+  createdAt: string
+  updatedAt: string
+}
+
+interface StoredMessage {
+  id: string
+  sessionId: string
+  role: 'user' | 'assistant' | 'tool'
+  content: MessageContent          // text, tool_use, tool_result blocks
+  createdAt: string
+  tokenCount?: number              // tracked for future context management
+}
+```
+
+`Session.toolProfile` is a simple string hook for v1. Future: named toolsets like "safe-default", "devtools".
+
+### Permission Model
+
+```typescript
+interface PermissionSpec {
+  default: 'allow' | 'deny' | 'ask'
+  dangerous?: boolean              // UI hint: show warning
+}
+
+interface PermissionOverride {
+  tool: string                     // glob pattern: 'fs.*', 'shell.exec'
+  decision: 'allow' | 'deny'
+  scope: 'session' | 'persistent'
+}
+```
+
+When `ask` is triggered: host pauses loop, emits `status` event, waits for SDK to relay user's decision via approval canvas.
+
+### SDK Surface
+
+```typescript
+interface AosSDK {
+  chat: {
+    create(config: SessionConfig): Promise<Session>
+    send(sessionId: string, text: string): AsyncIterable<StreamEvent>
+    stop(sessionId: string): Promise<void>
+    resume(sessionId: string): Promise<Session>
+    list(): Promise<Session[]>
+  }
+  tools: {
+    list(): Promise<ToolDefinition[]>
+    register(def: ToolDefinition, executor: ToolExecutor): void
+  }
+  os: {
+    // existing aos-proxy surface: perceive, act, display, voice
+  }
+  wiki: {
+    search(query: string): Promise<WikiEntry[]>
+    read(path: string): Promise<WikiDocument>
+    list(options?: { tag?: string }): Promise<WikiEntry[]>
+  }
+}
+```
+
+`sdk.chat.send()` returns `AsyncIterable<StreamEvent>` — one stream for the consumer regardless of internal complexity (text, tool calls, tool results all flow through).
+
+## Agent Loop
+
+```
+receive message
+  │
+  ├─ append to history
+  ├─ resolve tools (registry.getTools(session.toolProfile))
+  ├─ build messages array (system + history + new message)
+  │
+  ▼
+┌─────────────────────────────────┐
+│  call provider adapter.stream() │◄──────────────────┐
+│  (Anthropic first)              │                    │
+└──────────┬──────────────────────┘                    │
+           │                                           │
+           ▼                                           │
+     for await (event of stream)                       │
+           │                                           │
+           ├─ text-delta → emit to SDK consumer        │
+           │                                           │
+           ├─ tool-call → permission check             │
+           │               ├─ allow → execute          │
+           │               ├─ deny → tool_result       │
+           │               │         with error        │
+           │               └─ ask → emit status,       │
+           │                   wait for approval,      │
+           │                   then execute or deny    │
+           │                                           │
+           │   execute → emit tool-progress (opt)      │
+           │            → get ToolResult               │
+           │            → emit tool-result             │
+           │            → append to messages           │
+           │            → LOOP BACK ───────────────────┘
+           │
+           ├─ finish → persist session, emit finish
+           │
+           └─ error → emit error, persist partial
+```
+
+### Loop Behavior
+
+- **Auto-loops on tool calls.** After every tool result, calls provider again with updated history. Continues until `end_turn` / `stop` / max iterations.
+- **Max iteration limit:** configurable, default 25. Explicit and enforced.
+- **Permission checks are synchronous from the loop's perspective.** When `ask` is needed, loop pauses and waits. No timeout pressure — provider stream is already consumed at that point.
+- **Stop/cancel:** `AbortSignal` propagates through adapter and into tool execution. Partial response persisted.
+- **No context window management in v1.** `tokenCount` tracked per message but not acted on. Schema supports future sliding window or summarization.
+
+## Tool Types
+
+The tool registry supports three types through the same `ToolDefinition` + `ToolExecutor` interface:
+
+### Simple Tools
+Local function calls. `read_file`, `list_files`, `shell_exec`.
+
+### Provider-Backed Tools (future, post-thin-slice)
+Implementation internally calls another model provider (e.g., Gemini for audio/video). The agent sees a normal tool; Gemini auth/payload/upload is hidden behind the executor.
+
+Examples: `transcribe_audio`, `get_youtube_transcript`, `analyze_video`.
+
+### Agent-Backed Capabilities (future)
+Specialist sub-agents with their own instructions, provider choice, and tools — exposed as a tool to the main agent. Implementation is a nested agent loop.
+
+Example: "Media Analyst" agent invoked via a tool interface.
+
+**All three types share:** same discovery, same permission flow, same JSON envelope, same `ToolExecutor` signature. Callers cannot distinguish them.
+
+## Session Provider ≠ Tool Provider
+
+The host picks a **session provider** (Anthropic) for the conversation loop. Individual tools may call **different providers** internally (e.g., Gemini for video analysis). The agent never sees the internal provider — it sees `analyze_video` return a result.
+
+This is by design, not a hack. The tool registry and permission engine treat all tools uniformly regardless of their internal implementation.
+
+## Wiki as Platform Primitive
+
+The wiki (`aos wiki`) is an agent-os primitive, not a Sigil feature:
+- Markdown files are the canonical store
+- SQLite FTS5 index is a rebuildable materialized view for search and link traversal
+- Exposed via SDK: `sdk.wiki.search()`, `sdk.wiki.read()`, `sdk.wiki.list()`
+- Also exposed as tools in the registry: `wiki.search`, `wiki.read`
+- Host can use wiki for context (reading entities/concepts) and workflow invocation (plugins/skills)
+- Sigil is just the first consumer of this capability
+
+## v1 Thin Slice
+
+### In Scope
+
+| Component | Details |
+|-----------|---------|
+| `packages/host/` scaffolding | TypeScript, `better-sqlite3`, Vercel AI SDK, Unix socket server |
+| Agent loop | Core loop: receive, call Anthropic, handle tool calls, stream back |
+| Anthropic adapter | Single concrete `ProviderAdapter` using `@ai-sdk/anthropic` |
+| 3 simple tools | `read_file` (allow), `list_files` (allow), `shell_exec` (deny by default — requires explicit override) |
+| Tool registry | In-memory, `ToolDefinition` + `ToolExecutor` interface |
+| Session store | SQLite: `sessions` + `messages` tables |
+| Permission engine | `allow`/`deny` only (no `ask` UI — needs canvas integration) |
+| SDK client | `sdk.chat.create()`, `sdk.chat.send()`, `sdk.chat.stop()` over Unix socket |
+| Sigil integration | Wire chat canvas `emit('user_message')` → SDK → host → stream back to canvas |
+
+### Out of Scope (architecture supports, not wired)
+
+- `ask` permission flow (needs interactive canvas work)
+- Provider-backed tools (Gemini etc.)
+- Wiki integration (separate track, same tool interface when ready)
+- OpenAI/Gemini session providers (interfaces exist, no concrete adapter)
+- Context window management (`tokenCount` tracked, not acted on)
+- `sdk.chat.resume()` (sessions persist, resumption UX deferred)
+
+### Success Criteria
+
+1. User types in Sigil chat window
+2. Message flows through SDK → host socket → Anthropic API
+3. Model responds with text — streams back to Sigil chat in real time
+4. Model calls `read_file` — host executes, sends result to model, model continues
+5. Full conversation persists in SQLite — survives host restart
+6. Stop button in Sigil aborts the stream cleanly
+
+## Standing Rules
+
+1. **Max-iteration limit** is explicit and configurable (default 25).
+2. **Build/adapt/borrow** is tagged on every major component boundary.
+3. **`shell_exec`** is the sharpest tool — default permission posture is conservative (`ask` when we have it, `deny` in v1 thin slice unless explicitly overridden).
+4. **Sigil is a consumer, not the definition.** Keep "Future App" in all architecture views. Don't hard-bake Sigil specifics into the core.
+5. **Don't blindly reinvent.** For each piece: build, adapt a focused library, or borrow the pattern. Note the choice.

--- a/memory/scratchpad/chat-dogfood-session-brief.md
+++ b/memory/scratchpad/chat-dogfood-session-brief.md
@@ -1,0 +1,165 @@
+---
+status: exploring
+session: chat-dogfood
+date: 2026-04-09
+---
+
+# Chat-Dogfood Session Brief
+
+Handoff from the `chat-dogfood` session. Goal was "see the chat surface live
+and dogfood it — use the chat surface to continue the session". The loop
+partially closed (assistant → canvas works end-to-end; canvas → assistant
+reaches a file on disk but is not consumed). The experiment surfaced one
+real architecture mismatch and three incidental bugs that were fixed along
+the way. This note is for the next session that picks up chat-surface work.
+
+## What shipped on `feat/sigil-wiki`
+
+Four commits past the wiki session's tip:
+
+- `e90caf7` — **docs(wiki): sync plan with post-review state and clarify skill wording**
+  The wiki-session-leftover plan-file edit. Task 3 post-review note + the
+  "pushy" → "assertive"/"clear and explicit"/"highly specific" wording tweaks
+  that were your earlier WIP. Committed as one honest commit rather than split.
+
+- `8fefe4d` — **fix(daemon): instantiate NSApplication.shared before NSApp access in serveCommand**
+  The real reason `./aos serve` had been crashing with SIGTRAP every time
+  since 2026-04-08 09:37. Commit `69425e6` introduced
+  `NSApp.setActivationPolicy(.accessory)` in `src/commands/serve.swift`
+  without ever touching `NSApplication.shared` first. `NSApp` is an
+  implicitly-unwrapped optional that is *only* populated as a side effect of
+  `NSApplication.shared`'s first access. Every `./aos serve` was trapping on
+  a nil force-unwrap at `serveCommand + 944`. Fix: call
+  `NSApplication.shared.setActivationPolicy(.accessory)` instead. See
+  `~/Library/Logs/DiagnosticReports/aos-2026-04-08-215113.ips` through
+  `...2026-04-09-123644.ips` — all identical, all at offset 944, all fixed
+  by this one-liner.
+
+- `915cba7` — **fix(display): propagate all interactive-flip state in handleUpdate**
+  When `show update --interactive` flipped a canvas at runtime,
+  `handleUpdate` only updated `ignoresMouseEvents`. But `CanvasWindow`'s
+  `canBecomeKey` and `sendEvent` overrides both read `isInteractiveCanvas`,
+  which stayed `false` on flipped canvases — meaning the canvas received
+  mouse events but could never become key window. Visible symptom: typing
+  in the chat canvas after a runtime flip played the system bonk sound on
+  every keystroke. The fix also updates `window.level` (`.statusBar` →
+  `.floating`). Documented that the `WKWebView` subclass cannot be swapped
+  at runtime, so flipped canvases may need an extra click for first-mouse
+  behavior — full ergonomics require `--interactive` at create time.
+
+## What's still working in this repo state
+
+After the above three fixes:
+
+- `./aos serve` stays up (launchctl-managed, post-fix build).
+- `./aos show create --id chat --at 80,80,460,680 --url "aos://sigil/chat/index.html" --interactive` works and produces a clickable, key-window-capable chat canvas.
+- `./aos show eval --id chat --js 'headsup.receive("<base64 JSON>")'` pushes assistant messages into it. Verified with multi-block content (text, thinking, tool_use, etc. all supported per `chat/index.html` dispatch).
+- `./aos show listen` subscribes to the daemon's broadcast stream and writes NDJSON to stdout. Captured `user_message` events successfully at `/tmp/aos-chat-dogfood/events.ndjson`.
+- `./aos content status --json` confirms the content server is live at `http://127.0.0.1:<port>/` with `/sigil/ → apps/sigil`.
+
+## The architecture mismatch (the real finding)
+
+**Claude Code is turn-based; the chat canvas dogfood loop is not.** My
+`show listen` background job successfully captured the user's typed message
+into `/tmp/aos-chat-dogfood/events.ndjson`, but nothing in the Claude Code
+runtime wakes me up on a new line in that file. I only see the message when
+the user hands me the next turn. Between turns, I'm not running — there's
+no event loop on the agent side that can notice the file change and
+generate a response.
+
+The chat-integration spec anticipated this: *"the chat canvas is a
+projection of an existing agent session. The agent (running in Claude
+Code, Desktop, etc.) creates the canvas and pushes messages to it."* The
+canvas is designed to be model-agnostic and runtime-agnostic. The daemon
+is the neutral middle layer. The question of how a specific agent runtime
+consumes canvas events is a runtime-specific concern, and **Claude Code
+does not have a primitive for event-driven consumption between turns**.
+
+Options considered (in order of decreasing model-agnosticism):
+
+1. **The `aos event` + daemon turn-end routing task on the queue** is the
+   right architectural answer. Its whole point is to make the daemon the
+   event hub so any agent runtime can subscribe via a neutral protocol.
+   Claude Code would subscribe via a `UserPromptSubmit` hook that drains
+   unread events at turn boundaries. Claude Desktop would subscribe via
+   its native event loop. Codex-CLI-based agents would subscribe via
+   `show listen` in a real event-driven wrapper. All of them talk to the
+   same chat canvas. That is the unblock.
+2. **Focus-on-show fix** (see "Queued work" below). Not related to the
+   closed-loop problem, but improves the chat canvas UX for every caller.
+3. **`/loop` polling workaround.** Works for a one-time demo but is
+   Claude-Code-specific and sets a bad precedent. Rejected.
+
+Full pros/cons analysis of approaches is in the original session transcript
+— ask Michael for it if useful.
+
+## Incidental UX findings (queued as follow-ups)
+
+- **Focus delay on show.** When you click into an `.accessory` app's window
+  to type, macOS delays activation by a noticeable amount — sometimes
+  several seconds. The current `CanvasWindow.sendEvent` override only
+  activates on `.leftMouseDown`, which is apparently debounced or deferred
+  by the window server when another app had focus. Proposed fix: add a
+  `--focus` flag on `show create` / `show update` that (a) runs
+  `NSApp.activate(ignoringOtherApps: true)` + `window.makeKey()` at show
+  time, (b) emits JS to call `userInput.focus()` once the page's `ready`
+  event arrives. Both halves are needed — JS `.focus()` respects key-window
+  state, so the Swift side must make the window key first.
+
+- **Schema hygiene: double-nested payload.** The `user_message` event
+  arrives as:
+  ```json
+  "data":{"id":"chat","payload":{"payload":{"text":"...","type":"user_message"},"type":"user_message"}}
+  ```
+  The chat page does `emit('user_message', {type: 'user_message', text: value})`
+  at `apps/sigil/chat/index.html:895`, and `emit()` wraps it as
+  `{type, payload}` at `:589`. The inner `type` duplicates the outer one.
+  Harmless but ugly — the inner `type` is redundant and should be dropped
+  in `sendUserInput()` (pass just `{text: value}` as the payload). Same
+  cleanup applies to the other `emit` call sites. Do this atomically with
+  the focus fix.
+
+## Running state at handoff
+
+- **Daemon**: running via launchctl, built from the post-fix tree at
+  `~/.config/aos/repo/sock`. Use `./aos show list` as a liveness check
+  (`./aos show ping` is broken — goes through a different client path that
+  reports `NO_DAEMON` even when the daemon is alive).
+- **Chat canvas**: `id=chat`, `at=[80,80,460,680]`, `interactive=true`,
+  `scope=global`, loaded from `aos://sigil/chat/index.html`. Will persist
+  across CLI invocations until explicitly removed or the daemon restarts.
+  If it's in the way, `./aos show remove --id chat`.
+- **Event listener**: the background `show listen` job from this session
+  was stopped during handoff. If the next session wants to resume
+  observing canvas events: `./aos show listen > /tmp/aos-chat-dogfood/events.ndjson &`.
+- **Content server**: running on a daemon-assigned port. `./aos content status --json` reports the current address and `/sigil/ → apps/sigil` root.
+
+## Gotchas worth remembering
+
+- **`show ping` is lying.** Use `show list` instead.
+- **`show create` can return `NO_RESPONSE` even on success.** The client has a 10-second timeout on the socket round-trip; canvas creation with `aos://` URLs sometimes takes longer because the content server is fetching the file. Always verify with `show list`.
+- **Base64 encoding must be UTF-8-safe.** The chat canvas uses `TextDecoder` on `atob` output, so emoji and accented characters round-trip fine — but on the sending side, go `JSON → UTF-8 bytes → base64`, not naive `btoa(json)`. From the shell: `printf '%s' '<json>' | base64`.
+- **`.sortedKeys` on `JSONSerialization.data` does NOT cause the daemon crash.** I initially suspected the spatial model's JSON broadcast based on a secondary crash report showing `_writeJSONObject` in the background thread. That was a noise crash from a still-broken earlier build; the actual fatal crash was always the NSApp nil trap on the main thread. Every `aos-2026-04-*.ips` report shows `serveCommand + 944` on the main thread as the primary faulting frame.
+
+## Queued work (concrete next steps)
+
+The next session picking up chat-surface work should do, in order:
+
+1. **`./aos show remove --id chat`** to clear the stale canvas from this session, then recreate fresh with `--interactive` if testing.
+2. **Implement Option B: focus fix + schema flatten.** Scope:
+   - Add `--focus` flag to `CanvasRequest` → `show create` + `show update` CLI → `handleCreate`/`handleUpdate` in `canvas.swift`. When set, `Canvas.show()` runs `NSApp.activate(ignoringOtherApps: true)` + `window.makeKey()`.
+   - In `apps/sigil/chat/index.html`: on the page's `ready` emit, if the host tells the page to autofocus (via a subsequent `evalCanvas('chat', 'focusInput()')` or a new flag in the manifest), call `document.getElementById('userInput').focus()`. Keep it agent-driven; don't hard-code it.
+   - Flatten the `emit()` wrapper in `chat/index.html` to drop the redundant inner `type`. Update all emit call sites and re-test via `show listen`.
+   - Update `apps/sigil/CLAUDE.md` "Chat Canvas Protocol" section to reflect the cleaned-up payload shape and the `--focus` flag.
+   - Commit as one atomic change: *"feat(display): add --focus flag for interactive canvases + clean up chat emit payload"*.
+3. **Park the closed-loop dogfood** until the `aos event` + daemon turn-end routing task ships. When that task is in flight, revisit this brief — the `UserPromptSubmit` hook approach becomes viable and the chat canvas becomes a real bidirectional surface for any Claude Code session.
+
+## Things NOT to touch
+
+- The uncommitted WIP in the working tree at session start (untracked
+  scratchpad files in `memory/scratchpad/sigil-*`, plan/spec drafts in
+  `docs/superpowers/`, `packages/heads-up/`, `.claude/launch.json`,
+  `.mcp.json`) is **Michael's**, not this session's and not the wiki
+  session's. Leave it alone unless he asks otherwise.
+- **`task-queue.md` got one line added for this session's follow-up** (see
+  below). Don't rewrite the file.

--- a/memory/task-queue.md
+++ b/memory/task-queue.md
@@ -4,14 +4,37 @@
 (none)
 
 ## Queued
-- **Chat surface integration**: Chat canvas (`apps/sigil/chat/`) is wired to studio "Open Chat" button via daemon IPC. Next: connect to actual Claude API or agent session for real conversations. Now writable as a gateway script using `aos.coordination.*`.
-- **side-eye decision**: Absorb into aos (true single binary) or keep as bundled sub-binary? Blocks packaging fixes.
-- **Packaging gaps**: Bundle side-eye + toolkit HTML into AOS.app so installed-mode commands are self-contained.
 - **StatusItemManager ↔ Sigil coordination**: Menu bar toggle creates/removes avatar canvas independently of Sigil. Need to reconcile so Sigil detects externally-created canvas or the toggle starts/stops Sigil.
 - **Radial menu reimplementation**: Port radial menu from old avatar.html to celestial live renderer. Concepts and logic preserved in old file.
 - **Studio WKWebView bundling**: Low priority — content server mostly solves this.
-
 ## Done
+
+### chat-integration (2026-04-08)
+Chat canvas bidirectional messaging.
+
+- Unlocked free-form input (always enabled, not gated on AskUserQuestion)
+- Split emit into `response` (tool use answer) and `user_message` (unprompted input)
+- Added stop button with `stop` emit for agent interruption
+- Documented chat canvas protocol in `apps/sigil/CLAUDE.md`
+
+### post-merge-cleanup (2026-04-08)
+Remove side-eye remnants after merge into aos.
+
+**Commits:** `b5f7d51` → `7c42a7b` (2 commits)
+
+- Migrated `zones.json` from `~/.config/side-eye/` to mode-scoped `~/.config/aos/{mode}/zones.json` with auto-migration on first load
+- Added `~/.config/side-eye/` removal to `aos reset`
+- Removed 12 stale side-eye references across 7 source files (comments, help text, MARK labels)
+- 4 remaining `side-eye` references are functional (migration path + reset cleanup)
+
+### packaging (2026-04-08)
+`package.sh` — self-contained AOS.app bundling.
+
+**Commits:** `c4229de` → `3fa2a98` (2 commits)
+
+- `package.sh` builds both binaries (aos + avatar-sub), assembles `.app` bundle with web assets (42 files: sigil renderer/studio/chat + toolkit components), writes Info.plist, ad-hoc codesigns (inside-out), installs to `~/Applications/AOS.app`
+- Trap cleanup on failure, rsync prune empty dirs, daemon stop before replace
+- Sentinel check + codesign verified passing
 
 ### sdk-tests-and-settings (2026-04-08)
 SDK proxy tests, settings panel wiring, display behavior tests.

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
+REPO_ROOT="$PWD"
+
+APP_NAME="AOS"
+BUNDLE_ID="com.agent-os.aos"
+VERSION="0.1.0"
+BUILD_VERSION="$(date +%Y.%m.%d.%H%M%S)"
+INSTALL_DIR="$HOME/Applications"
+APP_PATH="$INSTALL_DIR/$APP_NAME.app"
+STAGE_DIR="$(mktemp -d)"
+STAGED_APP="$STAGE_DIR/$APP_NAME.app"
+
+echo "=== AOS Packaging ==="
+echo "Version: $VERSION ($BUILD_VERSION)"
+
+# ── 1. Build binaries ──────────────────────────────────────────────
+echo ""
+echo "Building aos..."
+bash build.sh
+
+echo ""
+echo "Building avatar-sub..."
+bash apps/sigil/build-avatar.sh
+
+# ── 2. Assemble .app bundle ────────────────────────────────────────
+echo ""
+echo "Assembling $APP_NAME.app..."
+
+mkdir -p "$STAGED_APP/Contents/MacOS"
+mkdir -p "$STAGED_APP/Contents/Resources/agent-os"
+
+# Binaries
+cp aos "$STAGED_APP/Contents/MacOS/aos"
+cp apps/sigil/build/avatar-sub "$STAGED_APP/Contents/MacOS/avatar-sub"
+
+# ── 3. Copy web assets ─────────────────────────────────────────────
+# apps/sigil — HTML surfaces (renderer, studio, chat) + config JSON
+# Exclude: Swift source, shell scripts, build dir, CLAUDE.md, sigilctl, DS_Store
+rsync -a \
+    --include='*/' \
+    --include='*.html' --include='*.js' --include='*.mjs' \
+    --include='*.css' --include='*.json' --include='*.glsl' \
+    --include='*.svg' --include='*.png' --include='*.jpg' \
+    --include='*.woff' --include='*.woff2' --include='*.wasm' \
+    --exclude='*' \
+    apps/sigil/ "$STAGED_APP/Contents/Resources/agent-os/apps/sigil/"
+
+# packages/toolkit — reusable HTML components
+rsync -a \
+    --include='*/' \
+    --include='*.html' --include='*.js' --include='*.mjs' \
+    --include='*.css' --include='*.json' \
+    --exclude='*' \
+    packages/toolkit/ "$STAGED_APP/Contents/Resources/agent-os/packages/toolkit/"
+
+# ── 4. Info.plist ──────────────────────────────────────────────────
+cat > "$STAGED_APP/Contents/Info.plist" << PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key>
+  <string>$APP_NAME</string>
+  <key>CFBundleDisplayName</key>
+  <string>$APP_NAME</string>
+  <key>CFBundleIdentifier</key>
+  <string>$BUNDLE_ID</string>
+  <key>CFBundleVersion</key>
+  <string>$BUILD_VERSION</string>
+  <key>CFBundleShortVersionString</key>
+  <string>$VERSION</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleExecutable</key>
+  <string>aos</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>14.0</string>
+  <key>LSUIElement</key>
+  <true/>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+</dict>
+</plist>
+PLIST
+
+# ── 5. Codesign (ad-hoc) ──────────────────────────────────────────
+echo "Signing..."
+codesign -s - -f --deep "$STAGED_APP"
+
+# ── 6. Install ─────────────────────────────────────────────────────
+echo ""
+echo "Installing to $APP_PATH..."
+mkdir -p "$INSTALL_DIR"
+
+# Stop installed-mode daemon if running
+if "$APP_PATH/Contents/MacOS/aos" service status --json 2>/dev/null | grep -q '"running"'; then
+    echo "Stopping installed-mode daemon..."
+    "$APP_PATH/Contents/MacOS/aos" service stop 2>/dev/null || true
+fi
+
+# Replace existing bundle
+rm -rf "$APP_PATH"
+mv "$STAGED_APP" "$APP_PATH"
+rm -rf "$STAGE_DIR"
+
+echo ""
+echo "=== Done ==="
+echo "$APP_PATH ($(du -sh "$APP_PATH" | cut -f1 | xargs))"
+echo ""
+echo "Bundled content:"
+find "$APP_PATH/Contents/Resources/agent-os" -type f | wc -l | xargs echo "  files:"
+echo "  sentinel: $(test -f "$APP_PATH/Contents/Resources/agent-os/packages/toolkit/components/inspector-panel.html" && echo "OK" || echo "MISSING")"
+echo ""
+echo "Verify: $APP_PATH/Contents/MacOS/aos runtime status --json"

--- a/package.sh
+++ b/package.sh
@@ -10,6 +10,7 @@ BUILD_VERSION="$(date +%Y.%m.%d.%H%M%S)"
 INSTALL_DIR="$HOME/Applications"
 APP_PATH="$INSTALL_DIR/$APP_NAME.app"
 STAGE_DIR="$(mktemp -d)"
+trap 'rm -rf "$STAGE_DIR"' EXIT
 STAGED_APP="$STAGE_DIR/$APP_NAME.app"
 
 echo "=== AOS Packaging ==="
@@ -38,7 +39,7 @@ cp apps/sigil/build/avatar-sub "$STAGED_APP/Contents/MacOS/avatar-sub"
 # ── 3. Copy web assets ─────────────────────────────────────────────
 # apps/sigil — HTML surfaces (renderer, studio, chat) + config JSON
 # Exclude: Swift source, shell scripts, build dir, CLAUDE.md, sigilctl, DS_Store
-rsync -a \
+rsync -am \
     --include='*/' \
     --include='*.html' --include='*.js' --include='*.mjs' \
     --include='*.css' --include='*.json' --include='*.glsl' \
@@ -48,7 +49,7 @@ rsync -a \
     apps/sigil/ "$STAGED_APP/Contents/Resources/agent-os/apps/sigil/"
 
 # packages/toolkit — reusable HTML components
-rsync -a \
+rsync -am \
     --include='*/' \
     --include='*.html' --include='*.js' --include='*.mjs' \
     --include='*.css' --include='*.json' \
@@ -89,7 +90,9 @@ PLIST
 
 # ── 5. Codesign (ad-hoc) ──────────────────────────────────────────
 echo "Signing..."
-codesign -s - -f --deep "$STAGED_APP"
+codesign -s - -f "$STAGED_APP/Contents/MacOS/avatar-sub"
+codesign -s - -f "$STAGED_APP/Contents/MacOS/aos"
+codesign -s - -f "$STAGED_APP"
 
 # ── 6. Install ─────────────────────────────────────────────────────
 echo ""
@@ -99,13 +102,12 @@ mkdir -p "$INSTALL_DIR"
 # Stop installed-mode daemon if running
 if "$APP_PATH/Contents/MacOS/aos" service status --json 2>/dev/null | grep -q '"running"'; then
     echo "Stopping installed-mode daemon..."
-    "$APP_PATH/Contents/MacOS/aos" service stop 2>/dev/null || true
+    "$APP_PATH/Contents/MacOS/aos" service stop 2>/dev/null || echo "Warning: could not stop daemon"
 fi
 
 # Replace existing bundle
 rm -rf "$APP_PATH"
 mv "$STAGED_APP" "$APP_PATH"
-rm -rf "$STAGE_DIR"
 
 echo ""
 echo "=== Done ==="

--- a/packages/host/package-lock.json
+++ b/packages/host/package-lock.json
@@ -1,0 +1,786 @@
+{
+  "name": "@agent-os/host",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@agent-os/host",
+      "version": "0.1.0",
+      "dependencies": {
+        "@ai-sdk/anthropic": "^1.2.0",
+        "ai": "^4.3.0",
+        "better-sqlite3": "^11.0.0",
+        "ulid": "^2.3.0"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.0",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-1.2.12.tgz",
+      "integrity": "sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
+      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/ui-utils": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
+      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/diff-match-patch": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
+      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "4.3.19",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
+      "integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/react": "1.2.12",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "@opentelemetry/api": "1.9.0",
+        "jsondiffpatch": "0.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/jsondiffpatch": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
+      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/diff-match-patch": "^1.0.36",
+        "chalk": "^5.3.0",
+        "diff-match-patch": "^1.0.5"
+      },
+      "bin": {
+        "jsondiffpatch": "bin/jsondiffpatch.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ulid": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.4.0.tgz",
+      "integrity": "sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==",
+      "license": "MIT",
+      "bin": {
+        "ulid": "bin/cli.js"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -5,9 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
-    "start": "node dist/index.js",
+    "check": "tsc --noEmit",
+    "start": "node --experimental-strip-types src/index.ts",
     "test": "node --test --experimental-strip-types 'test/**/*.test.ts'"
   },
   "dependencies": {

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@agent-os/host",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "start": "node dist/index.js",
+    "test": "node --test --experimental-strip-types 'test/**/*.test.ts'"
+  },
+  "dependencies": {
+    "ai": "^4.3.0",
+    "@ai-sdk/anthropic": "^1.2.0",
+    "better-sqlite3": "^11.0.0",
+    "ulid": "^2.3.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.0",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/host/src/agent-loop.ts
+++ b/packages/host/src/agent-loop.ts
@@ -1,0 +1,197 @@
+// packages/host/src/agent-loop.ts
+import type {
+  ProviderAdapter, StreamEvent, ToolResult, ProviderMessage,
+  ProviderContentBlock, AgentLoopConfig, JSONValue,
+} from './types.ts';
+import type { SessionStore } from './session-store.ts';
+import type { ToolRegistry } from './tool-registry.ts';
+
+export class AgentLoop {
+  private store: SessionStore;
+  private registry: ToolRegistry;
+  private adapter: ProviderAdapter;
+  private config: AgentLoopConfig;
+
+  constructor(
+    store: SessionStore,
+    registry: ToolRegistry,
+    adapter: ProviderAdapter,
+    config: AgentLoopConfig,
+  ) {
+    this.store = store;
+    this.registry = registry;
+    this.adapter = adapter;
+    this.config = config;
+  }
+
+  async *send(
+    sessionId: string,
+    text: string,
+    signal?: AbortSignal,
+  ): AsyncGenerator<StreamEvent> {
+    const session = this.store.getSession(sessionId);
+    if (!session) throw new Error(`Session not found: ${sessionId}`);
+
+    // Append user message
+    this.store.appendMessage(sessionId, 'user', [{ type: 'text', text }]);
+
+    // Build message history
+    let messages = this.buildMessages(sessionId);
+    let iterations = 0;
+
+    while (iterations < this.config.maxIterations) {
+      iterations++;
+
+      if (signal?.aborted) {
+        yield { type: 'finish', reason: 'stop' };
+        return;
+      }
+
+      // Collect tool calls and text blocks from this turn
+      const toolCalls: Array<{ toolCallId: string; toolName: string; args: JSONValue }> = [];
+      const textParts: string[] = [];
+
+      try {
+        const stream = this.adapter.stream({
+          messages,
+          tools: this.registry.getDefinitions(),
+          system: session.system,
+          config: { model: session.model },
+        });
+
+        for await (const event of stream) {
+          if (signal?.aborted) {
+            if (textParts.length > 0) {
+              this.store.appendMessage(sessionId, 'assistant',
+                [{ type: 'text', text: textParts.join('') }]);
+            }
+            yield { type: 'finish', reason: 'stop' };
+            return;
+          }
+
+          switch (event.type) {
+            case 'text-delta':
+              textParts.push(event.text);
+              yield event;
+              break;
+            case 'tool-call':
+              toolCalls.push(event);
+              yield event;
+              break;
+            case 'finish':
+              break;
+            case 'error':
+              yield event;
+              break;
+          }
+        }
+      } catch (err: any) {
+        if (signal?.aborted) {
+          yield { type: 'finish', reason: 'stop' };
+          return;
+        }
+        yield { type: 'error', error: err.message };
+        return;
+      }
+
+      // No tool calls — conversation turn complete
+      if (toolCalls.length === 0) {
+        const assistantBlocks: ProviderContentBlock[] = [];
+        if (textParts.length > 0) {
+          assistantBlocks.push({ type: 'text', text: textParts.join('') });
+        }
+        this.store.appendMessage(sessionId, 'assistant', assistantBlocks);
+        yield { type: 'finish', reason: 'end_turn' };
+        return;
+      }
+
+      // Has tool calls — persist assistant message with tool_use blocks, then execute
+      const assistantBlocks: ProviderContentBlock[] = [];
+      if (textParts.length > 0) {
+        assistantBlocks.push({ type: 'text', text: textParts.join('') });
+      }
+      for (const tc of toolCalls) {
+        assistantBlocks.push({
+          type: 'tool_use',
+          id: tc.toolCallId,
+          name: tc.toolName,
+          input: tc.args,
+        });
+      }
+      this.store.appendMessage(sessionId, 'assistant', assistantBlocks);
+
+      // Execute each tool call
+      const toolResultBlocks: ProviderContentBlock[] = [];
+      for (const tc of toolCalls) {
+        const result = await this.executeTool(tc, sessionId, signal);
+        toolResultBlocks.push({
+          type: 'tool_result',
+          tool_use_id: tc.toolCallId,
+          content: typeof result.content === 'string'
+            ? result.content
+            : JSON.stringify(result.content),
+        });
+        yield {
+          type: 'tool-result',
+          toolCallId: tc.toolCallId,
+          result,
+        };
+      }
+
+      // Persist tool results as user message (Anthropic expects tool_result in user turn)
+      this.store.appendMessage(sessionId, 'user', toolResultBlocks);
+
+      // Rebuild messages for next iteration
+      messages = this.buildMessages(sessionId);
+    }
+
+    // Hit max iterations
+    yield { type: 'finish', reason: 'max_iterations' };
+  }
+
+  private async executeTool(
+    toolCall: { toolCallId: string; toolName: string; args: JSONValue },
+    sessionId: string,
+    signal?: AbortSignal,
+  ): Promise<ToolResult> {
+    const permission = this.registry.checkPermission(toolCall.toolName);
+
+    if (permission === 'deny') {
+      return {
+        content: `Tool '${toolCall.toolName}' denied by permission policy`,
+        isError: true,
+      };
+    }
+
+    if (permission === 'ask') {
+      return {
+        content: `Tool '${toolCall.toolName}' requires approval (not yet implemented)`,
+        isError: true,
+      };
+    }
+
+    const tool = this.registry.get(toolCall.toolName);
+    if (!tool) {
+      return { content: `Unknown tool: ${toolCall.toolName}`, isError: true };
+    }
+
+    try {
+      const context = {
+        sessionId,
+        signal: signal ?? AbortSignal.timeout(tool.definition.timeout ?? 30_000),
+        emit: () => {},
+      };
+      return await tool.executor(toolCall.args, context);
+    } catch (err: any) {
+      return { content: `Tool execution error: ${err.message}`, isError: true };
+    }
+  }
+
+  private buildMessages(sessionId: string): ProviderMessage[] {
+    const stored = this.store.getMessages(sessionId);
+    return stored.map(msg => ({
+      role: msg.role,
+      content: JSON.parse(msg.content) as ProviderContentBlock[],
+    }));
+  }
+}

--- a/packages/host/src/agent-loop.ts
+++ b/packages/host/src/agent-loop.ts
@@ -43,6 +43,7 @@ export class AgentLoop {
       iterations++;
 
       if (signal?.aborted) {
+        // Persist any partial text accumulated from prior iterations
         yield { type: 'finish', reason: 'stop' };
         return;
       }
@@ -86,6 +87,11 @@ export class AgentLoop {
           }
         }
       } catch (err: any) {
+        // Persist any partial text before reporting error/stop
+        if (textParts.length > 0) {
+          this.store.appendMessage(sessionId, 'assistant',
+            [{ type: 'text', text: textParts.join('') }]);
+        }
         if (signal?.aborted) {
           yield { type: 'finish', reason: 'stop' };
           return;

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -1,0 +1,116 @@
+// packages/host/src/index.ts
+import path from 'node:path';
+import fs from 'node:fs';
+import { HostServer } from './server.ts';
+import { SessionStore } from './session-store.ts';
+import { ToolRegistry } from './tool-registry.ts';
+import { AgentLoop } from './agent-loop.ts';
+import { AnthropicAdapter } from './provider/anthropic.ts';
+import { registerAdapter, getAdapter } from './provider/adapter.ts';
+import { readFileTool } from './tools/read-file.ts';
+import { listFilesTool } from './tools/list-files.ts';
+import { shellExecTool } from './tools/shell-exec.ts';
+import type { StreamEvent } from './types.ts';
+
+function getStateDir(): string {
+  const mode = process.env.AOS_MODE ?? 'repo';
+  const dir = path.join(
+    process.env.HOME ?? '/tmp',
+    '.config', 'aos', mode,
+  );
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+async function main() {
+  const stateDir = getStateDir();
+  const dbPath = path.join(stateDir, 'host.db');
+  const socketPath = path.join(stateDir, 'host.sock');
+
+  const store = new SessionStore(dbPath);
+  const registry = new ToolRegistry();
+  const anthropic = new AnthropicAdapter();
+  registerAdapter(anthropic);
+
+  registry.register(readFileTool.definition, readFileTool.executor);
+  registry.register(listFilesTool.definition, listFilesTool.executor);
+  registry.register(shellExecTool.definition, shellExecTool.executor);
+
+  const activeStreams = new Map<string, AbortController>();
+
+  const handler = async (
+    method: string,
+    params: Record<string, unknown>,
+    streamCallback: (event: StreamEvent) => void,
+  ): Promise<unknown> => {
+    switch (method) {
+      case 'chat.create': {
+        const session = store.createSession(params as any);
+        return session;
+      }
+
+      case 'chat.send': {
+        const { sessionId, text } = params as { sessionId: string; text: string };
+        const session = store.getSession(sessionId);
+        if (!session) throw new Error(`Session not found: ${sessionId}`);
+
+        const adapter = getAdapter(session.provider);
+        const loop = new AgentLoop(store, registry, adapter, {
+          maxIterations: (params.maxIterations as number) ?? 25,
+        });
+
+        const controller = new AbortController();
+        activeStreams.set(sessionId, controller);
+
+        try {
+          for await (const event of loop.send(sessionId, text, controller.signal)) {
+            streamCallback(event);
+          }
+        } finally {
+          activeStreams.delete(sessionId);
+        }
+        return { ok: true };
+      }
+
+      case 'chat.stop': {
+        const { sessionId } = params as { sessionId: string };
+        const controller = activeStreams.get(sessionId);
+        if (controller) controller.abort();
+        return { ok: true };
+      }
+
+      case 'chat.list': {
+        return store.listSessions();
+      }
+
+      case 'tools.list': {
+        return registry.getDefinitions();
+      }
+
+      default:
+        throw new Error(`Unknown method: ${method}`);
+    }
+  };
+
+  const server = new HostServer(handler);
+  await server.listen(socketPath);
+  console.log(`aos-host listening on ${socketPath}`);
+
+  const shutdown = async () => {
+    console.log('Shutting down...');
+    for (const controller of activeStreams.values()) {
+      controller.abort();
+    }
+    await server.close();
+    store.close();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/packages/host/src/provider/adapter.ts
+++ b/packages/host/src/provider/adapter.ts
@@ -1,0 +1,14 @@
+// packages/host/src/provider/adapter.ts
+import type { ProviderAdapter } from '../types.ts';
+
+const adapters = new Map<string, ProviderAdapter>();
+
+export function registerAdapter(adapter: ProviderAdapter): void {
+  adapters.set(adapter.id, adapter);
+}
+
+export function getAdapter(id: string): ProviderAdapter {
+  const adapter = adapters.get(id);
+  if (!adapter) throw new Error(`Unknown provider: ${id}`);
+  return adapter;
+}

--- a/packages/host/src/provider/anthropic.ts
+++ b/packages/host/src/provider/anthropic.ts
@@ -1,5 +1,6 @@
 // packages/host/src/provider/anthropic.ts
 import { streamText, jsonSchema } from 'ai';
+import type { CoreMessage } from 'ai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import type {
   ProviderAdapter, ProviderMessage, ProviderConfig,
@@ -20,7 +21,7 @@ export class AnthropicAdapter implements ProviderAdapter {
 
     // Convert our message format to Vercel AI SDK format
     const aiMessages = messages.map(msg => ({
-      role: msg.role as 'user' | 'assistant',
+      role: msg.role,
       content: msg.content.map(block => {
         if (block.type === 'text') return { type: 'text' as const, text: block.text };
         if (block.type === 'tool_use') return {
@@ -51,7 +52,7 @@ export class AnthropicAdapter implements ProviderAdapter {
 
     const result = streamText({
       model: this.provider(config.model),
-      messages: aiMessages,
+      messages: aiMessages as CoreMessage[],
       tools: Object.keys(aiTools).length > 0 ? aiTools : undefined,
       system,
       maxTokens: config.maxTokens,

--- a/packages/host/src/provider/anthropic.ts
+++ b/packages/host/src/provider/anthropic.ts
@@ -1,0 +1,88 @@
+// packages/host/src/provider/anthropic.ts
+import { streamText, jsonSchema } from 'ai';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import type {
+  ProviderAdapter, ProviderMessage, ProviderConfig,
+  ToolDefinition, StreamEvent, JSONValue,
+} from '../types.ts';
+
+export class AnthropicAdapter implements ProviderAdapter {
+  readonly id = 'anthropic';
+  private provider = createAnthropic();
+
+  async *stream(params: {
+    messages: ProviderMessage[];
+    tools: ToolDefinition[];
+    system?: string;
+    config: ProviderConfig;
+  }): AsyncIterable<StreamEvent> {
+    const { messages, tools, system, config } = params;
+
+    // Convert our message format to Vercel AI SDK format
+    const aiMessages = messages.map(msg => ({
+      role: msg.role as 'user' | 'assistant',
+      content: msg.content.map(block => {
+        if (block.type === 'text') return { type: 'text' as const, text: block.text };
+        if (block.type === 'tool_use') return {
+          type: 'tool-call' as const,
+          toolCallId: block.id,
+          toolName: block.name,
+          args: block.input as Record<string, unknown>,
+        };
+        if (block.type === 'tool_result') return {
+          type: 'tool-result' as const,
+          toolCallId: block.tool_use_id,
+          result: block.content,
+        };
+        return { type: 'text' as const, text: '' };
+      }),
+    }));
+
+    // Convert tool definitions to Vercel AI SDK format.
+    // The SDK requires `parameters` (not `inputSchema`) wrapping the JSON schema
+    // via the `jsonSchema()` helper so it doesn't try to validate with Zod.
+    const aiTools: Record<string, { description: string; parameters: ReturnType<typeof jsonSchema> }> = {};
+    for (const tool of tools) {
+      aiTools[tool.name] = {
+        description: tool.description,
+        parameters: jsonSchema(tool.inputSchema as Parameters<typeof jsonSchema>[0]),
+      };
+    }
+
+    const result = streamText({
+      model: this.provider(config.model),
+      messages: aiMessages,
+      tools: Object.keys(aiTools).length > 0 ? aiTools : undefined,
+      system,
+      maxTokens: config.maxTokens,
+      temperature: config.temperature,
+    });
+
+    for await (const part of result.fullStream) {
+      switch (part.type) {
+        case 'text-delta':
+          yield { type: 'text-delta', text: part.textDelta };
+          break;
+        case 'tool-call':
+          yield {
+            type: 'tool-call',
+            toolCallId: part.toolCallId,
+            toolName: part.toolName,
+            args: part.args as JSONValue,
+          };
+          break;
+        case 'finish':
+          yield {
+            type: 'finish',
+            reason: part.finishReason === 'length' ? 'max_tokens' : 'end_turn',
+          };
+          break;
+        case 'error':
+          yield { type: 'error', error: String(part.error) };
+          break;
+        // Intentionally ignore: reasoning, step-start, step-finish,
+        // tool-call-streaming-start, tool-call-delta, tool-result, source, file
+      }
+    }
+  }
+}

--- a/packages/host/src/sdk-client.ts
+++ b/packages/host/src/sdk-client.ts
@@ -1,0 +1,105 @@
+// packages/host/src/sdk-client.ts
+import net from 'node:net';
+import { ulid } from 'ulid';
+import type { SocketRequest, StreamEvent, Session, SessionConfig, ToolDefinition } from './types.ts';
+
+export class HostClient {
+  private socket: net.Socket | null = null;
+  private pending = new Map<string, {
+    resolve: (value: unknown) => void;
+    reject: (err: Error) => void;
+    onStream?: (event: StreamEvent) => void;
+  }>();
+
+  private socketPath: string;
+
+  constructor(socketPath: string) {
+    this.socketPath = socketPath;
+  }
+
+  connect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.socket = net.createConnection(this.socketPath);
+      let buffer = '';
+
+      this.socket.on('connect', resolve);
+      this.socket.once('error', reject);
+
+      this.socket.on('data', (data) => {
+        buffer += data.toString();
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const msg = JSON.parse(line);
+            const handler = this.pending.get(msg.id);
+            if (!handler) continue;
+
+            if ('stream' in msg) {
+              handler.onStream?.(msg.stream as StreamEvent);
+            } else if ('error' in msg) {
+              this.pending.delete(msg.id);
+              handler.reject(new Error(msg.error.message));
+            } else {
+              this.pending.delete(msg.id);
+              handler.resolve(msg.result);
+            }
+          } catch {}
+        }
+      });
+    });
+  }
+
+  disconnect(): void {
+    this.socket?.destroy();
+    this.socket = null;
+  }
+
+  async createSession(config: SessionConfig = {}): Promise<Session> {
+    return this.call('chat.create', config as Record<string, unknown>) as Promise<Session>;
+  }
+
+  async sendMessage(
+    sessionId: string,
+    text: string,
+    onStream: (event: StreamEvent) => void,
+  ): Promise<void> {
+    await this.callWithStream('chat.send', { sessionId, text }, onStream);
+  }
+
+  async stop(sessionId: string): Promise<void> {
+    await this.call('chat.stop', { sessionId });
+  }
+
+  async listSessions(): Promise<Session[]> {
+    return this.call('chat.list', {}) as Promise<Session[]>;
+  }
+
+  async listTools(): Promise<ToolDefinition[]> {
+    return this.call('tools.list', {}) as Promise<ToolDefinition[]>;
+  }
+
+  private call(method: string, params: Record<string, unknown>): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const id = ulid();
+      this.pending.set(id, { resolve, reject });
+      const req: SocketRequest = { id, method, params };
+      this.socket!.write(JSON.stringify(req) + '\n');
+    });
+  }
+
+  private callWithStream(
+    method: string,
+    params: Record<string, unknown>,
+    onStream: (event: StreamEvent) => void,
+  ): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const id = ulid();
+      this.pending.set(id, { resolve, reject, onStream });
+      const req: SocketRequest = { id, method, params };
+      this.socket!.write(JSON.stringify(req) + '\n');
+    });
+  }
+}

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -1,0 +1,88 @@
+// packages/host/src/server.ts
+import net from 'node:net';
+import fs from 'node:fs';
+import type { SocketRequest, SocketResponse, StreamEvent } from './types.ts';
+
+type RequestHandler = (
+  method: string,
+  params: Record<string, unknown>,
+  streamCallback: (event: StreamEvent) => void,
+) => Promise<unknown>;
+
+export class HostServer {
+  private handler: RequestHandler;
+  private server: net.Server;
+  private connections = new Set<net.Socket>();
+
+  constructor(handler: RequestHandler) {
+    this.handler = handler;
+    this.server = net.createServer(socket => this.handleConnection(socket));
+  }
+
+  listen(socketPath: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      try { fs.unlinkSync(socketPath); } catch {}
+      this.server.listen(socketPath, () => resolve());
+      this.server.once('error', reject);
+    });
+  }
+
+  close(): Promise<void> {
+    for (const conn of this.connections) {
+      conn.destroy();
+    }
+    return new Promise(resolve => this.server.close(() => resolve()));
+  }
+
+  private handleConnection(socket: net.Socket): void {
+    this.connections.add(socket);
+    let buffer = '';
+
+    socket.on('data', (data) => {
+      buffer += data.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        this.handleLine(socket, line.trim());
+      }
+    });
+
+    socket.on('close', () => {
+      this.connections.delete(socket);
+    });
+
+    socket.on('error', () => {
+      this.connections.delete(socket);
+    });
+  }
+
+  private async handleLine(socket: net.Socket, line: string): Promise<void> {
+    let req: SocketRequest;
+    try {
+      req = JSON.parse(line);
+    } catch {
+      return;
+    }
+
+    const streamCallback = (event: StreamEvent) => {
+      if (!socket.destroyed) {
+        const streamMsg = JSON.stringify({ id: req.id, stream: event });
+        socket.write(streamMsg + '\n');
+      }
+    };
+
+    try {
+      const result = await this.handler(req.method, req.params, streamCallback);
+      const response: SocketResponse = { id: req.id, result };
+      socket.write(JSON.stringify(response) + '\n');
+    } catch (err: any) {
+      const response: SocketResponse = {
+        id: req.id,
+        error: { message: err.message, code: err.code },
+      };
+      socket.write(JSON.stringify(response) + '\n');
+    }
+  }
+}

--- a/packages/host/src/session-store.ts
+++ b/packages/host/src/session-store.ts
@@ -1,0 +1,138 @@
+// packages/host/src/session-store.ts
+import Database from 'better-sqlite3';
+import { ulid } from 'ulid';
+import type { Session, SessionConfig, StoredMessage } from './types.ts';
+
+export class SessionStore {
+  private db: Database.Database;
+
+  constructor(dbPath: string) {
+    this.db = new Database(dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('foreign_keys = ON');
+    this.migrate();
+  }
+
+  private migrate(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS sessions (
+        id TEXT PRIMARY KEY,
+        provider TEXT NOT NULL DEFAULT 'anthropic',
+        model TEXT NOT NULL DEFAULT 'claude-sonnet-4-20250514',
+        system TEXT,
+        tool_profile TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS messages (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL REFERENCES sessions(id),
+        role TEXT NOT NULL CHECK(role IN ('user', 'assistant')),
+        content TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        token_count INTEGER
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_messages_session
+        ON messages(session_id, created_at);
+    `);
+  }
+
+  createSession(config: SessionConfig): Session {
+    const now = new Date().toISOString();
+    const session: Session = {
+      id: ulid(),
+      provider: config.provider ?? 'anthropic',
+      model: config.model ?? 'claude-sonnet-4-20250514',
+      system: config.system,
+      toolProfile: config.toolProfile,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    this.db.prepare(`
+      INSERT INTO sessions (id, provider, model, system, tool_profile, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(session.id, session.provider, session.model, session.system ?? null,
+           session.toolProfile ?? null, session.createdAt, session.updatedAt);
+
+    return session;
+  }
+
+  getSession(id: string): Session | undefined {
+    const row = this.db.prepare('SELECT * FROM sessions WHERE id = ?').get(id) as any;
+    if (!row) return undefined;
+    return {
+      id: row.id,
+      provider: row.provider,
+      model: row.model,
+      system: row.system ?? undefined,
+      toolProfile: row.tool_profile ?? undefined,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  listSessions(): Session[] {
+    const rows = this.db.prepare('SELECT * FROM sessions ORDER BY updated_at DESC').all() as any[];
+    return rows.map(row => ({
+      id: row.id,
+      provider: row.provider,
+      model: row.model,
+      system: row.system ?? undefined,
+      toolProfile: row.tool_profile ?? undefined,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
+  }
+
+  appendMessage(
+    sessionId: string,
+    role: 'user' | 'assistant',
+    content: unknown[],
+    tokenCount?: number
+  ): StoredMessage {
+    const now = new Date().toISOString();
+    const msg: StoredMessage = {
+      id: ulid(),
+      sessionId,
+      role,
+      content: JSON.stringify(content),
+      createdAt: now,
+      tokenCount,
+    };
+
+    const txn = this.db.transaction(() => {
+      this.db.prepare(`
+        INSERT INTO messages (id, session_id, role, content, created_at, token_count)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `).run(msg.id, msg.sessionId, msg.role, msg.content, msg.createdAt,
+             msg.tokenCount ?? null);
+
+      this.db.prepare('UPDATE sessions SET updated_at = ? WHERE id = ?')
+        .run(now, sessionId);
+    });
+    txn();
+
+    return msg;
+  }
+
+  getMessages(sessionId: string): StoredMessage[] {
+    const rows = this.db.prepare(
+      'SELECT * FROM messages WHERE session_id = ? ORDER BY created_at'
+    ).all(sessionId) as any[];
+    return rows.map(row => ({
+      id: row.id,
+      sessionId: row.session_id,
+      role: row.role,
+      content: row.content,
+      createdAt: row.created_at,
+      tokenCount: row.token_count ?? undefined,
+    }));
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}

--- a/packages/host/src/sigil-bridge.ts
+++ b/packages/host/src/sigil-bridge.ts
@@ -1,0 +1,89 @@
+// packages/host/src/sigil-bridge.ts
+import { HostClient } from './sdk-client.ts';
+import type { StreamEvent } from './types.ts';
+import path from 'node:path';
+
+const mode = process.env.AOS_MODE ?? 'repo';
+const stateDir = path.join(process.env.HOME ?? '/tmp', '.config', 'aos', mode);
+const socketPath = path.join(stateDir, 'host.sock');
+
+const client = new HostClient(socketPath);
+let sessionId: string | null = null;
+
+function sendToCanvas(msg: { type: string; content?: unknown[]; text?: string }): void {
+  process.stdout.write(JSON.stringify(msg) + '\n');
+}
+
+function streamEventToCanvasContent(event: StreamEvent): void {
+  switch (event.type) {
+    case 'text-delta':
+      sendToCanvas({ type: 'assistant', content: [{ type: 'text', text: event.text }] });
+      break;
+    case 'tool-call':
+      sendToCanvas({
+        type: 'status',
+        text: `Using ${event.toolName}...`,
+      });
+      break;
+    case 'tool-result':
+      if (event.result.isError) {
+        sendToCanvas({
+          type: 'status',
+          text: `Tool error: ${typeof event.result.content === 'string' ? event.result.content : JSON.stringify(event.result.content)}`,
+        });
+      }
+      break;
+    case 'finish':
+      sendToCanvas({ type: 'status', text: '' });
+      break;
+    case 'error':
+      sendToCanvas({ type: 'status', text: `Error: ${event.error}` });
+      break;
+  }
+}
+
+async function handleMessage(text: string): Promise<void> {
+  if (!sessionId) {
+    const session = await client.createSession({
+      system: 'You are a helpful assistant with access to file system tools. Be concise.',
+    });
+    sessionId = session.id;
+  }
+
+  sendToCanvas({ type: 'user', content: [{ type: 'text', text }] });
+
+  await client.sendMessage(sessionId, text, (event) => {
+    streamEventToCanvasContent(event);
+  });
+}
+
+async function main() {
+  await client.connect();
+
+  let buffer = '';
+  process.stdin.setEncoding('utf-8');
+  process.stdin.on('data', (chunk) => {
+    buffer += chunk;
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const msg = JSON.parse(line);
+        if (msg.type === 'user_message') {
+          handleMessage(msg.payload.text).catch(err => {
+            sendToCanvas({ type: 'status', text: `Error: ${err.message}` });
+          });
+        } else if (msg.type === 'stop') {
+          if (sessionId) client.stop(sessionId);
+        }
+      } catch {}
+    }
+  });
+}
+
+main().catch(err => {
+  console.error('Bridge error:', err);
+  process.exit(1);
+});

--- a/packages/host/src/tool-registry.ts
+++ b/packages/host/src/tool-registry.ts
@@ -1,0 +1,60 @@
+// packages/host/src/tool-registry.ts
+import type {
+  ToolDefinition, ToolExecutor, RegisteredTool, PermissionOverride,
+} from './types.ts';
+
+export class ToolRegistry {
+  private tools = new Map<string, RegisteredTool>();
+  private overrides: PermissionOverride[] = [];
+
+  register(definition: ToolDefinition, executor: ToolExecutor): void {
+    if (this.tools.has(definition.name)) {
+      throw new Error(`Tool '${definition.name}' already registered`);
+    }
+    this.tools.set(definition.name, { definition, executor });
+  }
+
+  get(name: string): RegisteredTool | undefined {
+    return this.tools.get(name);
+  }
+
+  list(): RegisteredTool[] {
+    return Array.from(this.tools.values());
+  }
+
+  getDefinitions(): ToolDefinition[] {
+    return this.list().map(t => t.definition);
+  }
+
+  checkPermission(toolName: string): 'allow' | 'deny' | 'ask' {
+    // Check overrides first (last match wins)
+    for (let i = this.overrides.length - 1; i >= 0; i--) {
+      const override = this.overrides[i];
+      if (this.matchGlob(override.tool, toolName)) {
+        return override.decision;
+      }
+    }
+
+    // Fall back to tool's default permission
+    const tool = this.tools.get(toolName);
+    if (!tool) return 'deny';
+    return tool.definition.permissions?.default ?? 'allow';
+  }
+
+  addOverride(override: PermissionOverride): void {
+    this.overrides.push(override);
+  }
+
+  clearSessionOverrides(): void {
+    this.overrides = this.overrides.filter(o => o.scope !== 'session');
+  }
+
+  private matchGlob(pattern: string, name: string): boolean {
+    if (pattern === name) return true;
+    if (!pattern.includes('*')) return false;
+    const regex = new RegExp(
+      '^' + pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$'
+    );
+    return regex.test(name);
+  }
+}

--- a/packages/host/src/tools/list-files.ts
+++ b/packages/host/src/tools/list-files.ts
@@ -1,0 +1,33 @@
+// packages/host/src/tools/list-files.ts
+import fs from 'node:fs/promises';
+import type { ToolDefinition, ToolExecutor, RegisteredTool } from '../types.ts';
+
+const definition: ToolDefinition = {
+  name: 'list_files',
+  description: 'List files and directories at the given path.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      path: { type: 'string', description: 'Absolute path to the directory to list' },
+    },
+    required: ['path'],
+  },
+  permissions: { default: 'allow' },
+  metadata: { type: 'simple', source: 'builtin' },
+};
+
+const executor: ToolExecutor = async (input, _context) => {
+  const { path: dirPath } = input as { path: string };
+  try {
+    const entries = await fs.readdir(dirPath, { withFileTypes: true });
+    const result = entries.map(entry => ({
+      name: entry.name,
+      type: entry.isDirectory() ? 'directory' : 'file',
+    }));
+    return { content: result };
+  } catch (err: any) {
+    return { content: err.message, isError: true };
+  }
+};
+
+export const listFilesTool: RegisteredTool = { definition, executor };

--- a/packages/host/src/tools/list-files.ts
+++ b/packages/host/src/tools/list-files.ts
@@ -24,7 +24,7 @@ const executor: ToolExecutor = async (input, _context) => {
       name: entry.name,
       type: entry.isDirectory() ? 'directory' : 'file',
     }));
-    return { content: result };
+    return { content: { items: result } };
   } catch (err: any) {
     return { content: err.message, isError: true };
   }

--- a/packages/host/src/tools/read-file.ts
+++ b/packages/host/src/tools/read-file.ts
@@ -1,0 +1,29 @@
+// packages/host/src/tools/read-file.ts
+import fs from 'node:fs/promises';
+import type { ToolDefinition, ToolExecutor, RegisteredTool } from '../types.ts';
+
+const definition: ToolDefinition = {
+  name: 'read_file',
+  description: 'Read the contents of a file at the given path.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      path: { type: 'string', description: 'Absolute path to the file to read' },
+    },
+    required: ['path'],
+  },
+  permissions: { default: 'allow' },
+  metadata: { type: 'simple', source: 'builtin' },
+};
+
+const executor: ToolExecutor = async (input, _context) => {
+  const { path: filePath } = input as { path: string };
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    return { content };
+  } catch (err: any) {
+    return { content: err.message, isError: true };
+  }
+};
+
+export const readFileTool: RegisteredTool = { definition, executor };

--- a/packages/host/src/tools/shell-exec.ts
+++ b/packages/host/src/tools/shell-exec.ts
@@ -1,0 +1,44 @@
+// packages/host/src/tools/shell-exec.ts
+import { execFile } from 'node:child_process';
+import type { ToolDefinition, ToolExecutor, RegisteredTool } from '../types.ts';
+
+const definition: ToolDefinition = {
+  name: 'shell_exec',
+  description: 'Execute a shell command. Use with caution.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      command: { type: 'string', description: 'The shell command to execute' },
+    },
+    required: ['command'],
+  },
+  permissions: { default: 'deny', dangerous: true },
+  timeout: 30_000,
+  metadata: { type: 'simple', source: 'builtin' },
+};
+
+const executor: ToolExecutor = async (input, context) => {
+  const { command } = input as { command: string };
+
+  return new Promise((resolve) => {
+    const child = execFile('/bin/sh', ['-c', command], {
+      timeout: 30_000,
+      maxBuffer: 1024 * 1024,
+      signal: context.signal,
+    }, (error, stdout, stderr) => {
+      if (error && error.name === 'AbortError') {
+        resolve({ content: 'Command aborted', isError: true });
+        return;
+      }
+
+      const exitCode = error ? ((error as any).code ?? 1) : 0;
+
+      resolve({
+        content: { stdout, stderr, exitCode },
+        isError: exitCode !== 0,
+      });
+    });
+  });
+};
+
+export const shellExecTool: RegisteredTool = { definition, executor };

--- a/packages/host/src/types.ts
+++ b/packages/host/src/types.ts
@@ -1,0 +1,138 @@
+// packages/host/src/types.ts
+
+// --- JSON primitives ---
+
+export type JSONValue = string | number | boolean | null | JSONValue[] | { [key: string]: JSONValue };
+export type JSONSchema = Record<string, unknown>;
+
+// --- Tool interfaces (BORROW PATTERN: MCP tool shape, extended) ---
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: JSONSchema;
+  permissions?: PermissionSpec;
+  timeout?: number; // ms, default 30_000
+  metadata?: {
+    type: 'simple' | 'provider-backed' | 'agent-backed';
+    source?: string;
+  };
+}
+
+export interface ToolContext {
+  sessionId: string;
+  signal: AbortSignal;
+  emit: (event: StreamEvent) => void;
+}
+
+export type ToolExecutor = (input: JSONValue, context: ToolContext) => Promise<ToolResult>;
+
+export interface ToolResult {
+  content: string | Record<string, unknown>;
+  isError?: boolean;
+}
+
+export interface RegisteredTool {
+  definition: ToolDefinition;
+  executor: ToolExecutor;
+}
+
+// --- Permission model (BUILD, borrow pattern from Claude Code) ---
+
+export interface PermissionSpec {
+  default: 'allow' | 'deny' | 'ask';
+  dangerous?: boolean;
+}
+
+export interface PermissionOverride {
+  tool: string; // glob pattern
+  decision: 'allow' | 'deny';
+  scope: 'session' | 'persistent';
+}
+
+// --- Stream events (ADAPT: Vercel AI SDK stream types, extended) ---
+
+export type StreamEvent =
+  | { type: 'text-delta'; text: string }
+  | { type: 'tool-call'; toolCallId: string; toolName: string; args: JSONValue }
+  | { type: 'tool-result'; toolCallId: string; result: ToolResult }
+  | { type: 'tool-progress'; toolCallId: string; message: string }
+  | { type: 'finish'; reason: 'end_turn' | 'stop' | 'max_tokens' | 'max_iterations' }
+  | { type: 'error'; error: string; code?: string }
+  | { type: 'status'; message: string };
+
+// --- Session & messages (BUILD on better-sqlite3) ---
+
+export interface Session {
+  id: string;
+  provider: string;
+  model: string;
+  system?: string;
+  toolProfile?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SessionConfig {
+  provider?: string;  // default: 'anthropic'
+  model?: string;     // default: 'claude-sonnet-4-20250514'
+  system?: string;
+  toolProfile?: string;
+}
+
+export interface StoredMessage {
+  id: string;
+  sessionId: string;
+  role: 'user' | 'assistant';
+  content: string; // JSON-serialized content blocks
+  createdAt: string;
+  tokenCount?: number;
+}
+
+// --- Provider adapter (ADAPT: wraps Vercel AI SDK) ---
+
+export interface ProviderConfig {
+  model: string;
+  temperature?: number;
+  maxTokens?: number;
+}
+
+export interface ProviderMessage {
+  role: 'user' | 'assistant';
+  content: ProviderContentBlock[];
+}
+
+export type ProviderContentBlock =
+  | { type: 'text'; text: string }
+  | { type: 'tool_use'; id: string; name: string; input: JSONValue }
+  | { type: 'tool_result'; tool_use_id: string; content: string };
+
+export interface ProviderAdapter {
+  id: string;
+  stream(params: {
+    messages: ProviderMessage[];
+    tools: ToolDefinition[];
+    system?: string;
+    config: ProviderConfig;
+  }): AsyncIterable<StreamEvent>;
+}
+
+// --- Agent loop config ---
+
+export interface AgentLoopConfig {
+  maxIterations: number; // default: 25
+}
+
+// --- Socket protocol (BORROW PATTERN: gateway line-delimited JSON) ---
+
+export interface SocketRequest {
+  id: string;
+  method: string;
+  params: Record<string, unknown>;
+}
+
+export interface SocketResponse {
+  id: string;
+  result?: unknown;
+  error?: { message: string; code?: string };
+}

--- a/packages/host/test/agent-loop.test.ts
+++ b/packages/host/test/agent-loop.test.ts
@@ -1,0 +1,204 @@
+// packages/host/test/agent-loop.test.ts
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { AgentLoop } from '../src/agent-loop.ts';
+import { SessionStore } from '../src/session-store.ts';
+import { ToolRegistry } from '../src/tool-registry.ts';
+import type { ProviderAdapter, StreamEvent, ToolExecutor } from '../src/types.ts';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+// Mock provider that returns predetermined responses
+function createMockAdapter(responses: StreamEvent[][]): ProviderAdapter {
+  let callIndex = 0;
+  return {
+    id: 'mock',
+    async *stream() {
+      const events = responses[callIndex++] ?? [{ type: 'finish', reason: 'end_turn' }];
+      for (const event of events) {
+        yield event;
+      }
+    },
+  };
+}
+
+describe('AgentLoop', () => {
+  let store: SessionStore;
+  let registry: ToolRegistry;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = path.join(os.tmpdir(), `host-loop-test-${Date.now()}.db`);
+    store = new SessionStore(dbPath);
+    registry = new ToolRegistry();
+  });
+
+  afterEach(() => {
+    store.close();
+    try { fs.unlinkSync(dbPath); } catch {}
+    try { fs.unlinkSync(dbPath + '-wal'); } catch {}
+    try { fs.unlinkSync(dbPath + '-shm'); } catch {}
+  });
+
+  it('streams a text-only response', async () => {
+    const adapter = createMockAdapter([
+      [
+        { type: 'text-delta', text: 'Hello' },
+        { type: 'text-delta', text: ' world' },
+        { type: 'finish', reason: 'end_turn' },
+      ],
+    ]);
+
+    const loop = new AgentLoop(store, registry, adapter, { maxIterations: 25 });
+    const session = store.createSession({});
+    const events: StreamEvent[] = [];
+
+    for await (const event of loop.send(session.id, 'hi')) {
+      events.push(event);
+    }
+
+    assert.equal(events.filter(e => e.type === 'text-delta').length, 2);
+    assert.equal(events.filter(e => e.type === 'finish').length, 1);
+
+    // Message persisted
+    const messages = store.getMessages(session.id);
+    assert.equal(messages.length, 2); // user + assistant
+    assert.equal(messages[0].role, 'user');
+    assert.equal(messages[1].role, 'assistant');
+  });
+
+  it('executes tool calls and loops', async () => {
+    const echoExec: ToolExecutor = async (input) => {
+      return { content: `echoed: ${(input as any).text}` };
+    };
+    registry.register({
+      name: 'echo',
+      description: 'Echo',
+      inputSchema: { type: 'object', properties: { text: { type: 'string' } } },
+      permissions: { default: 'allow' },
+    }, echoExec);
+
+    // Turn 1: model calls echo tool
+    // Turn 2: model responds with text after seeing tool result
+    const adapter = createMockAdapter([
+      [
+        { type: 'tool-call', toolCallId: 'tc1', toolName: 'echo', args: { text: 'test' } },
+        { type: 'finish', reason: 'end_turn' },
+      ],
+      [
+        { type: 'text-delta', text: 'Got it' },
+        { type: 'finish', reason: 'end_turn' },
+      ],
+    ]);
+
+    const loop = new AgentLoop(store, registry, adapter, { maxIterations: 25 });
+    const session = store.createSession({});
+    const events: StreamEvent[] = [];
+
+    for await (const event of loop.send(session.id, 'echo test')) {
+      events.push(event);
+    }
+
+    const toolCalls = events.filter(e => e.type === 'tool-call');
+    assert.equal(toolCalls.length, 1);
+
+    const toolResults = events.filter(e => e.type === 'tool-result');
+    assert.equal(toolResults.length, 1);
+    const tr = toolResults[0] as Extract<StreamEvent, { type: 'tool-result' }>;
+    assert.equal(tr.result.content, 'echoed: test');
+
+    const textDeltas = events.filter(e => e.type === 'text-delta');
+    assert.ok(textDeltas.length > 0);
+  });
+
+  it('denies tool calls without permission', async () => {
+    registry.register({
+      name: 'danger',
+      description: 'Dangerous',
+      inputSchema: { type: 'object', properties: {} },
+      permissions: { default: 'deny' },
+    }, async () => ({ content: 'should not run' }));
+
+    const adapter = createMockAdapter([
+      [
+        { type: 'tool-call', toolCallId: 'tc1', toolName: 'danger', args: {} },
+        { type: 'finish', reason: 'end_turn' },
+      ],
+      [
+        { type: 'text-delta', text: 'ok denied' },
+        { type: 'finish', reason: 'end_turn' },
+      ],
+    ]);
+
+    const loop = new AgentLoop(store, registry, adapter, { maxIterations: 25 });
+    const session = store.createSession({});
+    const events: StreamEvent[] = [];
+
+    for await (const event of loop.send(session.id, 'do danger')) {
+      events.push(event);
+    }
+
+    const toolResults = events.filter(e => e.type === 'tool-result');
+    assert.equal(toolResults.length, 1);
+    const tr = toolResults[0] as Extract<StreamEvent, { type: 'tool-result' }>;
+    assert.equal(tr.result.isError, true);
+    assert.ok((tr.result.content as string).includes('denied'));
+  });
+
+  it('enforces max iteration limit', async () => {
+    registry.register({
+      name: 'echo',
+      description: 'Echo',
+      inputSchema: { type: 'object', properties: { text: { type: 'string' } } },
+      permissions: { default: 'allow' },
+    }, async (input) => ({ content: 'echoed' }));
+
+    // Adapter always returns a tool call — should be stopped by max iterations
+    const adapter = createMockAdapter(
+      Array(10).fill([
+        { type: 'tool-call', toolCallId: 'tc', toolName: 'echo', args: { text: 'x' } },
+        { type: 'finish', reason: 'end_turn' },
+      ])
+    );
+
+    const loop = new AgentLoop(store, registry, adapter, { maxIterations: 3 });
+    const session = store.createSession({});
+    const events: StreamEvent[] = [];
+
+    for await (const event of loop.send(session.id, 'loop forever')) {
+      events.push(event);
+    }
+
+    const finishEvents = events.filter(e => e.type === 'finish');
+    const lastFinish = finishEvents[finishEvents.length - 1] as Extract<StreamEvent, { type: 'finish' }>;
+    assert.equal(lastFinish.reason, 'max_iterations');
+  });
+
+  it('handles stop via AbortSignal', async () => {
+    const controller = new AbortController();
+
+    const adapter: ProviderAdapter = {
+      id: 'mock',
+      async *stream() {
+        yield { type: 'text-delta' as const, text: 'start' };
+        await new Promise(r => setTimeout(r, 100));
+        yield { type: 'text-delta' as const, text: ' more' };
+        yield { type: 'finish' as const, reason: 'end_turn' as const };
+      },
+    };
+
+    const loop = new AgentLoop(store, registry, adapter, { maxIterations: 25 });
+    const session = store.createSession({});
+    const events: StreamEvent[] = [];
+
+    setTimeout(() => controller.abort(), 50);
+
+    for await (const event of loop.send(session.id, 'hello', controller.signal)) {
+      events.push(event);
+    }
+
+    const finishEvents = events.filter(e => e.type === 'finish');
+    assert.ok(finishEvents.length > 0);
+  });
+});

--- a/packages/host/test/provider/anthropic.test.ts
+++ b/packages/host/test/provider/anthropic.test.ts
@@ -1,0 +1,74 @@
+// packages/host/test/provider/anthropic.test.ts
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { AnthropicAdapter } from '../../src/provider/anthropic.ts';
+import type { StreamEvent } from '../../src/types.ts';
+
+describe('AnthropicAdapter', () => {
+  let adapter: AnthropicAdapter;
+
+  before(() => {
+    if (!process.env.ANTHROPIC_API_KEY) {
+      console.log('Skipping Anthropic tests — no API key');
+      return;
+    }
+    adapter = new AnthropicAdapter();
+  });
+
+  it('has correct id', () => {
+    const a = new AnthropicAdapter();
+    assert.equal(a.id, 'anthropic');
+  });
+
+  it('streams a simple text response', async () => {
+    if (!process.env.ANTHROPIC_API_KEY) return;
+
+    const events: StreamEvent[] = [];
+    const stream = adapter.stream({
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'Say "hello" and nothing else.' }] }],
+      tools: [],
+      system: 'You are a test assistant. Be extremely brief.',
+      config: { model: 'claude-sonnet-4-20250514', maxTokens: 50 },
+    });
+
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    const textEvents = events.filter(e => e.type === 'text-delta');
+    assert.ok(textEvents.length > 0, 'Should have text deltas');
+
+    const finishEvents = events.filter(e => e.type === 'finish');
+    assert.equal(finishEvents.length, 1, 'Should have exactly one finish event');
+  });
+
+  it('streams a tool call when tools are provided', async () => {
+    if (!process.env.ANTHROPIC_API_KEY) return;
+
+    const events: StreamEvent[] = [];
+    const stream = adapter.stream({
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'Read the file at /tmp/test.txt' }] }],
+      tools: [{
+        name: 'read_file',
+        description: 'Read a file',
+        inputSchema: {
+          type: 'object',
+          properties: { path: { type: 'string' } },
+          required: ['path'],
+        },
+      }],
+      system: 'Use tools when appropriate.',
+      config: { model: 'claude-sonnet-4-20250514', maxTokens: 200 },
+    });
+
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    const toolCalls = events.filter(e => e.type === 'tool-call');
+    assert.ok(toolCalls.length > 0, 'Should have at least one tool call');
+    const tc = toolCalls[0] as Extract<StreamEvent, { type: 'tool-call' }>;
+    assert.equal(tc.toolName, 'read_file');
+    assert.ok(tc.toolCallId);
+  });
+});

--- a/packages/host/test/session-store.test.ts
+++ b/packages/host/test/session-store.test.ts
@@ -1,0 +1,99 @@
+// packages/host/test/session-store.test.ts
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { SessionStore } from '../src/session-store.ts';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+describe('SessionStore', () => {
+  let store: SessionStore;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = path.join(os.tmpdir(), `host-test-${Date.now()}.db`);
+    store = new SessionStore(dbPath);
+  });
+
+  afterEach(() => {
+    store.close();
+    try { fs.unlinkSync(dbPath); } catch {}
+    try { fs.unlinkSync(dbPath + '-wal'); } catch {}
+    try { fs.unlinkSync(dbPath + '-shm'); } catch {}
+  });
+
+  describe('sessions', () => {
+    it('creates a session with defaults', () => {
+      const session = store.createSession({});
+      assert.ok(session.id);
+      assert.equal(session.provider, 'anthropic');
+      assert.equal(session.model, 'claude-sonnet-4-20250514');
+      assert.ok(session.createdAt);
+      assert.ok(session.updatedAt);
+    });
+
+    it('creates a session with custom config', () => {
+      const session = store.createSession({
+        provider: 'anthropic',
+        model: 'claude-opus-4-20250514',
+        system: 'You are a helpful assistant.',
+        toolProfile: 'devtools',
+      });
+      assert.equal(session.model, 'claude-opus-4-20250514');
+      assert.equal(session.system, 'You are a helpful assistant.');
+      assert.equal(session.toolProfile, 'devtools');
+    });
+
+    it('gets a session by id', () => {
+      const created = store.createSession({});
+      const fetched = store.getSession(created.id);
+      assert.deepEqual(fetched, created);
+    });
+
+    it('returns undefined for unknown session', () => {
+      const fetched = store.getSession('nonexistent');
+      assert.equal(fetched, undefined);
+    });
+
+    it('lists sessions', () => {
+      store.createSession({});
+      store.createSession({});
+      const sessions = store.listSessions();
+      assert.equal(sessions.length, 2);
+    });
+  });
+
+  describe('messages', () => {
+    it('appends and retrieves messages', () => {
+      const session = store.createSession({});
+      store.appendMessage(session.id, 'user', [{ type: 'text', text: 'hello' }]);
+      store.appendMessage(session.id, 'assistant', [{ type: 'text', text: 'hi there' }]);
+
+      const messages = store.getMessages(session.id);
+      assert.equal(messages.length, 2);
+      assert.equal(messages[0].role, 'user');
+      assert.equal(messages[1].role, 'assistant');
+    });
+
+    it('stores token count when provided', () => {
+      const session = store.createSession({});
+      store.appendMessage(session.id, 'user', [{ type: 'text', text: 'hello' }], 10);
+      const messages = store.getMessages(session.id);
+      assert.equal(messages[0].tokenCount, 10);
+    });
+
+    it('returns empty array for session with no messages', () => {
+      const session = store.createSession({});
+      const messages = store.getMessages(session.id);
+      assert.deepEqual(messages, []);
+    });
+
+    it('updates session updatedAt on message append', () => {
+      const session = store.createSession({});
+      const originalUpdatedAt = session.updatedAt;
+      store.appendMessage(session.id, 'user', [{ type: 'text', text: 'hello' }]);
+      const updated = store.getSession(session.id)!;
+      assert.ok(updated.updatedAt >= originalUpdatedAt);
+    });
+  });
+});

--- a/packages/host/test/tool-registry.test.ts
+++ b/packages/host/test/tool-registry.test.ts
@@ -1,0 +1,91 @@
+// packages/host/test/tool-registry.test.ts
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { ToolRegistry } from '../src/tool-registry.ts';
+import type { ToolDefinition, ToolExecutor } from '../src/types.ts';
+
+const echoTool: ToolDefinition = {
+  name: 'echo',
+  description: 'Echoes input back',
+  inputSchema: { type: 'object', properties: { text: { type: 'string' } } },
+  permissions: { default: 'allow' },
+};
+
+const dangerousTool: ToolDefinition = {
+  name: 'danger',
+  description: 'A dangerous tool',
+  inputSchema: { type: 'object', properties: {} },
+  permissions: { default: 'deny', dangerous: true },
+};
+
+const echoExecutor: ToolExecutor = async (input) => {
+  const { text } = input as { text: string };
+  return { content: text };
+};
+
+describe('ToolRegistry', () => {
+  let registry: ToolRegistry;
+
+  beforeEach(() => {
+    registry = new ToolRegistry();
+  });
+
+  it('registers and retrieves a tool', () => {
+    registry.register(echoTool, echoExecutor);
+    const tool = registry.get('echo');
+    assert.ok(tool);
+    assert.equal(tool.definition.name, 'echo');
+  });
+
+  it('lists all registered tools', () => {
+    registry.register(echoTool, echoExecutor);
+    registry.register(dangerousTool, echoExecutor);
+    const tools = registry.list();
+    assert.equal(tools.length, 2);
+  });
+
+  it('returns definitions for provider (tool list for API call)', () => {
+    registry.register(echoTool, echoExecutor);
+    registry.register(dangerousTool, echoExecutor);
+    const defs = registry.getDefinitions();
+    assert.equal(defs.length, 2);
+    assert.ok(defs.every(d => 'name' in d && 'inputSchema' in d));
+  });
+
+  it('rejects duplicate registration', () => {
+    registry.register(echoTool, echoExecutor);
+    assert.throws(() => registry.register(echoTool, echoExecutor), /already registered/);
+  });
+
+  it('checks permission — allow', () => {
+    registry.register(echoTool, echoExecutor);
+    const decision = registry.checkPermission('echo');
+    assert.equal(decision, 'allow');
+  });
+
+  it('checks permission — deny', () => {
+    registry.register(dangerousTool, echoExecutor);
+    const decision = registry.checkPermission('danger');
+    assert.equal(decision, 'deny');
+  });
+
+  it('checks permission — unknown tool returns deny', () => {
+    const decision = registry.checkPermission('nonexistent');
+    assert.equal(decision, 'deny');
+  });
+
+  it('applies overrides', () => {
+    registry.register(dangerousTool, echoExecutor);
+    registry.addOverride({ tool: 'danger', decision: 'allow', scope: 'session' });
+    const decision = registry.checkPermission('danger');
+    assert.equal(decision, 'allow');
+  });
+
+  it('override with glob pattern', () => {
+    registry.register({ ...dangerousTool, name: 'fs.read' }, echoExecutor);
+    registry.register({ ...dangerousTool, name: 'fs.write' }, echoExecutor);
+    registry.addOverride({ tool: 'fs.*', decision: 'allow', scope: 'session' });
+    assert.equal(registry.checkPermission('fs.read'), 'allow');
+    assert.equal(registry.checkPermission('fs.write'), 'allow');
+  });
+});

--- a/packages/host/test/tools/list-files.test.ts
+++ b/packages/host/test/tools/list-files.test.ts
@@ -29,7 +29,7 @@ describe('list_files tool', () => {
 
   it('lists directory contents', async () => {
     const result = await listFilesTool.executor({ path: tmpDir }, ctx);
-    const entries = result.content as Array<{ name: string; type: string }>;
+    const { items: entries } = result.content as { items: Array<{ name: string; type: string }> };
     assert.equal(entries.length, 3);
     const names = entries.map(e => e.name).sort();
     assert.deepEqual(names, ['a.txt', 'b.ts', 'subdir']);
@@ -37,7 +37,7 @@ describe('list_files tool', () => {
 
   it('marks directories vs files', async () => {
     const result = await listFilesTool.executor({ path: tmpDir }, ctx);
-    const entries = result.content as Array<{ name: string; type: string }>;
+    const { items: entries } = result.content as { items: Array<{ name: string; type: string }> };
     const subdir = entries.find(e => e.name === 'subdir');
     assert.equal(subdir?.type, 'directory');
     const file = entries.find(e => e.name === 'a.txt');

--- a/packages/host/test/tools/list-files.test.ts
+++ b/packages/host/test/tools/list-files.test.ts
@@ -1,0 +1,51 @@
+// packages/host/test/tools/list-files.test.ts
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { listFilesTool } from '../../src/tools/list-files.ts';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+describe('list_files tool', () => {
+  const tmpDir = path.join(os.tmpdir(), `host-test-list-${Date.now()}`);
+  const ctx = {
+    sessionId: 'test',
+    signal: AbortSignal.timeout(5000),
+    emit: () => {},
+  };
+
+  beforeEach(() => {
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'a.txt'), '');
+    fs.writeFileSync(path.join(tmpDir, 'b.ts'), '');
+    fs.mkdirSync(path.join(tmpDir, 'subdir'));
+  });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('has correct definition', () => {
+    assert.equal(listFilesTool.definition.name, 'list_files');
+    assert.equal(listFilesTool.definition.permissions?.default, 'allow');
+  });
+
+  it('lists directory contents', async () => {
+    const result = await listFilesTool.executor({ path: tmpDir }, ctx);
+    const entries = result.content as Array<{ name: string; type: string }>;
+    assert.equal(entries.length, 3);
+    const names = entries.map(e => e.name).sort();
+    assert.deepEqual(names, ['a.txt', 'b.ts', 'subdir']);
+  });
+
+  it('marks directories vs files', async () => {
+    const result = await listFilesTool.executor({ path: tmpDir }, ctx);
+    const entries = result.content as Array<{ name: string; type: string }>;
+    const subdir = entries.find(e => e.name === 'subdir');
+    assert.equal(subdir?.type, 'directory');
+    const file = entries.find(e => e.name === 'a.txt');
+    assert.equal(file?.type, 'file');
+  });
+
+  it('returns error for missing directory', async () => {
+    const result = await listFilesTool.executor({ path: '/nonexistent/dir' }, ctx);
+    assert.equal(result.isError, true);
+  });
+});

--- a/packages/host/test/tools/read-file.test.ts
+++ b/packages/host/test/tools/read-file.test.ts
@@ -1,0 +1,37 @@
+// packages/host/test/tools/read-file.test.ts
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileTool } from '../../src/tools/read-file.ts';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+describe('read_file tool', () => {
+  const tmpDir = path.join(os.tmpdir(), `host-test-${Date.now()}`);
+  const ctx = {
+    sessionId: 'test',
+    signal: AbortSignal.timeout(5000),
+    emit: () => {},
+  };
+
+  beforeEach(() => { fs.mkdirSync(tmpDir, { recursive: true }); });
+  afterEach(() => { fs.rmSync(tmpDir, { recursive: true, force: true }); });
+
+  it('has correct definition', () => {
+    assert.equal(readFileTool.definition.name, 'read_file');
+    assert.equal(readFileTool.definition.permissions?.default, 'allow');
+  });
+
+  it('reads a file', async () => {
+    const filePath = path.join(tmpDir, 'test.txt');
+    fs.writeFileSync(filePath, 'hello world');
+    const result = await readFileTool.executor({ path: filePath }, ctx);
+    assert.equal(result.content, 'hello world');
+  });
+
+  it('returns error for missing file', async () => {
+    const result = await readFileTool.executor({ path: '/nonexistent/file.txt' }, ctx);
+    assert.equal(result.isError, true);
+    assert.ok((result.content as string).includes('ENOENT'));
+  });
+});

--- a/packages/host/test/tools/shell-exec.test.ts
+++ b/packages/host/test/tools/shell-exec.test.ts
@@ -1,0 +1,46 @@
+// packages/host/test/tools/shell-exec.test.ts
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { shellExecTool } from '../../src/tools/shell-exec.ts';
+
+describe('shell_exec tool', () => {
+  const ctx = {
+    sessionId: 'test',
+    signal: AbortSignal.timeout(5000),
+    emit: () => {},
+  };
+
+  it('has correct definition', () => {
+    assert.equal(shellExecTool.definition.name, 'shell_exec');
+    assert.equal(shellExecTool.definition.permissions?.default, 'deny');
+    assert.equal(shellExecTool.definition.permissions?.dangerous, true);
+  });
+
+  it('executes a command', async () => {
+    const result = await shellExecTool.executor({ command: 'echo hello' }, ctx);
+    const output = result.content as { stdout: string; stderr: string; exitCode: number };
+    assert.equal(output.stdout.trim(), 'hello');
+    assert.equal(output.exitCode, 0);
+  });
+
+  it('captures stderr', async () => {
+    const result = await shellExecTool.executor({ command: 'echo err >&2' }, ctx);
+    const output = result.content as { stdout: string; stderr: string; exitCode: number };
+    assert.equal(output.stderr.trim(), 'err');
+  });
+
+  it('captures non-zero exit code', async () => {
+    const result = await shellExecTool.executor({ command: 'exit 42' }, ctx);
+    const output = result.content as { stdout: string; stderr: string; exitCode: number };
+    assert.equal(output.exitCode, 42);
+    assert.equal(result.isError, true);
+  });
+
+  it('respects timeout from tool definition', async () => {
+    const result = await shellExecTool.executor(
+      { command: 'sleep 10' },
+      { ...ctx, signal: AbortSignal.timeout(500) }
+    );
+    assert.equal(result.isError, true);
+  });
+});

--- a/packages/host/tsconfig.json
+++ b/packages/host/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/host/tsconfig.json
+++ b/packages/host/tsconfig.json
@@ -3,10 +3,8 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "outDir": "dist",
-    "rootDir": "src",
-    "declaration": true,
-    "sourceMap": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true

--- a/src/act/act-channel.swift
+++ b/src/act/act-channel.swift
@@ -1,5 +1,5 @@
 // act-channel.swift — Focus channel binding for action sessions.
-// Reads side-eye channel files, configures session context from channel targets,
+// Reads channel files, configures session context from channel targets,
 // and resolves AX elements from channel element data.
 
 import CoreGraphics

--- a/src/act/act-models.swift
+++ b/src/act/act-models.swift
@@ -353,7 +353,7 @@ struct LegacyTargetInfo: Encodable {
     var keys: String?
 }
 
-// MARK: - Focus Channel File Types (read from side-eye channel files)
+// MARK: - Focus Channel File Types
 
 struct ChannelFileBounds: Codable {
     let x: Double

--- a/src/commands/reset.swift
+++ b/src/commands/reset.swift
@@ -122,6 +122,13 @@ private func runReset(mode: ResetMode) -> ResetResponse {
         }
     }
 
+    // Remove legacy side-eye config directory
+    let sideEyeDir = NSString("~/.config/side-eye").expandingTildeInPath
+    if FileManager.default.fileExists(atPath: sideEyeDir) {
+        try? FileManager.default.removeItem(atPath: sideEyeDir)
+        removedPaths.append(sideEyeDir)
+    }
+
     if targetModes.contains(.repo), let repoRoot = aosCurrentRepoRoot() {
         for path in [
             "\(repoRoot)/aos",

--- a/src/commands/serve.swift
+++ b/src/commands/serve.swift
@@ -39,7 +39,12 @@ func serveCommand(args: [String]) {
 
     // Accessory policy: no dock icon, no menu bar, but can own key windows
     // and receive mouse/keyboard events. Required for interactive canvases.
-    NSApp.setActivationPolicy(.accessory)
+    //
+    // Note: use NSApplication.shared (not the NSApp global) to force
+    // initialization of the singleton. Accessing NSApp before NSApplication.shared
+    // has been evaluated traps, because NSApp is an implicitly-unwrapped optional
+    // that is only assigned as a side effect of NSApplication.shared's first access.
+    NSApplication.shared.setActivationPolicy(.accessory)
 
     // Run the main loop (needed for CGEventTap, NSWindow, WKWebView)
     NSApplication.shared.run()

--- a/src/commands/wiki-frontmatter.swift
+++ b/src/commands/wiki-frontmatter.swift
@@ -81,6 +81,11 @@ func parseWikiPage(content: String) -> WikiPage {
         }
     }
 
+    // Strip the YAML block scalar `>` indicator from multi-line description
+    if let desc = raw["description"] {
+        raw["description"] = cleanDescription(desc)
+    }
+
     // Extract typed fields
     let fm = WikiFrontmatter(
         type: raw["type"],

--- a/src/commands/wiki-frontmatter.swift
+++ b/src/commands/wiki-frontmatter.swift
@@ -1,0 +1,127 @@
+// wiki-frontmatter.swift — Parse YAML-like frontmatter from markdown files
+
+import Foundation
+
+struct WikiFrontmatter {
+    let type: String?           // "workflow", "entity", "concept"
+    let name: String?
+    let description: String?
+    let tags: [String]
+    let version: String?
+    let author: String?
+    let triggers: [String]
+    let requires: [String]
+    let plugin: String?         // set by indexer, not parsed from file
+    let raw: [String: String]   // all key-value pairs as strings
+}
+
+struct WikiPage {
+    let frontmatter: WikiFrontmatter
+    let body: String            // markdown body after frontmatter
+    let rawContent: String      // full file content including frontmatter
+}
+
+/// Parse a markdown file with optional YAML frontmatter delimited by `---`.
+/// Returns the frontmatter fields and the body separately.
+func parseWikiPage(content: String) -> WikiPage {
+    let lines = content.components(separatedBy: "\n")
+
+    // Must start with ---
+    guard lines.first?.trimmingCharacters(in: .whitespaces) == "---" else {
+        return WikiPage(
+            frontmatter: WikiFrontmatter(type: nil, name: nil, description: nil, tags: [], version: nil, author: nil, triggers: [], requires: [], plugin: nil, raw: [:]),
+            body: content,
+            rawContent: content
+        )
+    }
+
+    // Find closing ---
+    var closingIndex: Int?
+    for i in 1..<lines.count {
+        if lines[i].trimmingCharacters(in: .whitespaces) == "---" {
+            closingIndex = i
+            break
+        }
+    }
+
+    guard let endIdx = closingIndex else {
+        return WikiPage(
+            frontmatter: WikiFrontmatter(type: nil, name: nil, description: nil, tags: [], version: nil, author: nil, triggers: [], requires: [], plugin: nil, raw: [:]),
+            body: content,
+            rawContent: content
+        )
+    }
+
+    // Parse frontmatter lines (between the two ---)
+    let fmLines = Array(lines[1..<endIdx])
+    var raw: [String: String] = [:]
+    var currentKey: String?
+    var currentValue: String = ""
+
+    for line in fmLines {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty { continue }
+
+        // Check if this is a continuation line (starts with whitespace, for multi-line description)
+        if line.first?.isWhitespace == true, let key = currentKey {
+            currentValue += " " + trimmed
+            raw[key] = currentValue
+            continue
+        }
+
+        // key: value
+        if let colonRange = trimmed.range(of: ":") {
+            let key = String(trimmed[trimmed.startIndex..<colonRange.lowerBound]).trimmingCharacters(in: .whitespaces)
+            let value = String(trimmed[colonRange.upperBound...]).trimmingCharacters(in: .whitespaces)
+            // Strip surrounding quotes
+            let cleaned = value.trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+            raw[key] = cleaned
+            currentKey = key
+            currentValue = cleaned
+        }
+    }
+
+    // Extract typed fields
+    let fm = WikiFrontmatter(
+        type: raw["type"],
+        name: raw["name"],
+        description: raw["description"],
+        tags: parseYAMLArray(raw["tags"]),
+        version: raw["version"],
+        author: raw["author"],
+        triggers: parseYAMLArray(raw["triggers"]),
+        requires: parseYAMLArray(raw["requires"]),
+        plugin: nil,
+        raw: raw
+    )
+
+    // Body is everything after the closing ---
+    let bodyLines = Array(lines[(endIdx + 1)...])
+    let body = bodyLines.joined(separator: "\n").trimmingCharacters(in: .newlines)
+
+    return WikiPage(frontmatter: fm, body: body, rawContent: content)
+}
+
+/// Parse a YAML-style inline array: [item1, item2, item3]
+func parseYAMLArray(_ value: String?) -> [String] {
+    guard let value = value, !value.isEmpty else { return [] }
+    let trimmed = value.trimmingCharacters(in: .whitespaces)
+    guard trimmed.hasPrefix("["), trimmed.hasSuffix("]") else {
+        // Single value, not an array
+        return trimmed.isEmpty ? [] : [trimmed]
+    }
+    let inner = String(trimmed.dropFirst().dropLast())
+    return inner.components(separatedBy: ",")
+        .map { $0.trimmingCharacters(in: .whitespaces).trimmingCharacters(in: CharacterSet(charactersIn: "\"'")) }
+        .filter { !$0.isEmpty }
+}
+
+/// Parse a multi-line YAML description (handles `>` block scalar indicator)
+/// Strips the `>` prefix if present and joins continuation lines.
+private func cleanDescription(_ raw: String) -> String {
+    var s = raw
+    if s.hasPrefix(">") {
+        s = String(s.dropFirst()).trimmingCharacters(in: .whitespaces)
+    }
+    return s
+}

--- a/src/commands/wiki-index.swift
+++ b/src/commands/wiki-index.swift
@@ -3,8 +3,11 @@
 import Foundation
 import SQLite3
 
+private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
 // MARK: - Database Lifecycle
 
+/// SQLite wrapper for the wiki knowledge base. Not thread-safe; use one instance per caller.
 class WikiIndex {
     private var db: OpaquePointer?
     let dbPath: String
@@ -49,6 +52,8 @@ class WikiIndex {
                 UNIQUE(source_path, target_path)
             )
         """)
+        exec("CREATE INDEX IF NOT EXISTS idx_links_source ON links(source_path)")
+        exec("CREATE INDEX IF NOT EXISTS idx_links_target ON links(target_path)")
         exec("""
             CREATE TABLE IF NOT EXISTS plugins (
                 name        TEXT PRIMARY KEY,
@@ -82,29 +87,29 @@ class WikiIndex {
                 tags=excluded.tags, plugin=excluded.plugin, modified_at=excluded.modified_at
         """
         execBind(sql) { stmt in
-            sqlite3_bind_text(stmt, 1, path, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
-            sqlite3_bind_text(stmt, 2, type, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
-            sqlite3_bind_text(stmt, 3, name, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            sqlite3_bind_text(stmt, 1, path, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(stmt, 2, type, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(stmt, 3, name, -1, SQLITE_TRANSIENT)
             if let d = description {
-                sqlite3_bind_text(stmt, 4, d, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+                sqlite3_bind_text(stmt, 4, d, -1, SQLITE_TRANSIENT)
             } else { sqlite3_bind_null(stmt, 4) }
             if let t = tagsJSON {
-                sqlite3_bind_text(stmt, 5, t, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+                sqlite3_bind_text(stmt, 5, t, -1, SQLITE_TRANSIENT)
             } else { sqlite3_bind_null(stmt, 5) }
             if let p = plugin {
-                sqlite3_bind_text(stmt, 6, p, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+                sqlite3_bind_text(stmt, 6, p, -1, SQLITE_TRANSIENT)
             } else { sqlite3_bind_null(stmt, 6) }
-            sqlite3_bind_int(stmt, 7, Int32(modifiedAt))
+            sqlite3_bind_int64(stmt, 7, Int64(modifiedAt))
         }
     }
 
     func deletePage(path: String) {
         execBind("DELETE FROM pages WHERE path = ?") { stmt in
-            sqlite3_bind_text(stmt, 1, path, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            sqlite3_bind_text(stmt, 1, path, -1, SQLITE_TRANSIENT)
         }
         execBind("DELETE FROM links WHERE source_path = ? OR target_path = ?") { stmt in
-            sqlite3_bind_text(stmt, 1, path, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
-            sqlite3_bind_text(stmt, 2, path, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            sqlite3_bind_text(stmt, 1, path, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(stmt, 2, path, -1, SQLITE_TRANSIENT)
         }
     }
 
@@ -112,14 +117,14 @@ class WikiIndex {
 
     func upsertLink(source: String, target: String) {
         execBind("INSERT OR IGNORE INTO links (source_path, target_path) VALUES (?, ?)") { stmt in
-            sqlite3_bind_text(stmt, 1, source, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
-            sqlite3_bind_text(stmt, 2, target, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            sqlite3_bind_text(stmt, 1, source, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(stmt, 2, target, -1, SQLITE_TRANSIENT)
         }
     }
 
     func deleteLinksFrom(source: String) {
         execBind("DELETE FROM links WHERE source_path = ?") { stmt in
-            sqlite3_bind_text(stmt, 1, source, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            sqlite3_bind_text(stmt, 1, source, -1, SQLITE_TRANSIENT)
         }
     }
 
@@ -139,13 +144,13 @@ class WikiIndex {
                 triggers=excluded.triggers, requires=excluded.requires, modified_at=excluded.modified_at
         """
         execBind(sql) { stmt in
-            sqlite3_bind_text(stmt, 1, name, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
-            if let v = version { sqlite3_bind_text(stmt, 2, v, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self)) } else { sqlite3_bind_null(stmt, 2) }
-            if let a = author { sqlite3_bind_text(stmt, 3, a, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self)) } else { sqlite3_bind_null(stmt, 3) }
-            if let d = description { sqlite3_bind_text(stmt, 4, d, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self)) } else { sqlite3_bind_null(stmt, 4) }
-            if let t = triggersJSON { sqlite3_bind_text(stmt, 5, t, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self)) } else { sqlite3_bind_null(stmt, 5) }
-            if let r = requiresJSON { sqlite3_bind_text(stmt, 6, r, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self)) } else { sqlite3_bind_null(stmt, 6) }
-            sqlite3_bind_int(stmt, 7, Int32(modifiedAt))
+            sqlite3_bind_text(stmt, 1, name, -1, SQLITE_TRANSIENT)
+            if let v = version { sqlite3_bind_text(stmt, 2, v, -1, SQLITE_TRANSIENT) } else { sqlite3_bind_null(stmt, 2) }
+            if let a = author { sqlite3_bind_text(stmt, 3, a, -1, SQLITE_TRANSIENT) } else { sqlite3_bind_null(stmt, 3) }
+            if let d = description { sqlite3_bind_text(stmt, 4, d, -1, SQLITE_TRANSIENT) } else { sqlite3_bind_null(stmt, 4) }
+            if let t = triggersJSON { sqlite3_bind_text(stmt, 5, t, -1, SQLITE_TRANSIENT) } else { sqlite3_bind_null(stmt, 5) }
+            if let r = requiresJSON { sqlite3_bind_text(stmt, 6, r, -1, SQLITE_TRANSIENT) } else { sqlite3_bind_null(stmt, 6) }
+            sqlite3_bind_int64(stmt, 7, Int64(modifiedAt))
         }
     }
 
@@ -179,11 +184,21 @@ class WikiIndex {
     func listPages(type: String? = nil, plugin: String? = nil) -> [PageRow] {
         var sql = "SELECT path, type, name, description, tags, plugin, modified_at FROM pages"
         var conditions: [String] = []
-        if let t = type { conditions.append("type = '\(t)'") }
-        if let p = plugin { conditions.append("plugin = '\(p)'") }
+        if type != nil { conditions.append("type = ?") }
+        if plugin != nil { conditions.append("plugin = ?") }
         if !conditions.isEmpty { sql += " WHERE " + conditions.joined(separator: " AND ") }
         sql += " ORDER BY name"
-        return query(sql) { stmt in
+        return queryBind(sql, bind: { stmt in
+            var idx: Int32 = 1
+            if let t = type {
+                sqlite3_bind_text(stmt, idx, t, -1, SQLITE_TRANSIENT)
+                idx += 1
+            }
+            if let p = plugin {
+                sqlite3_bind_text(stmt, idx, p, -1, SQLITE_TRANSIENT)
+                idx += 1
+            }
+        }, map: { stmt in
             PageRow(
                 path: col(stmt, 0),
                 type: col(stmt, 1),
@@ -191,21 +206,33 @@ class WikiIndex {
                 description: colOpt(stmt, 3),
                 tags: decodeJSONArray(colOpt(stmt, 4)),
                 plugin: colOpt(stmt, 5),
-                modified_at: Int(sqlite3_column_int(stmt, 6))
+                modified_at: Int(sqlite3_column_int64(stmt, 6))
             )
-        }
+        })
     }
 
     func linksTo(path: String) -> [LinkRow] {
-        query("SELECT source_path, target_path FROM links WHERE target_path = '\(path)'") { stmt in
-            LinkRow(source_path: col(stmt, 0), target_path: col(stmt, 1))
-        }
+        queryBind(
+            "SELECT source_path, target_path FROM links WHERE target_path = ? ORDER BY source_path",
+            bind: { stmt in
+                sqlite3_bind_text(stmt, 1, path, -1, SQLITE_TRANSIENT)
+            },
+            map: { stmt in
+                LinkRow(source_path: col(stmt, 0), target_path: col(stmt, 1))
+            }
+        )
     }
 
     func linksFrom(path: String) -> [LinkRow] {
-        query("SELECT source_path, target_path FROM links WHERE source_path = '\(path)'") { stmt in
-            LinkRow(source_path: col(stmt, 0), target_path: col(stmt, 1))
-        }
+        queryBind(
+            "SELECT source_path, target_path FROM links WHERE source_path = ? ORDER BY target_path",
+            bind: { stmt in
+                sqlite3_bind_text(stmt, 1, path, -1, SQLITE_TRANSIENT)
+            },
+            map: { stmt in
+                LinkRow(source_path: col(stmt, 0), target_path: col(stmt, 1))
+            }
+        )
     }
 
     func orphanPages() -> [PageRow] {
@@ -219,7 +246,7 @@ class WikiIndex {
             PageRow(
                 path: col(stmt, 0), type: col(stmt, 1), name: col(stmt, 2),
                 description: colOpt(stmt, 3), tags: decodeJSONArray(colOpt(stmt, 4)),
-                plugin: colOpt(stmt, 5), modified_at: Int(sqlite3_column_int(stmt, 6))
+                plugin: colOpt(stmt, 5), modified_at: Int(sqlite3_column_int64(stmt, 6))
             )
         }
     }
@@ -229,17 +256,29 @@ class WikiIndex {
         let pattern = "%\(q)%"
         var sql = """
             SELECT path, type, name, description, tags, plugin, modified_at FROM pages
-            WHERE (name LIKE '\(pattern)' OR description LIKE '\(pattern)')
-        """
-        if let t = type { sql += " AND type = '\(t)'" }
-        sql += " ORDER BY CASE WHEN name LIKE '\(pattern)' THEN 0 ELSE 1 END, name"
-        return query(sql) { stmt in
+            WHERE (name LIKE ? OR description LIKE ?)
+            """
+        if type != nil { sql += " AND type = ?" }
+        sql += " ORDER BY CASE WHEN name LIKE ? THEN 0 ELSE 1 END, name"
+        return queryBind(sql, bind: { stmt in
+            var idx: Int32 = 1
+            sqlite3_bind_text(stmt, idx, pattern, -1, SQLITE_TRANSIENT)
+            idx += 1
+            sqlite3_bind_text(stmt, idx, pattern, -1, SQLITE_TRANSIENT)
+            idx += 1
+            if let t = type {
+                sqlite3_bind_text(stmt, idx, t, -1, SQLITE_TRANSIENT)
+                idx += 1
+            }
+            sqlite3_bind_text(stmt, idx, pattern, -1, SQLITE_TRANSIENT)
+            idx += 1
+        }, map: { stmt in
             PageRow(
                 path: col(stmt, 0), type: col(stmt, 1), name: col(stmt, 2),
                 description: colOpt(stmt, 3), tags: decodeJSONArray(colOpt(stmt, 4)),
-                plugin: colOpt(stmt, 5), modified_at: Int(sqlite3_column_int(stmt, 6))
+                plugin: colOpt(stmt, 5), modified_at: Int(sqlite3_column_int64(stmt, 6))
             )
-        }
+        })
     }
 
     func listPlugins() -> [PluginRow] {
@@ -247,23 +286,23 @@ class WikiIndex {
             PluginRow(
                 name: col(stmt, 0), version: colOpt(stmt, 1), author: colOpt(stmt, 2),
                 description: colOpt(stmt, 3), triggers: decodeJSONArray(colOpt(stmt, 4)),
-                requires: decodeJSONArray(colOpt(stmt, 5)), modified_at: Int(sqlite3_column_int(stmt, 6))
+                requires: decodeJSONArray(colOpt(stmt, 5)), modified_at: Int(sqlite3_column_int64(stmt, 6))
             )
         }
     }
 
     func pageCount() -> Int {
-        let rows: [Int] = query("SELECT COUNT(*) FROM pages") { stmt in Int(sqlite3_column_int(stmt, 0)) }
+        let rows: [Int] = query("SELECT COUNT(*) FROM pages") { stmt in Int(sqlite3_column_int64(stmt, 0)) }
         return rows.first ?? 0
     }
 
     func linkCount() -> Int {
-        let rows: [Int] = query("SELECT COUNT(*) FROM links") { stmt in Int(sqlite3_column_int(stmt, 0)) }
+        let rows: [Int] = query("SELECT COUNT(*) FROM links") { stmt in Int(sqlite3_column_int64(stmt, 0)) }
         return rows.first ?? 0
     }
 
     func pluginCount() -> Int {
-        let rows: [Int] = query("SELECT COUNT(*) FROM plugins") { stmt in Int(sqlite3_column_int(stmt, 0)) }
+        let rows: [Int] = query("SELECT COUNT(*) FROM plugins") { stmt in Int(sqlite3_column_int64(stmt, 0)) }
         return rows.first ?? 0
     }
 
@@ -287,7 +326,6 @@ class WikiIndex {
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             exitError("SQLite prepare error: \(dbError())\nSQL: \(sql)", code: "WIKI_DB_ERROR")
-            return
         }
         bind(stmt!)
         let result = sqlite3_step(stmt)
@@ -303,11 +341,38 @@ class WikiIndex {
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             exitError("SQLite query error: \(dbError())\nSQL: \(sql)", code: "WIKI_DB_ERROR")
-            return []
         }
         var results: [T] = []
-        while sqlite3_step(stmt) == SQLITE_ROW {
+        var stepResult = sqlite3_step(stmt)
+        while stepResult == SQLITE_ROW {
             results.append(map(stmt!))
+            stepResult = sqlite3_step(stmt)
+        }
+        if stepResult != SQLITE_DONE {
+            let msg = dbError()
+            sqlite3_finalize(stmt)
+            exitError("SQLite step error: \(msg)\nSQL: \(sql)", code: "WIKI_DB_ERROR")
+        }
+        sqlite3_finalize(stmt)
+        return results
+    }
+
+    private func queryBind<T>(_ sql: String, bind: (OpaquePointer) -> Void, map: (OpaquePointer) -> T) -> [T] {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            exitError("SQLite query error: \(dbError())\nSQL: \(sql)", code: "WIKI_DB_ERROR")
+        }
+        bind(stmt!)
+        var results: [T] = []
+        var stepResult = sqlite3_step(stmt)
+        while stepResult == SQLITE_ROW {
+            results.append(map(stmt!))
+            stepResult = sqlite3_step(stmt)
+        }
+        if stepResult != SQLITE_DONE {
+            let msg = dbError()
+            sqlite3_finalize(stmt)
+            exitError("SQLite step error: \(msg)\nSQL: \(sql)", code: "WIKI_DB_ERROR")
         }
         sqlite3_finalize(stmt)
         return results

--- a/src/commands/wiki-index.swift
+++ b/src/commands/wiki-index.swift
@@ -1,0 +1,332 @@
+// wiki-index.swift — SQLite index for the wiki knowledge base
+
+import Foundation
+import SQLite3
+
+// MARK: - Database Lifecycle
+
+class WikiIndex {
+    private var db: OpaquePointer?
+    let dbPath: String
+
+    init(dbPath: String) {
+        self.dbPath = dbPath
+    }
+
+    func open() {
+        guard sqlite3_open(dbPath, &db) == SQLITE_OK else {
+            exitError("Failed to open wiki database at \(dbPath): \(dbError())", code: "WIKI_DB_ERROR")
+        }
+        exec("PRAGMA journal_mode=WAL")
+        exec("PRAGMA foreign_keys=ON")
+    }
+
+    func close() {
+        if db != nil {
+            sqlite3_close(db)
+            db = nil
+        }
+    }
+
+    // MARK: - Schema
+
+    func createTables() {
+        exec("""
+            CREATE TABLE IF NOT EXISTS pages (
+                path        TEXT PRIMARY KEY,
+                type        TEXT NOT NULL,
+                name        TEXT NOT NULL,
+                description TEXT,
+                tags        TEXT,
+                plugin      TEXT,
+                modified_at INTEGER NOT NULL
+            )
+        """)
+        exec("""
+            CREATE TABLE IF NOT EXISTS links (
+                source_path TEXT NOT NULL,
+                target_path TEXT NOT NULL,
+                UNIQUE(source_path, target_path)
+            )
+        """)
+        exec("""
+            CREATE TABLE IF NOT EXISTS plugins (
+                name        TEXT PRIMARY KEY,
+                version     TEXT,
+                author      TEXT,
+                description TEXT,
+                triggers    TEXT,
+                requires    TEXT,
+                modified_at INTEGER NOT NULL
+            )
+        """)
+    }
+
+    func dropTables() {
+        exec("DROP TABLE IF EXISTS links")
+        exec("DROP TABLE IF EXISTS pages")
+        exec("DROP TABLE IF EXISTS plugins")
+    }
+
+    // MARK: - Page Operations
+
+    func upsertPage(path: String, type: String, name: String, description: String?, tags: [String], plugin: String?, modifiedAt: Int) {
+        let tagsJSON = tags.isEmpty ? nil : (try? JSONSerialization.data(withJSONObject: tags))
+            .flatMap { String(data: $0, encoding: .utf8) }
+
+        let sql = """
+            INSERT INTO pages (path, type, name, description, tags, plugin, modified_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(path) DO UPDATE SET
+                type=excluded.type, name=excluded.name, description=excluded.description,
+                tags=excluded.tags, plugin=excluded.plugin, modified_at=excluded.modified_at
+        """
+        execBind(sql) { stmt in
+            sqlite3_bind_text(stmt, 1, path, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            sqlite3_bind_text(stmt, 2, type, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            sqlite3_bind_text(stmt, 3, name, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            if let d = description {
+                sqlite3_bind_text(stmt, 4, d, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            } else { sqlite3_bind_null(stmt, 4) }
+            if let t = tagsJSON {
+                sqlite3_bind_text(stmt, 5, t, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            } else { sqlite3_bind_null(stmt, 5) }
+            if let p = plugin {
+                sqlite3_bind_text(stmt, 6, p, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            } else { sqlite3_bind_null(stmt, 6) }
+            sqlite3_bind_int(stmt, 7, Int32(modifiedAt))
+        }
+    }
+
+    func deletePage(path: String) {
+        execBind("DELETE FROM pages WHERE path = ?") { stmt in
+            sqlite3_bind_text(stmt, 1, path, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        }
+        execBind("DELETE FROM links WHERE source_path = ? OR target_path = ?") { stmt in
+            sqlite3_bind_text(stmt, 1, path, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            sqlite3_bind_text(stmt, 2, path, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        }
+    }
+
+    // MARK: - Link Operations
+
+    func upsertLink(source: String, target: String) {
+        execBind("INSERT OR IGNORE INTO links (source_path, target_path) VALUES (?, ?)") { stmt in
+            sqlite3_bind_text(stmt, 1, source, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            sqlite3_bind_text(stmt, 2, target, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        }
+    }
+
+    func deleteLinksFrom(source: String) {
+        execBind("DELETE FROM links WHERE source_path = ?") { stmt in
+            sqlite3_bind_text(stmt, 1, source, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        }
+    }
+
+    // MARK: - Plugin Operations
+
+    func upsertPlugin(name: String, version: String?, author: String?, description: String?, triggers: [String], requires: [String], modifiedAt: Int) {
+        let triggersJSON = triggers.isEmpty ? nil : (try? JSONSerialization.data(withJSONObject: triggers))
+            .flatMap { String(data: $0, encoding: .utf8) }
+        let requiresJSON = requires.isEmpty ? nil : (try? JSONSerialization.data(withJSONObject: requires))
+            .flatMap { String(data: $0, encoding: .utf8) }
+
+        let sql = """
+            INSERT INTO plugins (name, version, author, description, triggers, requires, modified_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(name) DO UPDATE SET
+                version=excluded.version, author=excluded.author, description=excluded.description,
+                triggers=excluded.triggers, requires=excluded.requires, modified_at=excluded.modified_at
+        """
+        execBind(sql) { stmt in
+            sqlite3_bind_text(stmt, 1, name, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            if let v = version { sqlite3_bind_text(stmt, 2, v, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self)) } else { sqlite3_bind_null(stmt, 2) }
+            if let a = author { sqlite3_bind_text(stmt, 3, a, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self)) } else { sqlite3_bind_null(stmt, 3) }
+            if let d = description { sqlite3_bind_text(stmt, 4, d, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self)) } else { sqlite3_bind_null(stmt, 4) }
+            if let t = triggersJSON { sqlite3_bind_text(stmt, 5, t, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self)) } else { sqlite3_bind_null(stmt, 5) }
+            if let r = requiresJSON { sqlite3_bind_text(stmt, 6, r, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self)) } else { sqlite3_bind_null(stmt, 6) }
+            sqlite3_bind_int(stmt, 7, Int32(modifiedAt))
+        }
+    }
+
+    // MARK: - Queries
+
+    struct PageRow: Encodable {
+        let path: String
+        let type: String
+        let name: String
+        let description: String?
+        let tags: [String]
+        let plugin: String?
+        let modified_at: Int
+    }
+
+    struct PluginRow: Encodable {
+        let name: String
+        let version: String?
+        let author: String?
+        let description: String?
+        let triggers: [String]
+        let requires: [String]
+        let modified_at: Int
+    }
+
+    struct LinkRow: Encodable {
+        let source_path: String
+        let target_path: String
+    }
+
+    func listPages(type: String? = nil, plugin: String? = nil) -> [PageRow] {
+        var sql = "SELECT path, type, name, description, tags, plugin, modified_at FROM pages"
+        var conditions: [String] = []
+        if let t = type { conditions.append("type = '\(t)'") }
+        if let p = plugin { conditions.append("plugin = '\(p)'") }
+        if !conditions.isEmpty { sql += " WHERE " + conditions.joined(separator: " AND ") }
+        sql += " ORDER BY name"
+        return query(sql) { stmt in
+            PageRow(
+                path: col(stmt, 0),
+                type: col(stmt, 1),
+                name: col(stmt, 2),
+                description: colOpt(stmt, 3),
+                tags: decodeJSONArray(colOpt(stmt, 4)),
+                plugin: colOpt(stmt, 5),
+                modified_at: Int(sqlite3_column_int(stmt, 6))
+            )
+        }
+    }
+
+    func linksTo(path: String) -> [LinkRow] {
+        query("SELECT source_path, target_path FROM links WHERE target_path = '\(path)'") { stmt in
+            LinkRow(source_path: col(stmt, 0), target_path: col(stmt, 1))
+        }
+    }
+
+    func linksFrom(path: String) -> [LinkRow] {
+        query("SELECT source_path, target_path FROM links WHERE source_path = '\(path)'") { stmt in
+            LinkRow(source_path: col(stmt, 0), target_path: col(stmt, 1))
+        }
+    }
+
+    func orphanPages() -> [PageRow] {
+        query("""
+            SELECT p.path, p.type, p.name, p.description, p.tags, p.plugin, p.modified_at
+            FROM pages p
+            LEFT JOIN links l ON l.target_path = p.path
+            WHERE l.source_path IS NULL
+            ORDER BY p.name
+        """) { stmt in
+            PageRow(
+                path: col(stmt, 0), type: col(stmt, 1), name: col(stmt, 2),
+                description: colOpt(stmt, 3), tags: decodeJSONArray(colOpt(stmt, 4)),
+                plugin: colOpt(stmt, 5), modified_at: Int(sqlite3_column_int(stmt, 6))
+            )
+        }
+    }
+
+    func searchPages(query q: String, type: String? = nil) -> [PageRow] {
+        // Simple LIKE search across name, description
+        let pattern = "%\(q)%"
+        var sql = """
+            SELECT path, type, name, description, tags, plugin, modified_at FROM pages
+            WHERE (name LIKE '\(pattern)' OR description LIKE '\(pattern)')
+        """
+        if let t = type { sql += " AND type = '\(t)'" }
+        sql += " ORDER BY CASE WHEN name LIKE '\(pattern)' THEN 0 ELSE 1 END, name"
+        return query(sql) { stmt in
+            PageRow(
+                path: col(stmt, 0), type: col(stmt, 1), name: col(stmt, 2),
+                description: colOpt(stmt, 3), tags: decodeJSONArray(colOpt(stmt, 4)),
+                plugin: colOpt(stmt, 5), modified_at: Int(sqlite3_column_int(stmt, 6))
+            )
+        }
+    }
+
+    func listPlugins() -> [PluginRow] {
+        query("SELECT name, version, author, description, triggers, requires, modified_at FROM plugins ORDER BY name") { stmt in
+            PluginRow(
+                name: col(stmt, 0), version: colOpt(stmt, 1), author: colOpt(stmt, 2),
+                description: colOpt(stmt, 3), triggers: decodeJSONArray(colOpt(stmt, 4)),
+                requires: decodeJSONArray(colOpt(stmt, 5)), modified_at: Int(sqlite3_column_int(stmt, 6))
+            )
+        }
+    }
+
+    func pageCount() -> Int {
+        let rows: [Int] = query("SELECT COUNT(*) FROM pages") { stmt in Int(sqlite3_column_int(stmt, 0)) }
+        return rows.first ?? 0
+    }
+
+    func linkCount() -> Int {
+        let rows: [Int] = query("SELECT COUNT(*) FROM links") { stmt in Int(sqlite3_column_int(stmt, 0)) }
+        return rows.first ?? 0
+    }
+
+    func pluginCount() -> Int {
+        let rows: [Int] = query("SELECT COUNT(*) FROM plugins") { stmt in Int(sqlite3_column_int(stmt, 0)) }
+        return rows.first ?? 0
+    }
+
+    // MARK: - SQLite Helpers
+
+    private func dbError() -> String {
+        if let err = sqlite3_errmsg(db) { return String(cString: err) }
+        return "unknown error"
+    }
+
+    private func exec(_ sql: String) {
+        var errMsg: UnsafeMutablePointer<CChar>?
+        if sqlite3_exec(db, sql, nil, nil, &errMsg) != SQLITE_OK {
+            let msg = errMsg.map { String(cString: $0) } ?? "unknown error"
+            sqlite3_free(errMsg)
+            exitError("SQLite error: \(msg)\nSQL: \(sql)", code: "WIKI_DB_ERROR")
+        }
+    }
+
+    private func execBind(_ sql: String, bind: (OpaquePointer) -> Void) {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            exitError("SQLite prepare error: \(dbError())\nSQL: \(sql)", code: "WIKI_DB_ERROR")
+            return
+        }
+        bind(stmt!)
+        let result = sqlite3_step(stmt)
+        if result != SQLITE_DONE && result != SQLITE_ROW {
+            let msg = dbError()
+            sqlite3_finalize(stmt)
+            exitError("SQLite step error: \(msg)\nSQL: \(sql)", code: "WIKI_DB_ERROR")
+        }
+        sqlite3_finalize(stmt)
+    }
+
+    private func query<T>(_ sql: String, map: (OpaquePointer) -> T) -> [T] {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            exitError("SQLite query error: \(dbError())\nSQL: \(sql)", code: "WIKI_DB_ERROR")
+            return []
+        }
+        var results: [T] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            results.append(map(stmt!))
+        }
+        sqlite3_finalize(stmt)
+        return results
+    }
+
+    private func col(_ stmt: OpaquePointer?, _ idx: Int32) -> String {
+        if let cStr = sqlite3_column_text(stmt, idx) { return String(cString: cStr) }
+        return ""
+    }
+
+    private func colOpt(_ stmt: OpaquePointer?, _ idx: Int32) -> String? {
+        if sqlite3_column_type(stmt, idx) == SQLITE_NULL { return nil }
+        if let cStr = sqlite3_column_text(stmt, idx) { return String(cString: cStr) }
+        return nil
+    }
+
+    private func decodeJSONArray(_ json: String?) -> [String] {
+        guard let json = json, let data = json.data(using: .utf8),
+              let arr = try? JSONSerialization.jsonObject(with: data) as? [String] else { return [] }
+        return arr
+    }
+}

--- a/src/commands/wiki.swift
+++ b/src/commands/wiki.swift
@@ -35,6 +35,10 @@ func wikiCommand(args: [String]) {
         wikiSearchCommand(args: subArgs)
     case "show":
         wikiShowCommand(args: subArgs)
+    case "link":
+        wikiLinkCommand(args: subArgs)
+    case "lint":
+        wikiLintCommand(args: subArgs)
     default:
         exitError("Unknown wiki subcommand: \(sub)", code: "UNKNOWN_SUBCOMMAND")
     }
@@ -577,6 +581,221 @@ func wikiShowCommand(args: [String]) {
         if !page.frontmatter.tags.isEmpty { print("Tags: \(page.frontmatter.tags.joined(separator: ", "))") }
         print("---")
         print(page.body)
+    }
+}
+
+// MARK: - Link
+
+func wikiLinkCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    let nonFlags = args.filter { !$0.hasPrefix("-") }
+    guard nonFlags.count >= 2 else {
+        exitError("Usage: aos wiki link <from-path> <to-path> [--json]", code: "MISSING_ARG")
+    }
+    let fromPath = nonFlags[0]
+    let toPath = nonFlags[1]
+
+    let wikiDir = aosWikiDir()
+
+    // Resolve from path
+    let fromFull = resolveWikiPath(wikiDir: wikiDir, arg: fromPath)
+    guard let fromFull = fromFull else {
+        exitError("Source page '\(fromPath)' not found", code: "WIKI_NOT_FOUND")
+    }
+
+    // Resolve to path
+    let toFull = resolveWikiPath(wikiDir: wikiDir, arg: toPath)
+    guard let toFull = toFull else {
+        exitError("Target page '\(toPath)' not found", code: "WIKI_NOT_FOUND")
+    }
+
+    // Add link to index
+    let index = openWikiIndex()
+    index.upsertLink(source: fromFull.relative, target: toFull.relative)
+    index.close()
+
+    // Append to Related section in source file
+    let relativeLink = makeRelativeLink(from: fromFull.relative, to: toFull.relative)
+    if var content = try? String(contentsOfFile: fromFull.absolute, encoding: .utf8) {
+        let toPage = parseWikiPage(content: (try? String(contentsOfFile: toFull.absolute, encoding: .utf8)) ?? "")
+        let linkName = toPage.frontmatter.name ?? toPath
+        let linkLine = "- [\(linkName)](\(relativeLink))"
+
+        if content.contains("## Related") {
+            content = content.replacingOccurrences(of: "## Related\n", with: "## Related\n\(linkLine)\n")
+        } else {
+            content += "\n## Related\n\(linkLine)\n"
+        }
+        try? content.write(toFile: fromFull.absolute, atomically: true, encoding: .utf8)
+    }
+
+    if asJSON {
+        print(jsonString(["status": "ok", "from": fromFull.relative, "to": toFull.relative]))
+    } else {
+        print("Linked \(fromFull.relative) → \(toFull.relative)")
+    }
+}
+
+struct ResolvedPath {
+    let relative: String
+    let absolute: String
+}
+
+func resolveWikiPath(wikiDir: String, arg: String) -> ResolvedPath? {
+    if arg.contains("/") || arg.contains(".md") {
+        let abs = "\(wikiDir)/\(arg)"
+        if FileManager.default.fileExists(atPath: abs) { return ResolvedPath(relative: arg, absolute: abs) }
+        return nil
+    }
+    let candidates = [
+        ("entities/\(arg).md", "\(wikiDir)/entities/\(arg).md"),
+        ("concepts/\(arg).md", "\(wikiDir)/concepts/\(arg).md"),
+        ("plugins/\(arg)/SKILL.md", "\(wikiDir)/plugins/\(arg)/SKILL.md")
+    ]
+    for (rel, abs) in candidates {
+        if FileManager.default.fileExists(atPath: abs) { return ResolvedPath(relative: rel, absolute: abs) }
+    }
+    return nil
+}
+
+/// Compute a relative path from one wiki page to another
+func makeRelativeLink(from: String, to: String) -> String {
+    let fromParts = from.components(separatedBy: "/").dropLast() // directory of source
+    let toParts = to.components(separatedBy: "/")
+
+    // Find common prefix length
+    var common = 0
+    for i in 0..<min(fromParts.count, toParts.count) {
+        if Array(fromParts)[i] == toParts[i] { common += 1 } else { break }
+    }
+
+    let ups = Array(repeating: "..", count: fromParts.count - common)
+    let downs = Array(toParts[common...])
+    return (ups + downs).joined(separator: "/")
+}
+
+// MARK: - Lint
+
+struct LintIssue: Encodable {
+    let severity: String  // "error", "warning"
+    let category: String  // "broken_link", "orphan", "missing_frontmatter", "malformed_plugin", "index_drift"
+    let path: String
+    let message: String
+}
+
+func wikiLintCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    let fix = hasFlag(args, "--fix")
+    let wikiDir = aosWikiDir()
+    var issues: [LintIssue] = []
+
+    // If --fix, reindex first
+    if fix {
+        wikiReindexCommand(args: ["--json"])
+    }
+
+    let index = openWikiIndex()
+    let allPages = index.listPages()
+    let allPagePaths = Set(allPages.map { $0.path })
+
+    // 1. Broken links: links pointing to paths that don't exist
+    for page in allPages {
+        let outgoing = index.linksFrom(path: page.path)
+        for link in outgoing {
+            if !allPagePaths.contains(link.target_path) {
+                // Also check if file exists on disk but just not indexed
+                let diskPath = "\(wikiDir)/\(link.target_path)"
+                if !FileManager.default.fileExists(atPath: diskPath) {
+                    issues.append(LintIssue(
+                        severity: "error", category: "broken_link",
+                        path: page.path, message: "Links to '\(link.target_path)' which does not exist"
+                    ))
+                }
+            }
+        }
+    }
+
+    // 2. Orphan pages
+    let orphans = index.orphanPages()
+    for page in orphans {
+        // SKILL.md pages are entry points, not orphans
+        if page.path.hasSuffix("SKILL.md") { continue }
+        issues.append(LintIssue(
+            severity: "warning", category: "orphan",
+            path: page.path, message: "No incoming links (orphan page)"
+        ))
+    }
+
+    // 3. Missing frontmatter
+    for page in allPages {
+        if page.name.isEmpty {
+            issues.append(LintIssue(
+                severity: "error", category: "missing_frontmatter",
+                path: page.path, message: "Missing 'name' in frontmatter"
+            ))
+        }
+    }
+
+    // 4. Malformed plugins
+    let plugins = index.listPlugins()
+    for plugin in plugins {
+        let skillPath = "\(wikiDir)/plugins/\(plugin.name)/SKILL.md"
+        if !FileManager.default.fileExists(atPath: skillPath) {
+            issues.append(LintIssue(
+                severity: "error", category: "malformed_plugin",
+                path: "plugins/\(plugin.name)", message: "Plugin directory exists but SKILL.md is missing"
+            ))
+        }
+        if plugin.description == nil || plugin.description?.isEmpty == true {
+            issues.append(LintIssue(
+                severity: "warning", category: "malformed_plugin",
+                path: "plugins/\(plugin.name)/SKILL.md", message: "Plugin has no description (will not trigger reliably)"
+            ))
+        }
+    }
+
+    // 5. Index drift: files on disk not in the index
+    let fm = FileManager.default
+    for dirType in ["entities", "concepts"] {
+        let dirPath = "\(wikiDir)/\(dirType)"
+        guard let files = try? fm.contentsOfDirectory(atPath: dirPath) else { continue }
+        for file in files where file.hasSuffix(".md") {
+            let relative = "\(dirType)/\(file)"
+            if !allPagePaths.contains(relative) {
+                issues.append(LintIssue(
+                    severity: "warning", category: "index_drift",
+                    path: relative, message: "File exists on disk but not in index (run 'aos wiki reindex')"
+                ))
+            }
+        }
+    }
+
+    index.close()
+
+    // Fix: remove broken link entries from index
+    if fix {
+        let brokenLinks = issues.filter { $0.category == "broken_link" }
+        if !brokenLinks.isEmpty {
+            let idx = openWikiIndex()
+            // Reindex already handled this via dropTables + rebuild
+            idx.close()
+        }
+    }
+
+    if asJSON {
+        print(jsonString(issues))
+    } else {
+        if issues.isEmpty {
+            print("Wiki is clean. No issues found.")
+        } else {
+            let errors = issues.filter { $0.severity == "error" }
+            let warnings = issues.filter { $0.severity == "warning" }
+            for issue in issues {
+                let icon = issue.severity == "error" ? "ERROR" : "WARN "
+                print("\(icon)  [\(issue.category)] \(issue.path): \(issue.message)")
+            }
+            print("\n\(errors.count) error(s), \(warnings.count) warning(s)")
+        }
     }
 }
 

--- a/src/commands/wiki.swift
+++ b/src/commands/wiki.swift
@@ -29,6 +29,12 @@ func wikiCommand(args: [String]) {
         wikiAddCommand(args: subArgs)
     case "rm":
         wikiRmCommand(args: subArgs)
+    case "list":
+        wikiListCommand(args: subArgs)
+    case "search":
+        wikiSearchCommand(args: subArgs)
+    case "show":
+        wikiShowCommand(args: subArgs)
     default:
         exitError("Unknown wiki subcommand: \(sub)", code: "UNKNOWN_SUBCOMMAND")
     }
@@ -369,6 +375,208 @@ func wikiRmCommand(args: [String]) {
            let s = String(data: data, encoding: .utf8) { print(s) }
     } else {
         print("Removed \(relativePath)")
+    }
+}
+
+// MARK: - List
+
+func wikiListCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    let typeFilter = getArg(args, "--type")
+    let pluginFilter = getArg(args, "--plugin")
+    let linksTo = getArg(args, "--links-to")
+    let linksFrom = getArg(args, "--links-from")
+    let orphans = hasFlag(args, "--orphans")
+
+    let index = openWikiIndex()
+
+    if orphans {
+        let pages = index.orphanPages()
+        index.close()
+        if asJSON {
+            print(jsonString(pages))
+        } else {
+            if pages.isEmpty { print("No orphan pages."); return }
+            for p in pages { print("\(p.type.padding(toLength: 10, withPad: " ", startingAt: 0)) \(p.path)  — \(p.name)") }
+        }
+        return
+    }
+
+    if let target = linksTo {
+        let links = index.linksTo(path: target)
+        index.close()
+        if asJSON {
+            print(jsonString(links))
+        } else {
+            if links.isEmpty { print("No pages link to \(target)."); return }
+            for l in links { print("  \(l.source_path)") }
+        }
+        return
+    }
+
+    if let source = linksFrom {
+        let links = index.linksFrom(path: source)
+        index.close()
+        if asJSON {
+            print(jsonString(links))
+        } else {
+            if links.isEmpty { print("No outgoing links from \(source)."); return }
+            for l in links { print("  \(l.target_path)") }
+        }
+        return
+    }
+
+    let pages = index.listPages(type: typeFilter, plugin: pluginFilter)
+    index.close()
+
+    if asJSON {
+        print(jsonString(pages))
+    } else {
+        if pages.isEmpty { print("Wiki is empty. Run 'aos wiki seed' to get started."); return }
+        for p in pages {
+            let desc = p.description.map { " — \($0.prefix(60))" } ?? ""
+            print("\(p.type.padding(toLength: 10, withPad: " ", startingAt: 0)) \(p.path)\(desc)")
+        }
+    }
+}
+
+// MARK: - Search
+
+func wikiSearchCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    let typeFilter = getArg(args, "--type")
+    let nonFlags = args.filter { !$0.hasPrefix("-") && $0 != getArg(args, "--type") }
+
+    guard let query = nonFlags.first else {
+        exitError("Usage: aos wiki search <query> [--type <type>] [--json]", code: "MISSING_ARG")
+    }
+
+    let index = openWikiIndex()
+    var results = index.searchPages(query: query, type: typeFilter)
+
+    // Also search file content for matches not caught by index
+    let wikiDir = aosWikiDir()
+    let indexPaths = Set(results.map { $0.path })
+    let contentMatches = searchFileContent(wikiDir: wikiDir, query: query, excluding: indexPaths)
+    results.append(contentsOf: contentMatches)
+
+    index.close()
+
+    if asJSON {
+        print(jsonString(results))
+    } else {
+        if results.isEmpty { print("No results for '\(query)'."); return }
+        for r in results {
+            let desc = r.description.map { " — \($0.prefix(60))" } ?? ""
+            print("\(r.type.padding(toLength: 10, withPad: " ", startingAt: 0)) \(r.path)\(desc)")
+        }
+    }
+}
+
+/// Search file content for a query string, returning pages not already in index results
+func searchFileContent(wikiDir: String, query: String, excluding: Set<String>) -> [WikiIndex.PageRow] {
+    var results: [WikiIndex.PageRow] = []
+    let fm = FileManager.default
+    let lowerQuery = query.lowercased()
+
+    for dirType in ["plugins", "entities", "concepts"] {
+        let dirPath = "\(wikiDir)/\(dirType)"
+        guard let enumerator = fm.enumerator(atPath: dirPath) else { continue }
+        while let relativePath = enumerator.nextObject() as? String {
+            guard relativePath.hasSuffix(".md") else { continue }
+            let fullRelative = "\(dirType)/\(relativePath)"
+            guard !excluding.contains(fullRelative) else { continue }
+            let fullPath = "\(dirPath)/\(relativePath)"
+            guard let content = try? String(contentsOfFile: fullPath, encoding: .utf8) else { continue }
+            if content.lowercased().contains(lowerQuery) {
+                let page = parseWikiPage(content: content)
+                let inferredType: String
+                switch dirType {
+                case "plugins":  inferredType = "workflow"
+                case "entities": inferredType = "entity"
+                case "concepts": inferredType = "concept"
+                default:         inferredType = dirType
+                }
+                results.append(WikiIndex.PageRow(
+                    path: fullRelative,
+                    type: page.frontmatter.type ?? inferredType,
+                    name: page.frontmatter.name ?? relativePath.replacingOccurrences(of: ".md", with: ""),
+                    description: page.frontmatter.description,
+                    tags: page.frontmatter.tags,
+                    plugin: nil,
+                    modified_at: fileModTime(fullPath)
+                ))
+            }
+        }
+    }
+    return results
+}
+
+// MARK: - Show
+
+struct WikiShowResponse: Encodable {
+    let path: String
+    let frontmatter: [String: String]
+    let body: String
+    let raw: String
+}
+
+func wikiShowCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    let rawMode = hasFlag(args, "--raw")
+    guard let pathArg = args.first(where: { !$0.hasPrefix("-") }) else {
+        exitError("Usage: aos wiki show <path-or-name> [--raw] [--json]", code: "MISSING_ARG")
+    }
+
+    let wikiDir = aosWikiDir()
+    let fullPath: String
+    let relativePath: String
+
+    if pathArg.contains("/") || pathArg.contains(".md") {
+        relativePath = pathArg
+        fullPath = "\(wikiDir)/\(pathArg)"
+    } else {
+        // Search by name across all directories
+        let candidates = [
+            "entities/\(pathArg).md",
+            "concepts/\(pathArg).md",
+            "plugins/\(pathArg)/SKILL.md"
+        ]
+        if let found = candidates.first(where: { FileManager.default.fileExists(atPath: "\(wikiDir)/\($0)") }) {
+            relativePath = found
+            fullPath = "\(wikiDir)/\(found)"
+        } else {
+            exitError("Page '\(pathArg)' not found. Try 'aos wiki list' to see available pages.", code: "WIKI_NOT_FOUND")
+        }
+    }
+
+    guard let content = try? String(contentsOfFile: fullPath, encoding: .utf8) else {
+        exitError("Could not read \(fullPath)", code: "WIKI_READ_ERROR")
+    }
+
+    if rawMode {
+        print(content)
+        return
+    }
+
+    let page = parseWikiPage(content: content)
+
+    if asJSON {
+        let response = WikiShowResponse(
+            path: relativePath,
+            frontmatter: page.frontmatter.raw,
+            body: page.body,
+            raw: content
+        )
+        print(jsonString(response))
+    } else {
+        // Print formatted: metadata header then body
+        if let name = page.frontmatter.name { print("# \(name)") }
+        if let type = page.frontmatter.type { print("Type: \(type)") }
+        if let desc = page.frontmatter.description { print("Description: \(desc)") }
+        if !page.frontmatter.tags.isEmpty { print("Tags: \(page.frontmatter.tags.joined(separator: ", "))") }
+        print("---")
+        print(page.body)
     }
 }
 

--- a/src/commands/wiki.swift
+++ b/src/commands/wiki.swift
@@ -1,0 +1,54 @@
+// wiki.swift — aos wiki subcommands: knowledge base + workflow plugins
+
+import Foundation
+import SQLite3
+
+// MARK: - Path Helpers
+
+func aosWikiDir(for mode: AOSRuntimeMode? = nil) -> String {
+    "\(aosStateDir(for: mode))/wiki"
+}
+
+func aosWikiDbPath(for mode: AOSRuntimeMode? = nil) -> String {
+    "\(aosWikiDir(for: mode))/wiki.db"
+}
+
+// MARK: - Command Router
+
+func wikiCommand(args: [String]) {
+    guard let sub = args.first else {
+        exitError("Usage: aos wiki <create-plugin|add|rm|link|list|search|show|invoke|reindex|lint|seed>", code: "MISSING_SUBCOMMAND")
+    }
+    let subArgs = Array(args.dropFirst())
+    switch sub {
+    case "reindex":
+        wikiReindexCommand(args: subArgs)
+    default:
+        exitError("Unknown wiki subcommand: \(sub)", code: "UNKNOWN_SUBCOMMAND")
+    }
+}
+
+// MARK: - Placeholder: reindex
+
+func wikiReindexCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    let wikiDir = aosWikiDir()
+
+    // Verify SQLite3 works
+    var db: OpaquePointer?
+    let dbPath = aosWikiDbPath()
+
+    // Ensure wiki directory exists
+    try? FileManager.default.createDirectory(atPath: wikiDir, withIntermediateDirectories: true)
+
+    guard sqlite3_open(dbPath, &db) == SQLITE_OK else {
+        exitError("Failed to open wiki database at \(dbPath)", code: "WIKI_DB_ERROR")
+    }
+    sqlite3_close(db)
+
+    if asJSON {
+        print(jsonString(["status": "ok", "wiki_dir": wikiDir, "db": dbPath]))
+    } else {
+        print("Wiki database OK at \(dbPath)")
+    }
+}

--- a/src/commands/wiki.swift
+++ b/src/commands/wiki.swift
@@ -41,6 +41,8 @@ func wikiCommand(args: [String]) {
         wikiLintCommand(args: subArgs)
     case "invoke":
         wikiInvokeCommand(args: subArgs)
+    case "seed":
+        wikiSeedCommand(args: subArgs)
     default:
         exitError("Unknown wiki subcommand: \(sub)", code: "UNKNOWN_SUBCOMMAND")
     }
@@ -851,6 +853,85 @@ func wikiInvokeCommand(args: [String]) {
         print(jsonString(response))
     } else {
         print(bundle)
+    }
+}
+
+// MARK: - Seed
+
+func wikiSeedCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    let force = hasFlag(args, "--force")
+    let fromPath = getArg(args, "--from")
+
+    let wikiDir = aosWikiDir()
+
+    // Check if wiki already has content
+    let fm = FileManager.default
+    let hasContent = ["plugins", "entities", "concepts"].contains { dir in
+        let dirPath = "\(wikiDir)/\(dir)"
+        return (try? fm.contentsOfDirectory(atPath: dirPath))?.contains(where: { $0.hasSuffix(".md") || !$0.hasPrefix(".") }) ?? false
+    }
+
+    if hasContent && !force {
+        if asJSON {
+            print(jsonString(["status": "skipped", "reason": "Wiki already has content. Use --force to overwrite."]))
+        } else {
+            print("Wiki already has content. Use --force to seed anyway.")
+        }
+        return
+    }
+
+    // Determine source directory
+    let sourceDir: String
+    if let from = fromPath {
+        sourceDir = from
+    } else if let repoRoot = aosCurrentRepoRoot() {
+        sourceDir = "\(repoRoot)/wiki-seed"
+    } else {
+        exitError("No seed source found. Use --from <path> or run from the repo.", code: "WIKI_SEED_NOT_FOUND")
+    }
+
+    guard fm.fileExists(atPath: sourceDir) else {
+        exitError("Seed directory not found at \(sourceDir)", code: "WIKI_SEED_NOT_FOUND")
+    }
+
+    // Copy seed files without overwriting existing
+    var copied = 0
+    for subDir in ["plugins", "entities", "concepts"] {
+        let srcDir = "\(sourceDir)/\(subDir)"
+        let dstDir = "\(wikiDir)/\(subDir)"
+        guard let enumerator = fm.enumerator(atPath: srcDir) else { continue }
+        while let relativePath = enumerator.nextObject() as? String {
+            let srcPath = "\(srcDir)/\(relativePath)"
+            let dstPath = "\(dstDir)/\(relativePath)"
+
+            var isDir: ObjCBool = false
+            fm.fileExists(atPath: srcPath, isDirectory: &isDir)
+
+            if isDir.boolValue {
+                try? fm.createDirectory(atPath: dstPath, withIntermediateDirectories: true)
+            } else {
+                if !force && fm.fileExists(atPath: dstPath) { continue }
+                let dstParent = (dstPath as NSString).deletingLastPathComponent
+                try? fm.createDirectory(atPath: dstParent, withIntermediateDirectories: true)
+                try? fm.copyItem(atPath: srcPath, toPath: dstPath)
+                copied += 1
+            }
+        }
+    }
+
+    // Reindex after seeding
+    wikiReindexCommand(args: asJSON ? ["--json"] : [])
+
+    if asJSON {
+        let result: [String: Any] = [
+            "status": "ok",
+            "files_copied": copied
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: result, options: [.prettyPrinted, .sortedKeys]),
+           let s = String(data: data, encoding: .utf8) { print(s) }
+    } else {
+        print("Seeded \(copied) files. Wiki is ready.")
     }
 }
 

--- a/src/commands/wiki.swift
+++ b/src/commands/wiki.swift
@@ -28,27 +28,194 @@ func wikiCommand(args: [String]) {
     }
 }
 
-// MARK: - Placeholder: reindex
+// MARK: - Reindex
 
 func wikiReindexCommand(args: [String]) {
     let asJSON = hasFlag(args, "--json")
     let wikiDir = aosWikiDir()
 
-    // Verify SQLite3 works
-    var db: OpaquePointer?
-    let dbPath = aosWikiDbPath()
-
-    // Ensure wiki directory exists
-    try? FileManager.default.createDirectory(atPath: wikiDir, withIntermediateDirectories: true)
-
-    guard sqlite3_open(dbPath, &db) == SQLITE_OK else {
-        exitError("Failed to open wiki database at \(dbPath)", code: "WIKI_DB_ERROR")
+    // Ensure directory structure exists
+    for sub in ["plugins", "entities", "concepts"] {
+        try? FileManager.default.createDirectory(
+            atPath: "\(wikiDir)/\(sub)",
+            withIntermediateDirectories: true
+        )
     }
-    sqlite3_close(db)
+
+    let index = WikiIndex(dbPath: aosWikiDbPath())
+    index.open()
+    index.dropTables()
+    index.createTables()
+
+    let fm = FileManager.default
+    var pageCount = 0
+    var linkCount = 0
+    var pluginCount = 0
+
+    // Scan plugins/
+    let pluginsDir = "\(wikiDir)/plugins"
+    if let pluginDirs = try? fm.contentsOfDirectory(atPath: pluginsDir) {
+        for pluginName in pluginDirs {
+            let pluginPath = "\(pluginsDir)/\(pluginName)"
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: pluginPath, isDirectory: &isDir), isDir.boolValue else { continue }
+
+            let skillPath = "\(pluginPath)/SKILL.md"
+            guard let skillContent = try? String(contentsOfFile: skillPath, encoding: .utf8) else { continue }
+
+            let page = parseWikiPage(content: skillContent)
+            let relativePath = "plugins/\(pluginName)/SKILL.md"
+            let mtime = fileModTime(skillPath)
+
+            // Index the plugin itself
+            index.upsertPlugin(
+                name: pluginName,
+                version: page.frontmatter.version,
+                author: page.frontmatter.author,
+                description: page.frontmatter.description,
+                triggers: page.frontmatter.triggers,
+                requires: page.frontmatter.requires,
+                modifiedAt: mtime
+            )
+            pluginCount += 1
+
+            // Index SKILL.md as a workflow page
+            index.upsertPage(
+                path: relativePath,
+                type: "workflow",
+                name: page.frontmatter.name ?? pluginName,
+                description: page.frontmatter.description,
+                tags: page.frontmatter.tags,
+                plugin: pluginName,
+                modifiedAt: mtime
+            )
+            pageCount += 1
+
+            // Extract and index links
+            let links = extractMarkdownLinks(from: page.body, relativeTo: "plugins/\(pluginName)")
+            for target in links {
+                index.upsertLink(source: relativePath, target: target)
+                linkCount += 1
+            }
+
+            // Scan references/ within the plugin
+            let refsDir = "\(pluginPath)/references"
+            if let refFiles = try? fm.contentsOfDirectory(atPath: refsDir) {
+                for refFile in refFiles where refFile.hasSuffix(".md") {
+                    let refPath = "\(refsDir)/\(refFile)"
+                    guard let refContent = try? String(contentsOfFile: refPath, encoding: .utf8) else { continue }
+                    let refPage = parseWikiPage(content: refContent)
+                    let refRelPath = "plugins/\(pluginName)/references/\(refFile)"
+                    let refMtime = fileModTime(refPath)
+
+                    index.upsertPage(
+                        path: refRelPath,
+                        type: refPage.frontmatter.type ?? "concept",
+                        name: refPage.frontmatter.name ?? refFile.replacingOccurrences(of: ".md", with: ""),
+                        description: refPage.frontmatter.description,
+                        tags: refPage.frontmatter.tags,
+                        plugin: pluginName,
+                        modifiedAt: refMtime
+                    )
+                    pageCount += 1
+
+                    let refLinks = extractMarkdownLinks(from: refPage.body, relativeTo: "plugins/\(pluginName)/references")
+                    for target in refLinks {
+                        index.upsertLink(source: refRelPath, target: target)
+                        linkCount += 1
+                    }
+                }
+            }
+        }
+    }
+
+    // Scan entities/ and concepts/
+    for dirType in ["entities", "concepts"] {
+        let typeDir = "\(wikiDir)/\(dirType)"
+        guard let files = try? fm.contentsOfDirectory(atPath: typeDir) else { continue }
+        for file in files where file.hasSuffix(".md") {
+            let filePath = "\(typeDir)/\(file)"
+            guard let content = try? String(contentsOfFile: filePath, encoding: .utf8) else { continue }
+            let page = parseWikiPage(content: content)
+            let relativePath = "\(dirType)/\(file)"
+            let mtime = fileModTime(filePath)
+            let inferredType = dirType == "entities" ? "entity" : "concept"
+
+            index.upsertPage(
+                path: relativePath,
+                type: page.frontmatter.type ?? inferredType,
+                name: page.frontmatter.name ?? file.replacingOccurrences(of: ".md", with: ""),
+                description: page.frontmatter.description,
+                tags: page.frontmatter.tags,
+                plugin: nil,
+                modifiedAt: mtime
+            )
+            pageCount += 1
+
+            let links = extractMarkdownLinks(from: page.body, relativeTo: dirType)
+            for target in links {
+                index.upsertLink(source: relativePath, target: target)
+                linkCount += 1
+            }
+        }
+    }
+
+    index.close()
 
     if asJSON {
-        print(jsonString(["status": "ok", "wiki_dir": wikiDir, "db": dbPath]))
+        let result: [String: Any] = [
+            "status": "ok",
+            "pages": pageCount,
+            "links": linkCount,
+            "plugins": pluginCount
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: result, options: [.prettyPrinted, .sortedKeys]),
+           let s = String(data: data, encoding: .utf8) { print(s) }
     } else {
-        print("Wiki database OK at \(dbPath)")
+        print("Reindexed: \(pageCount) pages, \(linkCount) links, \(pluginCount) plugins")
     }
+}
+
+// MARK: - Helpers
+
+/// Extract markdown links like [text](../path/to/file.md) and return resolved relative paths.
+func extractMarkdownLinks(from body: String, relativeTo dir: String) -> [String] {
+    var results: [String] = []
+    // Match [text](path) where path ends in .md
+    let pattern = "\\[([^\\]]+)\\]\\(([^)]+\\.md)\\)"
+    guard let regex = try? NSRegularExpression(pattern: pattern) else { return results }
+    let nsBody = body as NSString
+    let matches = regex.matches(in: body, range: NSRange(location: 0, length: nsBody.length))
+    for match in matches {
+        let pathRange = match.range(at: 2)
+        let linkPath = nsBody.substring(with: pathRange)
+        // Skip external URLs
+        if linkPath.hasPrefix("http://") || linkPath.hasPrefix("https://") { continue }
+        // Resolve relative path
+        let resolved = resolveRelativePath(linkPath, from: dir)
+        results.append(resolved)
+    }
+    return results
+}
+
+/// Resolve a relative path like "../concepts/ipc-protocol.md" from a base directory
+func resolveRelativePath(_ link: String, from baseDir: String) -> String {
+    let baseParts = baseDir.components(separatedBy: "/")
+    let linkParts = link.components(separatedBy: "/")
+    var result = baseParts
+    for part in linkParts {
+        if part == ".." {
+            if !result.isEmpty { result.removeLast() }
+        } else if part != "." {
+            result.append(part)
+        }
+    }
+    return result.joined(separator: "/")
+}
+
+/// Get file modification time as unix epoch
+func fileModTime(_ path: String) -> Int {
+    guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+          let date = attrs[.modificationDate] as? Date else { return 0 }
+    return Int(date.timeIntervalSince1970)
 }

--- a/src/commands/wiki.swift
+++ b/src/commands/wiki.swift
@@ -23,6 +23,12 @@ func wikiCommand(args: [String]) {
     switch sub {
     case "reindex":
         wikiReindexCommand(args: subArgs)
+    case "create-plugin":
+        wikiCreatePluginCommand(args: subArgs)
+    case "add":
+        wikiAddCommand(args: subArgs)
+    case "rm":
+        wikiRmCommand(args: subArgs)
     default:
         exitError("Unknown wiki subcommand: \(sub)", code: "UNKNOWN_SUBCOMMAND")
     }
@@ -176,6 +182,196 @@ func wikiReindexCommand(args: [String]) {
     }
 }
 
+// MARK: - Create Plugin
+
+func wikiCreatePluginCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    guard let name = args.first(where: { !$0.hasPrefix("-") }) else {
+        exitError("Usage: aos wiki create-plugin <name> [--json]", code: "MISSING_ARG")
+    }
+
+    let wikiDir = aosWikiDir()
+    let pluginDir = "\(wikiDir)/plugins/\(name)"
+    let skillPath = "\(pluginDir)/SKILL.md"
+
+    if FileManager.default.fileExists(atPath: skillPath) {
+        exitError("Plugin '\(name)' already exists at \(pluginDir)", code: "WIKI_PLUGIN_EXISTS")
+    }
+
+    // Create directory structure
+    try? FileManager.default.createDirectory(atPath: "\(pluginDir)/references", withIntermediateDirectories: true)
+
+    // Write SKILL.md template
+    let template = """
+    ---
+    name: \(name)
+    description: >
+      Describe when this plugin should be used. Include trigger phrases
+      and contexts where it should activate.
+    version: "0.1.0"
+    author: ""
+    tags: []
+    triggers: []
+    requires: []
+    ---
+
+    # \(name.replacingOccurrences(of: "-", with: " ").capitalized)
+
+    ## Purpose
+
+    Describe what this workflow does and why.
+
+    ## Steps
+
+    1. First step
+    2. Second step
+
+    ## Related
+
+    """
+    try? template.write(toFile: skillPath, atomically: true, encoding: .utf8)
+
+    // Update index
+    let index = openWikiIndex()
+    let page = parseWikiPage(content: template)
+    let relativePath = "plugins/\(name)/SKILL.md"
+    index.upsertPage(
+        path: relativePath, type: "workflow", name: name,
+        description: page.frontmatter.description, tags: [],
+        plugin: name, modifiedAt: Int(Date().timeIntervalSince1970)
+    )
+    index.upsertPlugin(
+        name: name, version: "0.1.0", author: nil, description: page.frontmatter.description,
+        triggers: [], requires: [], modifiedAt: Int(Date().timeIntervalSince1970)
+    )
+    index.close()
+
+    if asJSON {
+        let payload: [String: Any] = ["status": "ok", "plugin": name, "path": pluginDir]
+        if let data = try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys]),
+           let s = String(data: data, encoding: .utf8) { print(s) }
+    } else {
+        print("Created plugin '\(name)' at \(pluginDir)")
+        print("Edit: \(skillPath)")
+    }
+}
+
+// MARK: - Add Page
+
+func wikiAddCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    let nonFlags = args.filter { !$0.hasPrefix("-") }
+    guard nonFlags.count >= 2 else {
+        exitError("Usage: aos wiki add <entity|concept> <name> [--json]", code: "MISSING_ARG")
+    }
+    let typeArg = nonFlags[0]
+    let name = nonFlags[1]
+
+    guard typeArg == "entity" || typeArg == "concept" else {
+        exitError("Type must be 'entity' or 'concept', got '\(typeArg)'", code: "WIKI_INVALID_TYPE")
+    }
+
+    let wikiDir = aosWikiDir()
+    let dirName = typeArg == "entity" ? "entities" : "concepts"
+    let filePath = "\(wikiDir)/\(dirName)/\(name).md"
+
+    if FileManager.default.fileExists(atPath: filePath) {
+        exitError("Page '\(name)' already exists at \(filePath)", code: "WIKI_PAGE_EXISTS")
+    }
+
+    try? FileManager.default.createDirectory(
+        atPath: "\(wikiDir)/\(dirName)", withIntermediateDirectories: true
+    )
+
+    let displayName = name.replacingOccurrences(of: "-", with: " ").capitalized
+    let template = """
+    ---
+    type: \(typeArg)
+    name: \(displayName)
+    description: ""
+    tags: []
+    ---
+
+    # \(displayName)
+
+    ## Overview
+
+    ## Related
+
+    """
+    try? template.write(toFile: filePath, atomically: true, encoding: .utf8)
+
+    // Update index
+    let index = openWikiIndex()
+    let relativePath = "\(dirName)/\(name).md"
+    index.upsertPage(
+        path: relativePath, type: typeArg, name: displayName,
+        description: nil, tags: [], plugin: nil,
+        modifiedAt: Int(Date().timeIntervalSince1970)
+    )
+    index.close()
+
+    if asJSON {
+        let payload: [String: Any] = ["status": "ok", "type": typeArg, "name": name, "path": filePath]
+        if let data = try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys]),
+           let s = String(data: data, encoding: .utf8) { print(s) }
+    } else {
+        print("Created \(typeArg) '\(name)' at \(filePath)")
+    }
+}
+
+// MARK: - Remove Page
+
+func wikiRmCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    guard let pathArg = args.first(where: { !$0.hasPrefix("-") }) else {
+        exitError("Usage: aos wiki rm <relative-path-or-name> [--json]", code: "MISSING_ARG")
+    }
+
+    let wikiDir = aosWikiDir()
+    let fullPath: String
+    let relativePath: String
+
+    // Resolve: could be a relative path or a bare name
+    if pathArg.contains("/") {
+        relativePath = pathArg
+        fullPath = "\(wikiDir)/\(pathArg)"
+    } else {
+        // Search for it
+        let candidates = ["entities/\(pathArg).md", "concepts/\(pathArg).md"]
+        if let found = candidates.first(where: { FileManager.default.fileExists(atPath: "\(wikiDir)/\($0)") }) {
+            relativePath = found
+            fullPath = "\(wikiDir)/\(found)"
+        } else {
+            exitError("Page '\(pathArg)' not found", code: "WIKI_NOT_FOUND")
+        }
+    }
+
+    guard FileManager.default.fileExists(atPath: fullPath) else {
+        exitError("File not found: \(fullPath)", code: "WIKI_NOT_FOUND")
+    }
+
+    // Check for incoming links
+    let index = openWikiIndex()
+    let incoming = index.linksTo(path: relativePath)
+    if !incoming.isEmpty && !asJSON {
+        print("Warning: \(incoming.count) page(s) link to this page:")
+        for link in incoming { print("  \(link.source_path)") }
+    }
+
+    try? FileManager.default.removeItem(atPath: fullPath)
+    index.deletePage(path: relativePath)
+    index.close()
+
+    if asJSON {
+        let payload: [String: Any] = ["status": "ok", "removed": relativePath, "broken_links": incoming.count]
+        if let data = try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys]),
+           let s = String(data: data, encoding: .utf8) { print(s) }
+    } else {
+        print("Removed \(relativePath)")
+    }
+}
+
 // MARK: - Helpers
 
 /// Extract markdown links like [text](../path/to/file.md) and return resolved relative paths.
@@ -218,4 +414,16 @@ func fileModTime(_ path: String) -> Int {
     guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
           let date = attrs[.modificationDate] as? Date else { return 0 }
     return Int(date.timeIntervalSince1970)
+}
+
+// MARK: - Index Helper
+
+/// Open the wiki index, creating tables if needed
+func openWikiIndex() -> WikiIndex {
+    let wikiDir = aosWikiDir()
+    try? FileManager.default.createDirectory(atPath: wikiDir, withIntermediateDirectories: true)
+    let index = WikiIndex(dbPath: aosWikiDbPath())
+    index.open()
+    index.createTables()
+    return index
 }

--- a/src/commands/wiki.swift
+++ b/src/commands/wiki.swift
@@ -39,6 +39,8 @@ func wikiCommand(args: [String]) {
         wikiLinkCommand(args: subArgs)
     case "lint":
         wikiLintCommand(args: subArgs)
+    case "invoke":
+        wikiInvokeCommand(args: subArgs)
     default:
         exitError("Unknown wiki subcommand: \(sub)", code: "UNKNOWN_SUBCOMMAND")
     }
@@ -796,6 +798,59 @@ func wikiLintCommand(args: [String]) {
             }
             print("\n\(errors.count) error(s), \(warnings.count) warning(s)")
         }
+    }
+}
+
+// MARK: - Invoke
+
+func wikiInvokeCommand(args: [String]) {
+    let asJSON = hasFlag(args, "--json")
+    guard let name = args.first(where: { !$0.hasPrefix("-") }) else {
+        exitError("Usage: aos wiki invoke <plugin-name> [--json]", code: "MISSING_ARG")
+    }
+
+    let wikiDir = aosWikiDir()
+    let pluginDir = "\(wikiDir)/plugins/\(name)"
+    let skillPath = "\(pluginDir)/SKILL.md"
+
+    guard let skillContent = try? String(contentsOfFile: skillPath, encoding: .utf8) else {
+        exitError("Plugin '\(name)' not found at \(pluginDir)", code: "WIKI_NOT_FOUND")
+    }
+
+    var bundle = skillContent
+
+    // Bundle references
+    let refsDir = "\(pluginDir)/references"
+    let refFiles = ((try? FileManager.default.contentsOfDirectory(atPath: refsDir))?.sorted()) ?? []
+    for refFile in refFiles where refFile.hasSuffix(".md") {
+        let refPath = "\(refsDir)/\(refFile)"
+        if let refContent = try? String(contentsOfFile: refPath, encoding: .utf8) {
+            bundle += "\n\n--- BEGIN reference: \(refFile) ---\n\n"
+            bundle += refContent
+            bundle += "\n\n--- END reference: \(refFile) ---"
+        }
+    }
+
+    // Bundle scripts (show content so agent knows what's available)
+    let scriptsDir = "\(pluginDir)/scripts"
+    let scriptFiles = ((try? FileManager.default.contentsOfDirectory(atPath: scriptsDir))?.sorted()) ?? []
+    for scriptFile in scriptFiles {
+        let scriptPath = "\(scriptsDir)/\(scriptFile)"
+        if let scriptContent = try? String(contentsOfFile: scriptPath, encoding: .utf8) {
+            bundle += "\n\n--- BEGIN script: \(scriptFile) ---\n\n"
+            bundle += scriptContent
+            bundle += "\n\n--- END script: \(scriptFile) ---"
+        }
+    }
+
+    if asJSON {
+        let response: [String: String] = [
+            "plugin": name,
+            "bundle": bundle
+        ]
+        print(jsonString(response))
+    } else {
+        print(bundle)
     }
 }
 

--- a/src/display/canvas.swift
+++ b/src/display/canvas.swift
@@ -106,6 +106,11 @@ class Canvas {
     var anchorChannelID: String?
     var offset: CGRect?
     var isInteractive: Bool
+    /// When true, the canvas should grab focus (app activation + key window)
+    /// and — if set via handleCreate — the next 'ready' event from the page
+    /// will trigger a focusInput() eval. Cleared after the ready handler fires
+    /// so the focus request is one-shot per set.
+    var focusOnReady: Bool = false
     var ttlTimer: DispatchSourceTimer?
     var ttlDeadline: Date?
     var onTTLExpired: (() -> Void)?
@@ -198,6 +203,16 @@ class Canvas {
         } else {
             window.orderFront(nil)
         }
+    }
+
+    /// Activate the aos process and make this window key so keystrokes route
+    /// here immediately, without the user needing to click into the canvas.
+    /// macOS debounces click-based activation for .accessory apps, so callers
+    /// that need instant keyboard focus must invoke this explicitly.
+    func grabFocus() {
+        guard isInteractive else { return }
+        NSApp.activate(ignoringOtherApps: true)
+        window.makeKeyAndOrderFront(nil)
     }
 
     func close() {
@@ -391,6 +406,13 @@ class CanvasManager {
 
         let interactive = req.interactive ?? false
         let canvas = Canvas(id: id, cgFrame: cgFrame, interactive: interactive)
+        // --focus on create: activate immediately and arm a one-shot
+        // focusInput() eval for when the page emits 'ready'. The OS-level
+        // activation avoids the click-to-focus delay macOS applies to
+        // .accessory apps; the JS call lands keystrokes in the right field.
+        if req.focus == true && interactive {
+            canvas.focusOnReady = true
+        }
 
         // Connection-scoped lifecycle
         let scope = req.scope ?? "global"
@@ -455,6 +477,21 @@ class CanvasManager {
                 // drag_start and drag_end — don't relay, just consume
                 if type == "drag_start" || type == "drag_end" {
                     return
+                }
+
+                // Page signaled it's loaded. If the canvas was created with
+                // --focus, tell the page to focus its input field. One-shot:
+                // clear the flag so we don't re-focus on subsequent ready
+                // emits (the page can re-emit after navigation).
+                if type == "ready" && canvas.focusOnReady {
+                    canvas.focusOnReady = false
+                    DispatchQueue.main.async {
+                        canvas.webView.evaluateJavaScript(
+                            "typeof focusInput === 'function' && focusInput()",
+                            completionHandler: nil
+                        )
+                    }
+                    // fall through to relay
                 }
 
                 // Config IPC: read/write daemon config from canvas JS
@@ -553,6 +590,9 @@ class CanvasManager {
         }
 
         canvas.show()
+        if req.focus == true && interactive {
+            canvas.grabFocus()
+        }
         canvases[id] = canvas
 
         if let ttl = req.ttl {
@@ -668,6 +708,18 @@ class CanvasManager {
                 self?.removeByTTL(id)
             }
             canvas.setTTL(ttl > 0 ? ttl : nil)  // ttl=0 clears the TTL
+        }
+
+        // --focus on update: the canvas is already loaded, so we can both
+        // activate at the OS level and eval focusInput() right away.
+        if req.focus == true && canvas.isInteractive {
+            canvas.grabFocus()
+            DispatchQueue.main.async {
+                canvas.webView.evaluateJavaScript(
+                    "typeof focusInput === 'function' && focusInput()",
+                    completionHandler: nil
+                )
+            }
         }
 
         return .ok()

--- a/src/display/canvas.swift
+++ b/src/display/canvas.swift
@@ -648,6 +648,19 @@ class CanvasManager {
         if let interactive = req.interactive {
             canvas.isInteractive = interactive
             canvas.window.ignoresMouseEvents = !interactive
+            // The CanvasWindow reads isInteractiveCanvas to decide canBecomeKey
+            // and whether sendEvent should activate on first click. Without
+            // updating it, flipped-to-interactive canvases can receive mouse
+            // events but never become key window, so keyboard input bounces
+            // back to the previously-active app (system bonk on every keystroke).
+            (canvas.window as? CanvasWindow)?.isInteractiveCanvas = interactive
+            canvas.window.level = interactive ? .floating : .statusBar
+            // NOTE: the WKWebView subclass (CanvasWebView vs plain WKWebView)
+            // is chosen at construction time and cannot be swapped at runtime.
+            // The only behavioral difference is acceptsFirstMouse, which only
+            // affects the first-click-starts-drag ergonomic. A flipped canvas
+            // may require one extra click to activate; recreate the canvas with
+            // --interactive at creation time for full first-mouse behavior.
         }
 
         if let ttl = req.ttl {

--- a/src/display/channel.swift
+++ b/src/display/channel.swift
@@ -1,11 +1,11 @@
 // display — Focus channel integration
-// Reads side-eye channel files from ~/.config/agent-os/channels/<id>.json
+// Reads channel files from ~/.config/agent-os/channels/<id>.json
 // Used by anchorChannel and auto-projection modes.
 
 import CoreGraphics
 import Foundation
 
-// MARK: - Channel File Types (mirrors side-eye ChannelFile schema)
+// MARK: - Channel File Types
 
 struct ChannelData: Codable {
     let channel_id: String

--- a/src/display/client.swift
+++ b/src/display/client.swift
@@ -120,6 +120,7 @@ func createCommand(args: [String]) {
     var fileValue: String? = nil
     var urlValue: String? = nil
     var interactive = false
+    var focus = false
     var ttlValue: String? = nil
     var scope: String? = nil
     var autoProject: String? = nil
@@ -153,6 +154,8 @@ func createCommand(args: [String]) {
             urlValue = args[i]
         case "--interactive":
             interactive = true
+        case "--focus":
+            focus = true
         case "--ttl":
             i += 1; guard i < args.count else { exitError("--ttl requires a duration (e.g. 5s, 10m)", code: "MISSING_ARG") }
             ttlValue = args[i]
@@ -176,6 +179,7 @@ func createCommand(args: [String]) {
     var request = CanvasRequest(action: "create")
     request.id = canvasID
     request.interactive = interactive
+    if focus { request.focus = true }
     request.scope = scope
 
     if let ttlStr = ttlValue {
@@ -222,6 +226,7 @@ func updateCommand(args: [String]) {
     var fileValue: String? = nil
     var urlValue: String? = nil
     var interactive: Bool? = nil
+    var focus: Bool? = nil
     var ttlValue: String? = nil
 
     var i = 0
@@ -255,6 +260,10 @@ func updateCommand(args: [String]) {
             interactive = true
         case "--no-interactive":
             interactive = false
+        case "--focus":
+            focus = true
+        case "--no-focus":
+            focus = false
         case "--ttl":
             i += 1; guard i < args.count else { exitError("--ttl requires a duration (e.g. 5s, 10m)", code: "MISSING_ARG") }
             ttlValue = args[i]
@@ -269,6 +278,7 @@ func updateCommand(args: [String]) {
     var request = CanvasRequest(action: "update")
     request.id = canvasID
     request.interactive = interactive
+    request.focus = focus
 
     if let ttlStr = ttlValue {
         request.ttl = parseDuration(ttlStr)

--- a/src/display/protocol.swift
+++ b/src/display/protocol.swift
@@ -64,6 +64,7 @@ struct CanvasRequest: Codable {
     var html: String?           // HTML content (resolved by client)
     var url: String?            // URL for WKWebView to load directly
     var interactive: Bool?      // override click-through (default: false)
+    var focus: Bool?            // activate app + make window key; on create, also eval focusInput() after page ready
     var ttl: Double?            // seconds until auto-remove (nil = no expiry)
     var js: String?             // JavaScript to evaluate (for "eval" action)
     var scope: String?          // "connection" or "global" (default: global)

--- a/src/main.swift
+++ b/src/main.swift
@@ -105,7 +105,7 @@ func printUsage() {
       permissions          Permission preflight and one-time onboarding
       inspect              Live AX element inspector overlay
       log                  Display log console panel
-      wiki <subcommand>  Knowledge base — browse, search, invoke workflow plugins
+      wiki <subcommand>    Knowledge base — browse, search, invoke workflow plugins
 
     Perception (aos see):
       cursor               What's under the cursor (display, window, AX element)
@@ -202,6 +202,19 @@ func printUsage() {
       inspect [--at x,y,w,h]  Live AX inspector — shows element under cursor
       log [--at x,y,w,h]      Log console — scrolling output panel
 
+    Wiki (aos wiki):
+      create-plugin <name>   Scaffold a new workflow plugin
+      add <type> <name>      Create an entity or concept page
+      rm <path>              Remove a page (warns about broken links)
+      link <from> <to>       Add a cross-reference between pages
+      list                   List pages (--type, --plugin, --links-to, --links-from, --orphans)
+      search <query>         Search pages (--type filter)
+      show <name>            Display a page (--raw for markdown, --json for structured)
+      invoke <plugin>        Bundle a plugin into a prompt payload
+      reindex                Rebuild the index from filesystem
+      lint                   Check for broken links, orphans, missing frontmatter
+      seed                   Populate wiki with starter content
+
     Examples:
       aos see cursor                    # What's under the cursor
       aos see capture main --out /tmp/screen.png   # Screenshot main display
@@ -234,6 +247,14 @@ func printUsage() {
       aos inspect                        # Live AX element inspector
       echo "hello" | aos log             # Stream to log overlay
       aos log push "test message"        # One-shot log entry
+      aos wiki seed                      # Populate with starter content
+      aos wiki list                      # List all wiki pages
+      aos wiki list --type workflow      # List workflow plugins
+      aos wiki show gateway --json       # View a page as JSON
+      aos wiki search "IPC protocol"     # Search the wiki
+      aos wiki create-plugin my-flow     # Create a new plugin
+      aos wiki invoke self-check         # Bundle a plugin for chat injection
+      aos wiki lint                      # Check wiki health
     """
     print(usage)
 }

--- a/src/main.swift
+++ b/src/main.swift
@@ -106,7 +106,7 @@ func printUsage() {
 
     Perception (aos see):
       cursor               What's under the cursor (display, window, AX element)
-      capture <target>     Screenshot capture (delegates to side-eye)
+      capture <target>     Screenshot capture
       <target>             Shorthand for capture (main, external, user_active, selfie, mouse, all)
       observe              Subscribe to perception stream (requires daemon)
 
@@ -117,7 +117,7 @@ func printUsage() {
       selfie               Display hosting the calling process
       mouse                Display under cursor (with --radius for area)
       all                  All connected displays
-      <zone-name>          Named zone (configured via side-eye zone)
+      <zone-name>          Named zone (configured via aos see zone)
 
     Capture options:
       --out <path>         Output file path (default: ./screenshot.png)

--- a/src/main.swift
+++ b/src/main.swift
@@ -72,6 +72,8 @@ struct AOS {
             inspectCommand(args: Array(args.dropFirst()))
         case "log":
             logCommand(args: Array(args.dropFirst()))
+        case "wiki":
+            wikiCommand(args: Array(args.dropFirst()))
         case "--help", "-h", "help":
             printUsage()
         default:
@@ -103,6 +105,7 @@ func printUsage() {
       permissions          Permission preflight and one-time onboarding
       inspect              Live AX element inspector overlay
       log                  Display log console panel
+      wiki <subcommand>  Knowledge base — browse, search, invoke workflow plugins
 
     Perception (aos see):
       cursor               What's under the cursor (display, window, AX element)

--- a/src/perceive/capture-pipeline.swift
+++ b/src/perceive/capture-pipeline.swift
@@ -872,9 +872,15 @@ let captureTargets: Set<String> = ["main", "center", "middle", "external", "user
 
 // MARK: - Named Zones
 
-let zonesFilePath = NSString("~/.config/side-eye/zones.json").expandingTildeInPath
+let zonesFilePath = (aosStateDir() as NSString).appendingPathComponent("zones.json")
+private let legacyZonesFilePath = NSString("~/.config/side-eye/zones.json").expandingTildeInPath
 
 func loadZones() -> [String: ZoneEntry] {
+    // Migrate from legacy side-eye path if needed
+    if !FileManager.default.fileExists(atPath: zonesFilePath),
+       FileManager.default.fileExists(atPath: legacyZonesFilePath) {
+        try? FileManager.default.copyItem(atPath: legacyZonesFilePath, toPath: zonesFilePath)
+    }
     guard let data = FileManager.default.contents(atPath: zonesFilePath),
           let zones = try? JSONDecoder().decode([String: ZoneEntry].self, from: data)
     else { return [:] }

--- a/src/perceive/capture-pipeline.swift
+++ b/src/perceive/capture-pipeline.swift
@@ -1,8 +1,7 @@
-// capture-pipeline.swift — Full capture pipeline (ported from side-eye)
+// capture-pipeline.swift — Full capture pipeline
 //
-// This is the core screenshot pipeline: parse args → resolve target → capture →
-// crop → overlay → encode → output. Formerly lived in packages/side-eye/main.swift,
-// now compiled directly into the aos unified binary.
+// Core screenshot pipeline: parse args → resolve target → capture →
+// crop → overlay → encode → output.
 
 import Cocoa
 import ScreenCaptureKit
@@ -1155,11 +1154,7 @@ func showInteractiveSelection(on display: CaptureDisplayEntry, timeout: Double =
 func seeListCommand() {
     let displays = getCaptureDisplays()
 
-    // Build the CaptureDisplayEntry → side-eye DisplayEntry bridge for enumerateWindows
-    // enumerateWindows expects the side-eye DisplayEntry type. For now we need to
-    // create a compatible call. The enumerateWindows function lives in packages/side-eye.
-    // Since it hasn't been ported yet (Task 3), we implement a simpler version here
-    // that uses CGWindowList directly.
+    // Build window list using CGWindowList directly.
 
     let windowInfoList = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as? [[String: Any]] ?? []
 

--- a/src/perceive/focus-commands.swift
+++ b/src/perceive/focus-commands.swift
@@ -1,7 +1,6 @@
 // focus-commands.swift — CLI commands for focus channels and graph navigation
 //
-// Ported from packages/side-eye/client.swift. These commands talk to the
-// aos unified daemon via daemonOneShot() instead of side-eye's standalone daemon.
+// These commands talk to the aos unified daemon via daemonOneShot().
 
 import Foundation
 

--- a/src/perceive/spatial.swift
+++ b/src/perceive/spatial.swift
@@ -4,8 +4,8 @@
 // manages channel lifecycle: create, update, remove, refresh.
 // Channels are written as JSON files to ~/.config/agent-os/channels/.
 //
-// Ported from packages/side-eye/spatial.swift. Uses shared AX helpers
-// from ax.swift and channel types from display/channel.swift.
+// Uses shared AX helpers from ax.swift and channel types from
+// display/channel.swift.
 
 import ApplicationServices
 import Cocoa
@@ -583,8 +583,8 @@ class SpatialModel {
     // MARK: - Daemon Action Dispatch
 
     /// Route an incoming daemon action to the appropriate spatial model method.
-    /// Returns a dictionary suitable for sendResponseJSON(). Mirrors side-eye's
-    /// daemon.swift dispatchRequest but uses dictionary I/O for the unified daemon.
+    /// Returns a dictionary suitable for sendResponseJSON(). Uses dictionary I/O
+    /// for the unified daemon.
     func handleAction(_ action: String, json: [String: Any]) -> [String: Any] {
         switch action {
         case "focus-create":

--- a/tests/wiki-integration.sh
+++ b/tests/wiki-integration.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+set -euo pipefail
+
+# wiki-integration.sh — end-to-end test of aos wiki commands
+# Requires: ./aos built, no existing wiki (or will be reset)
+
+AOS="./aos"
+WIKI_DIR=$(${AOS} wiki reindex --json 2>/dev/null | grep -o '"wiki_dir":"[^"]*"' | cut -d'"' -f4 || echo "$HOME/.config/aos/repo/wiki")
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== aos wiki integration tests ==="
+echo "Wiki dir: $WIKI_DIR"
+
+# Clean slate
+rm -rf "$WIKI_DIR"
+
+# Test: reindex on empty wiki
+echo ""
+echo "--- reindex (empty) ---"
+OUTPUT=$($AOS wiki reindex --json)
+echo "$OUTPUT" | grep -q '"pages" : 0' && pass "reindex empty" || fail "reindex empty"
+
+# Test: seed
+echo ""
+echo "--- seed ---"
+OUTPUT=$($AOS wiki seed --json)
+echo "$OUTPUT" | grep -q '"status" : "ok"' && pass "seed" || fail "seed"
+
+# Test: reindex after seed
+echo ""
+echo "--- reindex (after seed) ---"
+OUTPUT=$($AOS wiki reindex --json)
+PAGES=$(echo "$OUTPUT" | grep -o '"pages" : [0-9]*' | grep -o '[0-9]*')
+[ "$PAGES" -gt 0 ] && pass "reindex found $PAGES pages" || fail "reindex found 0 pages"
+
+# Test: list
+echo ""
+echo "--- list ---"
+OUTPUT=$($AOS wiki list --json)
+echo "$OUTPUT" | grep -q "gateway" && pass "list contains gateway" || fail "list missing gateway"
+
+# Test: list --type
+OUTPUT=$($AOS wiki list --type workflow --json)
+echo "$OUTPUT" | grep -q "self-check" && pass "list --type workflow" || fail "list --type workflow"
+
+# Test: show
+echo ""
+echo "--- show ---"
+OUTPUT=$($AOS wiki show gateway --json)
+echo "$OUTPUT" | grep -q '"name" : "Gateway"' && pass "show gateway" || fail "show gateway"
+
+# Test: show --raw
+OUTPUT=$($AOS wiki show gateway --raw)
+echo "$OUTPUT" | grep -q "^---" && pass "show --raw has frontmatter" || fail "show --raw"
+
+# Test: search
+echo ""
+echo "--- search ---"
+OUTPUT=$($AOS wiki search "MCP server" --json)
+echo "$OUTPUT" | grep -q "gateway" && pass "search finds gateway" || fail "search"
+
+# Test: create-plugin
+echo ""
+echo "--- create-plugin ---"
+OUTPUT=$($AOS wiki create-plugin test-workflow --json)
+echo "$OUTPUT" | grep -q '"status" : "ok"' && pass "create-plugin" || fail "create-plugin"
+
+# Test: add entity
+OUTPUT=$($AOS wiki add entity test-entity --json)
+echo "$OUTPUT" | grep -q '"status" : "ok"' && pass "add entity" || fail "add entity"
+
+# Test: link
+echo ""
+echo "--- link ---"
+OUTPUT=$($AOS wiki link test-entity gateway --json)
+echo "$OUTPUT" | grep -q '"status" : "ok"' && pass "link" || fail "link"
+
+# Test: list --links-to
+OUTPUT=$($AOS wiki list --links-to entities/gateway.md --json)
+echo "$OUTPUT" | grep -q "test-entity" && pass "list --links-to" || fail "list --links-to"
+
+# Test: invoke
+echo ""
+echo "--- invoke ---"
+OUTPUT=$($AOS wiki invoke self-check)
+echo "$OUTPUT" | grep -q "Self-Check" && pass "invoke self-check" || fail "invoke self-check"
+
+# Test: lint
+echo ""
+echo "--- lint ---"
+OUTPUT=$($AOS wiki lint --json)
+# Should run without error
+[ $? -eq 0 ] && pass "lint runs" || fail "lint runs"
+
+# Test: rm
+echo ""
+echo "--- rm ---"
+OUTPUT=$($AOS wiki rm test-entity --json)
+echo "$OUTPUT" | grep -q '"status" : "ok"' && pass "rm" || fail "rm"
+
+# Cleanup test plugin
+rm -rf "$WIKI_DIR/plugins/test-workflow"
+$AOS wiki reindex > /dev/null 2>&1
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ $FAIL -eq 0 ] && exit 0 || exit 1

--- a/wiki-seed/concepts/content-server.md
+++ b/wiki-seed/concepts/content-server.md
@@ -1,0 +1,32 @@
+---
+type: concept
+name: Content Server
+description: Local HTTP server for serving HTML assets to WKWebView canvases
+tags: [infrastructure, http, content]
+---
+
+# Content Server
+
+The daemon runs a local HTTP file server that serves HTML, CSS, and JavaScript files to WKWebView canvases. This eliminates the need to bundle multi-file web apps into single HTML files.
+
+## URL Scheme
+
+Canvases use `aos://` URLs which the daemon rewrites to `http://127.0.0.1:PORT/...` at canvas creation time.
+
+Example: `aos://sigil/studio/index.html` resolves to the studio interface.
+
+## Configuration
+
+Content roots map URL prefixes to filesystem directories:
+
+```bash
+aos set content.roots.sigil apps/sigil
+```
+
+## Why
+
+WKWebView in file:// mode blocks ES module imports and cross-origin CSS. The HTTP server bypasses these restrictions while keeping everything local.
+
+## Related
+- [Canvas System](../entities/canvas-system.md)
+- [Daemon](../entities/daemon.md)

--- a/wiki-seed/concepts/daemon-lifecycle.md
+++ b/wiki-seed/concepts/daemon-lifecycle.md
@@ -1,0 +1,34 @@
+---
+type: concept
+name: Daemon Lifecycle
+description: How the aos daemon starts, runs, and stops across runtime modes
+tags: [daemon, lifecycle, service]
+---
+
+# Daemon Lifecycle
+
+## Startup
+
+1. Parse config from `~/.config/aos/{mode}/config.json`
+2. Create Unix socket at `~/.config/aos/{mode}/sock`
+3. Start content server (HTTP) on an OS-assigned port
+4. Start configuration file watcher for live reload
+5. Begin accepting client connections
+
+## Connection Handling
+
+Each client gets an independent ndjson stream. Canvas operations, eval calls, and queries are routed through the daemon's central state.
+
+## Shutdown
+
+- `aos service stop` — sends SIGTERM via launchctl
+- `aos reset` — stops service, removes socket, cleans state directory
+- The daemon cleans up canvases and closes connections on exit
+
+## Auto-Start
+
+CLI commands that need the daemon (canvas operations, eval, listen) attempt to auto-start it via `DaemonSession.connect()`, which launches `aos serve` as a background process if no socket exists.
+
+## Related
+- [Daemon](../entities/daemon.md)
+- [Runtime Modes](./runtime-modes.md)

--- a/wiki-seed/concepts/ipc-protocol.md
+++ b/wiki-seed/concepts/ipc-protocol.md
@@ -1,0 +1,37 @@
+---
+type: concept
+name: IPC Protocol
+description: Newline-delimited JSON messaging over Unix socket between daemon and clients
+tags: [protocol, ipc, messaging]
+---
+
+# IPC Protocol
+
+All communication between the aos daemon and its clients (CLI commands, Sigil, gateway) uses newline-delimited JSON (ndjson) over a Unix socket.
+
+## Envelope Format
+
+```json
+{"v":1,"service":"display","event":"canvas_created","ts":1712345678,"data":{...},"ref":"optional-correlation-id"}
+```
+
+| Field | Description |
+|-------|-------------|
+| v | Protocol version (always 1) |
+| service | Originating subsystem |
+| event | Event type (snake_case) |
+| ts | Unix timestamp |
+| data | Event payload |
+| ref | Optional correlation ID for request/response |
+
+## Request/Response
+
+CLI commands use a request/response pattern: send a command, receive a response with the same `ref`. The `DaemonSession` class handles this via `sendAndReceive()`.
+
+## Streaming
+
+Long-lived connections (Sigil, observe) receive continuous events. The daemon broadcasts relevant events to all connected clients.
+
+## Related
+- [Daemon](../entities/daemon.md)
+- [Gateway](../entities/gateway.md)

--- a/wiki-seed/concepts/runtime-modes.md
+++ b/wiki-seed/concepts/runtime-modes.md
@@ -1,0 +1,29 @@
+---
+type: concept
+name: Runtime Modes
+description: Repo vs installed mode — separate state directories prevent cross-contamination
+tags: [infrastructure, runtime, configuration]
+---
+
+# Runtime Modes
+
+AOS has two explicit runtime modes that determine where state is stored and which binaries are used.
+
+## Modes
+
+| Mode | Binary | State Dir | When |
+|------|--------|-----------|------|
+| repo | `./aos` | `~/.config/aos/repo/` | Building/testing from source |
+| installed | `~/Applications/AOS.app/.../aos` | `~/.config/aos/installed/` | Packaged runtime |
+
+## Detection
+
+Automatic: if the executable path contains `.app/Contents/MacOS/`, it's installed mode. Otherwise, repo mode. Can be overridden via `AOS_RUNTIME_MODE` environment variable.
+
+## Isolation
+
+Each mode gets its own socket, config, logs, and launchd labels. This prevents development builds from interfering with the installed runtime.
+
+## Related
+- [Daemon](../entities/daemon.md)
+- [Daemon Lifecycle](./daemon-lifecycle.md)

--- a/wiki-seed/entities/canvas-system.md
+++ b/wiki-seed/entities/canvas-system.md
@@ -1,0 +1,32 @@
+---
+type: entity
+name: Canvas System
+description: Daemon-managed transparent overlay windows for HTML content
+tags: [display, canvas, overlay]
+---
+
+# Canvas System
+
+Canvases are transparent NSWindow overlays managed by the aos daemon. Each canvas loads HTML content via WKWebView and communicates bidirectionally with the daemon through JavaScript evaluation.
+
+## Operations
+
+- `create` — create a canvas with ID, position, and URL
+- `update` — modify canvas content, position, or style
+- `remove` — destroy a canvas
+- `eval` — run JavaScript in a canvas context
+- `list` — enumerate active canvases
+
+## Canvas Types
+
+- **Interactive** (`.floating` level) — receive clicks. Used for studio, chat, inspector.
+- **Overlay** (`.statusBar` level) — click-through. Used for display overlays, annotations.
+
+## Content Loading
+
+Canvases load content from the daemon's content server via `aos://` URLs, which resolve to `http://127.0.0.1:PORT/...`. This allows multi-file web apps (ES modules, CSS) without bundling.
+
+## Related
+- [Content Server](../concepts/content-server.md)
+- [Daemon](./daemon.md)
+- [Sigil](./sigil.md)

--- a/wiki-seed/entities/daemon.md
+++ b/wiki-seed/entities/daemon.md
@@ -1,0 +1,37 @@
+---
+type: entity
+name: Daemon
+description: Unified aos daemon — socket server, canvas manager, autonomic behaviors
+tags: [infrastructure, daemon, service]
+---
+
+# Daemon
+
+The aos daemon (`aos serve`) is the central process that manages canvases, routes IPC messages, runs the content server, and provides autonomic behaviors (voice, visual feedback).
+
+## Communication
+
+Unix socket at `~/.config/aos/{mode}/sock`. Messages are newline-delimited JSON (ndjson) using the daemon event envelope format.
+
+## Responsibilities
+
+- Canvas lifecycle (create, update, remove, eval)
+- Content server (HTTP file serving for WKWebView)
+- IPC routing between connected clients
+- Autonomic voice announcements
+- Configuration watching and live reload
+
+## Service Management
+
+The daemon can run as a launchd service:
+```
+aos service install --mode repo
+aos service start
+aos service status --json
+```
+
+## Related
+- [IPC Protocol](../concepts/ipc-protocol.md)
+- [Canvas System](./canvas-system.md)
+- [Daemon Lifecycle](../concepts/daemon-lifecycle.md)
+- [Runtime Modes](../concepts/runtime-modes.md)

--- a/wiki-seed/entities/gateway.md
+++ b/wiki-seed/entities/gateway.md
@@ -1,0 +1,31 @@
+---
+type: entity
+name: Gateway
+description: MCP server for typed script execution and cross-harness coordination
+tags: [infrastructure, mcp, tools]
+---
+
+# Gateway
+
+The gateway is an MCP (Model Context Protocol) server that provides typed tool access to the agent-os runtime. It exposes coordination tools (session management, state, messaging) and execution tools (OS script running, script registry).
+
+## Location
+
+`packages/gateway/` in the agent-os repo. Runs as a Node.js process, typically started via MCP configuration in `.mcp.json`.
+
+## Tools
+
+### Coordination
+- `register_session` — register a named session with metadata
+- `set_state` / `get_state` — per-session key-value state
+- `post_message` / `read_stream` — cross-session messaging
+- `who_is_online` — list active sessions
+
+### Execution
+- `run_os_script` — execute TypeScript scripts with SDK access
+- `save_script` / `list_scripts` — persistent script registry
+- `discover_capabilities` — runtime capability detection
+
+## Related
+- [IPC Protocol](../concepts/ipc-protocol.md)
+- [Daemon](./daemon.md)

--- a/wiki-seed/entities/sigil.md
+++ b/wiki-seed/entities/sigil.md
@@ -1,0 +1,26 @@
+---
+type: entity
+name: Sigil
+description: Avatar presence system — the visual face of agent-os
+tags: [display, avatar, presence]
+---
+
+# Sigil
+
+Sigil is the avatar presence system for agent-os. It renders a Three.js celestial animation on full-screen transparent canvases, tracks cursor position across displays, and provides visual feedback for agent activity.
+
+## Components
+
+- **avatar-sub** — Swift binary, Sigil's entry point. Manages state machine, IPC, and animation loop.
+- **renderer/** — Three.js live renderer (bundled single HTML for WKWebView compatibility)
+- **studio/** — Customization UI for avatar appearance and behavior
+- **chat/** — Chat surface for agent conversations (in development)
+
+## Architecture
+
+Sigil runs as a separate process from the daemon. It connects via Unix socket IPC, receives cursor position and event updates, and sends scene-position commands to its canvases.
+
+## Related
+- [Canvas System](./canvas-system.md)
+- [Daemon](./daemon.md)
+- [Studio](./studio.md)

--- a/wiki-seed/entities/studio.md
+++ b/wiki-seed/entities/studio.md
@@ -1,0 +1,28 @@
+---
+type: entity
+name: Studio
+description: Sigil customization UI — avatar appearance, surfaces, settings
+tags: [display, ui, configuration]
+---
+
+# Studio
+
+Studio is Sigil's customization interface, rendered as an interactive canvas. It provides controls for avatar appearance, companion surface management, and settings.
+
+## Panels
+
+- **Avatar** — visual appearance controls, animation parameters
+- **Surfaces** — launch companion canvases (chat, inspector)
+- **Settings** — voice, visual feedback toggles
+
+## Runtime
+
+Studio runs as a WKWebView canvas loaded via the content server. It communicates with the daemon through IPC — sends config changes, receives state updates.
+
+## Location
+
+`apps/sigil/studio/` — HTML, CSS, JavaScript files served by the content server.
+
+## Related
+- [Sigil](./sigil.md)
+- [Canvas System](./canvas-system.md)

--- a/wiki-seed/plugins/customize-with-agent/SKILL.md
+++ b/wiki-seed/plugins/customize-with-agent/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: customize-with-agent
+description: >
+  Create new wiki plugins or edit existing ones through guided conversation.
+  Use when the user asks to create a plugin, build a workflow, make a new
+  skill, automate a task, or says "customize with agent". Also use when
+  the user wants to turn a conversation or process into a reusable workflow.
+version: "1.0.0"
+author: agent-os
+tags: [meta, authoring, plugin-creation]
+triggers: ["create a plugin", "build a workflow", "make a skill", "customize with agent", "turn this into a plugin"]
+requires: []
+---
+
+# Customize with Agent — Plugin Creator
+
+Create new wiki plugins or improve existing ones through collaborative dialogue.
+
+## Overview
+
+A plugin is a reusable workflow stored in the wiki. It consists of:
+- `SKILL.md` — instructions the agent follows when the plugin is invoked
+- `references/` — supporting knowledge documents loaded on demand
+- `scripts/` — optional executable code for deterministic tasks
+- `assets/` — optional templates, icons, or other files
+
+Your job is to help the user define what the plugin should do, then create it using wiki tools.
+
+## Process
+
+### 1. Capture Intent
+
+Understand what the user wants to automate or codify. Ask:
+
+1. What should this plugin enable an agent to do?
+2. When should it trigger? (what user phrases or contexts)
+3. What's the expected output?
+4. Are there existing tools, commands, or APIs it should use?
+
+If the current conversation already contains a workflow the user wants to capture, extract answers from context first. The user may need to fill gaps.
+
+### 2. Interview for Details
+
+Ask one question at a time about:
+- Edge cases and error handling
+- Input/output formats
+- Dependencies (does it need the daemon running? gateway? specific tools?)
+- Success criteria — how do you know it worked?
+
+### 3. Create the Plugin
+
+Use wiki tools to scaffold:
+
+```bash
+aos wiki create-plugin <name>
+```
+
+Then write the SKILL.md and any reference files. Follow these guidelines:
+
+**SKILL.md structure:**
+- Frontmatter with name, description (assertive — include trigger phrases), version, tags
+- Clear purpose statement
+- Step-by-step instructions
+- Decision trees for branching logic
+- Related links to wiki pages
+
+**Writing principles:**
+- Explain the *why* behind instructions, not just the *what*
+- Keep SKILL.md under 500 lines — move domain knowledge to `references/`
+- Use concrete examples over abstract descriptions
+- If all test runs would write a similar helper script, bundle it in `scripts/`
+
+**Description field:**
+The description is the primary trigger mechanism. Make it clear and explicit:
+- Include what the skill does AND specific contexts for activation
+- List natural language phrases that should trigger it
+- Err on the side of over-matching — undertriggering is worse
+
+### 4. Test
+
+Offer to test the plugin:
+> "Want me to try running this plugin to see how it works?"
+
+If yes, invoke it: `aos wiki invoke <name>` — read the output and follow the instructions as if you were a fresh agent receiving them. Note any confusion, missing context, or unclear steps.
+
+### 5. Iterate
+
+Based on testing or user feedback:
+- Revise SKILL.md for clarity
+- Add missing reference files
+- Improve the description for better triggering
+- Update the index: `aos wiki reindex`
+
+### 6. Finalize
+
+After the user approves:
+- Verify with `aos wiki lint` — fix any issues
+- Confirm the plugin appears in `aos wiki list --type workflow`
+- Tell the user how to invoke it: from chat compose menu or by asking the agent
+
+## Editing Existing Plugins
+
+If the user wants to modify an existing plugin:
+
+1. Read it: `aos wiki show <name> --raw`
+2. Understand what needs to change
+3. Edit the files directly
+4. Reindex: `aos wiki reindex`
+5. Test the changes
+
+## Reference
+
+See [Skill Writing Guide](references/skill-writing-guide.md) for detailed authoring conventions.

--- a/wiki-seed/plugins/customize-with-agent/references/skill-writing-guide.md
+++ b/wiki-seed/plugins/customize-with-agent/references/skill-writing-guide.md
@@ -1,0 +1,85 @@
+---
+type: concept
+name: Skill Writing Guide
+description: Conventions and best practices for writing wiki plugin SKILL.md files
+tags: [meta, authoring, conventions]
+---
+
+# Skill Writing Guide
+
+## Anatomy of a Plugin
+
+```
+plugin-name/
+├── SKILL.md          # Required: frontmatter + instructions
+├── references/       # Optional: domain knowledge loaded on demand
+├── scripts/          # Optional: executable code
+└── assets/           # Optional: templates, icons, files
+```
+
+## SKILL.md Frontmatter
+
+Required fields:
+- `name` — plugin identifier (kebab-case)
+- `description` — when to trigger, what it does (be highly specific)
+
+Optional fields:
+- `version` — semver string
+- `author` — who created this
+- `tags` — categorization keywords
+- `triggers` — natural language phrases that should activate this plugin
+- `requires` — runtime dependencies (e.g., gateway, aos-daemon)
+
+## Progressive Disclosure
+
+1. **Metadata** (~100 words) — name + description, always in agent context
+2. **SKILL.md body** (<500 lines) — loaded when plugin triggers
+3. **References** (unlimited) — loaded on demand when the agent needs deeper context
+
+Keep SKILL.md focused on the workflow. Move domain knowledge, schemas, and frameworks to `references/`.
+
+## Writing Style
+
+- Use imperative form: "Run the build" not "You should run the build"
+- Explain *why* things matter, not just *what* to do
+- Prefer concrete examples over abstract descriptions
+- Use decision trees for branching logic
+- Include exact commands with expected output where applicable
+
+## Description as Trigger
+
+The description field determines whether an agent invokes the plugin. Write it to over-match rather than under-match:
+
+**Weak:** "Audit competitor employer brands"
+**Strong:** "Run employer brand competitor audits using the KILOS framework. Use when the user asks to research competitors, audit employer brands, analyze careers sites, do a KILOS audit, or build a competitor analysis. Trigger whenever a user provides a client name and a list of companies to research."
+
+## Cross-Linking
+
+Link to wiki entity and concept pages from your SKILL.md and references:
+```markdown
+See [Gateway](../../entities/gateway.md) for tool documentation.
+```
+
+This connects the plugin to the broader knowledge graph and helps agents find relevant context during execution.
+
+## Common Patterns
+
+**Mode detection:** If a plugin operates differently based on input, use a mode table at the top:
+```markdown
+| Mode | When |
+|------|------|
+| Plan | User provides requirements, no artifacts yet |
+| Execute | User provides plan + data |
+| Resume | Partial output, continue from last point |
+```
+
+**Decision trees:** For branching logic, use explicit if/then:
+```markdown
+- If build fails → check [Build Troubleshooting](references/build-troubleshooting.md)
+- If tests pass → proceed to deployment step
+```
+
+**Reference loading:** Tell the agent when to read references:
+```markdown
+For the full KILOS framework details, read `references/kilos-framework.md` before beginning analysis.
+```

--- a/wiki-seed/plugins/self-check/SKILL.md
+++ b/wiki-seed/plugins/self-check/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: self-check
+description: >
+  Run a health check on the aos runtime. Use when the user asks
+  to check system status, verify the runtime is healthy, diagnose
+  issues, or troubleshoot aos problems.
+version: "1.0.0"
+author: agent-os
+tags: [diagnostics, health, runtime]
+triggers: ["check system health", "is aos working", "diagnose issues", "run health check"]
+requires: [aos-daemon]
+---
+
+# Self-Check — Runtime Health Verification
+
+Run a comprehensive health check of the aos runtime and report status.
+
+## Steps
+
+1. Run `aos doctor --json` and parse the output
+2. Check each section:
+   - **Permissions**: accessibility and screen recording granted?
+   - **Daemon**: running? Socket exists?
+   - **Service**: launch agent installed and loaded?
+3. If issues found, suggest specific fix commands
+4. Report summary to the user
+
+## Decision Tree
+
+- If permissions missing → suggest `aos permissions setup --once`
+- If daemon not running → suggest `aos service start`
+- If service not installed → suggest `aos service install --mode repo`
+- If everything healthy → confirm all systems operational
+
+## Related
+- [Daemon](../../entities/daemon.md)
+- [Runtime Modes](../../concepts/runtime-modes.md)


### PR DESCRIPTION
## Summary

Adds `packages/host/`, a Node.js agent host sidecar that runs model-backed agent loops with tool execution, streaming, and session persistence. This branch establishes the host runtime and contracts — the next branch lights up the full user-facing experience.

- **Agent loop**: receive message → call provider → execute tools → loop until done, with configurable max-iteration limit (default 25), AbortSignal cancellation, and partial-response persistence
- **Anthropic adapter**: wraps Vercel AI SDK (`ai` + `@ai-sdk/anthropic`) into a provider-agnostic `ProviderAdapter` interface with normalized `StreamEvent` stream
- **Tool registry**: in-memory, MCP-shaped `ToolDefinition` with permission model (`allow`/`deny`/`ask`), glob-pattern overrides, three tool types (simple, provider-backed, agent-backed) sharing one interface
- **Session store**: SQLite via `better-sqlite3`, WAL mode, `sessions` + `messages` tables with token count tracking
- **3 builtin tools**: `read_file` (allow), `list_files` (allow), `shell_exec` (deny by default)
- **Socket server**: line-delimited JSON over Unix socket (`host.sock`), same pattern as gateway
- **SDK client**: typed `HostClient` with streaming support for consumer apps
- **Sigil bridge**: wires chat canvas `user_message`/`stop` events through a Node.js subprocess to the host, with canvas eval response path

### Architecture decisions (locked in spec)

- **Hybrid topology**: Swift daemon (canvases/OS) + Node.js host (agent loops/tools/sessions)
- **Direct sockets + unified SDK**: `host.sock` for chat, `sock` for OS primitives, SDK abstracts both
- **Session provider ≠ tool provider**: Anthropic runs the conversation; individual tools may call Gemini/etc internally
- **Build/adapt/borrow discipline**: Vercel AI SDK (adapted), MCP tool shape (borrowed), everything else built

### What's verified

| Level | Coverage |
|-------|----------|
| Unit tests | 38/38 passing — agent loop, session store, tool registry, tools, adapter |
| E2E (no API) | Session CRUD, tool discovery, socket protocol, persistence, error handling, graceful shutdown |
| Sigil build | Compiles with bridge wiring (additive change to `avatar-sub.swift`) |

### What's deferred (next branch)

- [ ] Wire and verify live Sigil → SDK → host → Anthropic path with real API key
- [ ] Implement `ask` permission UI flow via interactive canvas
- [ ] Gemini-backed media tools (YouTube/audio/video) using provider-backed tool interface
- [ ] Wiki integration as tools (`wiki.search`, `wiki.read`, plugin invoke)
- [ ] Context window management + `sdk.chat.resume` UX

**Spec:** `docs/superpowers/specs/2026-04-10-chat-native-agent-host-design.md`
**Plan:** `docs/superpowers/plans/2026-04-10-chat-native-agent-host.md`

## Test plan

- [x] `cd packages/host && npm test` — 38/38 passing
- [x] Host starts on `host.sock`, shuts down cleanly on SIGINT
- [x] SDK client connects, creates sessions, lists tools
- [x] SQLite persistence verified via `sqlite3` query
- [ ] Live Anthropic streaming (requires API key — deferred to next branch)
- [ ] Full Sigil user path (requires daemon + Sigil + host running together)

🤖 Generated with [Claude Code](https://claude.com/claude-code)