### PR TITLE
[codex] Add AOS status entrypoint and agent introspection

### DIFF
--- a/.agents/hooks/aos-agent-policy.py
+++ b/.agents/hooks/aos-agent-policy.py
@@ -217,6 +217,9 @@ def parse_command(command: str) -> dict[str, Any]:
                         "show",
                         "do",
                         "content",
+                        "voice",
+                        "config",
+                        "set",
                         "service",
                         "runtime",
                         "permissions",
@@ -239,6 +242,8 @@ def is_recovery_command(info: dict[str, Any]) -> bool:
     path = info.get("path") or []
     if not path:
         return False
+    if path[0] == "introspect":
+        return True
     joined = "/".join(path)
     return joined in {"status", "help", "introspect/review"}
 

--- a/.agents/hooks/aos-agent-policy.py
+++ b/.agents/hooks/aos-agent-policy.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""Silent AOS usage telemetry + failure-streak policy for hook scripts."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+FAIL_LIMIT = int(os.environ.get("AOS_AGENT_FAILURE_LIMIT", "4"))
+TTL_SECONDS = int(os.environ.get("AOS_AGENT_USAGE_TTL_SECONDS", str(72 * 60 * 60)))
+MAX_LOG_LINES = int(os.environ.get("AOS_AGENT_USAGE_MAX_LINES", "4000"))
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def sanitize(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]", "_", value)
+
+
+def detect_harness() -> str:
+    if os.environ.get("AOS_SESSION_HARNESS"):
+        return os.environ["AOS_SESSION_HARNESS"]
+    if os.environ.get("CODEX_THREAD_ID"):
+        return "codex"
+    if os.environ.get("CLAUDE_CODE_SSE_PORT"):
+        return "claude-code"
+    return "unknown"
+
+
+def detect_session() -> str:
+    if os.environ.get("AOS_SESSION_ID"):
+        return sanitize(os.environ["AOS_SESSION_ID"])
+    if os.environ.get("CODEX_THREAD_ID"):
+        return sanitize(f"codex-{os.environ['CODEX_THREAD_ID']}")
+    if os.environ.get("AOS_SESSION_NAME"):
+        return sanitize(f"name-{os.environ['AOS_SESSION_NAME']}")
+    if os.environ.get("CLAUDE_CODE_SSE_PORT"):
+        return sanitize(f"claude-port-{os.environ['CLAUDE_CODE_SSE_PORT']}")
+    return sanitize(f"pid-{os.getppid()}")
+
+
+def state_dir() -> Path:
+    root = os.environ.get("AOS_STATE_ROOT") or os.path.expanduser("~/.config/aos")
+    mode = os.environ.get("AOS_RUNTIME_MODE", "repo")
+    return Path(root) / mode / "agent-introspection"
+
+
+def usage_log_path() -> Path:
+    return state_dir() / "aos-usage.jsonl"
+
+
+def session_state_path(session: str) -> Path:
+    return state_dir() / "sessions" / f"{session}.json"
+
+
+def load_payload() -> dict[str, Any]:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return {}
+    try:
+        return json.loads(raw)
+    except Exception:
+        return {}
+
+
+def dig(obj: Any, path: list[str]) -> Any:
+    cur = obj
+    for key in path:
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(key)
+    return cur
+
+
+def find_scalar(obj: Any, keys: set[str]) -> Any:
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if key in keys and isinstance(value, (str, int, float, bool)):
+                return value
+            found = find_scalar(value, keys)
+            if found is not None:
+                return found
+    elif isinstance(obj, list):
+        for item in obj:
+            found = find_scalar(item, keys)
+            if found is not None:
+                return found
+    return None
+
+
+def extract_command(payload: dict[str, Any]) -> str:
+    for path in (
+        ["tool_input", "command"],
+        ["tool_input", "cmd"],
+        ["toolUse", "input", "command"],
+        ["input", "command"],
+        ["command"],
+        ["payload", "tool_input", "command"],
+    ):
+        value = dig(payload, path)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    value = find_scalar(payload, {"command"})
+    return value.strip() if isinstance(value, str) else ""
+
+
+def extract_text(payload: dict[str, Any], preferred_paths: list[list[str]], fallback_keys: set[str]) -> str:
+    for path in preferred_paths:
+        value = dig(payload, path)
+        if isinstance(value, str) and value:
+            return value
+    value = find_scalar(payload, fallback_keys)
+    return value if isinstance(value, str) else ""
+
+
+def extract_exit_code(payload: dict[str, Any]) -> int | None:
+    for path in (
+        ["tool_output", "exit_code"],
+        ["tool_response", "exit_code"],
+        ["tool_result", "exit_code"],
+        ["output", "exit_code"],
+        ["result", "exit_code"],
+        ["payload", "exit_code"],
+        ["exit_code"],
+        ["content", "return_code"],
+        ["return_code"],
+    ):
+        value = dig(payload, path)
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str) and value.lstrip("-").isdigit():
+            return int(value)
+    value = find_scalar(payload, {"exit_code", "return_code"})
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.lstrip("-").isdigit():
+        return int(value)
+    return None
+
+
+def extract_duration_ms(payload: dict[str, Any]) -> int | None:
+    for path in (
+        ["duration_ms"],
+        ["tool_output", "duration_ms"],
+        ["tool_response", "duration_ms"],
+        ["result", "duration_ms"],
+    ):
+        value = dig(payload, path)
+        if isinstance(value, int):
+            return value
+    value = find_scalar(payload, {"duration_ms"})
+    return value if isinstance(value, int) else None
+
+
+def parse_json_object(text: str) -> dict[str, Any] | None:
+    if not text:
+        return None
+    text = text.strip()
+    if not text or not text.startswith("{"):
+        return None
+    try:
+        value = json.loads(text)
+    except Exception:
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def extract_error(stdout: str, stderr: str) -> tuple[str | None, bool]:
+    for blob in (stderr, stdout):
+        obj = parse_json_object(blob)
+        if not obj:
+            continue
+        code = obj.get("code")
+        has_error = "error" in obj
+        if isinstance(code, str):
+            return code, has_error or bool(code)
+        if has_error:
+            return None, True
+    return None, False
+
+
+def parse_command(command: str) -> dict[str, Any]:
+    if not command.strip():
+        return {"is_aos": False, "bare": False, "token": None, "path": []}
+
+    try:
+        tokens = shlex.split(command)
+    except Exception:
+        tokens = command.split()
+
+    for index, token in enumerate(tokens):
+        if token == "aos" or token == "./aos" or token.endswith("/aos"):
+            after = tokens[index + 1 :]
+            path: list[str] = []
+            if after:
+                if after[0] in {"--help", "-h"}:
+                    path = ["help"]
+                elif after[0] == "help":
+                    path = ["help"]
+                    for item in after[1:]:
+                        if item.startswith("-"):
+                            break
+                        path.append(item)
+                else:
+                    path = [after[0]]
+                    if len(after) > 1 and not after[1].startswith("-") and after[0] in {
+                        "see",
+                        "show",
+                        "do",
+                        "content",
+                        "service",
+                        "runtime",
+                        "permissions",
+                        "focus",
+                        "graph",
+                        "introspect",
+                        "wiki",
+                    }:
+                        path.append(after[1])
+            return {
+                "is_aos": True,
+                "bare": token == "aos",
+                "token": token,
+                "path": path,
+            }
+    return {"is_aos": False, "bare": False, "token": None, "path": []}
+
+
+def is_recovery_command(info: dict[str, Any]) -> bool:
+    path = info.get("path") or []
+    if not path:
+        return False
+    joined = "/".join(path)
+    return joined in {"status", "help", "introspect/review"}
+
+
+def load_session_state(session: str) -> dict[str, Any]:
+    path = session_state_path(session)
+    if not path.exists():
+        return {
+            "session": session,
+            "harness": detect_harness(),
+            "consecutive_failures": 0,
+            "total_events": 0,
+            "last_updated": None,
+        }
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return {
+            "session": session,
+            "harness": detect_harness(),
+            "consecutive_failures": 0,
+            "total_events": 0,
+            "last_updated": None,
+        }
+
+
+def write_session_state(session: str, state: dict[str, Any]) -> None:
+    path = session_state_path(session)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, sort_keys=True, indent=2))
+
+
+def prune_logs_and_state() -> None:
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=TTL_SECONDS)
+    log_path = usage_log_path()
+    state_dir().mkdir(parents=True, exist_ok=True)
+    (state_dir() / "sessions").mkdir(parents=True, exist_ok=True)
+
+    kept_lines: list[str] = []
+    if log_path.exists():
+        for raw in log_path.read_text().splitlines():
+            if not raw.strip():
+                continue
+            try:
+                obj = json.loads(raw)
+            except Exception:
+                continue
+            timestamp = obj.get("timestamp")
+            if not isinstance(timestamp, str):
+                continue
+            try:
+                dt = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+            except Exception:
+                continue
+            if dt >= cutoff:
+                kept_lines.append(json.dumps(obj, sort_keys=True))
+    kept_lines = kept_lines[-MAX_LOG_LINES:]
+    if kept_lines:
+        log_path.write_text("\n".join(kept_lines) + "\n")
+    elif log_path.exists():
+        log_path.unlink()
+
+    sessions_dir = state_dir() / "sessions"
+    for path in sessions_dir.glob("*.json"):
+        try:
+            obj = json.loads(path.read_text())
+            timestamp = obj.get("last_updated")
+            dt = datetime.fromisoformat(str(timestamp).replace("Z", "+00:00"))
+        except Exception:
+            path.unlink(missing_ok=True)
+            continue
+        if dt < cutoff:
+            path.unlink(missing_ok=True)
+
+
+def append_event(event: dict[str, Any], *, preserve_streak: bool = False) -> None:
+    prune_logs_and_state()
+    session = event["session"]
+    state = load_session_state(session)
+    state["harness"] = event.get("harness") or state.get("harness")
+    state["total_events"] = int(state.get("total_events") or 0) + 1
+    state["last_updated"] = event["timestamp"]
+
+    if not preserve_streak:
+        outcome = event.get("outcome")
+        if outcome == "success":
+            state["consecutive_failures"] = 0
+        elif outcome in {"error", "blocked"}:
+            state["consecutive_failures"] = int(state.get("consecutive_failures") or 0) + 1
+
+    write_session_state(session, state)
+
+    log_path = usage_log_path()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, sort_keys=True))
+        handle.write("\n")
+
+
+def base_event(command: str, info: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "timestamp": now_iso(),
+        "session": detect_session(),
+        "harness": detect_harness(),
+        "command": command,
+        "command_path": info.get("path") or [],
+        "prefix": info.get("token"),
+    }
+
+
+def handle_pre(payload: dict[str, Any]) -> int:
+    command = extract_command(payload)
+    info = parse_command(command)
+    session = detect_session()
+    state = load_session_state(session)
+    streak = int(state.get("consecutive_failures") or 0)
+
+    if info.get("bare"):
+        event = base_event(command, info)
+        event.update(
+            {
+                "source": "pre",
+                "outcome": "blocked",
+                "error_code": "USE_REPO_AOS",
+                "blocked_reason": "Use ./aos, not aos, in repo mode.",
+            }
+        )
+        append_event(event)
+        print("Blocked: use ./aos, not aos, in this repo.", file=sys.stderr)
+        return 2
+
+    if streak >= FAIL_LIMIT and not is_recovery_command(info):
+        event = base_event(command, info)
+        event.update(
+            {
+                "source": "pre",
+                "outcome": "blocked",
+                "error_code": "AOS_REVIEW_REQUIRED",
+                "blocked_reason": f"Repeated failed ./aos attempts ({streak}). Run ./aos introspect review or ./aos help/status before more shell work.",
+            }
+        )
+        append_event(event, preserve_streak=True)
+        print(
+            f"Blocked: repeated failed ./aos attempts ({streak}). Run ./aos introspect review or ./aos help/status before more shell work.",
+            file=sys.stderr,
+        )
+        return 2
+
+    return 0
+
+
+def handle_post(payload: dict[str, Any]) -> int:
+    command = extract_command(payload)
+    info = parse_command(command)
+    if not info.get("is_aos") or info.get("bare"):
+        return 0
+
+    stdout = extract_text(
+        payload,
+        preferred_paths=[
+            ["tool_output", "stdout"],
+            ["tool_response", "stdout"],
+            ["result", "stdout"],
+            ["output", "stdout"],
+            ["content", "stdout"],
+            ["stdout"],
+        ],
+        fallback_keys={"stdout"},
+    )
+    stderr = extract_text(
+        payload,
+        preferred_paths=[
+            ["tool_output", "stderr"],
+            ["tool_response", "stderr"],
+            ["result", "stderr"],
+            ["output", "stderr"],
+            ["content", "stderr"],
+            ["stderr"],
+        ],
+        fallback_keys={"stderr"},
+    )
+    exit_code = extract_exit_code(payload)
+    duration_ms = extract_duration_ms(payload)
+    error_code, has_error = extract_error(stdout, stderr)
+
+    if exit_code is None and not stdout and not stderr:
+        outcome = "unknown"
+    elif (exit_code is not None and exit_code != 0) or has_error:
+        outcome = "error"
+    else:
+        outcome = "success"
+
+    event = base_event(command, info)
+    event.update(
+        {
+            "source": "post",
+            "outcome": outcome,
+            "exit_code": exit_code,
+            "error_code": error_code,
+            "duration_ms": duration_ms,
+        }
+    )
+    append_event(event)
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) != 2 or sys.argv[1] not in {"pre", "post"}:
+        print("usage: aos-agent-policy.py <pre|post>", file=sys.stderr)
+        return 1
+
+    payload = load_payload()
+    if sys.argv[1] == "pre":
+        return handle_pre(payload)
+    return handle_post(payload)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/hooks/post-tool-use.sh
+++ b/.agents/hooks/post-tool-use.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Shared post-tool telemetry hook for agent-os providers.
+
+set -euo pipefail
+ROOT="$(git -C "$(dirname "$0")/../.." rev-parse --show-toplevel 2>/dev/null || pwd)"
+python3 "$ROOT/.agents/hooks/aos-agent-policy.py" post

--- a/.agents/hooks/pre-tool-use.sh
+++ b/.agents/hooks/pre-tool-use.sh
@@ -5,15 +5,17 @@
 set -euo pipefail
 INPUT=$(cat)
 CMD=$(echo "$INPUT" | python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" 2>/dev/null || echo "")
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 echo "$CMD" | grep -qE 'rm -rf /|git push.*--force.*main|git reset --hard' && {
   echo "Blocked: destructive command on main" >&2
   exit 2
 }
 
+printf '%s' "$INPUT" | python3 "$ROOT/.agents/hooks/aos-agent-policy.py" pre || exit $?
+
 echo "$CMD" | grep -q 'git commit' || exit 0
 
-ROOT="$(git rev-parse --show-toplevel 2>/dev/null || exit 0)"
 cd "$ROOT"
 
 SECRETS=$(git diff --cached --name-only 2>/dev/null | grep -iE '\.env$|\.env\.|credentials|\.pem$|\.key$|secret.*\.json' || true)
@@ -40,4 +42,3 @@ if [ -n "$BAD_PATHS" ]; then
 fi
 
 exit 0
-

--- a/.agents/hooks/session-start.sh
+++ b/.agents/hooks/session-start.sh
@@ -5,7 +5,17 @@ set -euo pipefail
 ROOT="$(git -C "$(dirname "$0")/../.." rev-parse --show-toplevel 2>/dev/null || pwd)"
 AOS="$ROOT/aos"
 cd "$ROOT"
-SESSION_NAME="${AOS_SESSION_NAME:-}"
+HOOK_INPUT="$(cat || true)"
+
+# shellcheck source=/dev/null
+source "$(dirname "$0")/session-common.sh"
+
+SESSION_ID="$(aos_resolve_session_id "$HOOK_INPUT")"
+SESSION_HARNESS="$(aos_detect_harness)"
+SESSION_NAME="$(aos_resolve_session_name "$SESSION_ID" "$SESSION_HARNESS")"
+SESSION_CHANNEL="$(aos_session_channel "$SESSION_ID" "$SESSION_NAME")"
+SESSION_SOURCE="$(aos_session_name_source "$SESSION_ID")"
+REGISTRATION_STATUS="skipped"
 BOOTSTRAP_FILE=""
 AOS_DOCTOR_JSON=""
 AOS_STARTUP_STATE="missing"
@@ -94,6 +104,25 @@ PY
 fi
 
 ensure_aos_runtime || true
+
+if [ -x "$AOS" ] && [ -n "$SESSION_NAME" ]; then
+  if aos_refresh_session_registration "$SESSION_ID" "$SESSION_NAME" "worker" "$SESSION_HARNESS" "$AOS"; then
+    REGISTRATION_STATUS="ok"
+  else
+    REGISTRATION_STATUS="failed"
+  fi
+fi
+
+echo ""
+echo "## Session Identity"
+if [ -n "$SESSION_ID" ]; then
+  echo "name=${SESSION_NAME} harness=${SESSION_HARNESS} session_id=${SESSION_ID} channel=${SESSION_CHANNEL} source=${SESSION_SOURCE} registered=${REGISTRATION_STATUS}"
+else
+  echo "name=${SESSION_NAME} harness=${SESSION_HARNESS} source=${SESSION_SOURCE} registered=${REGISTRATION_STATUS}"
+fi
+if [ "$SESSION_SOURCE" = "generated" ]; then
+  echo "Rename later with: scripts/session-name --name <meaningful-name>"
+fi
 
 echo "--- agent-os session context ---"
 
@@ -189,5 +218,12 @@ if [ "$WT_COUNT" -gt 1 ]; then
   echo "worktrees=$WT_COUNT (check for parallel work)"
 fi
 
+echo ""
+echo "## Shared Start-of-Session Method"
+echo "Open with a compact status preamble: branch, ahead/dirty, AOS runtime, stale-resource status, and the 2-3 most relevant issues."
+echo "When verifying toolkit or display work, use real \`./aos\` canvases and \`./aos see\`, not a raw browser page."
+echo ""
+echo "## Shared Handoff Method"
+echo "When handing off, post the brief with \`aos tell handoff\` (and any direct target channel/session) and emit one ready-to-run continuation path for the active runtime."
 echo ""
 echo "--- end session context ---"

--- a/.agents/hooks/session-start.sh
+++ b/.agents/hooks/session-start.sh
@@ -4,51 +4,120 @@
 set -euo pipefail
 ROOT="$(git -C "$(dirname "$0")/../.." rev-parse --show-toplevel 2>/dev/null || pwd)"
 AOS="$ROOT/aos"
-HOOK_INPUT="$(cat || true)"
+cd "$ROOT"
+SESSION_NAME="${AOS_SESSION_NAME:-}"
+BOOTSTRAP_FILE=""
+AOS_DOCTOR_JSON=""
+AOS_STARTUP_STATE="missing"
 
-# shellcheck source=/dev/null
-source "$(dirname "$0")/session-common.sh"
+refresh_aos_doctor_json() {
+  if [ ! -x "$AOS" ]; then
+    AOS_DOCTOR_JSON=""
+    return 1
+  fi
+  if ! AOS_DOCTOR_JSON="$("$AOS" doctor --json 2>/dev/null)"; then
+    AOS_DOCTOR_JSON=""
+    return 1
+  fi
+  return 0
+}
 
-# --- Session Communication Layer ---
-SESSION_ID="$(aos_resolve_session_id "$HOOK_INPUT")"
-SESSION_HARNESS="$(aos_detect_harness)"
-SESSION_NAME="$(aos_resolve_session_name "$SESSION_ID" "$SESSION_HARNESS")"
-SESSION_CHANNEL="$(aos_session_channel "$SESSION_ID" "$SESSION_NAME")"
-SESSION_SOURCE="$(aos_session_name_source "$SESSION_ID")"
-REGISTRATION_STATUS="skipped"
+aos_runtime_ready() {
+  [ -n "${AOS_DOCTOR_JSON:-}" ] || return 1
+  printf '%s' "$AOS_DOCTOR_JSON" | python3 -c "
+import json, sys
+try:
+    payload = json.load(sys.stdin)
+except Exception:
+    raise SystemExit(1)
+runtime = payload.get('runtime', {})
+service = payload.get('aos_service', {})
+ready = bool(runtime.get('socket_reachable') or runtime.get('daemon_running') or service.get('running'))
+raise SystemExit(0 if ready else 1)
+" >/dev/null 2>&1
+}
 
-if [ -x "$AOS" ] && [ -n "$SESSION_NAME" ]; then
-  if aos_refresh_session_registration "$SESSION_ID" "$SESSION_NAME" "worker" "$SESSION_HARNESS" "$AOS"; then
-    REGISTRATION_STATUS="ok"
+ensure_aos_runtime() {
+  if [ ! -x "$AOS" ]; then
+    AOS_STARTUP_STATE="missing"
+    return 1
+  fi
+
+  if refresh_aos_doctor_json && aos_runtime_ready; then
+    AOS_STARTUP_STATE="already-running"
+    return 0
+  fi
+
+  if "$AOS" service start --json >/dev/null 2>&1; then
+    AOS_STARTUP_STATE="started-via-service"
   else
-    REGISTRATION_STATUS="failed"
+    AOS_STARTUP_STATE="started-via-serve"
+    if command -v nohup >/dev/null 2>&1; then
+      nohup "$AOS" serve --idle-timeout none >/dev/null 2>&1 &
+    else
+      "$AOS" serve --idle-timeout none >/dev/null 2>&1 &
+    fi
+  fi
+
+  for _ in $(seq 1 20); do
+    sleep 0.2
+    if refresh_aos_doctor_json && aos_runtime_ready; then
+      return 0
+    fi
+  done
+
+  AOS_STARTUP_STATE="startup-failed"
+  refresh_aos_doctor_json || true
+  return 1
+}
+
+if [ -n "$SESSION_NAME" ]; then
+  BOOTSTRAP_FILE="/tmp/aos-handoff-${SESSION_NAME}.json"
+  if [ -f "$BOOTSTRAP_FILE" ]; then
+    if ! BRIEF="$(python3 - "$BOOTSTRAP_FILE" <<'PY' 2>/dev/null
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+print(payload.get("brief", ""))
+PY
+    )"; then
+      BRIEF="(failed to parse bootstrap file)"
+    fi
+    echo ""
+    echo "## Handoff Brief"
+    echo "$BRIEF"
+    rm -f "$BOOTSTRAP_FILE"
   fi
 fi
 
-echo ""
-echo "## Session Identity"
-if [ -n "$SESSION_ID" ]; then
-  echo "name=${SESSION_NAME} harness=${SESSION_HARNESS} session_id=${SESSION_ID} channel=${SESSION_CHANNEL} source=${SESSION_SOURCE} registered=${REGISTRATION_STATUS}"
-else
-  echo "name=${SESSION_NAME} harness=${SESSION_HARNESS} source=${SESSION_SOURCE} registered=${REGISTRATION_STATUS}"
-fi
-if [ "$SESSION_SOURCE" = "generated" ]; then
-  echo "Rename later with: scripts/session-name --name <meaningful-name>"
-fi
-
-if [ -n "$SESSION_NAME" ] && [ -f "/tmp/aos-handoff-${SESSION_NAME}.json" ]; then
-  BRIEF=$(python3 -c "
-import json
-d = json.load(open('/tmp/aos-handoff-${SESSION_NAME}.json'))
-print(d.get('brief', ''))
-" 2>/dev/null || echo "(failed to parse bootstrap file)")
-  echo ""
-  echo "## Handoff Brief"
-  echo "$BRIEF"
-  rm -f "/tmp/aos-handoff-${SESSION_NAME}.json"
-fi
+ensure_aos_runtime || true
 
 echo "--- agent-os session context ---"
+
+if [ -x "$AOS" ]; then
+  HELP_TEXT="$("$AOS" --help 2>/dev/null || true)"
+  if [ -n "${HELP_TEXT:-}" ]; then
+    echo ""
+    echo "## AOS Control Surface"
+    echo "You are developing agent-os. Your primary tools should be the following control surface:"
+    echo ""
+    echo "| Role | Instruction |"
+    echo "| --- | --- |"
+    echo "| Invocation | Use \`./aos\` in this repo, not \`aos\`. |"
+    echo "| Point of entry | Start with \`./aos status\`. |"
+    echo "| Self-review / recovery | Use \`./aos introspect review\` after failed attempts or when asked to self-review. |"
+    echo "| Perception first | Prefer \`./aos see\` and AX-aware x-ray capture over raw image blobs when the CLI can answer the question directly. |"
+    echo "| Live control surface | Lean on \`./aos focus\`, \`./aos graph\`, and \`./aos show\` to stay inside the live agent-os control surface. |"
+    echo "| Lower-level verbs | The hook already handled daemon bring-up and stale-resource detection; drop to \`doctor\`, \`daemon-snapshot\`, and \`clean\` only when you need deeper detail or explicit cleanup. |"
+    echo ""
+    echo '```text'
+    echo "$HELP_TEXT"
+    echo '```'
+  fi
+fi
 
 if command -v gh >/dev/null 2>&1; then
   ISSUES=$(gh issue list --repo michaelblum/agent-os --limit 10 --json number,title,labels --template '{{range .}}- #{{.number}} {{.title}}{{range .labels}} [{{.name}}]{{end}}
@@ -63,7 +132,7 @@ fi
 if [ -x "$AOS" ]; then
   echo ""
   echo "## AOS Runtime"
-  STATUS=$("$AOS" doctor --json 2>/dev/null | python3 -c "
+  STATUS="$(printf '%s' "$AOS_DOCTOR_JSON" | python3 -c "
 import json, sys
 try:
     d = json.load(sys.stdin)
@@ -73,10 +142,10 @@ try:
     acc = d.get('permissions',{}).get('accessibility', False)
     scr = d.get('permissions',{}).get('screen_recording', False)
     commit = d.get('identity',{}).get('git_commit','?')
-    print(f'mode={mode} status={status} pid={pid} commit={commit} acc={\"ok\" if acc else \"NO\"} scr={\"ok\" if scr else \"NO\"}')
+    print(f'mode={mode} status={status} pid={pid} startup=${AOS_STARTUP_STATE} commit={commit} acc={\"ok\" if acc else \"NO\"} scr={\"ok\" if scr else \"NO\"}')
 except Exception:
     print('aos doctor failed to parse')
-" 2>/dev/null || echo "aos not running or not built")
+" 2>/dev/null || echo "aos not running or not built")"
   echo "$STATUS"
 fi
 
@@ -103,7 +172,7 @@ except Exception:
     echo ""
     echo "## Stale Resources"
     echo "$CLEAN"
-    echo "Run \`aos clean\` immediately before launching canvases or doing display work."
+    echo "Run \`./aos clean\` immediately before launching canvases or doing display work."
     echo "Do not ask the user whether stale resources should be cleaned."
   fi
 fi
@@ -120,12 +189,5 @@ if [ "$WT_COUNT" -gt 1 ]; then
   echo "worktrees=$WT_COUNT (check for parallel work)"
 fi
 
-echo ""
-echo "## Shared Start-of-Session Method"
-echo "Open with a compact status preamble: branch, ahead/dirty, AOS runtime, stale-resource status, and the 2-3 most relevant issues."
-echo "When verifying toolkit or display work, use real \`aos\` canvases and \`aos see\`, not a raw browser page."
-echo ""
-echo "## Shared Handoff Method"
-echo "When handing off, post the brief with \`aos tell handoff\` (and any direct target channel/session) and emit one ready-to-run continuation path for the active runtime."
 echo ""
 echo "--- end session context ---"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,12 +30,37 @@
     ],
     "PostToolUse": [
       {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ROOT=\"${AOS_HOOK_REPO_ROOT:-/Users/Michael/Code/agent-os}\"; AOS_SESSION_HARNESS=claude-code bash \"$ROOT/.agents/hooks/check-messages.sh\"",
+            "timeout": 3
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
             "command": "ROOT=\"${AOS_HOOK_REPO_ROOT:-/Users/Michael/Code/agent-os}\"; bash \"$ROOT/.agents/hooks/post-tool-use.sh\"",
             "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ROOT=\"${AOS_HOOK_REPO_ROOT:-/Users/Michael/Code/agent-os}\"; AOS_SESSION_HARNESS=claude-code bash \"$ROOT/.agents/hooks/final-response.sh\"",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "ROOT=\"${AOS_HOOK_REPO_ROOT:-/Users/Michael/Code/agent-os}\"; AOS_SESSION_HARNESS=claude-code bash \"$ROOT/.agents/hooks/session-stop.sh\"",
+            "timeout": 5
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,27 +30,12 @@
     ],
     "PostToolUse": [
       {
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "ROOT=\"${AOS_HOOK_REPO_ROOT:-/Users/Michael/Code/agent-os}\"; AOS_SESSION_HARNESS=claude-code bash \"$ROOT/.agents/hooks/check-messages.sh\"",
-            "timeout": 3
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "ROOT=\"${AOS_HOOK_REPO_ROOT:-/Users/Michael/Code/agent-os}\"; AOS_SESSION_HARNESS=claude-code bash \"$ROOT/.agents/hooks/final-response.sh\"",
-            "timeout": 30
-          },
-          {
-            "type": "command",
-            "command": "ROOT=\"${AOS_HOOK_REPO_ROOT:-/Users/Michael/Code/agent-os}\"; AOS_SESSION_HARNESS=claude-code bash \"$ROOT/.agents/hooks/session-stop.sh\"",
-            "timeout": 5
+            "command": "ROOT=\"${AOS_HOOK_REPO_ROOT:-/Users/Michael/Code/agent-os}\"; bash \"$ROOT/.agents/hooks/post-tool-use.sh\"",
+            "timeout": 10
           }
         ]
       }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -17,29 +17,6 @@
             "timeout": 10
           }
         ]
-      },
-      {
-        "matcher": "startup|resume",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo 'CAVEMAN MODE ACTIVE. Rules: Drop articles/filler/pleasantries/hedging. Fragments OK. Short synonyms. Pattern: [thing] [action] [reason]. [next step]. Not: Sure! I would be happy to help you with that. Yes: Bug in auth middleware. Fix: Code/commits/security: write normal. User says stop caveman or normal mode to deactivate.'",
-            "timeout": 5,
-            "statusMessage": "Loading caveman mode"
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "ROOT=\"${AOS_HOOK_REPO_ROOT:-/Users/Michael/Code/agent-os}\"; AOS_SESSION_HARNESS=codex bash \"$ROOT/.agents/hooks/check-messages.sh\"",
-            "statusMessage": "Checking coordination messages",
-            "timeout": 3
-          }
-        ]
       }
     ],
     "PreToolUse": [
@@ -55,14 +32,14 @@
         ]
       }
     ],
-    "Stop": [
+    "PostToolUse": [
       {
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "ROOT=\"${AOS_HOOK_REPO_ROOT:-/Users/Michael/Code/agent-os}\"; AOS_SESSION_HARNESS=codex bash \"$ROOT/.agents/hooks/final-response.sh\"",
-            "statusMessage": "Reading final response aloud",
-            "timeout": 30
+            "command": "ROOT=\"${AOS_HOOK_REPO_ROOT:-/Users/Michael/Code/agent-os}\"; bash \"$ROOT/.agents/hooks/post-tool-use.sh\"",
+            "timeout": 10
           }
         ]
       }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -17,6 +17,39 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'CAVEMAN MODE ACTIVE. Rules: Drop articles/filler/pleasantries/hedging. Fragments OK. Short synonyms. Pattern: [thing] [action] [reason]. [next step]. Not: Sure! I would be happy to help you with that. Yes: Bug in auth middleware. Fix: Code/commits/security: write normal. User says stop caveman or normal mode to deactivate.'",
+            "timeout": 5,
+            "statusMessage": "Loading caveman mode"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ROOT=\"${AOS_HOOK_REPO_ROOT:-/Users/Michael/Code/agent-os}\"; AOS_SESSION_HARNESS=codex bash \"$ROOT/.agents/hooks/check-messages.sh\"",
+            "statusMessage": "Checking coordination messages",
+            "timeout": 3
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ROOT=\"${AOS_HOOK_REPO_ROOT:-/Users/Michael/Code/agent-os}\"; bash \"$ROOT/.agents/hooks/post-tool-use.sh\"",
+            "timeout": 10
+          }
+        ]
       }
     ],
     "PreToolUse": [
@@ -32,14 +65,14 @@
         ]
       }
     ],
-    "PostToolUse": [
+    "Stop": [
       {
-        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "ROOT=\"${AOS_HOOK_REPO_ROOT:-/Users/Michael/Code/agent-os}\"; bash \"$ROOT/.agents/hooks/post-tool-use.sh\"",
-            "timeout": 10
+            "command": "ROOT=\"${AOS_HOOK_REPO_ROOT:-/Users/Michael/Code/agent-os}\"; AOS_SESSION_HARNESS=codex bash \"$ROOT/.agents/hooks/final-response.sh\"",
+            "statusMessage": "Reading final response aloud",
+            "timeout": 30
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,17 @@ spec at `docs/superpowers/specs/2026-04-15-tell-hear-coordination-verbs-design.m
   `tests/studio/` and `tests/renderer/`.
 - Shell/integration tests under `tests/` that invoke `./aos` do require a fresh
   build when relevant Swift code has changed.
+- Use `./aos` as the real host when verifying display or toolkit behavior.
+  Prefer `aos://...` canvases over raw browser pages unless the problem is
+  purely DOM debugging.
+- Use `./aos see` for visual verification before asking the user to inspect a
+  canvas manually.
+- If display work starts from stale daemons or orphaned canvases, run
+  `./aos clean` first and report what was cleaned.
+- Sessions should register themselves on startup so `aos tell --who` reflects
+  live collaborators. If no explicit `AOS_SESSION_NAME` is provided at launch,
+  accept the harness-generated fallback name first and rename later with
+  `scripts/session-name --name <meaningful-name>` once the task is clear.
 - Default repo work to `main` unless the user explicitly asks for branch-based
   work. Temporary worktrees or helper branches are fine when they materially
   reduce risk or enable parallelism, but they should stay temporary: land the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,13 @@ spec at `docs/superpowers/specs/2026-04-15-tell-hear-coordination-verbs-design.m
 
 - `aos` CLI is the canonical interface for development inside agent-os. MCP tools
   exist as an optional adapter for external consumers, not for dev work.
+- In repo mode, start with `./aos status`. That is the primary runtime/session
+  entrypoint for agent work inside this repo.
+- Use `./aos introspect review` for self-review or recovery after repeated failed
+  `./aos` attempts.
+- The startup hook already handles daemon bring-up and stale-resource detection.
+  Treat `doctor`, `daemon-snapshot`, and `clean` as deeper follow-up tools, not
+  the first move.
 
 - Do not default to `bash build.sh` before every test or verification step.
   Rebuild `./aos` only when the work changes Swift sources in `src/` or
@@ -75,17 +82,6 @@ spec at `docs/superpowers/specs/2026-04-15-tell-hear-coordination-verbs-design.m
   `tests/studio/` and `tests/renderer/`.
 - Shell/integration tests under `tests/` that invoke `./aos` do require a fresh
   build when relevant Swift code has changed.
-- Use `aos` as the real host when verifying display or toolkit behavior. Prefer
-  `aos://...` canvases over raw browser pages unless the problem is purely DOM
-  debugging.
-- Use `aos see` for visual verification before asking the user to inspect a
-  canvas manually.
-- If display work starts from stale daemons or orphaned canvases, run
-  `aos clean` first and report what was cleaned.
-- Sessions should register themselves on startup so `aos tell --who` reflects
-  live collaborators. If no explicit `AOS_SESSION_NAME` is provided at launch,
-  accept the harness-generated fallback name first and rename later with
-  `scripts/session-name --name <meaningful-name>` once the task is clear.
 - Default repo work to `main` unless the user explicitly asks for branch-based
   work. Temporary worktrees or helper branches are fine when they materially
   reduce risk or enable parallelism, but they should stay temporary: land the

--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -38,8 +38,8 @@ aos see cursor
 aos show create --id demo --at 100,100,300,200 --html '<div>hello</div>'
 aos do click 500,300
 aos say "Hello"
-aos tell human "Done."
-aos listen ops --limit 10
+aos tell handoff "task complete"
+aos listen handoff
 ```
 
 ### Success / Failure
@@ -78,8 +78,8 @@ The current top-level commands are:
 | `aos introspect` | Session self-review over recent `./aos` usage |
 | `aos help` | Registry and command-specific help |
 | `aos say` | Voice output |
-| `aos tell` | Manual communication output: human, channel, or direct session routing |
-| `aos listen` | Manual communication input: channel or direct session reads/follow |
+| `aos tell` | Communication output: human, channel, or direct session routing |
+| `aos listen` | Communication input: channel or direct session reads/follow |
 | `aos wiki` | local knowledge-base workflows |
 | `aos config` | Discoverable runtime configuration (`get`, `set`, dump) |
 | `aos set` | Runtime configuration |
@@ -146,18 +146,18 @@ aos show wait --id inspector --manifest inspector-panel
 aos show post --id inspector --event '{"type":"inspector-panel/bootstrap","payload":{"note":"hello"}}'
 ```
 
-### 4. Manual Communication and Debugging
+### 4. Coordinate Through Channels or Direct Session Messaging
 
 ```bash
-aos tell human "Done."
+aos tell handoff "task complete"
+aos tell handoff --from wiki-focus "task complete"
 aos tell --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c "ready for review"
-aos listen ops --limit 10
-aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c
+aos tell --register --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c --name wiki-focus --role worker --harness codex
+echo 'queued update' | aos tell handoff
+aos tell --who
+aos listen handoff
+aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c --follow
 ```
-
-`aos tell` / `aos listen` remain available for explicit operator workflows and
-debugging. They are not part of the default Codex or Claude hook stack in
-agent-os.
 
 ## Subcommand Reference
 
@@ -339,26 +339,26 @@ discoverability misses like unknown commands or missing arguments over time.
 
 ## `aos tell`
 
-Manual / advanced communication surface. Use this when you explicitly want the
-daemon to route a message or inspect session-facing communication. Do not treat
-it as required session plumbing for normal harness operation.
-
 Primary public forms:
 
 | Form | Purpose |
 | --- | --- |
 | `<audience>\|--session-id <id> [--json <payload>] [--from <name>] [--from-session-id <id>] [--purpose <name>] [<text>]` | send text or JSON to `human`, a channel, a comma-separated mix, or one canonical session id |
-| `--register [<legacy-name>] [--session-id <id>] [--name <name>] [--role <role>] [--harness <harness>]` | advanced: register session presence manually |
-| `--unregister [<legacy-name>] [--session-id <id>]` | advanced: remove session presence manually |
-| `--who` | advanced: list online sessions |
+| `--register [<legacy-name>] [--session-id <id>] [--name <name>] [--role <role>] [--harness <harness>]` | register session presence |
+| `--unregister [<legacy-name>] [--session-id <id>]` | remove session presence |
+| `--who` | list online sessions |
 
 Examples:
 
 ```bash
 aos tell human "Hello"
 aos tell human --from-session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c --purpose final_response "Done."
+aos tell handoff "task complete"
+aos tell human,handoff "done"
+aos tell handoff --from wiki-focus "task complete"
 aos tell --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c "ready for review"
-echo 'queued update' | aos tell ops
+aos tell --register --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c --name wiki-focus --role worker --harness codex
+echo 'queued update' | aos tell handoff
 ```
 
 If no text args and no `--json` payload are provided, `aos tell` reads plain text from `stdin`.
@@ -367,17 +367,10 @@ For `human` delivery, `--from-session-id` lets the daemon resolve that
 session's leased voice, and `--purpose final_response` applies the configured
 final-response shaping policy before speaking.
 
-Direct routing should prefer canonical session ids. Human-readable names remain
-display metadata for `aos tell --who` and operator ergonomics.
-Presence registration exists for advanced/manual workflows. Normal Codex and
-Claude usage in agent-os does not depend on automatic `tell --register`,
-`tell --unregister`, or `tell --who` hook activity.
+Direct routing should prefer canonical session ids. Human-readable names remain display metadata for `aos tell --who` and operator ergonomics.
+Presence is lease-based and restored from the runtime snapshot after daemon restart. Discover peers with `aos tell --who`, then keep using direct `--session-id` routing once a peer id is known; direct session messaging does not require `--who` to be non-empty at send time.
 
 ## `aos listen`
-
-Manual / advanced communication surface for reading channel or direct-session
-messages. This is useful for debugging or explicit operator workflows, not as a
-default polling mechanism in harness hooks.
 
 Primary public forms:
 
@@ -390,8 +383,8 @@ Primary public forms:
 Examples:
 
 ```bash
-aos listen ops
-aos listen ops --limit 10
+aos listen handoff
+aos listen handoff --limit 10
 aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c
 aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c --follow
 aos listen --channels

--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -10,6 +10,23 @@ Use this doc when you are:
 
 For architecture and philosophy, see [ARCHITECTURE.md](../../ARCHITECTURE.md).
 
+## Repo Development Entry Points
+
+When you are developing inside the `agent-os` repo, invoke the binary as
+`./aos`, not bare `aos`.
+
+Start here:
+
+```bash
+./aos status
+./aos help <command> [--json]
+./aos introspect review
+```
+
+`./aos status` is the primary runtime/session entrypoint. Use `doctor`,
+`daemon-snapshot`, and `clean` when you need deeper diagnostics or explicit
+cleanup, not as the default first move.
+
 ## Contract
 
 `aos` is a single binary with Unix-style subcommand groups.
@@ -21,8 +38,8 @@ aos see cursor
 aos show create --id demo --at 100,100,300,200 --html '<div>hello</div>'
 aos do click 500,300
 aos say "Hello"
-aos tell handoff "task complete"
-aos listen handoff
+aos tell human "Done."
+aos listen ops --limit 10
 ```
 
 ### Success / Failure
@@ -52,28 +69,31 @@ The current top-level commands are:
 
 | Command | Role |
 | --- | --- |
+| `aos status` | primary runtime/session status entrypoint |
 | `aos see` | Perception: cursor state, captures, observation streams, zones |
-| `aos show` | Projection: canvas create/update/remove/list/eval/render |
 | `aos do` | Action: mouse, keyboard, AX actions, AppleScript, session mode |
+| `aos show` | Projection: canvas create/update/remove/list/eval/render |
+| `aos focus` | Focus-channel management |
+| `aos graph` | Display/window graph queries |
+| `aos introspect` | Session self-review over recent `./aos` usage |
+| `aos help` | Registry and command-specific help |
 | `aos say` | Voice output |
-| `aos tell` | Communication output: human, channel, or direct session routing |
-| `aos listen` | Communication input: channel or direct session reads/follow |
+| `aos tell` | Manual communication output: human, channel, or direct session routing |
+| `aos listen` | Manual communication input: channel or direct session reads/follow |
+| `aos wiki` | local knowledge-base workflows |
 | `aos config` | Discoverable runtime configuration (`get`, `set`, dump) |
 | `aos set` | Runtime configuration |
-| `aos serve` | Unified daemon |
 | `aos content` | Content-server status |
+| `aos serve` | Unified daemon |
 | `aos service` | launchd lifecycle for the daemon |
 | `aos runtime` | packaged runtime utilities |
-| `aos doctor` | health and runtime diagnostics |
-| `aos reset` | cleanup/reset workflows |
-| `aos clean` | stale daemon / canvas cleanup |
 | `aos permissions` | preflight and onboarding |
-| `aos focus` | focus-channel management |
-| `aos graph` | display/window graph queries |
+| `aos doctor` | detailed runtime and permission diagnostics |
+| `aos clean` | explicit stale daemon / canvas cleanup |
+| `aos reset` | cleanup/reset workflows |
 | `aos daemon-snapshot` | daemon state snapshot |
 | `aos inspect` | live AX inspector overlay |
 | `aos log` | log overlay |
-| `aos wiki` | local knowledge-base workflows |
 
 ## Core Usage Patterns
 
@@ -126,18 +146,18 @@ aos show wait --id inspector --manifest inspector-panel
 aos show post --id inspector --event '{"type":"inspector-panel/bootstrap","payload":{"note":"hello"}}'
 ```
 
-### 4. Coordinate Through Channels or Direct Session Messaging
+### 4. Manual Communication and Debugging
 
 ```bash
-aos tell handoff "task complete"
-aos tell handoff --from wiki-focus "task complete"
+aos tell human "Done."
 aos tell --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c "ready for review"
-aos tell --register --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c --name wiki-focus --role worker --harness codex
-echo 'queued update' | aos tell handoff
-aos tell --who
-aos listen handoff
-aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c --follow
+aos listen ops --limit 10
+aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c
 ```
+
+`aos tell` / `aos listen` remain available for explicit operator workflows and
+debugging. They are not part of the default Codex or Claude hook stack in
+agent-os.
 
 ## Subcommand Reference
 
@@ -319,26 +339,26 @@ discoverability misses like unknown commands or missing arguments over time.
 
 ## `aos tell`
 
+Manual / advanced communication surface. Use this when you explicitly want the
+daemon to route a message or inspect session-facing communication. Do not treat
+it as required session plumbing for normal harness operation.
+
 Primary public forms:
 
 | Form | Purpose |
 | --- | --- |
 | `<audience>\|--session-id <id> [--json <payload>] [--from <name>] [--from-session-id <id>] [--purpose <name>] [<text>]` | send text or JSON to `human`, a channel, a comma-separated mix, or one canonical session id |
-| `--register [<legacy-name>] [--session-id <id>] [--name <name>] [--role <role>] [--harness <harness>]` | register session presence |
-| `--unregister [<legacy-name>] [--session-id <id>]` | remove session presence |
-| `--who` | list online sessions |
+| `--register [<legacy-name>] [--session-id <id>] [--name <name>] [--role <role>] [--harness <harness>]` | advanced: register session presence manually |
+| `--unregister [<legacy-name>] [--session-id <id>]` | advanced: remove session presence manually |
+| `--who` | advanced: list online sessions |
 
 Examples:
 
 ```bash
 aos tell human "Hello"
 aos tell human --from-session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c --purpose final_response "Done."
-aos tell handoff "task complete"
-aos tell human,handoff "done"
-aos tell handoff --from wiki-focus "task complete"
 aos tell --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c "ready for review"
-aos tell --register --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c --name wiki-focus --role worker --harness codex
-echo 'queued update' | aos tell handoff
+echo 'queued update' | aos tell ops
 ```
 
 If no text args and no `--json` payload are provided, `aos tell` reads plain text from `stdin`.
@@ -347,10 +367,17 @@ For `human` delivery, `--from-session-id` lets the daemon resolve that
 session's leased voice, and `--purpose final_response` applies the configured
 final-response shaping policy before speaking.
 
-Direct routing should prefer canonical session ids. Human-readable names remain display metadata for `aos tell --who` and operator ergonomics.
-Presence is lease-based and restored from the runtime snapshot after daemon restart. Discover peers with `aos tell --who`, then keep using direct `--session-id` routing once a peer id is known; direct session messaging does not require `--who` to be non-empty at send time.
+Direct routing should prefer canonical session ids. Human-readable names remain
+display metadata for `aos tell --who` and operator ergonomics.
+Presence registration exists for advanced/manual workflows. Normal Codex and
+Claude usage in agent-os does not depend on automatic `tell --register`,
+`tell --unregister`, or `tell --who` hook activity.
 
 ## `aos listen`
+
+Manual / advanced communication surface for reading channel or direct-session
+messages. This is useful for debugging or explicit operator workflows, not as a
+default polling mechanism in harness hooks.
 
 Primary public forms:
 
@@ -363,8 +390,8 @@ Primary public forms:
 Examples:
 
 ```bash
-aos listen handoff
-aos listen handoff --limit 10
+aos listen ops
+aos listen ops --limit 10
 aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c
 aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c --follow
 aos listen --channels
@@ -400,7 +427,9 @@ These are still public, but they are more specialized:
 | `aos inspect` | you want the built-in live AX overlay |
 | `aos log` | you want the built-in log console overlay |
 | `aos permissions` | you need machine-readable readiness checks |
-| `aos doctor` | you need a fuller runtime health snapshot |
+| `aos doctor` | you need a fuller runtime health snapshot than `aos status` |
+| `aos clean` | `aos status` reports stale resources and you want explicit cleanup |
+| `aos daemon-snapshot` | you need the low-level spatial snapshot directly |
 | `aos focus` / `aos graph` | you are consuming focus channels / display-window topology |
 | `aos wiki` | you are consuming the local wiki/plugin system |
 

--- a/shared/swift/ipc/runtime-paths.swift
+++ b/shared/swift/ipc/runtime-paths.swift
@@ -29,6 +29,41 @@ struct AOSRuntimeIdentity: Encodable {
     let bundle_build: String?
 }
 
+func aosCurrentSessionHarness() -> String {
+    let env = ProcessInfo.processInfo.environment
+    if let harness = env["AOS_SESSION_HARNESS"], !harness.isEmpty {
+        return harness
+    }
+    if let _ = env["CODEX_THREAD_ID"] {
+        return "codex"
+    }
+    if let _ = env["CLAUDE_CODE_SSE_PORT"] {
+        return "claude-code"
+    }
+    return "unknown"
+}
+
+func aosSanitizeSessionComponent(_ value: String) -> String {
+    value.replacingOccurrences(of: #"[^A-Za-z0-9._-]"#, with: "_", options: .regularExpression)
+}
+
+func aosCurrentSessionKey() -> String {
+    let env = ProcessInfo.processInfo.environment
+    if let sessionID = env["AOS_SESSION_ID"], !sessionID.isEmpty {
+        return aosSanitizeSessionComponent(sessionID)
+    }
+    if let threadID = env["CODEX_THREAD_ID"], !threadID.isEmpty {
+        return aosSanitizeSessionComponent("codex-\(threadID)")
+    }
+    if let name = env["AOS_SESSION_NAME"], !name.isEmpty {
+        return aosSanitizeSessionComponent("name-\(name)")
+    }
+    if let port = env["CLAUDE_CODE_SSE_PORT"], !port.isEmpty {
+        return aosSanitizeSessionComponent("claude-port-\(port)")
+    }
+    return aosSanitizeSessionComponent("pid-\(getpid())")
+}
+
 func aosHomeDir() -> String {
     FileManager.default.homeDirectoryForCurrentUser.path
 }
@@ -100,6 +135,22 @@ func aosVoiceAssignmentsPath(for mode: AOSRuntimeMode? = nil) -> String {
 
 func aosCLIErrorLogPath(for mode: AOSRuntimeMode? = nil) -> String {
     "\(aosStateDir(for: mode))/cli-errors.jsonl"
+}
+
+func aosAgentIntrospectionDir(for mode: AOSRuntimeMode? = nil) -> String {
+    "\(aosStateDir(for: mode))/agent-introspection"
+}
+
+func aosAgentUsageLogPath(for mode: AOSRuntimeMode? = nil) -> String {
+    "\(aosAgentIntrospectionDir(for: mode))/aos-usage.jsonl"
+}
+
+func aosAgentSessionStateDir(for mode: AOSRuntimeMode? = nil) -> String {
+    "\(aosAgentIntrospectionDir(for: mode))/sessions"
+}
+
+func aosAgentSessionStatePath(sessionKey: String, mode: AOSRuntimeMode? = nil) -> String {
+    "\(aosAgentSessionStateDir(for: mode))/\(sessionKey).json"
 }
 
 func aosVoiceEventLogPath(for mode: AOSRuntimeMode? = nil) -> String {

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -18,7 +18,7 @@ When an automated flow needs to rebuild and then immediately run an `./aos`
 command, prefer:
 
 ```bash
-scripts/aos-after-build -- ./aos doctor --json
+scripts/aos-after-build -- ./aos status --json
 ```
 
 That wrapper waits for any in-flight rebuild, refreshes the binary if needed,
@@ -47,11 +47,14 @@ Requires macOS 14+ and Accessibility permission.
 
 ## Setup
 
+In this repo, invoke the CLI as `./aos`, not `aos`.
+
 Before interactive commands (`do`, `see cursor/observe/capture`, `inspect`) will work:
 
 ```bash
-aos permissions setup --once     # One-time Accessibility + Screen Recording flow
-aos doctor --json                # Verify runtime health
+./aos permissions setup --once   # One-time Accessibility + Screen Recording flow
+./aos status                     # Primary runtime/session entrypoint
+./aos doctor --json              # Deeper runtime diagnostics when needed
 ```
 
 Interactive commands exit early with `PERMISSIONS_SETUP_REQUIRED` until onboarding completes for the current runtime mode.
@@ -63,56 +66,31 @@ See root `AGENTS.md` for the runtime model (repo vs installed modes, mode-scoped
 ### One-Shot Commands (no daemon needed)
 
 ```bash
-aos see cursor                    # What's under the cursor
-aos see capture main --out /tmp/screen.png   # Screenshot main display
-aos see main --base64 --format jpg           # Base64 shorthand
-aos see capture user_active --window --xray  # Window + AX overlay
-aos see mouse --radius 200                   # Area around cursor
-aos show render --html "..." --out /tmp/x.png
-aos do click 500,300              # Click at coordinates
-aos do type "hello world"         # Type with natural cadence
-aos say "Hello, I'm your agent"   # Speak text aloud (sugar for tell human)
-aos say --list-voices             # List available voices
-aos voice list                    # Curated session voice bank
-aos voice leases                  # Active one-session-per-voice leases
-aos voice bind --session-id <id> --voice <voice-id>
-aos voice final-response --harness codex --session-id <id> < hook.json
-aos config get voice.controls.cancel.key_code
-aos config get voice.enabled      # Discoverable config read
-aos config set voice.enabled true # Discoverable config write
-aos tell human "Hello"             # Speak (same as aos say)
-aos tell human --from-session-id <id> --purpose final_response "Done."
-aos tell handoff "task complete"    # Post to coordination channel
-aos tell --register --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c --name my-session
-aos tell --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c "status update"
-aos tell --who                     # List online sessions
-aos listen handoff                 # Read channel messages
-aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c
-aos listen handoff --follow        # Stream messages in real-time
-aos listen --channels              # List known channels
-aos set voice.enabled true        # Configure settings
-aos inspect                       # Live AX element inspector overlay
-aos log push "message"            # Push to log console
+./aos status                      # Primary runtime/session entrypoint
+./aos introspect review           # Self-review / recovery after failed attempts
+./aos see cursor                  # What's under the cursor
+./aos see capture main --out /tmp/screen.png   # Screenshot main display
+./aos see main --base64 --format jpg           # Base64 shorthand
+./aos see capture user_active --window --xray  # Window + AX overlay
+./aos see mouse --radius 200                   # Area around cursor
+./aos show render --html "..." --out /tmp/x.png
+./aos do click 500,300            # Click at coordinates
+./aos do type "hello world"       # Type with natural cadence
+./aos say "Hello, I'm your agent" # Speak text aloud (sugar for tell human)
+./aos say --list-voices           # List available voices
+./aos voice list                  # Curated session voice bank
+./aos voice leases                # Active one-session-per-voice leases
+./aos voice bind --session-id <id> --voice <voice-id>
+./aos voice final-response --harness codex --session-id <id> < hook.json
+./aos config get voice.controls.cancel.key_code
+./aos config get voice.enabled    # Discoverable config read
+./aos config set voice.enabled true # Discoverable config write
+./aos tell human "Hello"          # Speak (same as aos say)
+./aos tell human --from-session-id <id> --purpose final_response "Done."
+./aos set voice.enabled true      # Configure settings
+./aos inspect                     # Live AX element inspector overlay
+./aos log push "message"          # Push to log console
 ```
-
-### Session Coordination
-
-Sessions register themselves on startup. Use the canonical `session_id` as the
-direct inbox/channel once a peer is discovered; human-readable names are display
-metadata and a fallback alias, not the primary routing key.
-
-```bash
-scripts/session-name --current                    # Inspect current session_id/name
-scripts/session-name --name wiki-focus            # Rename the current session
-./aos tell --who                                 # List live peers + canonical ids
-./aos tell --session-id <peer-id> "STEER: ..."   # Direct peer message
-./aos listen --session-id <this-session-id>      # Read this session's inbox
-scripts/parallel-codex                           # Prepare paired display/wiki launchers
-```
-
-Shared session hooks live under `.agents/hooks/`. Startup and message polling
-run in both Claude Code and Codex. Clean stop unregistering is currently wired
-through Claude's stop hook only; Codex relies on lease refresh plus
 re-registration on startup/post-tool use.
 
 ### Capture (aos see capture)
@@ -168,16 +146,19 @@ echo "lines" | aos log            # Stream stdin to log overlay
 ### Runtime and Service Management
 
 ```bash
-aos runtime status [--json]       # Runtime identity, signing, mode
-aos runtime path                  # Print current executable path
-aos service install [--mode repo|installed]   # Install launch agent
-aos service start|stop|restart    # Service lifecycle
-aos service status [--json]       # Launch agent state
-aos doctor [--json]               # Full health check (permissions, daemon, services)
-aos reset --mode current|repo|installed|all  # Deterministic state cleanup
-aos clean [--dry-run] [--json]    # Session-boundary cleanup (stale daemons, orphaned canvases)
-aos permissions check [--json]    # Read-only permission check
-aos permissions setup --once      # Interactive onboarding flow
+./aos status [--json]             # Primary runtime/session status
+./aos introspect review [--json]  # Review recent ./aos usage for this session
+./aos runtime status [--json]     # Runtime identity, signing, mode
+./aos runtime path                # Print current executable path
+./aos service install [--mode repo|installed]   # Install launch agent
+./aos service start|stop|restart  # Service lifecycle
+./aos service status [--json]     # Launch agent state
+aos-fresh                         # Repo helper: clean lingering state + restart repo service
+./aos doctor [--json]             # Full health check (permissions, daemon, services)
+./aos reset --mode current|repo|installed|all  # Deterministic state cleanup
+./aos clean [--dry-run] [--json]  # Explicit stale-resource cleanup
+./aos permissions check [--json]  # Read-only permission check
+./aos permissions setup --once    # Interactive onboarding flow
 ```
 
 ### Autonomic Configuration

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -87,10 +87,37 @@ See root `AGENTS.md` for the runtime model (repo vs installed modes, mode-scoped
 ./aos config set voice.enabled true # Discoverable config write
 ./aos tell human "Hello"          # Speak (same as aos say)
 ./aos tell human --from-session-id <id> --purpose final_response "Done."
-./aos set voice.enabled true      # Configure settings
-./aos inspect                     # Live AX element inspector overlay
-./aos log push "message"          # Push to log console
+./aos tell handoff "task complete"    # Post to coordination channel
+./aos tell --register --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c --name my-session
+./aos tell --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c "status update"
+./aos tell --who                     # List online sessions
+./aos listen handoff                 # Read channel messages
+./aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c
+./aos listen handoff --follow        # Stream messages in real-time
+./aos listen --channels              # List known channels
+./aos set voice.enabled true         # Configure settings
+./aos inspect                        # Live AX element inspector overlay
+./aos log push "message"             # Push to log console
 ```
+
+### Session Coordination
+
+Sessions register themselves on startup. Use the canonical `session_id` as the
+direct inbox/channel once a peer is discovered; human-readable names are display
+metadata and a fallback alias, not the primary routing key.
+
+```bash
+scripts/session-name --current                    # Inspect current session_id/name
+scripts/session-name --name wiki-focus            # Rename the current session
+./aos tell --who                                 # List live peers + canonical ids
+./aos tell --session-id <peer-id> "STEER: ..."   # Direct peer message
+./aos listen --session-id <this-session-id>      # Read this session's inbox
+scripts/parallel-codex                           # Prepare paired display/wiki launchers
+```
+
+Shared session hooks live under `.agents/hooks/`. Startup and message polling
+run in both Claude Code and Codex. Clean stop unregistering is currently wired
+through Claude's stop hook only; Codex relies on lease refresh plus
 re-registration on startup/post-tool use.
 
 ### Capture (aos see capture)
@@ -153,7 +180,6 @@ echo "lines" | aos log            # Stream stdin to log overlay
 ./aos service install [--mode repo|installed]   # Install launch agent
 ./aos service start|stop|restart  # Service lifecycle
 ./aos service status [--json]     # Launch agent state
-aos-fresh                         # Repo helper: clean lingering state + restart repo service
 ./aos doctor [--json]             # Full health check (permissions, daemon, services)
 ./aos reset --mode current|repo|installed|all  # Deterministic state cleanup
 ./aos clean [--dry-run] [--json]  # Explicit stale-resource cleanup

--- a/src/commands/clean.swift
+++ b/src/commands/clean.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-private struct CleanReport: Encodable {
+struct CleanReport: Encodable {
     let status: String
     let stale_daemons: [StaleDaemonInfo]
     let canvases: [CleanCanvasEntry]
@@ -15,12 +15,12 @@ private struct CleanReport: Encodable {
     let notes: [String]
 }
 
-private struct StaleDaemonInfo: Encodable {
+struct StaleDaemonInfo: Encodable {
     let pid: Int
     let args: String
 }
 
-private struct CleanCanvasEntry: Encodable {
+struct CleanCanvasEntry: Encodable {
     let id: String
     let mode: String
 }
@@ -66,7 +66,7 @@ func cleanCommand(args: [String]) {
     }
 }
 
-private func runClean(dryRun: Bool) -> CleanReport {
+func runClean(dryRun: Bool) -> CleanReport {
     var actions: [String] = []
     var notes: [String] = []
     let mode = aosCurrentRuntimeMode()

--- a/src/commands/introspect.swift
+++ b/src/commands/introspect.swift
@@ -1,0 +1,263 @@
+// introspect.swift — review recent ./aos usage for the current session.
+
+import Foundation
+
+private struct AgentUsageEvent: Codable {
+    let timestamp: String
+    let session: String
+    let harness: String?
+    let source: String?
+    let command: String?
+    let command_path: [String]?
+    let outcome: String?
+    let exit_code: Int?
+    let error_code: String?
+    let duration_ms: Int?
+    let blocked_reason: String?
+}
+
+private struct AgentSessionState: Codable {
+    let session: String
+    let harness: String?
+    let consecutive_failures: Int?
+    let total_events: Int?
+    let last_updated: String?
+}
+
+private struct IntrospectRecentEntry: Encodable {
+    let timestamp: String
+    let command: String
+    let outcome: String
+    let error_code: String?
+}
+
+private struct IntrospectReviewResponse: Encodable {
+    let status: String
+    let session: String
+    let harness: String
+    let total_attempts: Int
+    let successes: Int
+    let failures: Int
+    let blocked: Int
+    let consecutive_failures: Int
+    let mastered_commands: [String]
+    let repeated_failure_commands: [String]
+    let learnings: [String]
+    let recommendations: [String]
+    let recent: [IntrospectRecentEntry]
+    let log_path: String
+}
+
+func introspectCommand(args: [String]) {
+    if args.contains("--help") || args.contains("-h") || args.isEmpty {
+        printCommandHelp(["introspect"], json: args.contains("--json"))
+        exit(0)
+    }
+
+    let sub = args[0]
+    switch sub {
+    case "review":
+        introspectReviewCommand(args: Array(args.dropFirst()))
+    default:
+        exitError("Unknown introspect subcommand: \(sub)", code: "UNKNOWN_SUBCOMMAND")
+    }
+}
+
+private func introspectReviewCommand(args: [String]) {
+    var asJSON = false
+    var sessionKey = aosCurrentSessionKey()
+    var i = 0
+    while i < args.count {
+        switch args[i] {
+        case "--json":
+            asJSON = true
+        case "--session":
+            i += 1
+            guard i < args.count else {
+                exitError("--session requires a value", code: "MISSING_ARG")
+            }
+            sessionKey = aosSanitizeSessionComponent(args[i])
+        default:
+            exitError("Unknown flag: \(args[i]). Usage: \(aosInvocationDisplayName()) introspect review [--session <key>] [--json]", code: "UNKNOWN_FLAG")
+        }
+        i += 1
+    }
+
+    let logPath = aosAgentUsageLogPath()
+    let events = loadAgentUsageEvents().filter { $0.session == sessionKey }
+    let state = loadAgentSessionState(sessionKey: sessionKey)
+    let harness = state?.harness ?? events.compactMap(\.harness).last ?? aosCurrentSessionHarness()
+
+    var successes = 0
+    var failures = 0
+    var blocked = 0
+    var mastered: Set<String> = []
+    var failureCounts: [String: Int] = [:]
+    var errorCounts: [String: Int] = [:]
+    var recent: [IntrospectRecentEntry] = []
+    var usedStatus = false
+    var usedDoctor = false
+    var usedDaemonSnapshot = false
+    var usedClean = false
+    var misuseRepoBinary = false
+    var invalidCommandLoops = false
+
+    for event in events {
+        let path = commandPathString(from: event)
+        switch event.outcome {
+        case "success":
+            successes += 1
+            if !path.isEmpty {
+                mastered.insert(path)
+            }
+        case "blocked":
+            blocked += 1
+            failures += 1
+            if !path.isEmpty {
+                failureCounts[path, default: 0] += 1
+            }
+        case "error":
+            failures += 1
+            if !path.isEmpty {
+                failureCounts[path, default: 0] += 1
+            }
+        default:
+            break
+        }
+
+        if let errorCode = event.error_code, !errorCode.isEmpty {
+            errorCounts[errorCode, default: 0] += 1
+            if errorCode == "USE_REPO_AOS" {
+                misuseRepoBinary = true
+            }
+            if errorCode == "UNKNOWN_COMMAND" || errorCode == "UNKNOWN_ARG" || errorCode == "UNKNOWN_FLAG" || errorCode == "MISSING_ARG" {
+                invalidCommandLoops = true
+            }
+        }
+
+        if path == "status" { usedStatus = true }
+        if path == "doctor" { usedDoctor = true }
+        if path == "daemon-snapshot" { usedDaemonSnapshot = true }
+        if path == "clean" { usedClean = true }
+
+        recent.append(IntrospectRecentEntry(
+            timestamp: event.timestamp,
+            command: path.isEmpty ? (event.command ?? "(unknown)") : path,
+            outcome: event.outcome ?? "unknown",
+            error_code: event.error_code
+        ))
+    }
+
+    recent = Array(Array(recent.suffix(8)).reversed())
+
+    var learnings: [String] = []
+    if misuseRepoBinary {
+        learnings.append("In repo mode, invoke the binary as `./aos`, not `aos`.")
+    }
+    if (usedDoctor || usedDaemonSnapshot || usedClean) && !usedStatus {
+        learnings.append("`\(aosInvocationDisplayName()) status` is the primary runtime entrypoint; use it before dropping to `doctor`, `daemon-snapshot`, or `clean`.")
+    }
+    if invalidCommandLoops {
+        learnings.append("When commands or flags miss, recover with `\(aosInvocationDisplayName()) help <command> [--json]` before retrying.")
+    }
+    if !mastered.isEmpty {
+        learnings.append("Successful command paths so far: \(mastered.sorted().joined(separator: ", ")).")
+    }
+
+    var recommendations: [String] = []
+    if events.isEmpty {
+        recommendations.append("Start with `\(aosInvocationDisplayName()) status`.")
+        recommendations.append("Use `\(aosInvocationDisplayName()) help <command> [--json]` to inspect a specific surface.")
+    }
+    if misuseRepoBinary {
+        recommendations.append("Replace bare `aos` invocations with `\(aosInvocationDisplayName())`.")
+    }
+    if (usedDoctor || usedDaemonSnapshot || usedClean) && !usedStatus {
+        recommendations.append("Use `\(aosInvocationDisplayName()) status` for routine runtime checks instead of chaining `doctor`, `daemon-snapshot`, and `clean` manually.")
+    }
+    if invalidCommandLoops {
+        recommendations.append("Use `\(aosInvocationDisplayName()) help <command>` before another retry loop.")
+    }
+    if recommendations.isEmpty {
+        recommendations.append("Keep using `\(aosInvocationDisplayName()) status` as the point of entry and `\(aosInvocationDisplayName()) introspect review` for self-review.")
+    }
+
+    let repeatedFailures = failureCounts
+        .filter { $0.value > 1 }
+        .sorted { lhs, rhs in
+            if lhs.value == rhs.value { return lhs.key < rhs.key }
+            return lhs.value > rhs.value
+        }
+        .map { "\($0.key) (\($0.value))" }
+
+    let response = IntrospectReviewResponse(
+        status: failures == 0 ? "ok" : "review",
+        session: sessionKey,
+        harness: harness,
+        total_attempts: events.count,
+        successes: successes,
+        failures: failures,
+        blocked: blocked,
+        consecutive_failures: state?.consecutive_failures ?? 0,
+        mastered_commands: mastered.sorted(),
+        repeated_failure_commands: repeatedFailures,
+        learnings: learnings,
+        recommendations: recommendations,
+        recent: recent,
+        log_path: logPath
+    )
+
+    if asJSON {
+        print(jsonString(response))
+        return
+    }
+
+    print("status=\(response.status) session=\(response.session) harness=\(response.harness) attempts=\(response.total_attempts) successes=\(response.successes) failures=\(response.failures) blocked=\(response.blocked) streak=\(response.consecutive_failures)")
+    print("Mastered: \(response.mastered_commands.isEmpty ? "(none yet)" : response.mastered_commands.joined(separator: ", "))")
+    print("Repeated failures: \(response.repeated_failure_commands.isEmpty ? "(none)" : response.repeated_failure_commands.joined(separator: ", "))")
+    print("Learnings:")
+    if response.learnings.isEmpty {
+        print("- No issues detected yet.")
+    } else {
+        for line in response.learnings {
+            print("- \(line)")
+        }
+    }
+    print("Recommendations:")
+    for line in response.recommendations {
+        print("- \(line)")
+    }
+    print("Recent:")
+    for entry in response.recent {
+        let errorSuffix = entry.error_code.map { " [\($0)]" } ?? ""
+        print("- \(entry.timestamp) \(entry.outcome) \(entry.command)\(errorSuffix)")
+    }
+    print("log_path=\(response.log_path)")
+}
+
+private func loadAgentUsageEvents() -> [AgentUsageEvent] {
+    let path = aosAgentUsageLogPath()
+    guard let raw = try? String(contentsOfFile: path, encoding: .utf8) else {
+        return []
+    }
+    let decoder = JSONDecoder()
+    return raw
+        .split(whereSeparator: \.isNewline)
+        .compactMap { line in
+            guard let data = line.data(using: .utf8) else { return nil }
+            return try? decoder.decode(AgentUsageEvent.self, from: data)
+        }
+}
+
+private func loadAgentSessionState(sessionKey: String) -> AgentSessionState? {
+    let path = aosAgentSessionStatePath(sessionKey: sessionKey)
+    guard let data = FileManager.default.contents(atPath: path) else { return nil }
+    return try? JSONDecoder().decode(AgentSessionState.self, from: data)
+}
+
+private func commandPathString(from event: AgentUsageEvent) -> String {
+    if let path = event.command_path, !path.isEmpty {
+        return path.joined(separator: "/")
+    }
+    return ""
+}

--- a/src/commands/operator.swift
+++ b/src/commands/operator.swift
@@ -127,7 +127,135 @@ private struct CanvasLookupResponse: Encodable {
     let notes: [String]
 }
 
+private struct GitStatusState: Encodable {
+    let branch: String
+    let ahead_of_origin_main: Int?
+    let dirty_files: Int
+    let worktrees: Int
+}
+
+private struct StatusStaleResources: Encodable {
+    let status: String
+    let stale_daemons: Int
+    let canvases: [String]
+    let notes: [String]
+}
+
+private struct StatusResponse: Encodable {
+    let status: String
+    let identity: RuntimeIdentityState
+    let runtime: RuntimeState
+    let permissions: PermissionsState
+    let permissions_setup: PermissionsSetupState
+    let daemon_snapshot: SpatialSnapshotData?
+    let stale_resources: StatusStaleResources
+    let git: GitStatusState?
+    let recommended_entrypoints: [String]
+    let notes: [String]
+}
+
 // MARK: - Public Commands
+
+func statusCommand(args: [String]) {
+    if args.contains("--help") || args.contains("-h") {
+        printCommandHelp(["status"], json: args.contains("--json"))
+        exit(0)
+    }
+    guard args.allSatisfy({ $0 == "--json" }) else {
+        let unknown = args.first(where: { $0 != "--json" }) ?? ""
+        exitError("Unknown flag: \(unknown). Usage: \(aosInvocationDisplayName()) status [--json]", code: "UNKNOWN_FLAG")
+    }
+
+    let prefix = aosInvocationDisplayName()
+    let permissions = currentPermissionsState()
+    let permissionsSetup = currentPermissionsSetupState(permissions: permissions)
+    let runtime = currentRuntimeState()
+    let identity = aosCurrentRuntimeIdentity(program: "aos")
+    let snapshotResult = currentSpatialSnapshot()
+    let cleanReport = runClean(dryRun: true)
+    let git = currentGitStatus()
+
+    var notes: [String] = []
+    if !runtime.daemon_running {
+        notes.append("Daemon is not running.")
+    } else if !runtime.socket_reachable {
+        notes.append("Daemon process appears to be running, but the socket is not reachable.")
+    }
+    if !permissions.accessibility {
+        notes.append("Accessibility permission is not granted.")
+    }
+    if !permissions.screen_recording {
+        notes.append("Screen Recording permission is not granted.")
+    }
+    if !permissionsSetup.setup_completed, let command = permissionsSetup.recommended_command {
+        notes.append("Run '\(command)' before interactive testing.")
+    }
+    if cleanReport.status == "dirty" {
+        let canvasIDs = cleanReport.canvases.map(\.id)
+        if !canvasIDs.isEmpty {
+            notes.append("Stale canvas cleanup recommended: \(canvasIDs.joined(separator: ", ")).")
+        }
+        if !cleanReport.stale_daemons.isEmpty {
+            notes.append("Stale daemon cleanup recommended: \(cleanReport.stale_daemons.map { String($0.pid) }.joined(separator: ", ")).")
+        }
+    }
+    notes.append(contentsOf: snapshotResult.notes)
+
+    let response = StatusResponse(
+        status: notes.isEmpty ? "ok" : "degraded",
+        identity: RuntimeIdentityState(
+            program: identity.program,
+            mode: identity.mode,
+            executable_path: identity.executable_path,
+            state_dir: identity.state_dir,
+            socket_path: identity.socket_path,
+            build_timestamp: identity.build_timestamp,
+            repo_root: identity.repo_root,
+            git_commit: identity.git_commit,
+            bundle_version: identity.bundle_version,
+            bundle_build: identity.bundle_build
+        ),
+        runtime: runtime,
+        permissions: permissions,
+        permissions_setup: permissionsSetup,
+        daemon_snapshot: snapshotResult.snapshot,
+        stale_resources: StatusStaleResources(
+            status: cleanReport.status,
+            stale_daemons: cleanReport.stale_daemons.count,
+            canvases: cleanReport.canvases.map(\.id),
+            notes: cleanReport.notes
+        ),
+        git: git,
+        recommended_entrypoints: [
+            "\(prefix) help <command> [--json]",
+            "\(prefix) introspect review",
+            "\(prefix) clean"
+        ],
+        notes: notes
+    )
+
+    if args.contains("--json") {
+        print(jsonString(response))
+        return
+    }
+
+    let focusedApp = snapshotResult.snapshot?.focused_app ?? "?"
+    let displays = snapshotResult.snapshot?.displays ?? 0
+    let windows = snapshotResult.snapshot?.windows ?? 0
+    let channels = snapshotResult.snapshot?.channels ?? 0
+    let staleCanvasCount = cleanReport.canvases.count
+    let daemonState = runtime.socket_reachable ? "reachable" : (runtime.daemon_running ? "running" : "down")
+    var line = "status=\(response.status) mode=\(runtime.mode) daemon=\(daemonState) pid=\(runtime.daemon_pid.map { String($0) } ?? "?") focused_app=\(focusedApp) displays=\(displays) windows=\(windows) channels=\(channels) stale_canvases=\(staleCanvasCount)"
+    if let git {
+        let ahead = git.ahead_of_origin_main.map { String($0) } ?? "?"
+        line += " branch=\(git.branch) ahead=\(ahead) dirty=\(git.dirty_files)"
+    }
+    print(line)
+    for note in response.notes {
+        print(note)
+    }
+    print("Next: \(prefix) help <command> | \(prefix) introspect review")
+}
 
 func doctorCommand(args: [String]) {
     if args.contains("--help") || args.contains("-h") {
@@ -136,7 +264,7 @@ func doctorCommand(args: [String]) {
     }
     guard args.allSatisfy({ $0 == "--json" }) else {
         let unknown = args.first(where: { $0 != "--json" }) ?? ""
-        exitError("Unknown flag: \(unknown). Usage: aos doctor [--json]", code: "UNKNOWN_FLAG")
+        exitError("Unknown flag: \(unknown). Usage: \(aosInvocationDisplayName()) doctor [--json]", code: "UNKNOWN_FLAG")
     }
 
     let permissions = currentPermissionsState()
@@ -312,6 +440,11 @@ private struct CanvasSnapshot {
     let notes: [String]
 }
 
+private struct SpatialSnapshotResult {
+    let snapshot: SpatialSnapshotData?
+    let notes: [String]
+}
+
 private func parseCanvasLookupArgs(_ args: [String]) -> CanvasLookupOptions {
     var id: String? = nil
     var i = 0
@@ -331,6 +464,27 @@ private func parseCanvasLookupArgs(_ args: [String]) -> CanvasLookupOptions {
 
     guard let canvasID = id else { exitError("Missing required argument: --id <name>", code: "MISSING_ARG") }
     return CanvasLookupOptions(id: canvasID)
+}
+
+private func currentGitStatus() -> GitStatusState? {
+    guard let repoRoot = aosCurrentRepoRoot() else { return nil }
+    let branch = runProcess("/usr/bin/git", arguments: ["-C", repoRoot, "branch", "--show-current"])
+        .stdout
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    let aheadRaw = runProcess("/usr/bin/git", arguments: ["-C", repoRoot, "rev-list", "--count", "origin/main..HEAD"])
+        .stdout
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    let dirtyRaw = runProcess("/usr/bin/git", arguments: ["-C", repoRoot, "status", "--porcelain"])
+        .stdout
+    let worktreesRaw = runProcess("/usr/bin/git", arguments: ["-C", repoRoot, "worktree", "list"])
+        .stdout
+
+    return GitStatusState(
+        branch: branch.isEmpty ? "?" : branch,
+        ahead_of_origin_main: Int(aheadRaw),
+        dirty_files: dirtyRaw.split(whereSeparator: \.isNewline).count,
+        worktrees: max(worktreesRaw.split(whereSeparator: \.isNewline).count, 1)
+    )
 }
 
 private func currentPermissionsState() -> PermissionsState {
@@ -490,6 +644,21 @@ private func fetchCanvasSnapshot() -> CanvasSnapshot {
         canvases: [],
         notes: response.error.map { [$0] } ?? ["Failed to decode canvas list."]
     )
+}
+
+private func currentSpatialSnapshot() -> SpatialSnapshotResult {
+    guard let response = daemonOneShot(["action": "snapshot"], autoStartBinary: aosExecutablePath()) else {
+        return SpatialSnapshotResult(snapshot: nil, notes: ["Daemon snapshot is unavailable."])
+    }
+    if let error = response["error"] as? String {
+        return SpatialSnapshotResult(snapshot: nil, notes: [error])
+    }
+    guard let snapshotDict = response["snapshot"] as? [String: Any],
+          let data = try? JSONSerialization.data(withJSONObject: snapshotDict, options: [.sortedKeys]),
+          let snapshot = try? JSONDecoder().decode(SpatialSnapshotData.self, from: data) else {
+        return SpatialSnapshotResult(snapshot: nil, notes: ["Failed to decode daemon snapshot."])
+    }
+    return SpatialSnapshotResult(snapshot: snapshot, notes: [])
 }
 
 private func daemonProcessID() -> Int? {

--- a/src/commands/operator.swift
+++ b/src/commands/operator.swift
@@ -483,7 +483,7 @@ private func currentGitStatus() -> GitStatusState? {
         branch: branch.isEmpty ? "?" : branch,
         ahead_of_origin_main: Int(aheadRaw),
         dirty_files: dirtyRaw.split(whereSeparator: \.isNewline).count,
-        worktrees: max(worktreesRaw.split(whereSeparator: \.isNewline).count, 1)
+        worktrees: worktreesRaw.split(whereSeparator: \.isNewline).count
     )
 }
 

--- a/src/main.swift
+++ b/src/main.swift
@@ -60,6 +60,8 @@ struct AOS {
             serviceCommand(args: Array(args.dropFirst()))
         case "runtime":
             runtimeCommand(args: Array(args.dropFirst()))
+        case "status":
+            statusCommand(args: Array(args.dropFirst()))
         case "doctor":
             doctorCommand(args: Array(args.dropFirst()))
         case "reset":
@@ -113,12 +115,14 @@ struct AOS {
             inspectCommand(args: Array(args.dropFirst()))
         case "log":
             logCommand(args: Array(args.dropFirst()))
+        case "introspect":
+            introspectCommand(args: Array(args.dropFirst()))
         case "wiki":
             wikiCommand(args: Array(args.dropFirst()))
         case "--help", "-h", "help":
             helpCommand(args: Array(args.dropFirst()))
         default:
-            exitError("Unknown command: \(command). Run 'aos --help' for usage.", code: "UNKNOWN_COMMAND")
+            exitError("Unknown command: \(command). Run '\(aosInvocationDisplayName()) --help' for usage.", code: "UNKNOWN_COMMAND")
         }
     }
 }

--- a/src/shared/command-help.swift
+++ b/src/shared/command-help.swift
@@ -7,6 +7,44 @@ import Foundation
 /// The global registry. Populated in command-registry-data.swift.
 var commandRegistry: [CommandDescriptor] = []
 
+func aosInvocationDisplayName() -> String {
+    let raw = CommandLine.arguments.first ?? "aos"
+    if raw == "aos" {
+        return "aos"
+    }
+    if raw == "./aos" {
+        return "./aos"
+    }
+
+    let standardized = NSString(string: raw).standardizingPath
+    if standardized == "aos" && !raw.contains("/") {
+        return "aos"
+    }
+
+    let cwdAOS = (FileManager.default.currentDirectoryPath as NSString).appendingPathComponent("aos")
+    if standardized == NSString(string: cwdAOS).standardizingPath {
+        return "./aos"
+    }
+
+    if let repoRoot = aosCurrentRepoRoot() {
+        let repoAOS = (repoRoot as NSString).appendingPathComponent("aos")
+        if standardized == NSString(string: repoAOS).standardizingPath {
+            return "./aos"
+        }
+    }
+
+    if standardized.hasSuffix("/aos") {
+        return standardized
+    }
+
+    return raw
+}
+
+private func renderInvocationText(_ value: String) -> String {
+    let prefix = aosInvocationDisplayName()
+    return value.replacingOccurrences(of: "aos ", with: "\(prefix) ")
+}
+
 /// Look up a command by path. Exact match first, then tries parent
 /// with form filtering for subcommand paths like ["show", "create"].
 func findCommand(path: [String]) -> CommandDescriptor? {
@@ -47,7 +85,10 @@ func helpCommand(args: [String]) {
                 printCommandText(cmd)
             }
         } else {
-            exitError("Unknown command: \(pathArgs.joined(separator: " ")). Run 'aos help --json' for full registry.", code: "UNKNOWN_COMMAND")
+            exitError(
+                "Unknown command: \(pathArgs.joined(separator: " ")). Run '\(aosInvocationDisplayName()) help --json' for full registry.",
+                code: "UNKNOWN_COMMAND"
+            )
         }
     }
 }
@@ -77,7 +118,7 @@ func printCommandHelp(_ path: [String], json: Bool) {
         return
     }
     exitError(
-        "Unknown command: \(path.joined(separator: " ")). Run 'aos help --json' for full registry.",
+        "Unknown command: \(path.joined(separator: " ")). Run '\(aosInvocationDisplayName()) help --json' for full registry.",
         code: "UNKNOWN_COMMAND")
 }
 
@@ -105,9 +146,10 @@ func printCommandJSON(_ cmd: CommandDescriptor) {
 // MARK: - Text Output
 
 func printFullRegistryText() {
+    let prefix = aosInvocationDisplayName()
     var lines: [String] = []
-    lines.append("aos — agent operating system\n")
-    lines.append("Usage: aos <command> [options]\n")
+    lines.append("\(prefix) — agent operating system\n")
+    lines.append("Usage: \(prefix) <command> [options]\n")
     lines.append("Commands:")
 
     // Group by top-level verb
@@ -117,7 +159,37 @@ func printFullRegistryText() {
         verbs[verb, default: []].append(cmd)
     }
 
-    for verb in verbs.keys.sorted() {
+    let preferredVerbOrder = [
+        "status",
+        "see",
+        "do",
+        "show",
+        "focus",
+        "graph",
+        "introspect",
+        "wiki",
+        "tell",
+        "listen",
+        "say",
+        "voice",
+        "config",
+        "set",
+        "content",
+        "serve",
+        "service",
+        "runtime",
+        "permissions",
+        "doctor",
+        "clean",
+        "reset",
+        "daemon-snapshot",
+        "inspect",
+        "log",
+    ]
+    let orderedVerbs = preferredVerbOrder.filter { verbs[$0] != nil } +
+        verbs.keys.filter { !preferredVerbOrder.contains($0) }.sorted()
+
+    for verb in orderedVerbs {
         let cmds = verbs[verb]!
         // Show top-level summary from first entry
         let topLevel = cmds.first { $0.path.count == 1 }
@@ -134,18 +206,19 @@ func printFullRegistryText() {
         }
     }
 
-    lines.append("\nRun 'aos help <command> [--json]' for details on a specific command.")
-    lines.append("Run 'aos help --json' for machine-readable full registry.")
+    lines.append("\nRun '\(prefix) help <command> [--json]' for details on a specific command.")
+    lines.append("Run '\(prefix) help --json' for machine-readable full registry.")
     print(lines.joined(separator: "\n"))
 }
 
 func printCommandText(_ cmd: CommandDescriptor) {
+    let prefix = aosInvocationDisplayName()
     var lines: [String] = []
-    let cmdName = "aos \(cmd.path.joined(separator: " "))"
+    let cmdName = "\(prefix) \(cmd.path.joined(separator: " "))"
     lines.append("\(cmdName) — \(cmd.summary)\n")
 
     for form in cmd.forms {
-        lines.append("  \(form.usage)")
+        lines.append("  \(renderInvocationText(form.usage))")
         if !form.args.isEmpty {
             lines.append("")
             for arg in form.args {
@@ -174,7 +247,7 @@ func printCommandText(_ cmd: CommandDescriptor) {
         if !form.examples.isEmpty {
             lines.append("\n  Examples:")
             for ex in form.examples {
-                lines.append("    \(ex)")
+                lines.append("    \(renderInvocationText(ex))")
             }
         }
         lines.append("")

--- a/src/shared/command-registry-data.swift
+++ b/src/shared/command-registry-data.swift
@@ -558,7 +558,7 @@ func buildCommandRegistry() -> [CommandDescriptor] {
     ]))
 
     // ── tell ──────────────────────────────────────────────
-    reg.append(CommandDescriptor(path: ["tell"], summary: "Manual communication — send to human, channel, or session", forms: [
+    reg.append(CommandDescriptor(path: ["tell"], summary: "Communication — send to human, channel, or session", forms: [
         InvocationForm(id: "tell-message", usage: "aos tell <audience>|--session-id <id> [--json <payload>] [--from <name>] [--from-session-id <id>] [--purpose <name>] [<text> | stdin]",
             args: [
                 pos("audience", "Target: human, channel name, or canonical session id", discovery: [
@@ -581,12 +581,12 @@ func buildCommandRegistry() -> [CommandDescriptor] {
                 "aos tell human \"Found the bug\"",
                 "printf '%s' \"$FINAL\" | aos tell human --from-session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c --purpose final_response",
                 "aos tell --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c \"status update\"",
-                "aos tell ops \"task complete\" --from my-session",
-                "echo 'update' | aos tell ops"
+                "aos tell handoff \"task complete\" --from my-session",
+                "echo 'update' | aos tell handoff"
             ]),
         InvocationForm(id: "tell-register", usage: "aos tell --register [<legacy-name>] [--session-id <id>] [--name <name>] [--role <role>] [--harness <harness>]",
             args: [
-                flag("register", "--register", "Advanced: register session presence", required: true),
+                flag("register", "--register", "Register session presence", required: true),
                 flag("session-id", "--session-id", "Canonical session id (preferred)"),
                 flag("name", "--name", "Human-readable display name"),
                 flag("role", "--role", "Session role",
@@ -606,7 +606,7 @@ func buildCommandRegistry() -> [CommandDescriptor] {
             ]),
         InvocationForm(id: "tell-unregister", usage: "aos tell --unregister [<legacy-name>] [--session-id <id>]",
             args: [
-                flag("unregister", "--unregister", "Advanced: remove session presence", required: true),
+                flag("unregister", "--unregister", "Remove session presence", required: true),
                 flag("session-id", "--session-id", "Canonical session id (preferred)")
             ],
             stdin: nil, constraints: nil,
@@ -614,7 +614,7 @@ func buildCommandRegistry() -> [CommandDescriptor] {
             output: outJSON,
             examples: ["aos tell --unregister --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c", "aos tell --unregister my-session"]),
         InvocationForm(id: "tell-who", usage: "aos tell --who",
-            args: [flag("who", "--who", "Advanced: list online sessions", type: .bool, required: true)],
+            args: [flag("who", "--who", "List online sessions", type: .bool, required: true)],
             stdin: nil, constraints: nil,
             execution: execReadOnly(daemon: true),
             output: outJSON,
@@ -622,7 +622,7 @@ func buildCommandRegistry() -> [CommandDescriptor] {
     ]))
 
     // ── listen ────────────────────────────────────────────
-    reg.append(CommandDescriptor(path: ["listen"], summary: "Manual communication — receive from channels or sessions", forms: [
+    reg.append(CommandDescriptor(path: ["listen"], summary: "Communication — receive from channels", forms: [
         InvocationForm(id: "listen-read", usage: "aos listen <channel>|--session-id <id> [--since id] [--limit N]",
             args: [
                 pos("channel", "Channel to read from", discovery: [.command(path: ["listen"], formId: "listen-channels")]),
@@ -633,7 +633,7 @@ func buildCommandRegistry() -> [CommandDescriptor] {
             stdin: nil, constraints: nil,
             execution: execReadOnly(daemon: true),
             output: outJSON,
-            examples: ["aos listen ops", "aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c", "aos listen ops --limit 10"]),
+            examples: ["aos listen handoff", "aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c", "aos listen handoff --limit 10"]),
         InvocationForm(id: "listen-follow", usage: "aos listen <channel>|--session-id <id> --follow [--since id]",
             args: [
                 pos("channel", "Channel to follow"),
@@ -644,7 +644,7 @@ func buildCommandRegistry() -> [CommandDescriptor] {
             stdin: nil, constraints: nil,
             execution: execStreaming(daemon: true),
             output: outNDJSON,
-            examples: ["aos listen ops --follow", "aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c --follow"]),
+            examples: ["aos listen handoff --follow", "aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c --follow"]),
         InvocationForm(id: "listen-channels", usage: "aos listen --channels",
             args: [flag("channels", "--channels", "List known channels", type: .bool, required: true)],
             stdin: nil, constraints: nil,

--- a/src/shared/command-registry-data.swift
+++ b/src/shared/command-registry-data.swift
@@ -558,7 +558,7 @@ func buildCommandRegistry() -> [CommandDescriptor] {
     ]))
 
     // ── tell ──────────────────────────────────────────────
-    reg.append(CommandDescriptor(path: ["tell"], summary: "Communication — send to human, channel, or session", forms: [
+    reg.append(CommandDescriptor(path: ["tell"], summary: "Manual communication — send to human, channel, or session", forms: [
         InvocationForm(id: "tell-message", usage: "aos tell <audience>|--session-id <id> [--json <payload>] [--from <name>] [--from-session-id <id>] [--purpose <name>] [<text> | stdin]",
             args: [
                 pos("audience", "Target: human, channel name, or canonical session id", discovery: [
@@ -581,12 +581,12 @@ func buildCommandRegistry() -> [CommandDescriptor] {
                 "aos tell human \"Found the bug\"",
                 "printf '%s' \"$FINAL\" | aos tell human --from-session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c --purpose final_response",
                 "aos tell --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c \"status update\"",
-                "aos tell handoff \"task complete\" --from my-session",
-                "echo 'update' | aos tell handoff"
+                "aos tell ops \"task complete\" --from my-session",
+                "echo 'update' | aos tell ops"
             ]),
         InvocationForm(id: "tell-register", usage: "aos tell --register [<legacy-name>] [--session-id <id>] [--name <name>] [--role <role>] [--harness <harness>]",
             args: [
-                flag("register", "--register", "Register session presence", required: true),
+                flag("register", "--register", "Advanced: register session presence", required: true),
                 flag("session-id", "--session-id", "Canonical session id (preferred)"),
                 flag("name", "--name", "Human-readable display name"),
                 flag("role", "--role", "Session role",
@@ -606,7 +606,7 @@ func buildCommandRegistry() -> [CommandDescriptor] {
             ]),
         InvocationForm(id: "tell-unregister", usage: "aos tell --unregister [<legacy-name>] [--session-id <id>]",
             args: [
-                flag("unregister", "--unregister", "Remove session presence", required: true),
+                flag("unregister", "--unregister", "Advanced: remove session presence", required: true),
                 flag("session-id", "--session-id", "Canonical session id (preferred)")
             ],
             stdin: nil, constraints: nil,
@@ -614,7 +614,7 @@ func buildCommandRegistry() -> [CommandDescriptor] {
             output: outJSON,
             examples: ["aos tell --unregister --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c", "aos tell --unregister my-session"]),
         InvocationForm(id: "tell-who", usage: "aos tell --who",
-            args: [flag("who", "--who", "List online sessions", type: .bool, required: true)],
+            args: [flag("who", "--who", "Advanced: list online sessions", type: .bool, required: true)],
             stdin: nil, constraints: nil,
             execution: execReadOnly(daemon: true),
             output: outJSON,
@@ -622,7 +622,7 @@ func buildCommandRegistry() -> [CommandDescriptor] {
     ]))
 
     // ── listen ────────────────────────────────────────────
-    reg.append(CommandDescriptor(path: ["listen"], summary: "Communication — receive from channels", forms: [
+    reg.append(CommandDescriptor(path: ["listen"], summary: "Manual communication — receive from channels or sessions", forms: [
         InvocationForm(id: "listen-read", usage: "aos listen <channel>|--session-id <id> [--since id] [--limit N]",
             args: [
                 pos("channel", "Channel to read from", discovery: [.command(path: ["listen"], formId: "listen-channels")]),
@@ -633,7 +633,7 @@ func buildCommandRegistry() -> [CommandDescriptor] {
             stdin: nil, constraints: nil,
             execution: execReadOnly(daemon: true),
             output: outJSON,
-            examples: ["aos listen handoff", "aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c", "aos listen handoff --limit 10"]),
+            examples: ["aos listen ops", "aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c", "aos listen ops --limit 10"]),
         InvocationForm(id: "listen-follow", usage: "aos listen <channel>|--session-id <id> --follow [--since id]",
             args: [
                 pos("channel", "Channel to follow"),
@@ -644,7 +644,7 @@ func buildCommandRegistry() -> [CommandDescriptor] {
             stdin: nil, constraints: nil,
             execution: execStreaming(daemon: true),
             output: outNDJSON,
-            examples: ["aos listen handoff --follow", "aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c --follow"]),
+            examples: ["aos listen ops --follow", "aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c --follow"]),
         InvocationForm(id: "listen-channels", usage: "aos listen --channels",
             args: [flag("channels", "--channels", "List known channels", type: .bool, required: true)],
             stdin: nil, constraints: nil,
@@ -779,7 +779,7 @@ func buildCommandRegistry() -> [CommandDescriptor] {
     ]))
 
     // ── daemon-snapshot ───────────────────────────────────
-    reg.append(CommandDescriptor(path: ["daemon-snapshot"], summary: "Daemon state snapshot", forms: [
+    reg.append(CommandDescriptor(path: ["daemon-snapshot"], summary: "Detailed daemon spatial snapshot", forms: [
         InvocationForm(id: "daemon-snapshot", usage: "aos daemon-snapshot",
             args: [],
             stdin: nil, constraints: nil,
@@ -906,8 +906,18 @@ func buildCommandRegistry() -> [CommandDescriptor] {
             examples: ["aos runtime display-union"])
     ]))
 
+    // ── status ────────────────────────────────────────────
+    reg.append(CommandDescriptor(path: ["status"], summary: "Primary runtime/session status entrypoint", forms: [
+        InvocationForm(id: "status", usage: "aos status [--json]",
+            args: [],
+            stdin: nil, constraints: nil,
+            execution: execReadOnly(),
+            output: outJSONFlag,
+            examples: ["aos status", "aos status --json"])
+    ]))
+
     // ── doctor ────────────────────────────────────────────
-    reg.append(CommandDescriptor(path: ["doctor"], summary: "Runtime and permission health checks", forms: [
+    reg.append(CommandDescriptor(path: ["doctor"], summary: "Detailed runtime and permission diagnostics", forms: [
         InvocationForm(id: "doctor", usage: "aos doctor [--json]",
             args: [],
             stdin: nil, constraints: nil,
@@ -935,13 +945,23 @@ func buildCommandRegistry() -> [CommandDescriptor] {
     ]))
 
     // ── clean ─────────────────────────────────────────────
-    reg.append(CommandDescriptor(path: ["clean"], summary: "Session-boundary cleanup (stale daemons, orphaned canvases)", forms: [
+    reg.append(CommandDescriptor(path: ["clean"], summary: "Explicit stale-resource cleanup (stale daemons, orphaned canvases)", forms: [
         InvocationForm(id: "clean", usage: "aos clean [--dry-run] [--json]",
             args: [flag("dry-run", "--dry-run", "Show what would be cleaned without doing it", type: .bool)],
             stdin: nil, constraints: nil,
             execution: execMutating(dryRun: true),
             output: outJSONFlag,
             examples: ["aos clean", "aos clean --dry-run --json"])
+    ]))
+
+    // ── introspect ────────────────────────────────────────
+    reg.append(CommandDescriptor(path: ["introspect"], summary: "Review recent ./aos usage for this session", forms: [
+        InvocationForm(id: "introspect-review", usage: "aos introspect review [--session <key>] [--json]",
+            args: [flag("session", "--session", "Override session key for review")],
+            stdin: nil, constraints: nil,
+            execution: execReadOnly(),
+            output: outJSONFlag,
+            examples: ["aos introspect review", "aos introspect review --json"])
     ]))
 
     // ── permissions ───────────────────────────────────────

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,6 +30,7 @@ Examples:
 - `bash tests/capture-parallel.sh`
 - `./aos runtime status --json`
 - `./aos show create ...`
+- `bash tests/sigil-status-item-lifecycle.sh`
 
 ## No `./aos` Rebuild Needed
 
@@ -87,10 +88,11 @@ Examples:
 - `bash tests/voice-bind.sh`
 - `bash tests/voice-final-response.sh`
 - `bash tests/voice-telemetry.sh`
-- `bash tests/final-response-hook.sh`
+- `bash tests/hook-config.sh`
 - `bash tests/config-surface.sh`
 - `bash tests/cli-error-log.sh`
 - `bash tests/sigil-avatar-interactions.sh`
+- `bash tests/sigil-status-item-lifecycle.sh`
 - `bash tests/sigil-workbench-studio-restage.sh`
 - `bash tests/sigil-workbench-launch.sh`
 
@@ -99,4 +101,8 @@ Examples:
 If an interrupted display/toolkit run leaves stale windows or extra non-launchd
 daemons behind, use:
 
+- `./aos status`
 - `./aos clean`
+
+Prefer `./aos status` as the first move. Use `./aos clean` when status reports
+stale resources or you need explicit cleanup.

--- a/tests/agent-introspection-policy.sh
+++ b/tests/agent-introspection-policy.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel 2>/dev/null || pwd)"
+POLICY="$ROOT/.agents/hooks/aos-agent-policy.py"
+STATE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/aos-agent-policy.XXXXXX")"
+STDOUT_FILE="$STATE_ROOT/stdout.txt"
+STDERR_FILE="$STATE_ROOT/stderr.txt"
+
+cleanup() {
+  rm -rf "$STATE_ROOT"
+}
+trap cleanup EXIT
+
+export AOS_STATE_ROOT="$STATE_ROOT"
+export AOS_RUNTIME_MODE="repo"
+export AOS_SESSION_ID="policy-session-$$"
+export AOS_SESSION_HARNESS="codex"
+
+mkdir -p "$STATE_ROOT/repo/agent-introspection/sessions"
+cat > "$STATE_ROOT/repo/agent-introspection/aos-usage.jsonl" <<'EOF'
+{"timestamp":"2000-01-01T00:00:00Z","session":"expired-session","harness":"codex","source":"post","command":"./aos old","command_path":["old"],"prefix":"./aos","outcome":"error","exit_code":1,"error_code":"UNKNOWN_COMMAND"}
+EOF
+cat > "$STATE_ROOT/repo/agent-introspection/sessions/expired-session.json" <<'EOF'
+{"session":"expired-session","harness":"codex","consecutive_failures":7,"total_events":9,"last_updated":"2000-01-01T00:00:00Z"}
+EOF
+
+if printf '{"tool_input":{"command":"aos status"}}' | python3 "$POLICY" pre >"$STDOUT_FILE" 2>"$STDERR_FILE"; then
+  echo "FAIL: bare aos invocation should have been blocked" >&2
+  exit 1
+else
+  STATUS=$?
+fi
+[[ "$STATUS" -eq 2 ]] || {
+  echo "FAIL: bare aos invocation should return exit code 2" >&2
+  exit 1
+}
+grep -q 'use ./aos, not aos' "$STDERR_FILE" || {
+  echo "FAIL: bare aos block message missing repo-mode guidance" >&2
+  exit 1
+}
+
+[[ ! -f "$STATE_ROOT/repo/agent-introspection/sessions/expired-session.json" ]] || {
+  echo "FAIL: expired session state was not pruned" >&2
+  exit 1
+}
+if grep -q 'expired-session' "$STATE_ROOT/repo/agent-introspection/aos-usage.jsonl"; then
+  echo "FAIL: expired usage log entry was not pruned" >&2
+  exit 1
+fi
+
+python3 - "$STATE_ROOT/repo/agent-introspection" "$AOS_SESSION_ID" <<'PY'
+import json, pathlib, sys
+
+root = pathlib.Path(sys.argv[1])
+session = sys.argv[2]
+state = json.loads((root / "sessions" / f"{session}.json").read_text())
+if state.get("consecutive_failures") != 1:
+    raise SystemExit(f"FAIL: expected streak=1 after bare aos block, got {state}")
+events = [json.loads(line) for line in (root / "aos-usage.jsonl").read_text().splitlines() if line.strip()]
+latest = events[-1]
+if latest.get("error_code") != "USE_REPO_AOS" or latest.get("outcome") != "blocked":
+    raise SystemExit(f"FAIL: unexpected latest event after bare aos block: {latest}")
+PY
+
+printf '%s' '{"tool_input":{"command":"./aos status --json"},"tool_output":{"stdout":"{\"status\":\"ok\"}\n","stderr":"","exit_code":0,"duration_ms":12}}' \
+  | python3 "$POLICY" post >/dev/null
+
+python3 - "$STATE_ROOT/repo/agent-introspection" "$AOS_SESSION_ID" <<'PY'
+import json, pathlib, sys
+
+root = pathlib.Path(sys.argv[1])
+session = sys.argv[2]
+state = json.loads((root / "sessions" / f"{session}.json").read_text())
+if state.get("consecutive_failures") != 0:
+    raise SystemExit(f"FAIL: expected streak reset after successful ./aos call, got {state}")
+PY
+
+for _ in 1 2 3 4; do
+  printf '%s' '{"tool_input":{"command":"./aos frob"},"tool_output":{"stdout":"","stderr":"{\"error\":\"unknown command\",\"code\":\"UNKNOWN_COMMAND\"}\n","exit_code":1,"duration_ms":5}}' \
+    | python3 "$POLICY" post >/dev/null
+done
+
+python3 - "$STATE_ROOT/repo/agent-introspection" "$AOS_SESSION_ID" <<'PY'
+import json, pathlib, sys
+
+root = pathlib.Path(sys.argv[1])
+session = sys.argv[2]
+state = json.loads((root / "sessions" / f"{session}.json").read_text())
+if state.get("consecutive_failures") != 4:
+    raise SystemExit(f"FAIL: expected streak=4 after repeated errors, got {state}")
+PY
+
+if printf '{"tool_input":{"command":"./aos see cursor"}}' | python3 "$POLICY" pre >"$STDOUT_FILE" 2>"$STDERR_FILE"; then
+  echo "FAIL: repeated failures should block more shell work" >&2
+  exit 1
+else
+  STATUS=$?
+fi
+[[ "$STATUS" -eq 2 ]] || {
+  echo "FAIL: repeated failure gate should return exit code 2" >&2
+  exit 1
+}
+grep -q 'Run ./aos introspect review or ./aos help/status' "$STDERR_FILE" || {
+  echo "FAIL: repeated failure gate message missing recovery guidance" >&2
+  exit 1
+}
+
+printf '{"tool_input":{"command":"./aos introspect review"}}' | python3 "$POLICY" pre >/dev/null 2>"$STDERR_FILE" || {
+  echo "FAIL: introspect review should be allowed as a recovery command" >&2
+  cat "$STDERR_FILE" >&2
+  exit 1
+}
+
+echo "PASS"

--- a/tests/agent-introspection-policy.sh
+++ b/tests/agent-introspection-policy.sh
@@ -112,4 +112,10 @@ printf '{"tool_input":{"command":"./aos introspect review"}}' | python3 "$POLICY
   exit 1
 }
 
+printf '{"tool_input":{"command":"./aos introspect"}}' | python3 "$POLICY" pre >/dev/null 2>"$STDERR_FILE" || {
+  echo "FAIL: bare introspect should be allowed as a recovery command" >&2
+  cat "$STDERR_FILE" >&2
+  exit 1
+}
+
 echo "PASS"

--- a/tests/hook-config.sh
+++ b/tests/hook-config.sh
@@ -17,33 +17,19 @@ def flatten_commands(payload):
                 commands.append((key, hook.get("command", "")))
     return hooks, commands
 
-def assert_minimal(label, path):
+def assert_hooks(label, path):
     payload = json.load(open(path))
-    hooks, commands = flatten_commands(payload)
-
-    if hooks.get("Stop"):
-        raise SystemExit(f"FAIL: {label} should not define Stop hooks")
-
+    _, commands = flatten_commands(payload)
     command_strings = [command for _, command in commands]
-    required = ("session-start.sh", "git-health.sh", "pre-tool-use.sh", "post-tool-use.sh")
+    required = ["session-start.sh", "git-health.sh", "pre-tool-use.sh", "check-messages.sh", "post-tool-use.sh", "final-response.sh"]
+    if label == "claude":
+        required.append("session-stop.sh")
     for needle in required:
         if not any(needle in command for command in command_strings):
             raise SystemExit(f"FAIL: {label} missing required hook command containing {needle!r}: {command_strings}")
 
-    forbidden = (
-        "check-messages.sh",
-        "final-response.sh",
-        "session-stop.sh",
-        "session-common.sh",
-        "session-name",
-        "parallel-codex",
-    )
-    for needle in forbidden:
-        if any(needle in command for command in command_strings):
-            raise SystemExit(f"FAIL: {label} still references removed coordination hook asset {needle!r}: {command_strings}")
-
-assert_minimal("codex", sys.argv[1])
-assert_minimal("claude", sys.argv[2])
+assert_hooks("codex", sys.argv[1])
+assert_hooks("claude", sys.argv[2])
 PY
 
 echo "PASS"

--- a/tests/hook-config.sh
+++ b/tests/hook-config.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+python3 - "$ROOT/.codex/hooks.json" "$ROOT/.claude/settings.json" <<'PY'
+import json
+import sys
+
+def flatten_commands(payload):
+    hooks = payload.get("hooks", {})
+    commands = []
+    for key in ("SessionStart", "PreToolUse", "PostToolUse", "Stop"):
+        for matcher in hooks.get(key, []):
+            for hook in matcher.get("hooks", []):
+                commands.append((key, hook.get("command", "")))
+    return hooks, commands
+
+def assert_minimal(label, path):
+    payload = json.load(open(path))
+    hooks, commands = flatten_commands(payload)
+
+    if hooks.get("Stop"):
+        raise SystemExit(f"FAIL: {label} should not define Stop hooks")
+
+    command_strings = [command for _, command in commands]
+    required = ("session-start.sh", "git-health.sh", "pre-tool-use.sh", "post-tool-use.sh")
+    for needle in required:
+        if not any(needle in command for command in command_strings):
+            raise SystemExit(f"FAIL: {label} missing required hook command containing {needle!r}: {command_strings}")
+
+    forbidden = (
+        "check-messages.sh",
+        "final-response.sh",
+        "session-stop.sh",
+        "session-common.sh",
+        "session-name",
+        "parallel-codex",
+    )
+    for needle in forbidden:
+        if any(needle in command for command in command_strings):
+            raise SystemExit(f"FAIL: {label} still references removed coordination hook asset {needle!r}: {command_strings}")
+
+assert_minimal("codex", sys.argv[1])
+assert_minimal("claude", sys.argv[2])
+PY
+
+echo "PASS"

--- a/tests/session-start-bootstrap.sh
+++ b/tests/session-start-bootstrap.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel 2>/dev/null || pwd)"
+SESSION_NAME="session-start-bootstrap-$$"
+BOOTSTRAP_FILE="/tmp/aos-handoff-${SESSION_NAME}.json"
+
+cleanup() {
+  rm -f "$BOOTSTRAP_FILE"
+}
+trap cleanup EXIT
+
+printf '{"brief":"Startup bootstrap smoke test"}\n' > "$BOOTSTRAP_FILE"
+
+OUTPUT="$(AOS_SESSION_NAME="$SESSION_NAME" bash "$ROOT/.agents/hooks/session-start.sh" 2>/dev/null)"
+
+printf '%s' "$OUTPUT" | grep -q "## Handoff Brief" || {
+  echo "FAIL: startup hook did not emit handoff brief heading" >&2
+  exit 1
+}
+
+printf '%s' "$OUTPUT" | grep -q "Startup bootstrap smoke test" || {
+  echo "FAIL: startup hook did not emit bootstrap brief body" >&2
+  exit 1
+}
+
+[[ ! -f "$BOOTSTRAP_FILE" ]] || {
+  echo "FAIL: startup hook did not consume bootstrap file" >&2
+  exit 1
+}
+
+echo "PASS"

--- a/tests/session-start-control-surface.sh
+++ b/tests/session-start-control-surface.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel 2>/dev/null || pwd)"
+HELP_TEXT="$("$ROOT/aos" --help)"
+OUTPUT="$(AOS_SESSION_NAME="session-start-control-surface-$$" bash "$ROOT/.agents/hooks/session-start.sh" 2>/dev/null)"
+
+[[ "$OUTPUT" == *"You are developing agent-os. Your primary tools should be the following control surface:"* ]] || {
+  echo "FAIL: startup hook missing control-surface instruction" >&2
+  exit 1
+}
+
+[[ "$OUTPUT" == *"| Role | Instruction |"* ]] || {
+  echo "FAIL: startup hook missing structured control-surface table" >&2
+  exit 1
+}
+
+[[ "$OUTPUT" == *'```text'* ]] || {
+  echo "FAIL: startup hook missing fenced help block" >&2
+  exit 1
+}
+
+[[ "$OUTPUT" == *"$HELP_TEXT"* ]] || {
+  echo "FAIL: startup hook did not embed live ./aos --help output" >&2
+  exit 1
+}
+
+[[ "$OUTPUT" == *'Prefer `./aos see` and AX-aware x-ray capture over raw image blobs'* ]] || {
+  echo "FAIL: startup hook missing perception guidance" >&2
+  exit 1
+}
+
+[[ "$OUTPUT" == *'Lean on `./aos focus`, `./aos graph`, and `./aos show`'* ]] || {
+  echo "FAIL: startup hook missing focus/graph/show guidance" >&2
+  exit 1
+}
+
+[[ "$OUTPUT" == *'Start with `./aos status`.'* ]] || {
+  echo "FAIL: startup hook missing status point of entry" >&2
+  exit 1
+}
+
+[[ "$OUTPUT" == *'Use `./aos introspect review` after failed attempts or when asked to self-review.'* ]] || {
+  echo "FAIL: startup hook missing introspection guidance" >&2
+  exit 1
+}
+
+echo "PASS"

--- a/tests/status-introspect.sh
+++ b/tests/status-introspect.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel 2>/dev/null || pwd)"
+POLICY="$ROOT/.agents/hooks/aos-agent-policy.py"
+STATE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/aos-status-introspect.XXXXXX")"
+
+cleanup() {
+  rm -rf "$STATE_ROOT"
+}
+trap cleanup EXIT
+
+export AOS_STATE_ROOT="$STATE_ROOT"
+export AOS_RUNTIME_MODE="repo"
+export AOS_SESSION_ID="status-introspect-$$"
+export AOS_SESSION_HARNESS="codex"
+
+cd "$ROOT"
+
+HELP_TEXT="$(./aos --help)"
+FIRST_COMMAND="$(printf '%s\n' "$HELP_TEXT" | awk '/^  [a-z0-9-]+/{print $1; exit}')"
+[[ "$HELP_TEXT" == *"Usage: ./aos <command> [options]"* ]] || {
+  echo "FAIL: ./aos --help should render repo-mode invocation prefix" >&2
+  exit 1
+}
+[[ "$FIRST_COMMAND" == "status" ]] || {
+  echo "FAIL: status should be the first top-level help entry, got '$FIRST_COMMAND'" >&2
+  exit 1
+}
+
+STATUS_JSON="$(./aos status --json)"
+python3 - "$STATUS_JSON" <<'PY'
+import json, sys
+
+payload = json.loads(sys.argv[1])
+required = {"status", "identity", "runtime", "permissions", "stale_resources", "recommended_entrypoints"}
+missing = sorted(required - payload.keys())
+if missing:
+    raise SystemExit(f"FAIL: status payload missing keys: {missing}")
+entrypoints = payload.get("recommended_entrypoints", [])
+expected = ["./aos help <command> [--json]", "./aos introspect review", "./aos clean"]
+if entrypoints != expected:
+    raise SystemExit(f"FAIL: unexpected recommended_entrypoints: {entrypoints}")
+PY
+
+printf '{"tool_input":{"command":"aos status"}}' | python3 "$POLICY" pre >/dev/null 2>/dev/null || true
+printf '%s' '{"tool_input":{"command":"./aos status --json"},"tool_output":{"stdout":"{\"status\":\"ok\"}\n","stderr":"","exit_code":0,"duration_ms":11}}' \
+  | python3 "$POLICY" post >/dev/null
+
+INTROSPECT_JSON="$(./aos introspect review --json)"
+python3 - "$INTROSPECT_JSON" "$STATE_ROOT" <<'PY'
+import json, os, sys
+
+payload = json.loads(sys.argv[1])
+state_root = sys.argv[2]
+if payload.get("successes") != 1 or payload.get("failures") != 1:
+    raise SystemExit(f"FAIL: unexpected introspect counters: {payload}")
+if "status" not in payload.get("mastered_commands", []):
+    raise SystemExit(f"FAIL: status should be counted as a mastered command: {payload}")
+learnings = payload.get("learnings", [])
+if not any("invoke the binary as `./aos`, not `aos`" in line for line in learnings):
+    raise SystemExit(f"FAIL: missing repo-mode invocation learning: {payload}")
+log_path = payload.get("log_path", "")
+expected_prefix = os.path.realpath(os.path.join(state_root, "repo", "agent-introspection"))
+if not os.path.realpath(log_path).startswith(expected_prefix):
+    raise SystemExit(f"FAIL: introspect log path should live under temp repo-mode state root: {log_path}")
+PY
+
+echo "PASS"


### PR DESCRIPTION
## What changed

This PR makes `./aos` the primary developer control surface inside the repo and adds a deterministic self-review loop when agents fail to use that surface effectively.

It adds:
- `./aos status` as the primary runtime/session entrypoint
- `./aos introspect review` as the session self-review surface
- silent hook-based telemetry for `./aos` successes, failures, and repeated misuse
- a startup hook block that prints live `./aos --help` output with repo-mode `./aos` invocation and stronger guidance toward `status`, `introspect review`, `see`, `focus`, `graph`, and `show`

## Scope

This PR does **not** remove the existing coordination/session-presence hooks. `check-messages`, `final-response`, `session-stop`, and session registration remain in place. The new post-tool hook is additive and only records silent `./aos` telemetry.

## Why it changed

Agents were being told to use AOS, but the repo did not present a clear first command, a self-review path, or a deterministic way to stop repeated failed attempts. That made weak sessions waste tokens retrying shell commands without mastering the AOS surface.

This PR turns `./aos status` into the front door, keeps lower-level verbs as follow-up tools, and adds a short-lived failure-streak gate plus ephemeral telemetry so sessions can be reviewed later and the AOS surface can be tuned from real usage.

## User and developer impact

Agents working in repo mode now see `./aos` as the canonical invocation, get `status` as the first entrypoint, and have an explicit `introspect review` path for recovery and self-review.

Repeated failed `./aos` attempts are blocked until the session recovers through `./aos status`, `./aos help`, or `./aos introspect review`.

Docs and help text now de-emphasize `doctor`, `daemon-snapshot`, and `clean` as first moves because the startup hook already handles daemon bring-up and stale-resource detection.

## Validation

- `bash build.sh`
- `bash tests/status-introspect.sh`
- `bash tests/agent-introspection-policy.sh`
- `bash tests/session-start-control-surface.sh`
- `bash tests/session-start-bootstrap.sh`
- `bash tests/hook-config.sh`
- `bash tests/handoff.sh`