### PR TITLE
Add AOS accessibility semantics for toolkit and Sigil surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,9 @@ spec at `docs/superpowers/specs/2026-04-15-tell-hear-coordination-verbs-design.m
   purely DOM debugging.
 - Use `./aos see` for visual verification before asking the user to inspect a
   canvas manually.
+- When building AOS apps or toolkit components, expose actionable controls with
+  macOS-style accessibility semantics instead of adding agent-only visual hints.
+  See `docs/recipes/aos-app-accessibility-surfaces.md`.
 - If the user explicitly puts themselves in the verification loop, treat the
   human as the sensor. Set up the state quickly, use at most one orienting
   `./aos see` check if needed, then ask them to confirm what they see instead
@@ -186,4 +189,6 @@ source of truth at the interface boundary:
 
 - `ARCHITECTURE.md` for system architecture
 - nearest subtree markdown file for package or app specifics
+- `docs/recipes/aos-app-accessibility-surfaces.md` for AOS app and toolkit
+  accessibility surface contracts
 - today, many of those local files are still named `CLAUDE.md`

--- a/apps/sigil/AGENTS.md
+++ b/apps/sigil/AGENTS.md
@@ -55,6 +55,7 @@ doc lands at `~/.config/aos/{mode}/wiki/sigil/agents/default.md`.
 | `chat/` | Bidirectional conversational canvas (see Chat Canvas Protocol below). |
 | `workbench/` | Historical multi-tab surface. Do not use as the standard launch or verification path for current Sigil work unless the task explicitly targets that surface. |
 | `renderer/hit-area.html` | Minimal interactive child canvas the renderer spawns at the avatar's position so clicks/drags on the dot land somewhere while the parent canvas stays click-through. |
+| `renderer/radial-menu-surface.html` | Minimal interactive child canvas the renderer spawns around live radial-menu items so `aos see --xray` can discover labeled item targets and `aos do` can act on them. |
 | `renderer/appearance.js` / `renderer/state.js` | Runtime appearance and interaction config, including Sigil's radial gesture menu defaults. |
 | `seed/wiki/sigil/` | Seed source for the default agent wiki doc. |
 | `sigilctl-seed.sh` | Wraps `aos wiki seed` for the Sigil namespace. |
@@ -85,6 +86,16 @@ removal gate.
 If a hit canvas forwards native DOM events, the renderer must immediately
 normalize them into the same DesktopWorld event path used by daemon `input_event`
 delivery. Do not add a parallel DOM-owned interaction stream for convenience.
+
+Interactive Sigil surfaces must be ergonomic for AOS agents as well as humans.
+Canvas-only visuals that represent actionable controls should have a small
+child surface or equivalent AX-visible affordance with stable labels, adequate
+target size, and daemon-routed behavior before tests reach for renderer debug
+state. If the visual control is already rendered by the parent canvas, keep the
+child surface's labels in ARIA/AX semantics rather than painting duplicate text
+or tooltips into the user-facing composition. See
+`docs/recipes/aos-app-accessibility-surfaces.md` for the repo-wide app and
+toolkit contract.
 
 ### Content Server
 

--- a/apps/sigil/renderer/live-modules/main.js
+++ b/apps/sigil/renderer/live-modules/main.js
@@ -36,6 +36,7 @@ import {
 } from './display-utils.js';
 import { createFastTravelController } from './fast-travel.js';
 import { createSigilRadialGestureMenu } from './radial-gesture-menu.js';
+import { createRadialMenuTargetSurface } from './radial-menu-target-surface.js';
 import { createSigilRadialGestureVisuals } from './radial-gesture-visuals.js';
 import { createSigilContextMenu } from '../../context-menu/menu.js';
 import { loadAgent } from '../agent-loader.js';
@@ -57,6 +58,11 @@ const hitTarget = createHitTargetController({
     url: 'aos://sigil/renderer/hit-area.html',
     size: state.avatarHitRadius * 2,
     id: 'sigil-hit-avatar-main',
+});
+const radialTargetSurface = createRadialMenuTargetSurface({
+    runtime: host,
+    url: 'aos://sigil/renderer/radial-menu-surface.html',
+    id: 'sigil-radial-menu-avatar-main',
 });
 
 const liveJs = {
@@ -217,6 +223,7 @@ function shouldProcessGlobalDaemonEvent(msg = {}) {
     if (msg.type === 'display_geometry') return false;
     if (msg.type === 'input_event' || msg.envelope_type === 'input_event') return false;
     if (msg.type === 'canvas_message' && msg.id === hitTarget.hit.id) return false;
+    if (msg.type === 'canvas_message' && msg.id === radialTargetSurface.id) return false;
     return true;
 }
 
@@ -1016,6 +1023,7 @@ function setInteractionState(next, reason) {
     liveJs.currentState = next;
     liveJs.state = next;
     if (next === 'IDLE' && !liveJs.travel) postLastPositionToDaemon();
+    emitAvatarMark();
 }
 
 function postLastPositionToDaemon() {
@@ -1083,7 +1091,7 @@ const fastTravel = createFastTravelController({
     liveJs,
     projectStagePoint: stagePoint,
     getExcludedCanvasIds() {
-        return ['avatar-main', hitTarget.hit.id].filter(Boolean);
+        return ['avatar-main', hitTarget.hit.id, radialTargetSurface.id].filter(Boolean);
     },
     canCaptureDisplayImages: isPrimarySurfaceSegment,
 });
@@ -1166,6 +1174,25 @@ const MARKS_OBJECT_ID = 'avatar';
 const MARKS_HEARTBEAT_MS = 5000;
 let _lastMarkEmitAt = 0;
 
+function radialGestureObjectMarks() {
+    const radial = liveJs.radialGestureMenu;
+    if (!radial || radial.phase !== 'radial' || !Array.isArray(radial.items)) return [];
+    return radial.items
+        .filter((item) => item?.id && item?.center)
+        .map((item) => ({
+            id: `radial-${item.id}`,
+            x: Math.round(Number(item.center.x) || 0),
+            y: Math.round(Number(item.center.y) || 0),
+            name: item.label || item.id,
+            color: item.id === radial.activeItemId ? '#ffffff' : '#8cf8ff',
+            w: Math.max(44, Math.round(Number(item.hitRadius || item.visualRadius || 24) * 2)),
+            h: Math.max(44, Math.round(Number(item.hitRadius || item.visualRadius || 24) * 2)),
+            rect: true,
+            ellipse: true,
+            cross: false,
+        }));
+}
+
 function emitAvatarMark() {
     if (!isPrimarySurfaceSegment()) return;
     if (!liveJs.avatarPos.valid) return;
@@ -1177,14 +1204,15 @@ function emitAvatarMark() {
         _lastMarkEmitAt = performance.now();
         return;
     }
+    const objects = [{
+        id: MARKS_OBJECT_ID,
+        x: Math.round(liveJs.avatarPos.x),
+        y: Math.round(liveJs.avatarPos.y),
+        name: 'Avatar',
+    }, ...radialGestureObjectMarks()];
     host.post('canvas_object.marks', {
         canvas_id: MARKS_CANVAS_ID,
-        objects: [{
-            id: MARKS_OBJECT_ID,
-            x: Math.round(liveJs.avatarPos.x),
-            y: Math.round(liveJs.avatarPos.y),
-            name: 'Avatar',
-        }],
+        objects,
     });
     _lastMarkEmitAt = performance.now();
 }
@@ -1327,6 +1355,7 @@ function openContextMenuAt(x, y, options = {}) {
 
 function applyRadialGestureMove(update, x, y) {
     liveJs.radialGestureMenu = update?.snapshot ?? radialGestureMenu.snapshot();
+    emitAvatarMark();
     if (update?.enteredFastTravel) {
         fastTravel.beginGesture({ ...liveJs.avatarPos });
         fastTravel.updateGesture({ x, y, valid: true });
@@ -1583,6 +1612,42 @@ function handleHitCanvasEvent(payload = {}) {
     });
 }
 
+function handleRadialTargetSurfaceEvent(payload = {}) {
+    if (payload.source !== 'sigil-radial-menu-surface') return;
+    interactionTrace.record('radial-surface', {
+        kind: payload.kind,
+        itemId: payload.itemId,
+        radialPhase: liveJs.radialGestureMenu?.phase ?? null,
+    });
+    if (payload.kind === 'radial_cancel') {
+        radialGestureMenu.cancel('radial-surface-cancel');
+        clearGestureState();
+        fastTravel.clearGesture('radial-surface-cancel');
+        setInteractionState('IDLE', 'radial-surface-cancel');
+        return;
+    }
+    if (payload.kind !== 'radial_item_click') return;
+    if (liveJs.currentState !== 'RADIAL' || !liveJs.radialGestureMenu) {
+        interactionTrace.record('radial-surface:ignored', {
+            reason: 'state-not-radial',
+            itemId: payload.itemId,
+        });
+        return;
+    }
+    const item = liveJs.radialGestureMenu.items?.find((candidate) => candidate.id === payload.itemId);
+    if (!item?.center) {
+        interactionTrace.record('radial-surface:ignored', {
+            reason: 'missing-item',
+            itemId: payload.itemId,
+        });
+        return;
+    }
+    const result = radialGestureMenu.release({ ...item.center, valid: true });
+    clearGestureState();
+    fastTravel.clearGesture(result?.committed?.type === 'item' ? 'radial-surface-item' : 'radial-surface-release');
+    setInteractionState('IDLE', result?.committed?.type === 'item' ? 'radial-surface-item' : 'radial-surface-release');
+}
+
 function originFromMessage(msg = {}) {
     const x = Number(msg.origin_x ?? msg.originX);
     const y = Number(msg.origin_y ?? msg.originY);
@@ -1769,6 +1834,11 @@ function handleHostMessage(rawMsg) {
         return;
     }
 
+    if (msg.type === 'canvas_message' && msg.id === radialTargetSurface.id) {
+        handleRadialTargetSurfaceEvent(msg.payload || {});
+        return;
+    }
+
     if (INPUT_POINTER_EVENT_TYPES.has(msg.type) && typeof msg.x === 'number' && typeof msg.y === 'number') {
         const worldPoint = nativeToDesktopWorldPoint({ x: msg.x, y: msg.y }, liveJs.displays) ?? { x: msg.x, y: msg.y };
         handleInputEvent({ ...msg, x: worldPoint.x, y: worldPoint.y });
@@ -1804,6 +1874,9 @@ function startPrimarySurfaceServices() {
     startMarkHeartbeat();
     void hitTarget.ensureCreated().catch((error) => {
         console.error('[sigil] avatar hit target create failed:', error);
+    });
+    void radialTargetSurface.ensureCreated().catch((error) => {
+        console.error('[sigil] radial menu target surface create failed:', error);
     });
 }
 
@@ -2012,6 +2085,9 @@ function animate() {
     } else if (primarySegment && liveJs.avatarPos.valid) {
         syncHitTargetToAvatar();
     }
+    if (primarySegment) {
+        radialTargetSurface.sync(liveJs.radialGestureMenu, { displays: liveJs.displays });
+    }
     const avatarStagePos = stagePoint(renderAvatarPos);
     const dragOriginStage = stagePoint(liveJs.mousedownAvatarPos);
     overlay.draw({
@@ -2092,6 +2168,7 @@ window.__sigilDebug = {
             hitTargetReady: hitTarget.hit.ready,
             hitTargetFrame: hitTarget.hit.frame,
             hitTargetInteractive: hitTarget.hit.interactive,
+            radialTargetSurface: radialTargetSurface.snapshot(),
             transition: visibilityTransition.active?.effect ?? null,
             surface: desktopWorldSurface ? {
                 segment: desktopWorldSurface.segment,

--- a/apps/sigil/renderer/live-modules/radial-menu-target-surface.js
+++ b/apps/sigil/renderer/live-modules/radial-menu-target-surface.js
@@ -1,0 +1,376 @@
+const TOOLKIT_SURFACE_SPECIFIER = (
+    typeof window !== 'undefined'
+    && typeof location !== 'undefined'
+    && /^https?:$/.test(location.protocol)
+)
+    ? '/toolkit/runtime/interaction-surface.js'
+    : (
+        typeof location !== 'undefined'
+        && location.protocol === 'aos:'
+    )
+        ? 'aos://toolkit/runtime/interaction-surface.js'
+        : '../../../../packages/toolkit/runtime/interaction-surface.js';
+
+const TOOLKIT_SPATIAL_SPECIFIER = (
+    typeof window !== 'undefined'
+    && typeof location !== 'undefined'
+    && /^https?:$/.test(location.protocol)
+)
+    ? '/toolkit/runtime/spatial.js'
+    : (
+        typeof location !== 'undefined'
+        && location.protocol === 'aos:'
+    )
+        ? 'aos://toolkit/runtime/spatial.js'
+        : '../../../../packages/toolkit/runtime/spatial.js';
+
+const TOOLKIT_SEMANTIC_SPECIFIER = (
+    typeof window !== 'undefined'
+    && typeof location !== 'undefined'
+    && /^https?:$/.test(location.protocol)
+)
+    ? '/toolkit/runtime/semantic-targets.js'
+    : (
+        typeof location !== 'undefined'
+        && location.protocol === 'aos:'
+    )
+        ? 'aos://toolkit/runtime/semantic-targets.js'
+        : '../../../../packages/toolkit/runtime/semantic-targets.js';
+
+const { createInteractionSurface } = await import(TOOLKIT_SURFACE_SPECIFIER);
+const { desktopWorldToNativePoint } = await import(TOOLKIT_SPATIAL_SPECIFIER);
+const { normalizeSemanticTarget } = await import(TOOLKIT_SEMANTIC_SPECIFIER);
+
+const DEFAULT_TARGET_MIN_SIZE = 56;
+const DEFAULT_FRAME_PADDING = 10;
+
+function finite(value, fallback = 0) {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : fallback;
+}
+
+function appendQuery(url, params) {
+    const separator = url.includes('?') ? '&' : '?';
+    const query = new URLSearchParams(params).toString();
+    return `${url}${separator}${query}`;
+}
+
+function sameFrame(a, b) {
+    return Array.isArray(a)
+        && Array.isArray(b)
+        && a.length >= 4
+        && b.length >= 4
+        && a[0] === b[0]
+        && a[1] === b[1]
+        && a[2] === b[2]
+        && a[3] === b[3];
+}
+
+function safeId(value) {
+    return String(value || 'item').replace(/[^a-zA-Z0-9_-]/g, '-');
+}
+
+function labelForItem(item = {}) {
+    return String(item.label || item.title || item.id || 'Radial item');
+}
+
+function actionForItem(item = {}) {
+    return String(item.action || item.id || 'unknown');
+}
+
+function ownerCanvasId() {
+    return (
+        typeof window !== 'undefined'
+        && (window.__aosCanvasId || window.__aosSurfaceCanvasId)
+    ) || 'avatar-main';
+}
+
+function offscreenFrame(size = [1, 1]) {
+    return [-10000, -10000, Math.max(1, Math.round(size[0] || 1)), Math.max(1, Math.round(size[1] || 1))];
+}
+
+function normalizeFrame(frame) {
+    return frame.slice(0, 4).map((value) => Math.round(finite(value, 0)));
+}
+
+export function radialMenuTargetsFromSnapshot(snapshot, options = {}) {
+    if (!snapshot || snapshot.phase !== 'radial' || !Array.isArray(snapshot.items)) return [];
+    const minSize = Math.max(1, finite(options.targetMinSize, DEFAULT_TARGET_MIN_SIZE));
+    return snapshot.items
+        .filter((item) => item?.id && item?.center)
+        .map((item) => {
+            const x = finite(item.center.x, NaN);
+            const y = finite(item.center.y, NaN);
+            if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+            const modelRadius = Math.max(
+                finite(item.hitRadius, 0),
+                finite(item.visualRadius, 0),
+                minSize / 2
+            );
+            const size = Math.max(minSize, Math.ceil(modelRadius * 2));
+            const id = String(item.id);
+            const label = labelForItem(item);
+            const action = actionForItem(item);
+            const semantic = normalizeSemanticTarget({
+                id,
+                role: 'AXButton',
+                name: label,
+                action,
+                aosRef: `sigil-radial-item-${safeId(id)}`,
+                surface: options.surfaceId,
+                parentCanvasId: options.parentCanvasId,
+                current: snapshot.activeItemId === item.id,
+            });
+            return {
+                id,
+                label,
+                action,
+                role: 'AXButton',
+                name: semantic.name,
+                ariaLabel: semantic.name,
+                aosRef: semantic.aosRef,
+                surface: semantic.surface,
+                active: snapshot.activeItemId === item.id,
+                center: { x, y },
+                angle: finite(item.angle, 0),
+                size,
+                radius: size / 2,
+            };
+        })
+        .filter(Boolean);
+}
+
+export function radialMenuWorldRect(targets = [], options = {}) {
+    if (!Array.isArray(targets) || targets.length === 0) return null;
+    const padding = Math.max(0, finite(options.padding, DEFAULT_FRAME_PADDING));
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (const target of targets) {
+        const radius = finite(target.radius, finite(target.size, DEFAULT_TARGET_MIN_SIZE) / 2);
+        minX = Math.min(minX, target.center.x - radius);
+        minY = Math.min(minY, target.center.y - radius);
+        maxX = Math.max(maxX, target.center.x + radius);
+        maxY = Math.max(maxY, target.center.y + radius);
+    }
+    if (!Number.isFinite(minX) || !Number.isFinite(minY) || !Number.isFinite(maxX) || !Number.isFinite(maxY)) return null;
+    return {
+        x: Math.floor(minX - padding),
+        y: Math.floor(minY - padding),
+        w: Math.ceil((maxX - minX) + padding * 2),
+        h: Math.ceil((maxY - minY) + padding * 2),
+    };
+}
+
+function localizeTargets(targets, worldRect) {
+    return targets.map((target) => ({
+        ...target,
+        x: Math.round(target.center.x - worldRect.x),
+        y: Math.round(target.center.y - worldRect.y),
+        size: Math.round(target.size),
+        radius: Math.round(target.radius),
+    }));
+}
+
+function payloadKey(payload) {
+    return JSON.stringify({
+        phase: payload.phase,
+        activeItemId: payload.activeItemId,
+        bounds: payload.bounds,
+        items: payload.items.map((item) => [
+            item.id,
+            item.label,
+            item.name,
+            item.action,
+            item.ariaLabel,
+            item.aosRef,
+            item.active,
+            item.x,
+            item.y,
+            item.size,
+        ]),
+    });
+}
+
+function postCanvasMessage(runtime, target, message) {
+    if (typeof runtime?.post === 'function') {
+        runtime.post('canvas.send', { target, message });
+    }
+}
+
+export function createRadialMenuTargetSurface({
+    runtime,
+    url,
+    id = null,
+    idPrefix = 'sigil-radial-menu',
+    targetMinSize = DEFAULT_TARGET_MIN_SIZE,
+    framePadding = DEFAULT_FRAME_PADDING,
+} = {}) {
+    if (!runtime) throw new Error('RadialMenuTargetSurface requires runtime');
+    if (!url) throw new Error('RadialMenuTargetSurface requires url');
+
+    const parent = ownerCanvasId();
+    const surfaceId = id || `${idPrefix}-${Math.random().toString(36).slice(2, 8)}`;
+    const state = {
+        id: surfaceId,
+        parent,
+        ready: false,
+        creating: false,
+        interactive: false,
+        frame: offscreenFrame([1, 1]),
+        targets: [],
+        lastPayloadKey: null,
+        pendingSnapshot: null,
+        pendingDisplays: [],
+    };
+    const surface = createInteractionSurface({
+        runtime,
+        id: surfaceId,
+        url: appendQuery(url, { parent, id: surfaceId }),
+        parent,
+        frame: state.frame,
+        interactive: false,
+        windowLevel: 'screen_saver',
+    });
+
+    async function ensureCreated() {
+        if (state.ready || state.creating) return state.id;
+        state.creating = true;
+        try {
+            await surface.ensureCreated();
+            state.ready = true;
+            return state.id;
+        } catch (error) {
+            if (String(error?.message || error).includes('DUPLICATE')) {
+                state.ready = true;
+                return state.id;
+            }
+            throw error;
+        } finally {
+            state.creating = false;
+        }
+    }
+
+    function sendUpdate(payload) {
+        const key = payloadKey(payload);
+        if (key === state.lastPayloadKey) return;
+        state.lastPayloadKey = key;
+        postCanvasMessage(runtime, state.id, {
+            type: 'radial_menu.surface.update',
+            payload,
+        });
+    }
+
+    function applySnapshot(snapshot, displays = []) {
+        if (!state.ready) return false;
+        const targets = radialMenuTargetsFromSnapshot(snapshot, {
+            targetMinSize,
+            surfaceId: state.id,
+            parentCanvasId: state.parent,
+        });
+        if (targets.length === 0) {
+            if (state.interactive) {
+                const disabledFrame = offscreenFrame([state.frame[2], state.frame[3]]);
+                surface.setPlacement(disabledFrame, false);
+                state.frame = disabledFrame;
+                state.interactive = false;
+                state.targets = [];
+            }
+            sendUpdate({
+                phase: snapshot?.phase || 'idle',
+                activeItemId: null,
+                bounds: { x: 0, y: 0, w: 1, h: 1 },
+                items: [],
+            });
+            return false;
+        }
+
+        const worldRect = radialMenuWorldRect(targets, { padding: framePadding });
+        if (!worldRect) return false;
+        const nativeOrigin = desktopWorldToNativePoint({ x: worldRect.x, y: worldRect.y }, displays) || { x: worldRect.x, y: worldRect.y };
+        const frame = normalizeFrame([nativeOrigin.x, nativeOrigin.y, worldRect.w, worldRect.h]);
+        if (!sameFrame(frame, state.frame) || !state.interactive) {
+            surface.setPlacement(frame, true);
+            state.frame = frame;
+            state.interactive = true;
+        }
+        state.targets = localizeTargets(targets, worldRect);
+        sendUpdate({
+            phase: snapshot.phase,
+            activeItemId: snapshot.activeItemId || null,
+            bounds: {
+                x: 0,
+                y: 0,
+                w: frame[2],
+                h: frame[3],
+                worldX: worldRect.x,
+                worldY: worldRect.y,
+            },
+            items: state.targets,
+        });
+        return true;
+    }
+
+    function sync(snapshot, options = {}) {
+        state.pendingSnapshot = snapshot || null;
+        state.pendingDisplays = Array.isArray(options.displays) ? options.displays : [];
+        if (!state.ready) {
+            void ensureCreated()
+                .then(() => applySnapshot(state.pendingSnapshot, state.pendingDisplays))
+                .catch((error) => {
+                    console.warn('[sigil] radial menu target surface create failed:', error);
+                });
+            return false;
+        }
+        return applySnapshot(state.pendingSnapshot, state.pendingDisplays);
+    }
+
+    function disable() {
+        state.pendingSnapshot = null;
+        if (!state.ready) return false;
+        return applySnapshot(null, state.pendingDisplays);
+    }
+
+    async function remove() {
+        if (!state.ready && !state.creating) return;
+        try {
+            await surface.remove();
+        } finally {
+            state.ready = false;
+            state.creating = false;
+            state.interactive = false;
+            state.targets = [];
+            state.frame = offscreenFrame([1, 1]);
+        }
+    }
+
+    function snapshot() {
+        return {
+            id: state.id,
+            parent: state.parent,
+            ready: state.ready,
+            creating: state.creating,
+            interactive: state.interactive,
+            frame: [...state.frame],
+            targets: state.targets.map((target) => ({
+                id: target.id,
+                label: target.label,
+                action: target.action,
+                active: target.active,
+                x: target.x,
+                y: target.y,
+                size: target.size,
+            })),
+        };
+    }
+
+    return {
+        id: state.id,
+        ensureCreated,
+        sync,
+        disable,
+        remove,
+        snapshot,
+    };
+}

--- a/apps/sigil/renderer/radial-menu-surface.html
+++ b/apps/sigil/renderer/radial-menu-surface.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<style>
+:root {
+    color-scheme: dark;
+    --sigil-radial-focus: rgba(140, 248, 255, 0.95);
+}
+
+html,
+body {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    background: transparent;
+    overflow: hidden;
+    font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+}
+
+.radial-surface {
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+}
+
+.radial-empty {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+
+.radial-item {
+    position: absolute;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transform: translate(-50%, -50%);
+    min-width: 56px;
+    min-height: 56px;
+    border: 0;
+    border-radius: 999px;
+    background: transparent;
+    cursor: pointer;
+    pointer-events: auto;
+    padding: 0;
+    appearance: none;
+}
+
+.radial-item[data-active="true"] {
+    background: transparent;
+}
+
+.radial-item:focus-visible {
+    outline: 3px solid var(--sigil-radial-focus);
+    outline-offset: 3px;
+}
+</style>
+</head>
+<body>
+<div id="radial-surface" class="radial-surface" role="group" aria-label="Sigil radial menu"></div>
+<script type="module">
+window.headsup = window.headsup || {};
+
+const TOOLKIT_SEMANTIC_SPECIFIER = (
+    typeof location !== 'undefined'
+    && /^https?:$/.test(location.protocol)
+)
+    ? '/toolkit/runtime/semantic-targets.js'
+    : (
+        typeof location !== 'undefined'
+        && location.protocol === 'aos:'
+    )
+        ? 'aos://toolkit/runtime/semantic-targets.js'
+        : '../../../packages/toolkit/runtime/semantic-targets.js';
+
+const { applySemanticTargetAttributes } = await import(TOOLKIT_SEMANTIC_SPECIFIER);
+
+const PARAMS = new URLSearchParams(window.location.search);
+const PARENT_ID = PARAMS.get('parent') || 'avatar-main';
+const SURFACE_ID = PARAMS.get('id') || 'sigil-radial-menu';
+const root = document.getElementById('radial-surface');
+const buttons = new Map();
+
+function emit(kind, payload = {}) {
+    window.webkit?.messageHandlers?.headsup?.postMessage({
+        type: 'canvas.send',
+        payload: {
+            target: PARENT_ID,
+            message: {
+                type: 'canvas_message',
+                id: SURFACE_ID,
+                payload: {
+                    source: 'sigil-radial-menu-surface',
+                    kind,
+                    ...payload,
+                },
+            },
+        },
+    });
+}
+
+function safeId(value) {
+    return String(value || 'item').replace(/[^a-zA-Z0-9_-]/g, '-');
+}
+
+function createButton(item) {
+    const button = document.createElement('button');
+    button.className = 'radial-item';
+    button.dataset.radialItemId = item.id;
+    button.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        emit('radial_item_click', { itemId: item.id });
+    });
+
+    root.append(button);
+    buttons.set(item.id, button);
+    return button;
+}
+
+function updateButton(button, item) {
+    const size = Math.max(44, Math.round(Number(item.size) || 56));
+    button.style.left = `${Math.round(Number(item.x) || 0)}px`;
+    button.style.top = `${Math.round(Number(item.y) || 0)}px`;
+    button.style.width = `${size}px`;
+    button.style.height = `${size}px`;
+    button.dataset.active = item.active ? 'true' : 'false';
+    applySemanticTargetAttributes(button, {
+        id: item.id,
+        role: item.role || 'AXButton',
+        name: item.name || item.ariaLabel || item.label || item.id || 'Radial item',
+        action: item.action,
+        aosRef: item.aosRef || `sigil-radial-item-${safeId(item.id)}`,
+        surface: item.surface || SURFACE_ID,
+        parentCanvasId: PARENT_ID,
+        current: item.active ? true : null,
+    }, {
+        idPrefix: 'sigil-radial-item',
+        surface: SURFACE_ID,
+        parentCanvasId: PARENT_ID,
+    });
+    button.dataset.radialItemId = item.id;
+    if (item.action) {
+        button.dataset.radialAction = item.action;
+    } else {
+        delete button.dataset.radialAction;
+    }
+}
+
+function render(payload = {}) {
+    const items = Array.isArray(payload.items) ? payload.items : [];
+    const liveIds = new Set(items.map((item) => item.id));
+    for (const [id, button] of buttons) {
+        if (liveIds.has(id)) continue;
+        button.remove();
+        buttons.delete(id);
+    }
+    root.hidden = items.length === 0;
+    for (const item of items) {
+        const button = buttons.get(item.id) || createButton(item);
+        updateButton(button, item);
+    }
+}
+
+window.headsup.receive = function receive(b64) {
+    try {
+        const message = JSON.parse(atob(b64));
+        if (message.type === 'radial_menu.surface.update') {
+            render(message.payload || {});
+            return;
+        }
+        if (message.type === 'lifecycle' && message.action === 'resume') {
+            window.webkit?.messageHandlers?.headsup?.postMessage({
+                type: 'lifecycle.complete',
+                payload: { action: 'resume' },
+            });
+        }
+    } catch (error) {
+        console.warn('[sigil-radial-menu-surface] failed to handle message', error);
+    }
+};
+
+render({ items: [] });
+console.log('[sigil-radial-menu-surface] ready');
+</script>
+</body>
+</html>

--- a/docs/recipes/aos-app-accessibility-surfaces.md
+++ b/docs/recipes/aos-app-accessibility-surfaces.md
@@ -1,0 +1,144 @@
+# Recipe: AOS App Accessibility Surfaces
+
+Use this recipe when building or reviewing controls for AOS apps, toolkit
+components, canvases, WebGL scenes, or Three.js surfaces.
+
+The goal is for agents and humans using assistive technology to perceive and
+operate the same app controls through standard macOS accessibility semantics,
+without adding agent-only visual hints to the UI.
+
+## Default Model
+
+Treat macOS Accessibility as the default control model. Every actionable or
+meaningful control should expose:
+
+- a standard role
+- a semantic name
+- a screen frame
+- enabled, disabled, selected, checked, expanded, or value state when relevant
+- the normal accessibility action for the control
+
+Prefer ordinary roles when they fit: `AXButton`, `AXMenu`, `AXMenuItem`,
+`AXCheckBox`, `AXSlider`, `AXTextField`, `AXGroup`, `AXStaticText`, and
+`AXImage`. If a custom visual does not map perfectly, choose the closest
+standard role first and document the gap before inventing an AOS-only
+semantic.
+
+The visible implementation can be HTML, canvas, WebGL, Swift, or toolkit code.
+The accessibility surface should still behave like a Mac app: `aos see --xray`
+can discover it, and `aos do` can operate it through the daemon route when the
+runtime is ready.
+
+## Labels And Names
+
+Keep visible labels and semantic names separate.
+
+A visible label is part of the visual design. A semantic AX name is the stable
+human-readable name exposed to accessibility clients and AOS perception. When a
+control already has meaningful visible text, the semantic name can usually
+match it. When the control is icon-only, gesture-driven, or rendered inside a
+canvas, provide the semantic name through the accessibility layer instead of
+painting duplicate text into the UI.
+
+Do not use visible text as an agent marker. Do not stuff identifiers, action
+ids, routing hints, or debug state into accessible names. Names should read like
+Mac controls, for example `Open radial menu`, `Brush size`, or `Submit`, not
+`sigil.radial.action.open.primary`.
+
+Use descriptions or help text only for user-facing clarification. Use AOS
+metadata for identity and routing.
+
+## AOS Identity Metadata
+
+AOS-specific identity belongs in stable metadata, not in labels.
+
+Use metadata channels to answer "which app object is this?" while keeping the
+AX name human-readable:
+
+- DOM `id` for stable document identity
+- `data-aos-ref` for the canonical AOS object reference
+- `data-aos-action` for the daemon or app action id
+- canvas id for the owning AOS canvas or child surface
+- context groups for local scope such as menu, toolbar, panel, scene, or mode
+- marks for non-DOM canvas objects that need spatial identity
+
+Context groups should usually be represented both structurally and
+semantically. For example, a radial menu can be an `AXMenu` or `AXGroup` with
+`AXMenuItem` children, while `data-aos-ref`, `data-aos-action`, canvas id, and
+marks carry the exact AOS routing identity.
+
+This lets `aos see --xray`, traces, tests, and future structured perception
+join semantic controls back to app state without label pollution.
+
+## Canvas Companion Layers
+
+Canvas, WebGL, and Three.js controls need a semantic companion layer whenever a
+drawn object is actionable, focusable, stateful, or important for task context.
+
+Common companion patterns:
+
+- transparent HTML controls aligned over rendered geometry
+- child interaction surfaces that expose standard AX roles for drawn controls
+- toolkit-owned semantic overlays generated from scene or component state
+- a structured menu/list companion for non-spatial command sets
+- canvas object marks tied to semantic companions for spatial targets
+
+The companion layer must route to the same behavior as the visual interaction.
+It must not become a second DOM-only shortcut, a debug backdoor, or a parallel
+interaction model. Pointer input, keyboard input, AX actions, and `aos do`
+should converge on the same command path whenever possible.
+
+Keep companion state synchronized with the visual scene: bounds, focus order,
+enabled state, selection, pressed state, checked state, slider value, text
+value, and menu expansion should update together. A visually hidden companion
+must remain AX-visible when it represents a real control; do not hide it from
+the accessibility tree.
+
+## Verification
+
+Start with the runtime gate:
+
+```bash
+./aos ready
+```
+
+If readiness is blocked, report the blocker or follow the repo repair handoff
+before claiming runtime verification. In installed mode, use the installed
+`aos` binary instead of repo `./aos`.
+
+For representative controls, verify:
+
+- `./aos see --xray` exposes the expected role, semantic name, frame, state, and
+  action.
+- `./aos do` can operate the control through the daemon/AOS route, not only
+  through app-local JavaScript or a synthetic unit test.
+- Screenshots show the intended visual design, with no duplicate agent labels
+  or debug identifiers painted into the UI.
+- Canvas/WebGL companion bounds line up with the visible control and any marks
+  or context groups used for spatial identity.
+- Real mouse, keyboard, focus, or drag input is checked when the bug or feature
+  depends on real event routing.
+
+Synthetic tests are useful for deterministic state and routing logic. They are
+not enough for defects that were observed through real input, visual placement,
+AX discovery, or daemon-routed actions.
+
+## Checklist
+
+1. Pick the standard AX role before designing custom metadata.
+2. Give every meaningful control a concise semantic name.
+3. Keep visible text, semantic names, and AOS identity metadata distinct.
+4. Put AOS routing identity in `data-aos-ref`, `data-aos-action`, canvas ids,
+   context groups, and marks.
+5. Add a semantic companion layer for canvas/WebGL/Three.js controls.
+6. Route companion actions through the same command path as visible input.
+7. Verify with `./aos ready`, `./aos see --xray`, `./aos do`, screenshots, and
+   real-input checks when relevant.
+
+## Related Work
+
+- #165 tracks the AOS app accessibility surface contract epic.
+- #137 tracks macOS Accessibility resources as first-class AOS capability
+  references.
+- #136 tracks structured DOM perception for AOS canvases.
+- #93 tracks AX/xray and multi-bundle semantics for interaction exports.

--- a/packages/toolkit/components/canvas-inspector/index.js
+++ b/packages/toolkit/components/canvas-inspector/index.js
@@ -26,6 +26,7 @@ import { normalizeMarks } from './marks/normalize.js'
 import { createMarksState, applySnapshot, evictCanvas } from './marks/reconcile.js'
 import { createScheduler } from './marks/scheduler.js'
 import { renderMinimapMark } from './marks/render.js'
+import { canvasActionAttrs, inspectorControlAttrs } from './semantics.js'
 import {
   applyMouseEffectsInput,
   clearMouseEffectsState,
@@ -104,6 +105,64 @@ function renderCanvasStatusPrefix(c = {}) {
     + `</span>`
 }
 
+function renderCanvasActionButtons(canvasId, options = {}) {
+  const tintedIds = options.tintedIds || new Set()
+  const statsIds = options.statsIds || new Set()
+  const tintClass = tintedIds.has(canvasId) ? 'btn tint-btn active' : 'btn tint-btn'
+  const statsClass = statsIds.has(canvasId) ? 'btn stats-btn active' : 'btn stats-btn'
+  return `<button class="${statsClass}" data-id="${escapeHTML(canvasId)}" ${canvasActionAttrs(canvasId, 'stats', { pressed: statsIds.has(canvasId) })}>stats</button>`
+    + `<button class="${tintClass}" data-id="${escapeHTML(canvasId)}" ${canvasActionAttrs(canvasId, 'tint', { pressed: tintedIds.has(canvasId) })}>tint</button>`
+    + `<button class="btn remove-btn" data-id="${escapeHTML(canvasId)}" ${canvasActionAttrs(canvasId, 'remove')}>\u2715</button>`
+}
+
+export function renderCursorToggleRowHTML(options = {}) {
+  const enabled = !!options.enabled
+  const depth = Number.isFinite(Number(options.depth)) ? Number(options.depth) : 0
+  const toggleClass = enabled ? 'btn cursor-toggle-btn active' : 'btn cursor-toggle-btn'
+  const toggleLabel = enabled ? 'on' : 'off'
+  return `<div class="tree-row cursor-toggle-row" style="${rowIndentStyle(depth)}">`
+    + `<span class="cursor-toggle-label">minimap cursor</span>`
+    + `<span class="cursor-toggle-state">${enabled ? 'live' : 'hidden'}</span>`
+    + `<span class="canvas-flags">`
+    + `<button class="${toggleClass}" data-enabled="${enabled ? '1' : '0'}" ${inspectorControlAttrs('minimap-cursor', {
+      name: 'Minimap cursor',
+      action: 'toggle_minimap_cursor',
+      pressed: enabled,
+    })}>${toggleLabel}</button>`
+    + `</span>`
+    + `</div>`
+}
+
+export function renderMouseEventsToggleRowHTML(options = {}) {
+  const enabled = !!options.enabled
+  const depth = Number.isFinite(Number(options.depth)) ? Number(options.depth) : 0
+  const toggleClass = enabled ? 'btn mouse-events-toggle-btn active' : 'btn mouse-events-toggle-btn'
+  const toggleLabel = enabled ? 'on' : 'off'
+  return `<div class="tree-row cursor-toggle-row" style="${rowIndentStyle(depth)}">`
+    + `<span class="cursor-toggle-label">mouse events</span>`
+    + `<span class="cursor-toggle-state">${enabled ? 'live' : 'hidden'}</span>`
+    + `<span class="canvas-flags">`
+    + `<button class="${toggleClass}" data-enabled="${enabled ? '1' : '0'}" ${inspectorControlAttrs('mouse-events', {
+      name: 'Mouse events',
+      action: 'toggle_mouse_events',
+      pressed: enabled,
+    })}>${toggleLabel}</button>`
+    + `</span>`
+    + `</div>`
+}
+
+export function renderCanvasListToggleButton(options = {}) {
+  const collapsed = options.collapsed !== false
+  const label = collapsed ? 'Show canvas list' : 'Hide canvas list'
+  return `<button class="canvas-list-toggle" type="button" ${inspectorControlAttrs('canvas-list-toggle', {
+    name: label,
+    action: 'toggle_canvas_list',
+    expanded: !collapsed,
+  })} title="${escapeHTML(label)}">`
+    + `<span class="canvas-list-caret ${collapsed ? '' : 'open'}" aria-hidden="true"></span>`
+    + `</button>`
+}
+
 function renderSurfaceSegmentRow(segment, depth) {
   return `<div class="tree-row surface-segment" data-display-id="${escapeHTML(segment.display_id)}" style="${rowIndentStyle(depth)}">`
     + `<span class="seg-index">[${escapeHTML(segment.index)}]</span>`
@@ -113,11 +172,7 @@ function renderSurfaceSegmentRow(segment, depth) {
 }
 
 function renderSurfaceRow(c, depth, options = {}) {
-  const tintedIds = options.tintedIds || new Set()
-  const statsIds = options.statsIds || new Set()
   const segmentCount = Array.isArray(c.segments) ? c.segments.length : 0
-  const tintClass = tintedIds.has(c.id) ? 'btn tint-btn active' : 'btn tint-btn'
-  const statsClass = statsIds.has(c.id) ? 'btn stats-btn active' : 'btn stats-btn'
   let html = `<div class="tree-row surface" data-id="${escapeHTML(c.id)}" style="${rowIndentStyle(depth)}">`
   html += renderCanvasStatusPrefix(c)
   html += `<span class="canvas-id">${escapeHTML(c.id)}</span>`
@@ -125,9 +180,7 @@ function renderSurfaceRow(c, depth, options = {}) {
   html += `<span class="canvas-kind-detail">${segmentCount} segment${segmentCount === 1 ? '' : 's'}</span>`
   html += `<span class="canvas-dims">${formatAt(c.atResolved || c.at)}</span>`
   html += `<span class="canvas-flags">`
-  html += `<button class="${statsClass}" data-id="${escapeHTML(c.id)}" title="Toggle inline stats.js for this canvas">stats</button>`
-  html += `<button class="${tintClass}" data-id="${escapeHTML(c.id)}">tint</button>`
-  html += `<button class="btn remove-btn" data-id="${escapeHTML(c.id)}">\u2715</button>`
+  html += renderCanvasActionButtons(c.id, options)
   html += `</span></div>`
   html += (c.segments || []).map((segment) => renderSurfaceSegmentRow(segment, depth + 1)).join('')
   return html
@@ -146,11 +199,7 @@ export function renderCanvasRow(c, depth = 0, options = {}) {
   html += `<span class="canvas-id">${escapeHTML(c?.id)}</span>`
   html += `<span class="canvas-dims">${dims}</span>`
   html += `<span class="canvas-flags">`
-  const tintClass = tintedIds.has(c?.id) ? 'btn tint-btn active' : 'btn tint-btn'
-  const statsClass = statsIds.has(c?.id) ? 'btn stats-btn active' : 'btn stats-btn'
-  html += `<button class="${statsClass}" data-id="${escapeHTML(c?.id)}" title="Toggle inline stats.js for this canvas">stats</button>`
-  html += `<button class="${tintClass}" data-id="${escapeHTML(c?.id)}">tint</button>`
-  html += `<button class="btn remove-btn" data-id="${escapeHTML(c?.id)}">\u2715</button>`
+  html += renderCanvasActionButtons(c?.id, { tintedIds, statsIds })
   html += `</span></div>`
   return html
 }
@@ -481,11 +530,11 @@ export default function CanvasInspector() {
       html += `<div class="${cls}" style="left:${x}px;top:${y}px;width:${w}px;height:${h}px;${tintStyle}" title="${esc(c.id)}"></div>`
     }
     // Object marks: projected CG position, primitive composition at logical w/h.
-    for (const [, entry] of marksState.marksByCanvas) {
+    for (const [canvasId, entry] of marksState.marksByCanvas) {
       for (const m of entry.marks) {
         const projected = projectPointToMinimap(layout, { x: m.x, y: m.y })
         if (!projected) continue
-        html += renderMinimapMark(m, projected)
+        html += renderMinimapMark(m, projected, { canvasId })
       }
     }
     html += `<div class="minimap-dynamic-layer"></div>`
@@ -542,27 +591,11 @@ export default function CanvasInspector() {
   }
 
   function renderCursorToggleRow(depth) {
-    const toggleClass = cursorTrackingEnabled ? 'btn cursor-toggle-btn active' : 'btn cursor-toggle-btn'
-    const toggleLabel = cursorTrackingEnabled ? 'on' : 'off'
-    return `<div class="tree-row cursor-toggle-row" style="${indentStyle(depth)}">`
-      + `<span class="cursor-toggle-label">minimap cursor</span>`
-      + `<span class="cursor-toggle-state">${cursorTrackingEnabled ? 'live' : 'hidden'}</span>`
-      + `<span class="canvas-flags">`
-      + `<button class="${toggleClass}" data-enabled="${cursorTrackingEnabled ? '1' : '0'}">${toggleLabel}</button>`
-      + `</span>`
-      + `</div>`
+    return renderCursorToggleRowHTML({ depth, enabled: cursorTrackingEnabled })
   }
 
   function renderMouseEventsToggleRow(depth) {
-    const toggleClass = mouseEventsEnabled ? 'btn mouse-events-toggle-btn active' : 'btn mouse-events-toggle-btn'
-    const toggleLabel = mouseEventsEnabled ? 'on' : 'off'
-    return `<div class="tree-row cursor-toggle-row" style="${indentStyle(depth)}">`
-      + `<span class="cursor-toggle-label">mouse events</span>`
-      + `<span class="cursor-toggle-state">${mouseEventsEnabled ? 'live' : 'hidden'}</span>`
-      + `<span class="canvas-flags">`
-      + `<button class="${toggleClass}" data-enabled="${mouseEventsEnabled ? '1' : '0'}">${toggleLabel}</button>`
-      + `</span>`
-      + `</div>`
+    return renderMouseEventsToggleRowHTML({ depth, enabled: mouseEventsEnabled })
   }
 
   function renderMarkTreeRow(mark, depth) {
@@ -588,9 +621,7 @@ export default function CanvasInspector() {
     }
     return `<div class="status-bar">`
       + `<span class="event-count">${eventCount} events</span>`
-      + `<button class="canvas-list-toggle" type="button" aria-expanded="${listCollapsed ? 'false' : 'true'}" title="${listCollapsed ? 'Show canvas list' : 'Hide canvas list'}">`
-      + `<span class="canvas-list-caret ${listCollapsed ? '' : 'open'}" aria-hidden="true"></span>`
-      + `</button>`
+      + renderCanvasListToggleButton({ collapsed: listCollapsed })
       + `<span>${detail}</span>`
       + `</div>`
   }

--- a/packages/toolkit/components/canvas-inspector/marks/render.js
+++ b/packages/toolkit/components/canvas-inspector/marks/render.js
@@ -7,6 +7,8 @@
 // Layers are drawn in that order so cross appears on top.
 // Stroke is centered inside a (w × h) bounding box so outer pixels fit.
 
+import { canvasInspectorAosRef, semanticAttrString } from '../semantics.js';
+
 const STROKE = 1;
 
 function escAttr(s) {
@@ -22,6 +24,16 @@ function escText(s) {
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
+}
+
+function markSemanticAttrs(mark, canvasId) {
+  return semanticAttrString({
+    id: `mark-${canvasId}-${mark.id}`,
+    role: 'AXImage',
+    name: mark.name || mark.id,
+    aosRef: canvasInspectorAosRef('mark', canvasId, mark.id),
+    parentCanvasId: canvasId,
+  });
 }
 
 // Build the inner layer SVG for a mark given its bounding size + color.
@@ -73,13 +85,15 @@ export function renderMarkListRow(mark, { showCoords = false } = {}) {
 
 // Render a minimap-placed mark as a positioned SVG element.
 // `projected` is the center point from projectPointToMinimap.
-export function renderMinimapMark(mark, projected) {
+export function renderMinimapMark(mark, projected, { canvasId = mark.canvasId || 'unknown' } = {}) {
   const { id, name, w, h } = mark;
   const left = Math.round(projected.x - w / 2);
   const top = Math.round(projected.y - h / 2);
   const inner = buildMarkLayers(mark);
   return (
-    `<svg class="minimap-mark" data-mark-id="${escAttr(id)}"`
+    `<svg class="minimap-mark" ${markSemanticAttrs(mark, canvasId)}`
+    + ` data-canvas-id="${escAttr(canvasId)}" data-mark-id="${escAttr(id)}"`
+    + ` data-mark-x="${escAttr(mark.x)}" data-mark-y="${escAttr(mark.y)}"`
     + ` style="left:${left}px;top:${top}px;width:${w}px;height:${h}px"`
     + ` viewBox="0 0 ${w} ${h}" width="${w}" height="${h}"`
     + ` xmlns="http://www.w3.org/2000/svg">`

--- a/packages/toolkit/components/canvas-inspector/semantics.js
+++ b/packages/toolkit/components/canvas-inspector/semantics.js
@@ -1,0 +1,80 @@
+import { normalizeSemanticTarget } from '../../runtime/semantic-targets.js'
+
+const SURFACE = 'canvas-inspector'
+
+function escAttr(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+function boolAttr(value) {
+  return value ? 'true' : 'false'
+}
+
+export function canvasInspectorAosRef(...parts) {
+  return [SURFACE, ...parts]
+    .map((part) => String(part || 'unknown').replace(/\s+/g, '-'))
+    .join(':')
+}
+
+export function semanticAttrString(target = {}, options = {}) {
+  const normalized = normalizeSemanticTarget({
+    ...target,
+    surface: SURFACE,
+  })
+  const attrs = [
+    ['aria-label', normalized.name],
+    ['data-aos-ref', normalized.aosRef],
+    ['data-aos-surface', normalized.surface],
+    ['data-semantic-target-id', normalized.id],
+    ['data-aos-parent-canvas', normalized.parentCanvasId],
+  ]
+  if (normalized.role && !(options.nativeButton && normalized.role === 'button')) attrs.push(['role', normalized.role])
+  if (normalized.action) attrs.push(['data-aos-action', normalized.action])
+  if (!normalized.enabled) attrs.push(['aria-disabled', 'true'])
+  if (normalized.pressed !== null) attrs.push(['aria-pressed', boolAttr(normalized.pressed)])
+  if (normalized.current !== null) attrs.push(['aria-current', normalized.current === true ? 'true' : normalized.current])
+  if (normalized.selected !== null) attrs.push(['aria-selected', boolAttr(normalized.selected)])
+  if (normalized.checked !== null) attrs.push(['aria-checked', boolAttr(normalized.checked)])
+  if (normalized.expanded !== null) attrs.push(['aria-expanded', boolAttr(normalized.expanded)])
+  return attrs
+    .filter(([, value]) => value !== undefined && value !== null && value !== '')
+    .map(([name, value]) => `${name}="${escAttr(value)}"`)
+    .join(' ')
+}
+
+export function canvasActionAttrs(canvasId, action, options = {}) {
+  const labels = {
+    stats: `Stats for canvas ${canvasId}`,
+    tint: `Tint canvas ${canvasId}`,
+    remove: `Remove canvas ${canvasId}`,
+  }
+  const actions = {
+    stats: 'toggle_stats',
+    tint: 'toggle_tint',
+    remove: 'remove_canvas',
+  }
+  return semanticAttrString({
+    id: `${action}-${canvasId}`,
+    role: 'AXButton',
+    name: options.name || labels[action] || `${action} ${canvasId}`,
+    action: options.action || actions[action] || action,
+    aosRef: canvasInspectorAosRef('canvas', canvasId, action),
+    pressed: options.pressed ?? null,
+  }, { nativeButton: true })
+}
+
+export function inspectorControlAttrs(id, options = {}) {
+  return semanticAttrString({
+    id,
+    role: 'AXButton',
+    name: options.name || id,
+    action: options.action || id,
+    aosRef: options.aosRef || canvasInspectorAosRef('control', id),
+    pressed: options.pressed ?? null,
+    expanded: options.expanded ?? null,
+  }, { nativeButton: true })
+}

--- a/packages/toolkit/components/inspector-panel/index.js
+++ b/packages/toolkit/components/inspector-panel/index.js
@@ -50,6 +50,8 @@ export default function InspectorPanel() {
     render(_host) {
       contentEl = document.createElement('div')
       contentEl.className = 'inspector-panel-body'
+      contentEl.setAttribute('role', 'region')
+      contentEl.setAttribute('aria-label', BASE_TITLE)
       contentEl.innerHTML = renderEmpty()
       return contentEl
     },

--- a/packages/toolkit/components/integration-hub/index.js
+++ b/packages/toolkit/components/integration-hub/index.js
@@ -1,4 +1,5 @@
 import { esc } from '../../runtime/bridge.js'
+import { applyIntegrationHubSemantics } from './semantics.js'
 
 const DEFAULT_BROKER_URL = 'http://127.0.0.1:47231'
 
@@ -295,6 +296,8 @@ export default function IntegrationHub(options = {}) {
         </section>
       </div>
     `
+
+    applyIntegrationHubSemantics(rootEl, state)
 
     rootEl.querySelector('.integration-hub-refresh')?.addEventListener('click', () => {
       void loadSnapshot()

--- a/packages/toolkit/components/integration-hub/semantics.js
+++ b/packages/toolkit/components/integration-hub/semantics.js
@@ -1,0 +1,89 @@
+import { applySemanticTargetAttributes } from '../../runtime/semantic-targets.js'
+
+const SURFACE = 'integration-hub'
+
+function controlId(value, fallback = 'target') {
+  return String(value || fallback).replace(/[^a-zA-Z0-9_-]/g, '-')
+}
+
+function text(value, fallback = '') {
+  const normalized = String(value ?? '').replace(/\s+/g, ' ').trim()
+  return normalized || fallback
+}
+
+export function integrationHubAosRef(id) {
+  return `${SURFACE}:${controlId(id, 'unknown')}`
+}
+
+export function applyIntegrationHubSemanticTarget(element, target = {}, options = {}) {
+  if (!element) return null
+  const preservedText = options.preserveText ? element.textContent : null
+  const normalized = applySemanticTargetAttributes(element, {
+    id: target.id,
+    role: target.role || 'AXButton',
+    name: target.name,
+    action: target.action,
+    aosRef: target.aosRef || integrationHubAosRef(target.id),
+    surface: SURFACE,
+    enabled: target.enabled,
+    current: target.current,
+    selected: target.selected,
+    value: target.value,
+  }, {
+    idPrefix: options.idPrefix === undefined ? SURFACE : options.idPrefix,
+    visibleLabel: options.visibleLabel,
+  })
+  if (options.preserveText) element.textContent = preservedText
+  return normalized
+}
+
+export function applyIntegrationHubSemantics(rootEl, state = {}) {
+  if (!rootEl?.querySelector) return
+
+  const input = rootEl.querySelector('#integration-hub-command')
+  applyIntegrationHubSemanticTarget(input, {
+    id: 'command-input',
+    role: 'AXTextField',
+    name: 'Integration command',
+    action: 'edit_command',
+    value: input?.value ?? state.simulateText,
+  }, {
+    idPrefix: null,
+  })
+
+  applyIntegrationHubSemanticTarget(rootEl.querySelector('.integration-hub-action'), {
+    id: 'command-send',
+    name: state.sending ? 'Sending command' : 'Send command',
+    action: 'send_command',
+  }, {
+    preserveText: true,
+  })
+
+  applyIntegrationHubSemanticTarget(rootEl.querySelector('.integration-hub-refresh'), {
+    id: 'refresh',
+    name: 'Refresh',
+    action: 'refresh_snapshot',
+  }, {
+    visibleLabel: true,
+  })
+
+  const panel = rootEl.querySelector('.integration-hub-grid')
+  panel?.setAttribute?.('id', 'integration-hub-surface-panel')
+  panel?.setAttribute?.('role', 'tabpanel')
+
+  rootEl.querySelectorAll?.('.integration-hub-surface-tab').forEach((button) => {
+    const surfaceId = controlId(button.dataset?.surface, 'surface')
+    const label = text(button.textContent, surfaceId)
+    const selected = surfaceId === state.activeSurface || button.classList?.contains?.('active') || false
+    applyIntegrationHubSemanticTarget(button, {
+      id: `surface-tab-${surfaceId}`,
+      role: 'AXTab',
+      name: label,
+      action: 'select_surface',
+      selected,
+    }, {
+      preserveText: true,
+    })
+    button.setAttribute?.('aria-controls', 'integration-hub-surface-panel')
+  })
+}

--- a/packages/toolkit/components/log-console/index.js
+++ b/packages/toolkit/components/log-console/index.js
@@ -54,6 +54,10 @@ export default function LogConsole() {
       host = host_
       entriesEl = document.createElement('div')
       entriesEl.id = 'entries'
+      entriesEl.setAttribute('role', 'log')
+      entriesEl.setAttribute('aria-label', 'Log entries')
+      entriesEl.setAttribute('aria-live', 'polite')
+      entriesEl.setAttribute('aria-relevant', 'additions text')
       return entriesEl
     },
 

--- a/packages/toolkit/components/render-performance/index.js
+++ b/packages/toolkit/components/render-performance/index.js
@@ -50,7 +50,7 @@ function mergeLatestStats(samples) {
 function renderSparkline(samples, targetFps) {
   const bars = buildSparkline(samples, { targetFps, limit: 64 });
   if (bars.length === 0) return '<div class="perf-empty">Waiting for frames</div>';
-  return `<div class="perf-sparkline" aria-label="Frame-time sparkline">${
+  return `<div class="perf-sparkline" role="img" aria-label="Frame-time sparkline">${
     bars.map((bar) => (
       `<span class="perf-bar ${esc(bar.state)}" style="height:${Math.round(bar.ratio * 100)}%"></span>`
     )).join('')
@@ -102,7 +102,7 @@ function renderSourceSummary(source, samples, options) {
 function renderEventLog(events) {
   if (events.length === 0) return '<div class="perf-empty">No render marks</div>';
   return (
-    `<div class="perf-events">`
+    `<div class="perf-events" role="log" aria-label="Render marks" aria-live="polite">`
       + events.slice(-24).reverse().map((entry) => (
         `<div class="perf-event">`
           + `<span>${esc(entry.ts)}</span>`
@@ -261,6 +261,8 @@ export default function RenderPerformance(options = {}) {
       host.contentEl.style.overflow = 'hidden';
       root = document.createElement('div');
       root.className = 'render-performance-root';
+      root.setAttribute('role', 'region');
+      root.setAttribute('aria-label', BASE_TITLE);
       root.innerHTML = '<div class="perf-empty">Waiting for frames</div>';
       window.__renderPerformanceDebug = {
         sample(payload = {}) {

--- a/packages/toolkit/components/spatial-telemetry/index.js
+++ b/packages/toolkit/components/spatial-telemetry/index.js
@@ -68,7 +68,7 @@ function renderDisplayRows(snapshot) {
       + `</tr>`
   )).join('');
   return (
-    `<table class="telemetry-table">`
+    `<table class="telemetry-table" aria-label="Display geometry">`
       + `<thead><tr><th>display</th><th>scale</th><th>native bounds</th><th>DesktopWorld</th><th>native visible</th><th>VisibleDesktopWorld</th></tr></thead>`
       + `<tbody>${rows}</tbody>`
       + `</table>`
@@ -93,7 +93,7 @@ function renderCanvasRows(snapshot) {
       + `</tr>`
   )).join('');
   return (
-    `<table class="telemetry-table">`
+    `<table class="telemetry-table" aria-label="Canvas geometry">`
       + `<thead><tr><th>canvas</th><th>parent</th><th>owner</th><th>track</th><th>int</th><th>DesktopWorld</th><th>world local</th><th>parent local</th>${renderDisplayHeader(snapshot.displayColumns)}</tr></thead>`
       + `<tbody>${rows}</tbody>`
       + `</table>`
@@ -117,7 +117,7 @@ function renderMarkRows(snapshot) {
       + `</tr>`
   )).join('');
   return (
-    `<table class="telemetry-table">`
+    `<table class="telemetry-table" aria-label="Object marks">`
       + `<thead><tr><th>canvas</th><th>mark</th><th>name</th><th>owner</th><th>DesktopWorld</th><th>world local</th><th>canvas local</th>${renderDisplayHeader(snapshot.displayColumns)}</tr></thead>`
       + `<tbody>${rows}</tbody>`
       + `</table>`
@@ -130,7 +130,7 @@ function renderCursor(snapshot) {
   }
   const row = snapshot.cursorRow;
   return (
-    `<table class="telemetry-table">`
+    `<table class="telemetry-table" aria-label="Cursor position">`
       + `<thead><tr><th>owner</th><th>DesktopWorld</th><th>world local</th>${renderDisplayHeader(snapshot.displayColumns)}</tr></thead>`
       + `<tbody><tr>`
       + `<td>${esc(row.owner)}</td>`
@@ -146,7 +146,7 @@ function renderEventLog(events) {
     return '<div class="empty-state">No events yet</div>';
   }
   return (
-    `<div class="event-log">`
+    `<div class="event-log" role="log" aria-label="Telemetry events" aria-live="polite">`
       + events.map((entry) => (
         `<div class="event-row">`
           + `<span class="event-ts">${esc(entry.ts)}</span>`
@@ -267,6 +267,8 @@ export default function SpatialTelemetry() {
       host.contentEl.style.overflow = 'hidden';
       contentEl = document.createElement('div');
       contentEl.className = 'spatial-telemetry-root';
+      contentEl.setAttribute('role', 'region');
+      contentEl.setAttribute('aria-label', BASE_TITLE);
       contentEl.innerHTML = '<div class="empty-state">Waiting for telemetry…</div>';
       window.__spatialTelemetryDebug = {
         clearLog() {

--- a/packages/toolkit/components/wiki-kb/index.js
+++ b/packages/toolkit/components/wiki-kb/index.js
@@ -11,6 +11,10 @@ import {
   normalizeGraphPayload,
   renderMarkdown,
 } from './views/shared.js'
+import {
+  applyWikiKBSemanticTarget,
+  wikiKBAosRef,
+} from './semantics.js'
 
 const VIEW_DEFS = [
   { id: 'graph', label: 'Graph', factory: GraphView },
@@ -75,7 +79,13 @@ export default function WikiKB() {
     for (const button of rootEl.querySelectorAll('.wiki-kb-toggle-button')) {
       const isActive = button.dataset.mode === sidebarMode
       button.classList.toggle('active', isActive)
-      button.setAttribute('aria-pressed', isActive ? 'true' : 'false')
+      applyWikiKBSemanticTarget(button, {
+        id: `sidebar-mode-${button.dataset.mode}`,
+        name: button.textContent,
+        action: 'set_sidebar_mode',
+        aosRef: wikiKBAosRef('sidebar-mode', button.dataset.mode),
+        pressed: isActive,
+      })
     }
   }
 
@@ -127,6 +137,12 @@ export default function WikiKB() {
       button.type = 'button'
       button.className = 'wiki-kb-related-link'
       button.dataset.nodeId = relatedNode.id
+      applyWikiKBSemanticTarget(button, {
+        id: `related-${relatedNode.id}`,
+        name: `Related: ${relatedNode.name}`,
+        action: 'select_related_node',
+        aosRef: wikiKBAosRef('related', relatedNode.id),
+      })
 
       const dot = document.createElement('span')
       dot.className = 'wiki-kb-related-dot'
@@ -238,6 +254,9 @@ export default function WikiKB() {
     })
     const viewEl = instance.mount()
     viewEl.classList.add('wiki-kb-view')
+    viewEl.id = `wiki-kb-panel-${id}`
+    viewEl.setAttribute('role', 'tabpanel')
+    viewEl.setAttribute('aria-labelledby', `wiki-kb-tab-${id}`)
     viewEl.hidden = true
     contentEl.appendChild(viewEl)
 
@@ -258,7 +277,15 @@ export default function WikiKB() {
     for (const button of rootEl.querySelectorAll('.wiki-kb-view-tab')) {
       const isActive = button.dataset.view === id
       button.classList.toggle('active', isActive)
-      button.setAttribute('aria-selected', isActive ? 'true' : 'false')
+      const view = VIEW_DEFS.find((entry) => entry.id === button.dataset.view)
+      applyWikiKBSemanticTarget(button, {
+        id: `view-tab-${button.dataset.view}`,
+        role: 'AXTab',
+        name: view?.label || button.textContent,
+        action: 'set_view',
+        aosRef: wikiKBAosRef('tab', button.dataset.view),
+        selected: isActive,
+      })
     }
     focusActiveViewOnSelection()
   }
@@ -330,10 +357,12 @@ export default function WikiKB() {
           ${VIEW_DEFS.map((view, index) => `
             <button
               type="button"
+              id="wiki-kb-tab-${view.id}"
               class="wiki-kb-view-tab${index === 0 ? ' active' : ''}"
               data-view="${view.id}"
               role="tab"
               aria-selected="${index === 0 ? 'true' : 'false'}"
+              aria-controls="wiki-kb-panel-${view.id}"
             >${view.label}</button>
           `).join('')}
           <div class="wiki-kb-tab-spacer"></div>
@@ -375,6 +404,14 @@ export default function WikiKB() {
     dom.sidebarBodyEl = rootEl.querySelector('.wiki-kb-sidebar-body')
     dom.relatedSectionEl = rootEl.querySelector('.wiki-kb-sidebar-related')
     dom.relatedListEl = rootEl.querySelector('.wiki-kb-related-list')
+
+    applyWikiKBSemanticTarget(rootEl.querySelector('.wiki-kb-sidebar-close'), {
+      id: 'sidebar-close',
+      name: 'Close details',
+      action: 'close_details',
+      aosRef: wikiKBAosRef('sidebar', 'close'),
+    })
+    syncSidebarToggle()
 
     rootEl.addEventListener('click', onRootClick)
     updateStatus()

--- a/packages/toolkit/components/wiki-kb/launch.sh
+++ b/packages/toolkit/components/wiki-kb/launch.sh
@@ -30,7 +30,7 @@ GEOMETRY="$(
 import json, sys
 
 payload = json.load(sys.stdin)
-displays = payload.get("displays", payload) if isinstance(payload, dict) else payload
+displays = payload.get("data", {}).get("displays", payload.get("displays", [])) if isinstance(payload, dict) else payload
 main = next((entry for entry in displays if entry.get("is_main")), displays[0] if displays else None)
 if not main:
     print("0 0 1728 1117")

--- a/packages/toolkit/components/wiki-kb/semantics.js
+++ b/packages/toolkit/components/wiki-kb/semantics.js
@@ -1,0 +1,36 @@
+import { applySemanticTargetAttributes } from '../../runtime/semantic-targets.js'
+
+const SURFACE = 'wiki-kb'
+
+function refPart(part) {
+  return String(part || 'unknown').replace(/\s+/g, '-')
+}
+
+export function wikiKBAosRef(...parts) {
+  return [SURFACE, ...parts].map(refPart).join(':')
+}
+
+export function applyWikiKBSemanticTarget(element, target = {}, options = {}) {
+  if (!element) return null
+
+  const preserveContent = options.preserveContent ?? !options.visibleLabel
+  const canPreserveNodes = preserveContent &&
+    typeof element.replaceChildren === 'function' &&
+    element.childNodes
+  const preservedNodes = canPreserveNodes ? [...element.childNodes] : null
+  const preservedText = preserveContent && !preservedNodes ? element.textContent : null
+  const normalized = applySemanticTargetAttributes(element, {
+    role: 'AXButton',
+    ...target,
+    surface: SURFACE,
+    aosRef: target.aosRef || wikiKBAosRef(target.id),
+  }, {
+    idPrefix: null,
+    ...options,
+    visibleLabel: options.visibleLabel ?? false,
+  })
+
+  if (preservedNodes) element.replaceChildren(...preservedNodes)
+  else if (preserveContent) element.textContent = preservedText
+  return normalized
+}

--- a/packages/toolkit/components/wiki-kb/views/graph.js
+++ b/packages/toolkit/components/wiki-kb/views/graph.js
@@ -12,6 +12,10 @@ import {
   normalizeGraphViewConfig,
   resizeCanvasToContainer,
 } from './shared.js'
+import {
+  applyWikiKBSemanticTarget,
+  wikiKBAosRef,
+} from '../semantics.js'
 
 const COLORS = {
   edge: 'rgba(100, 100, 160, 0.35)',
@@ -251,6 +255,14 @@ export default function GraphView({ onSelectNode }) {
     return viewport.clientToWorld(canvas, clientX, clientY)
   }
 
+  function applyGraphSemanticTarget(element, id, target = {}) {
+    return applyWikiKBSemanticTarget(element, {
+      id,
+      ...target,
+      aosRef: target.aosRef || wikiKBAosRef('graph', id),
+    })
+  }
+
   function collectFocusNodes() {
     const selected = selectedNode()
     if (!selected) return []
@@ -316,8 +328,13 @@ export default function GraphView({ onSelectNode }) {
     dom.controlsShellEl?.classList.toggle('collapsed', !controlsOpen)
     dom.controlsPanelEl?.toggleAttribute('hidden', !controlsOpen)
     if (dom.controlsToggleEl) {
-      dom.controlsToggleEl.setAttribute('aria-pressed', controlsOpen ? 'true' : 'false')
       dom.controlsToggleEl.textContent = controlsOpen ? 'Hide Controls' : 'Show Controls'
+      applyGraphSemanticTarget(dom.controlsToggleEl, 'controls-toggle', {
+        name: controlsOpen ? 'Hide graph controls' : 'Show graph controls',
+        action: 'toggle_graph_controls',
+        pressed: controlsOpen,
+        expanded: controlsOpen,
+      })
     }
   }
 
@@ -409,7 +426,11 @@ export default function GraphView({ onSelectNode }) {
       button.textContent = type
       const isActive = activeTypes.has(type)
       button.classList.toggle('active', isActive)
-      button.setAttribute('aria-pressed', isActive ? 'true' : 'false')
+      applyGraphSemanticTarget(button, `type-filter-${type}`, {
+        name: `Type filter: ${type}`,
+        action: 'toggle_type_filter',
+        pressed: isActive,
+      })
       fragment.appendChild(button)
     }
     dom.typeFiltersEl.appendChild(fragment)
@@ -431,7 +452,11 @@ export default function GraphView({ onSelectNode }) {
       button.textContent = `${entry.value} (${entry.count})`
       const isActive = activeTags.has(entry.value)
       button.classList.toggle('active', isActive)
-      button.setAttribute('aria-pressed', isActive ? 'true' : 'false')
+      applyGraphSemanticTarget(button, `tag-filter-${entry.value}`, {
+        name: `Tag filter: ${entry.value}`,
+        action: 'toggle_tag_filter',
+        pressed: isActive,
+      })
       fragment.appendChild(button)
     }
     dom.tagFiltersEl.appendChild(fragment)
@@ -446,6 +471,11 @@ export default function GraphView({ onSelectNode }) {
     if (dom.searchInput) {
       dom.searchInput.value = searchQuery
       dom.searchSectionEl.toggleAttribute('hidden', !graphViewConfig.features.search)
+      applyGraphSemanticTarget(dom.searchInput, 'search', {
+        role: 'AXSearchField',
+        name: 'Search Wiki KB graph',
+        action: 'search_nodes',
+      })
     }
 
     if (dom.scopeSectionEl) {
@@ -459,12 +489,20 @@ export default function GraphView({ onSelectNode }) {
       if (dom.scopeGlobalButton) {
         const isGlobal = mode === 'global'
         dom.scopeGlobalButton.classList.toggle('active', isGlobal)
-        dom.scopeGlobalButton.setAttribute('aria-pressed', isGlobal ? 'true' : 'false')
+        applyGraphSemanticTarget(dom.scopeGlobalButton, 'scope-global', {
+          name: 'Global scope',
+          action: 'set_scope_global',
+          pressed: isGlobal,
+        })
       }
       if (dom.scopeLocalButton) {
         const isLocal = mode === 'local'
         dom.scopeLocalButton.classList.toggle('active', isLocal)
-        dom.scopeLocalButton.setAttribute('aria-pressed', isLocal ? 'true' : 'false')
+        applyGraphSemanticTarget(dom.scopeLocalButton, 'scope-local', {
+          name: 'Local scope',
+          action: 'set_scope_local',
+          pressed: isLocal,
+        })
       }
     }
 
@@ -473,6 +511,15 @@ export default function GraphView({ onSelectNode }) {
       dom.depthRange.max = String(graphViewConfig.limits.maxDepth)
       dom.depthRange.value = String(depth)
       dom.depthValueEl.textContent = String(depth)
+      applyGraphSemanticTarget(dom.depthRange, 'depth', {
+        role: 'AXSlider',
+        name: 'Graph depth',
+        action: 'set_depth',
+        value: `${depth}`,
+      })
+      dom.depthRange.setAttribute('aria-valuemin', dom.depthRange.min)
+      dom.depthRange.setAttribute('aria-valuemax', dom.depthRange.max)
+      dom.depthRange.setAttribute('aria-valuenow', String(depth))
     }
 
     if (dom.labelSectionEl) {
@@ -480,15 +527,31 @@ export default function GraphView({ onSelectNode }) {
       for (const button of dom.labelButtons) {
         const isActive = button.dataset.labelMode === labelMode
         button.classList.toggle('active', isActive)
-        button.setAttribute('aria-pressed', isActive ? 'true' : 'false')
+        applyGraphSemanticTarget(button, `label-mode-${button.dataset.labelMode}`, {
+          name: `Labels: ${button.textContent}`,
+          action: 'set_label_mode',
+          pressed: isActive,
+        })
       }
     }
 
     dom.summaryEl.textContent = `${filteredGraph.stats.visibleNodes}/${filteredGraph.stats.totalNodes} nodes · ${filteredGraph.stats.visibleLinks}/${filteredGraph.stats.totalLinks} links`
     dom.isolatedToggleRowEl.toggleAttribute('hidden', !graphViewConfig.features.isolated)
     dom.showIsolatedInput.checked = showIsolated
+    applyGraphSemanticTarget(dom.showIsolatedInput, 'show-isolated', {
+      role: 'AXCheckBox',
+      name: 'Show isolated nodes',
+      action: 'toggle_show_isolated',
+      checked: showIsolated,
+    })
     dom.neighborToggleRowEl.toggleAttribute('hidden', !graphViewConfig.features.neighbors)
     dom.highlightNeighborsInput.checked = highlightNeighbors
+    applyGraphSemanticTarget(dom.highlightNeighborsInput, 'highlight-neighbors', {
+      role: 'AXCheckBox',
+      name: 'Highlight neighbors',
+      action: 'toggle_highlight_neighbors',
+      checked: highlightNeighbors,
+    })
     dom.highlightSectionEl.toggleAttribute(
       'hidden',
       !(graphViewConfig.features.neighbors || graphViewConfig.features.path)
@@ -497,14 +560,55 @@ export default function GraphView({ onSelectNode }) {
     dom.pathCaptionEl.toggleAttribute('hidden', !graphViewConfig.features.path)
     dom.pathCaptionEl.textContent = formatPathCaption()
     dom.pathStartButton.disabled = !graphViewConfig.features.path || !selectedNodeId
+    applyGraphSemanticTarget(dom.pathStartButton, 'set-path-start', {
+      name: 'Set path start',
+      action: 'set_path_start',
+      enabled: !dom.pathStartButton.disabled,
+    })
     dom.clearPathButton.disabled = !graphViewConfig.features.path || !pathStartId
+    applyGraphSemanticTarget(dom.clearPathButton, 'clear-path', {
+      name: 'Clear path',
+      action: 'clear_path',
+      enabled: !dom.clearPathButton.disabled,
+    })
     dom.freezeToggleRowEl.toggleAttribute('hidden', !graphViewConfig.features.freeze)
     dom.freezeInput.checked = frozen
+    applyGraphSemanticTarget(dom.freezeInput, 'freeze-layout', {
+      role: 'AXCheckBox',
+      name: 'Freeze layout',
+      action: 'toggle_freeze_layout',
+      checked: frozen,
+    })
     dom.focusSelectionButton.toggleAttribute('hidden', !graphViewConfig.features.focus)
     dom.focusSelectionButton.disabled = !selectedNodeId
+    applyGraphSemanticTarget(dom.focusSelectionButton, 'focus-selection', {
+      name: 'Focus selection',
+      action: 'focus_selection',
+      enabled: !dom.focusSelectionButton.disabled,
+    })
     dom.fitButton.toggleAttribute('hidden', !graphViewConfig.features.fit)
+    applyGraphSemanticTarget(dom.fitButton, 'fit', {
+      name: 'Fit graph',
+      action: 'fit_graph',
+    })
     dom.resetViewButton.toggleAttribute('hidden', !graphViewConfig.features.reset)
+    applyGraphSemanticTarget(dom.resetViewButton, 'reset-view', {
+      name: 'Reset view',
+      action: 'reset_view',
+    })
     dom.resetFiltersButton.toggleAttribute('hidden', !graphViewConfig.features.reset)
+    applyGraphSemanticTarget(dom.resetFiltersButton, 'reset-filters', {
+      name: 'Reset filters',
+      action: 'reset_filters',
+    })
+    applyGraphSemanticTarget(dom.typesAllButton, 'types-all', {
+      name: 'Enable all type filters',
+      action: 'enable_all_type_filters',
+    })
+    applyGraphSemanticTarget(dom.tagsClearButton, 'tags-clear', {
+      name: 'Clear tag filters',
+      action: 'clear_tag_filters',
+    })
 
     setControlsOpen(controlsOpen)
     renderTypeFilters()
@@ -1059,8 +1163,10 @@ export default function GraphView({ onSelectNode }) {
       dom.labelSectionEl = rootEl.querySelector('.wiki-kb-controls-section-labels')
       dom.labelButtons = [...rootEl.querySelectorAll('[data-label-mode]')]
       dom.typeSectionEl = rootEl.querySelector('.wiki-kb-controls-section-types')
+      dom.typesAllButton = rootEl.querySelector('[data-action="types-all"]')
       dom.typeFiltersEl = rootEl.querySelector('.wiki-kb-type-filters')
       dom.tagSectionEl = rootEl.querySelector('.wiki-kb-controls-section-tags')
+      dom.tagsClearButton = rootEl.querySelector('[data-action="tags-clear"]')
       dom.tagFiltersEl = rootEl.querySelector('.wiki-kb-tag-filters')
       dom.tagEmptyEl = rootEl.querySelector('.wiki-kb-controls-empty')
       dom.highlightSectionEl = rootEl.querySelector('.wiki-kb-controls-section-highlights')

--- a/packages/toolkit/panel/layouts/tabs.js
+++ b/packages/toolkit/panel/layouts/tabs.js
@@ -7,7 +7,48 @@ import { wireBridge, emit } from '../../runtime/bridge.js'
 import { subscribe } from '../../runtime/subscribe.js'
 import { evalCanvas, spawnChild } from '../../runtime/canvas.js'
 import { declareManifest, emitReady } from '../../runtime/manifest.js'
+import { applySemanticTargetAttributes } from '../../runtime/semantic-targets.js'
 import { createRouter } from '../router.js'
+
+const TABS_SURFACE = 'panel-tabs'
+
+function text(value, fallback = '') {
+  const s = String(value ?? '').replace(/\s+/g, ' ').trim()
+  return s || fallback
+}
+
+function refPart(value, fallback = 'target') {
+  return text(value, fallback).replace(/[^a-zA-Z0-9_-]/g, '-')
+}
+
+export function panelTabAosRef(panelName, tabID) {
+  return [TABS_SURFACE, refPart(panelName, 'tabs-panel'), refPart(tabID, 'tab')].join(':')
+}
+
+export function panelTabSemanticTarget(content = {}, index = 0, options = {}) {
+  const label = text(content.manifest?.title || content.manifest?.name, `tab ${index + 1}`)
+  const tabID = text(content.manifest?.name, `tab-${index + 1}`)
+  return {
+    id: `tab-${tabID}`,
+    role: 'AXTab',
+    name: label,
+    action: 'tabs/activate',
+    surface: TABS_SURFACE,
+    aosRef: panelTabAosRef(options.panelName, tabID),
+    selected: !!options.selected,
+  }
+}
+
+function applyPanelTabSemanticTarget(element, content, index, options = {}) {
+  return applySemanticTargetAttributes(
+    element,
+    panelTabSemanticTarget(content, index, options),
+    {
+      idPrefix: 'aos-tab',
+      visibleLabel: true,
+    },
+  )
+}
 
 export function Tabs(factories, options = {}) {
   if (!Array.isArray(factories) || factories.length === 0) {
@@ -30,6 +71,7 @@ export function Tabs(factories, options = {}) {
       const elByContent = new Map()
       // Retained for future programmatic activation API (tear-off, keyboard nav).
       let activeIdx = -1
+      const panelName = chrome.titleEl.textContent || 'tabs-panel'
 
       // Build tab strip in the header's controls slot.
       const tabStrip = document.createElement('div')
@@ -41,9 +83,8 @@ export function Tabs(factories, options = {}) {
         const label = c.manifest?.title || c.manifest?.name || `tab ${i + 1}`
         const btn = document.createElement('button')
         btn.className = 'aos-tab'
-        btn.type = 'button'
         btn.textContent = label
-        btn.setAttribute('role', 'tab')
+        applyPanelTabSemanticTarget(btn, c, i, { panelName, selected: false })
         btn.addEventListener('click', () => activate(i))
         tabStrip.appendChild(btn)
         return btn
@@ -54,6 +95,11 @@ export function Tabs(factories, options = {}) {
         const slot = document.createElement('div')
         slot.className = 'aos-tab-content'
         slot.setAttribute('role', 'tabpanel')
+        const tabButtonID = tabButtons[i].id || tabButtons[i].getAttribute?.('id') || `aos-tab-${i + 1}`
+        const slotID = `${tabButtonID}-panel`
+        slot.setAttribute('id', slotID)
+        slot.setAttribute('aria-labelledby', tabButtonID)
+        tabButtons[i].setAttribute('aria-controls', slotID)
         chrome.contentEl.appendChild(slot)
         elByContent.set(c, slot)
 
@@ -129,8 +175,8 @@ export function Tabs(factories, options = {}) {
           const slot = elByContent.get(c)
           slot.hidden = !isActive
           slot.dataset.active = String(isActive)
+          applyPanelTabSemanticTarget(tabButtons[i], c, i, { panelName, selected: isActive })
           tabButtons[i].classList.toggle('active', isActive)
-          tabButtons[i].setAttribute('aria-selected', String(isActive))
           tabButtons[i].dataset.active = String(isActive)
         })
         const content = contents[idx]

--- a/packages/toolkit/runtime/index.js
+++ b/packages/toolkit/runtime/index.js
@@ -23,6 +23,13 @@ export {
 } from './interaction-region.js'
 export { createInteractionSurface } from './interaction-surface.js'
 export {
+  aosRefForTarget,
+  applySemanticTargetAttributes,
+  createSemanticTargetElement,
+  normalizeSemanticTarget,
+  normalizeSemanticTargets,
+} from './semantic-targets.js'
+export {
   createDesktopWorldRangeDrag,
   desktopWorldRangeValue,
   updateDesktopWorldRangeDrag,

--- a/packages/toolkit/runtime/semantic-targets.js
+++ b/packages/toolkit/runtime/semantic-targets.js
@@ -1,0 +1,205 @@
+// semantic-targets.js — accessibility metadata and companion DOM helpers.
+//
+// This module keeps semantic names, AOS routing identity, and visual rendering
+// separate. It is intentionally small: apps own layout/behavior, while toolkit
+// normalizes the target contract and stamps standard metadata consistently.
+
+const AX_ROLE_ALIASES = {
+  AXButton: 'button',
+  AXMenu: 'menu',
+  AXMenuItem: 'menuitem',
+  AXCheckBox: 'checkbox',
+  AXRadioButton: 'radio',
+  AXSlider: 'slider',
+  AXTextField: 'textbox',
+  AXTextArea: 'textbox',
+  AXSearchField: 'searchbox',
+  AXGroup: 'group',
+  AXStaticText: 'text',
+  AXImage: 'img',
+  AXTab: 'tab',
+  AXTabGroup: 'tablist',
+  AXLink: 'link',
+}
+
+const NATIVE_BUTTON_ROLES = new Set(['button'])
+
+function finite(value, fallback = 0) {
+  const n = Number(value)
+  return Number.isFinite(n) ? n : fallback
+}
+
+function text(value, fallback = '') {
+  const s = String(value ?? '').replace(/\s+/g, ' ').trim()
+  return s || fallback
+}
+
+function safeId(value, fallback = 'target') {
+  return text(value, fallback).replace(/[^a-zA-Z0-9_-]/g, '-')
+}
+
+function pickName(target = {}) {
+  return text(target.name ?? target.ariaLabel ?? target.label ?? target.title ?? target.id, 'Target')
+}
+
+function pickAction(target = {}) {
+  return text(target.action ?? target.actionId ?? target.command, '')
+}
+
+function normalizeRole(role = 'button') {
+  const value = text(role, 'button')
+  return AX_ROLE_ALIASES[value] || value
+}
+
+function normalizeFrame(frame = null, fallback = null) {
+  const source = frame ?? fallback
+  if (!source) return null
+  if (Array.isArray(source) && source.length >= 4) {
+    const [x, y, w, h] = source
+    return normalizeFrameObject({ x, y, width: w, height: h })
+  }
+  if (typeof source === 'object') return normalizeFrameObject(source)
+  return null
+}
+
+function normalizeFrameObject(source = {}) {
+  const x = finite(source.x ?? source.left, NaN)
+  const y = finite(source.y ?? source.top, NaN)
+  const width = finite(source.width ?? source.w, NaN)
+  const height = finite(source.height ?? source.h, NaN)
+  if (![x, y, width, height].every(Number.isFinite)) return null
+  return {
+    x: Math.round(x),
+    y: Math.round(y),
+    width: Math.max(1, Math.round(width)),
+    height: Math.max(1, Math.round(height)),
+  }
+}
+
+function boolAttr(value) {
+  return value ? 'true' : 'false'
+}
+
+function setOrRemoveAttr(element, name, value) {
+  if (!element?.setAttribute) return
+  if (value === undefined || value === null || value === '') {
+    element.removeAttribute?.(name)
+    return
+  }
+  element.setAttribute(name, String(value))
+}
+
+function setDataset(element, name, value) {
+  if (!element?.dataset) return
+  if (value === undefined || value === null || value === '') {
+    delete element.dataset[name]
+    return
+  }
+  element.dataset[name] = String(value)
+}
+
+function roleTag(role) {
+  if (NATIVE_BUTTON_ROLES.has(role)) return 'button'
+  return 'div'
+}
+
+export function aosRefForTarget(target = {}, options = {}) {
+  if (target.aosRef) return text(target.aosRef)
+  const surface = text(target.surface ?? target.surfaceId ?? options.surface ?? options.surfaceId, '')
+  const id = safeId(target.id ?? target.name)
+  return surface ? `${surface}:${id}` : id
+}
+
+export function normalizeSemanticTarget(target = {}, options = {}) {
+  if (!target || typeof target !== 'object') throw new Error('semantic target must be an object')
+  const id = text(target.id ?? target.ref ?? target.name, '')
+  if (!id) throw new Error('semantic target requires id')
+  const role = normalizeRole(target.role ?? options.role ?? 'button')
+  const name = pickName(target)
+  const action = pickAction(target)
+  const surface = text(target.surface ?? target.surfaceId ?? options.surface ?? options.surfaceId, '')
+  const frame = normalizeFrame(target.frame ?? target.rect ?? target.bounds, options.frame)
+  const normalized = {
+    id,
+    role,
+    name,
+    action,
+    enabled: target.enabled === undefined ? true : !!target.enabled,
+    current: target.current ?? target.active ?? null,
+    pressed: target.pressed ?? null,
+    selected: target.selected ?? null,
+    checked: target.checked ?? null,
+    expanded: target.expanded ?? null,
+    value: target.value ?? null,
+    surface,
+    parentCanvasId: text(target.parentCanvasId ?? options.parentCanvasId, ''),
+    aosRef: aosRefForTarget({ ...target, id, surface }, options),
+    metadata: {
+      ...(target.metadata && typeof target.metadata === 'object' ? target.metadata : {}),
+    },
+  }
+  if (frame) normalized.frame = frame
+  return normalized
+}
+
+export function normalizeSemanticTargets(targets = [], options = {}) {
+  if (!Array.isArray(targets)) return []
+  return targets.map((target) => normalizeSemanticTarget(target, options))
+}
+
+export function applySemanticTargetAttributes(element, target = {}, options = {}) {
+  if (!element) return null
+  const normalized = normalizeSemanticTarget(target, options)
+  const nativeTag = element.tagName?.toLowerCase?.()
+
+  setOrRemoveAttr(element, 'id', options.idPrefix === null ? element.id : `${options.idPrefix || 'aos-semantic-target'}-${safeId(normalized.id)}`)
+  if (!(nativeTag === 'button' && normalized.role === 'button')) {
+    setOrRemoveAttr(element, 'role', normalized.role)
+  } else {
+    element.removeAttribute?.('role')
+  }
+  if (nativeTag === 'button') setOrRemoveAttr(element, 'type', 'button')
+  setOrRemoveAttr(element, 'aria-label', normalized.name)
+  setOrRemoveAttr(element, 'aria-disabled', normalized.enabled ? null : 'true')
+  if (normalized.current !== null) setOrRemoveAttr(element, 'aria-current', normalized.current === true ? 'true' : normalized.current)
+  else element.removeAttribute?.('aria-current')
+  if (normalized.pressed !== null) setOrRemoveAttr(element, 'aria-pressed', boolAttr(normalized.pressed))
+  else element.removeAttribute?.('aria-pressed')
+  if (normalized.selected !== null) setOrRemoveAttr(element, 'aria-selected', boolAttr(normalized.selected))
+  else element.removeAttribute?.('aria-selected')
+  if (normalized.checked !== null) setOrRemoveAttr(element, 'aria-checked', boolAttr(normalized.checked))
+  else element.removeAttribute?.('aria-checked')
+  if (normalized.expanded !== null) setOrRemoveAttr(element, 'aria-expanded', boolAttr(normalized.expanded))
+  else element.removeAttribute?.('aria-expanded')
+  if (normalized.value !== null) setOrRemoveAttr(element, 'aria-valuetext', normalized.value)
+  else element.removeAttribute?.('aria-valuetext')
+
+  if ('disabled' in element) element.disabled = nativeTag === 'button' && !normalized.enabled
+  setDataset(element, 'aosRef', normalized.aosRef)
+  setDataset(element, 'aosAction', normalized.action)
+  setDataset(element, 'aosSurface', normalized.surface)
+  setDataset(element, 'semanticTargetId', normalized.id)
+  setDataset(element, 'aosParentCanvas', normalized.parentCanvasId)
+
+  if (normalized.frame && element.style) {
+    element.style.position = options.position || 'absolute'
+    element.style.left = `${normalized.frame.x}px`
+    element.style.top = `${normalized.frame.y}px`
+    element.style.width = `${normalized.frame.width}px`
+    element.style.height = `${normalized.frame.height}px`
+  }
+  if (options.visibleLabel) {
+    element.textContent = normalized.name
+  } else if (element.textContent) {
+    element.textContent = ''
+  }
+  return normalized
+}
+
+export function createSemanticTargetElement(documentRef, target = {}, options = {}) {
+  if (!documentRef?.createElement) throw new Error('document with createElement is required')
+  const normalized = normalizeSemanticTarget(target, options)
+  const element = documentRef.createElement(options.tagName || roleTag(normalized.role))
+  applySemanticTargetAttributes(element, normalized, options)
+  return element
+}

--- a/tests/renderer/radial-menu-target-surface.test.mjs
+++ b/tests/renderer/radial-menu-target-surface.test.mjs
@@ -1,0 +1,156 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import {
+  createRadialMenuTargetSurface,
+  radialMenuTargetsFromSnapshot,
+  radialMenuWorldRect,
+} from '../../apps/sigil/renderer/live-modules/radial-menu-target-surface.js'
+
+const radialSnapshot = {
+  phase: 'radial',
+  activeItemId: 'wiki-graph',
+  items: [
+    {
+      id: 'context-menu',
+      label: 'Context Menu',
+      action: 'contextMenu',
+      center: { x: 100, y: 80 },
+      hitRadius: 12,
+      visualRadius: 10,
+    },
+    {
+      id: 'wiki-graph',
+      label: 'Wiki Graph',
+      action: 'wikiGraph',
+      center: { x: 180, y: 80 },
+      hitRadius: 12,
+      visualRadius: 10,
+    },
+  ],
+}
+
+test('radial menu targets enforce AOS-sized hit surfaces', () => {
+  const targets = radialMenuTargetsFromSnapshot(radialSnapshot, { targetMinSize: 56 })
+
+  assert.equal(targets.length, 2)
+  assert.equal(targets[0].label, 'Context Menu')
+  assert.equal(targets[0].name, 'Context Menu')
+  assert.equal(targets[0].ariaLabel, 'Context Menu')
+  assert.equal(targets[0].role, 'AXButton')
+  assert.equal(targets[0].aosRef, 'sigil-radial-item-context-menu')
+  assert.equal(targets[0].size, 56)
+  assert.equal(targets[1].active, true)
+})
+
+test('radial menu surface keeps labels in AX attributes, not visible text', async () => {
+  const html = await readFile(new URL('../../apps/sigil/renderer/radial-menu-surface.html', import.meta.url), 'utf8')
+
+  assert.match(html, /applySemanticTargetAttributes/)
+  assert.match(html, /aria-label="Sigil radial menu"/)
+  assert.match(html, /dataset\.radialItemId/)
+  assert.match(html, /dataset\.radialAction/)
+  assert.doesNotMatch(html, /Sigil radial item:/)
+  assert.doesNotMatch(html, /radial-item-label/)
+  assert.doesNotMatch(html, /radial-item-action/)
+  assert.doesNotMatch(html, /textContent\s*=\s*item\.label/)
+  assert.doesNotMatch(html, /button\.title\s*=/)
+})
+
+test('radial menu target bounds include all exposed targets', () => {
+  const targets = radialMenuTargetsFromSnapshot(radialSnapshot, { targetMinSize: 56 })
+  const rect = radialMenuWorldRect(targets, { padding: 10 })
+
+  assert.deepEqual(rect, { x: 62, y: 42, w: 156, h: 76 })
+})
+
+test('radial menu target surface creates an offscreen child and posts live item geometry', async () => {
+  const creates = []
+  const updates = []
+  const posts = []
+  const runtime = {
+    canvasCreate(payload) {
+      creates.push(payload)
+      return Promise.resolve({ id: payload.id })
+    },
+    canvasUpdate(payload) {
+      updates.push(payload)
+    },
+    post(type, payload) {
+      posts.push({ type, payload })
+    },
+  }
+
+  const surface = createRadialMenuTargetSurface({
+    runtime,
+    url: 'aos://sigil/renderer/radial-menu-surface.html',
+    id: 'sigil-radial-menu-test',
+    targetMinSize: 56,
+    framePadding: 10,
+  })
+
+  await surface.ensureCreated()
+  assert.equal(creates.length, 1)
+  assert.equal(creates[0].interactive, false)
+  assert.equal(creates[0].window_level, 'screen_saver')
+  assert.equal(creates[0].parent, 'avatar-main')
+  assert.match(creates[0].url, /parent=avatar-main/)
+
+  assert.equal(surface.sync(radialSnapshot, { displays: [] }), true)
+  assert.deepEqual(updates[0], {
+    id: 'sigil-radial-menu-test',
+    frame: [62, 42, 156, 76],
+    interactive: true,
+  })
+  assert.equal(posts.length, 1)
+  assert.equal(posts[0].type, 'canvas.send')
+  assert.equal(posts[0].payload.target, 'sigil-radial-menu-test')
+  assert.equal(posts[0].payload.message.type, 'radial_menu.surface.update')
+  assert.deepEqual(
+    posts[0].payload.message.payload.items.map((item) => ({
+      id: item.id,
+      label: item.label,
+      name: item.name,
+      action: item.action,
+      ariaLabel: item.ariaLabel,
+      aosRef: item.aosRef,
+      active: item.active,
+      x: item.x,
+      y: item.y,
+      size: item.size,
+    })),
+    [
+      {
+        id: 'context-menu',
+        label: 'Context Menu',
+        name: 'Context Menu',
+        action: 'contextMenu',
+        ariaLabel: 'Context Menu',
+        aosRef: 'sigil-radial-item-context-menu',
+        active: false,
+        x: 38,
+        y: 38,
+        size: 56,
+      },
+      {
+        id: 'wiki-graph',
+        label: 'Wiki Graph',
+        name: 'Wiki Graph',
+        action: 'wikiGraph',
+        ariaLabel: 'Wiki Graph',
+        aosRef: 'sigil-radial-item-wiki-graph',
+        active: true,
+        x: 118,
+        y: 38,
+        size: 56,
+      },
+    ]
+  )
+
+  assert.equal(surface.sync({ phase: 'idle', items: [] }, { displays: [] }), false)
+  assert.deepEqual(updates[1], {
+    id: 'sigil-radial-menu-test',
+    frame: [-10000, -10000, 156, 76],
+    interactive: false,
+  })
+})

--- a/tests/sigil-avatar-interactions.sh
+++ b/tests/sigil-avatar-interactions.sh
@@ -174,8 +174,10 @@ wait_until(
     lambda: (
         lambda snap: snap
         if snap.get("radialGestureVisuals", {}).get("visible") is True
-        and set(snap.get("radialGestureVisuals", {}).get("itemIds", [])) == {"context-menu", "wiki-graph"}
+        and {"context-menu", "wiki-graph"}.issubset(set(snap.get("radialGestureVisuals", {}).get("itemIds", [])))
         and snap.get("radialGestureVisuals", {}).get("scales", {}).get("context-menu", 0) > 0
+        and snap.get("radialTargetSurface", {}).get("interactive") is True
+        and {"context-menu", "wiki-graph"}.issubset({target.get("id") for target in snap.get("radialTargetSurface", {}).get("targets", [])})
         else None
     )(show_eval_json("JSON.stringify(window.__sigilDebug.snapshot())")),
     timeout=3.0,

--- a/tests/toolkit/canvas-inspector-ax.test.mjs
+++ b/tests/toolkit/canvas-inspector-ax.test.mjs
@@ -1,0 +1,115 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  renderCanvasListToggleButton,
+  renderCanvasRow,
+  renderCursorToggleRowHTML,
+  renderMouseEventsToggleRowHTML,
+} from '../../packages/toolkit/components/canvas-inspector/index.js'
+import {
+  canvasActionAttrs,
+  canvasInspectorAosRef,
+  inspectorControlAttrs,
+} from '../../packages/toolkit/components/canvas-inspector/semantics.js'
+
+test('canvas action attrs expose stable AOS target metadata', () => {
+  const attrs = canvasActionAttrs('avatar-main', 'stats', { pressed: true })
+
+  assert.match(attrs, /aria-label="Stats for canvas avatar-main"/)
+  assert.match(attrs, /data-aos-ref="canvas-inspector:canvas:avatar-main:stats"/)
+  assert.match(attrs, /data-aos-surface="canvas-inspector"/)
+  assert.match(attrs, /data-aos-action="toggle_stats"/)
+  assert.match(attrs, /data-semantic-target-id="stats-avatar-main"/)
+  assert.match(attrs, /aria-pressed="true"/)
+})
+
+test('renderCanvasRow stamps semantic metadata on canvas action buttons', () => {
+  const html = renderCanvasRow({
+    id: 'avatar-main',
+    at: [0, 0, 200, 100],
+  }, 0, {
+    statsIds: new Set(['avatar-main']),
+    tintedIds: new Set(['avatar-main']),
+  })
+
+  assert.match(html, /class="btn stats-btn active"[^>]*aria-label="Stats for canvas avatar-main"[^>]*data-aos-action="toggle_stats"[^>]*aria-pressed="true"[^>]*>stats<\/button>/)
+  assert.match(html, /class="btn tint-btn active"[^>]*aria-label="Tint canvas avatar-main"[^>]*data-aos-action="toggle_tint"[^>]*aria-pressed="true"[^>]*>tint<\/button>/)
+  assert.match(html, /class="btn remove-btn"[^>]*aria-label="Remove canvas avatar-main"[^>]*data-aos-action="remove_canvas"[^>]*>\u2715<\/button>/)
+})
+
+test('renderCanvasRow stamps semantic metadata on DesktopWorld surface actions', () => {
+  const html = renderCanvasRow({
+    id: 'desktop-world',
+    at: [0, 0, 3840, 1080],
+    track: 'union',
+    segments: [
+      { display_id: 1, index: 0, dw_bounds: [0, 0, 1920, 1080], native_bounds: [0, 0, 1920, 1080] },
+    ],
+  }, 0, {
+    tintedIds: new Set(['desktop-world']),
+  })
+
+  assert.match(html, /desktop-world/)
+  assert.match(html, /data-aos-ref="canvas-inspector:canvas:desktop-world:stats"/)
+  assert.match(html, /data-aos-ref="canvas-inspector:canvas:desktop-world:tint"[^>]*aria-pressed="true"/)
+  assert.match(html, /data-aos-ref="canvas-inspector:canvas:desktop-world:remove"/)
+})
+
+test('canvas action attrs escape hostile canvas identifiers', () => {
+  const html = renderCanvasRow({
+    id: '<avatar>',
+    at: [0, 0, 200, 100],
+  }, 0)
+
+  assert.match(html, /aria-label="Stats for canvas &lt;avatar&gt;"/)
+  assert.match(html, /data-aos-ref="canvas-inspector:canvas:&lt;avatar&gt;:stats"/)
+  assert.match(html, /data-semantic-target-id="stats-&lt;avatar&gt;"/)
+  assert.doesNotMatch(html, /aria-label="Stats for canvas <avatar>"/)
+})
+
+test('inspector control attrs expose pressed and expanded states', () => {
+  const pressed = inspectorControlAttrs('minimap-cursor', {
+    name: 'Minimap cursor',
+    action: 'toggle_minimap_cursor',
+    pressed: true,
+  })
+  const expanded = inspectorControlAttrs('canvas-list-toggle', {
+    name: 'Hide canvas list',
+    action: 'toggle_canvas_list',
+    expanded: true,
+  })
+
+  assert.match(pressed, /aria-label="Minimap cursor"/)
+  assert.match(pressed, /data-aos-action="toggle_minimap_cursor"/)
+  assert.match(pressed, /data-aos-ref="canvas-inspector:control:minimap-cursor"/)
+  assert.match(pressed, /aria-pressed="true"/)
+  assert.match(expanded, /aria-label="Hide canvas list"/)
+  assert.match(expanded, /data-aos-action="toggle_canvas_list"/)
+  assert.match(expanded, /aria-expanded="true"/)
+})
+
+test('cursor and mouse event toggles keep visible on/off text but expose AX names', () => {
+  const cursor = renderCursorToggleRowHTML({ depth: 1, enabled: true })
+  const mouse = renderMouseEventsToggleRowHTML({ depth: 1, enabled: false })
+
+  assert.match(cursor, /<button class="btn cursor-toggle-btn active"[^>]*aria-label="Minimap cursor"[^>]*aria-pressed="true"[^>]*>on<\/button>/)
+  assert.match(mouse, /<button class="btn mouse-events-toggle-btn"[^>]*aria-label="Mouse events"[^>]*aria-pressed="false"[^>]*>off<\/button>/)
+})
+
+test('canvas list disclosure exposes semantic action and expanded state', () => {
+  const collapsed = renderCanvasListToggleButton({ collapsed: true })
+  const expanded = renderCanvasListToggleButton({ collapsed: false })
+
+  assert.match(collapsed, /class="canvas-list-toggle"[^>]*aria-label="Show canvas list"[^>]*aria-expanded="false"/)
+  assert.match(collapsed, /data-aos-action="toggle_canvas_list"/)
+  assert.match(expanded, /class="canvas-list-toggle"[^>]*aria-label="Hide canvas list"[^>]*aria-expanded="true"/)
+  assert.match(expanded, /class="canvas-list-caret open"/)
+})
+
+test('canvasInspectorAosRef normalizes whitespace in stable refs', () => {
+  assert.equal(
+    canvasInspectorAosRef('canvas', 'avatar main', 'stats'),
+    'canvas-inspector:canvas:avatar-main:stats',
+  )
+})

--- a/tests/toolkit/canvas-inspector-marks-render.test.mjs
+++ b/tests/toolkit/canvas-inspector-marks-render.test.mjs
@@ -73,18 +73,29 @@ test('buildMarkLayers respects custom w and h', () => {
 });
 
 test('renderMinimapMark centers mark on projected point and embeds metadata', () => {
-  const svg = renderMinimapMark(mark({ id: 'avatar', name: 'Avatar' }), { x: 50, y: 60 });
+  const svg = renderMinimapMark(mark({ id: 'avatar', name: 'Avatar', x: 100, y: 120 }), { x: 50, y: 60 }, { canvasId: 'avatar-main' });
   assert.match(svg, /left:40px/);  // 50 - 20/2
   assert.match(svg, /top:50px/);   // 60 - 20/2
+  assert.match(svg, /role="img"/);
+  assert.match(svg, /aria-label="Avatar"/);
+  assert.match(svg, /data-aos-ref="canvas-inspector:mark:avatar-main:avatar"/);
+  assert.match(svg, /data-aos-parent-canvas="avatar-main"/);
+  assert.match(svg, /data-canvas-id="avatar-main"/);
   assert.match(svg, /data-mark-id="avatar"/);
+  assert.match(svg, /data-mark-x="100"/);
+  assert.match(svg, /data-mark-y="120"/);
   assert.match(svg, /<title>Avatar<\/title>/);
   assert.match(svg, /class="minimap-mark"/);
   assert.match(svg, /viewBox="0 0 20 20"/);
+  assert.doesNotMatch(svg, /data-aos-action=/);
 });
 
 test('renderMinimapMark escapes id and name', () => {
-  const svg = renderMinimapMark(mark({ id: 'x"<y', name: '<b>bold</b>' }), { x: 0, y: 0 });
+  const svg = renderMinimapMark(mark({ id: 'x"<y', name: '<b>bold</b>' }), { x: 0, y: 0 }, { canvasId: 'canvas"<id' });
+  assert.match(svg, /aria-label="&lt;b&gt;bold&lt;\/b&gt;"/);
+  assert.match(svg, /data-canvas-id="canvas&quot;&lt;id"/);
   assert.match(svg, /data-mark-id="x&quot;&lt;y"/);
+  assert.match(svg, /data-aos-ref="canvas-inspector:mark:canvas&quot;&lt;id:x&quot;&lt;y"/);
   assert.match(svg, /<title>&lt;b&gt;bold&lt;\/b&gt;<\/title>/);
 });
 
@@ -95,6 +106,7 @@ test('renderMarkListRow emits name only by default (no coords, no swatch, no but
   assert.match(html, /<span class="mark-name">Avatar<\/span>/);
   assert.doesNotMatch(html, /mark-coords/);
   assert.doesNotMatch(html, /<button/);
+  assert.doesNotMatch(html, /data-aos-action=/);
   assert.doesNotMatch(html, /swatch/);
   assert.doesNotMatch(html, /<img/);
 });

--- a/tests/toolkit/integration-hub-semantics.test.mjs
+++ b/tests/toolkit/integration-hub-semantics.test.mjs
@@ -1,0 +1,286 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import IntegrationHub from '../../packages/toolkit/components/integration-hub/index.js'
+import {
+  applyIntegrationHubSemanticTarget,
+  applyIntegrationHubSemantics,
+  integrationHubAosRef,
+} from '../../packages/toolkit/components/integration-hub/semantics.js'
+
+function dataAttrName(name) {
+  return name.replace(/^data-/, '').replace(/-([a-z])/g, (_, char) => char.toUpperCase())
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+}
+
+class FakeElement {
+  constructor(tagName = 'div') {
+    this.tagName = tagName.toUpperCase()
+    this.attributes = new Map()
+    this.dataset = {}
+    this.style = {}
+    this.listeners = new Map()
+    this.disabled = false
+    this.className = ''
+    this.value = ''
+    this._textContent = ''
+    this._innerHTML = ''
+    this.controls = {}
+    this.classList = {
+      contains: (className) => this.className.split(/\s+/).includes(className),
+    }
+  }
+
+  set textContent(value) {
+    this._textContent = String(value ?? '')
+    if (!this.classList.contains('integration-hub-root')) {
+      this._innerHTML = escapeHtml(this._textContent)
+    }
+  }
+
+  get textContent() {
+    return this._textContent
+  }
+
+  set innerHTML(value) {
+    this._innerHTML = String(value ?? '')
+    if (this.classList.contains('integration-hub-root')) this.parseIntegrationHubControls()
+  }
+
+  get innerHTML() {
+    return this._innerHTML
+  }
+
+  setAttribute(name, value) {
+    const normalized = String(value)
+    this.attributes.set(name, normalized)
+    if (name === 'id') this.id = normalized
+    if (name === 'type') this.type = normalized
+    if (name === 'class') this.className = normalized
+    if (name.startsWith('data-')) this.dataset[dataAttrName(name)] = normalized
+  }
+
+  removeAttribute(name) {
+    this.attributes.delete(name)
+    if (name === 'id') delete this.id
+    if (name === 'type') delete this.type
+    if (name.startsWith('data-')) delete this.dataset[dataAttrName(name)]
+  }
+
+  getAttribute(name) {
+    if (name.startsWith('data-')) return this.dataset[dataAttrName(name)] ?? null
+    return this.attributes.get(name) ?? null
+  }
+
+  addEventListener(type, handler) {
+    const handlers = this.listeners.get(type) ?? []
+    handlers.push(handler)
+    this.listeners.set(type, handlers)
+  }
+
+  querySelector(selector) {
+    switch (selector) {
+      case '#integration-hub-command':
+        return this.controls.input ?? null
+      case '.integration-hub-action':
+        return this.controls.action ?? null
+      case '.integration-hub-refresh':
+        return this.controls.refresh ?? null
+      case '.integration-hub-grid':
+        return this.controls.panel ?? null
+      default:
+        return null
+    }
+  }
+
+  querySelectorAll(selector) {
+    if (selector === '.integration-hub-surface-tab') return this.controls.tabs ?? []
+    return []
+  }
+
+  parseIntegrationHubControls() {
+    const inputMatch = this._innerHTML.match(/<input[^>]*id="integration-hub-command"[^>]*value="([^"]*)"[^>]*>/)
+    const actionMatch = this._innerHTML.match(/<button[^>]*class="integration-hub-action"[^>]*>([^<]*)<\/button>/)
+    const tabs = [...this._innerHTML.matchAll(/<button[^>]*class="([^"]*integration-hub-surface-tab[^"]*)"[^>]*data-surface="([^"]*)"[^>]*>([^<]*)<\/button>/g)]
+
+    this.controls = {
+      refresh: this._innerHTML.includes('class="integration-hub-refresh"')
+        ? Object.assign(new FakeElement('button'), { className: 'integration-hub-refresh', textContent: 'Refresh' })
+        : null,
+      panel: this._innerHTML.includes('class="integration-hub-grid"')
+        ? Object.assign(new FakeElement('section'), { className: 'integration-hub-grid' })
+        : null,
+      input: inputMatch
+        ? Object.assign(new FakeElement('input'), { id: 'integration-hub-command', value: inputMatch[1] })
+        : null,
+      action: actionMatch
+        ? Object.assign(new FakeElement('button'), { className: 'integration-hub-action', textContent: actionMatch[1] })
+        : null,
+      tabs: tabs.map((match) => {
+        const button = new FakeElement('button')
+        button.className = match[1]
+        button.dataset.surface = match[2]
+        button.textContent = match[3]
+        return button
+      }),
+    }
+  }
+}
+
+class FakeDocument {
+  createElement(tagName) {
+    return new FakeElement(tagName)
+  }
+}
+
+test('integration hub refs are scoped to the surface', () => {
+  assert.equal(integrationHubAosRef('command-send'), 'integration-hub:command-send')
+  assert.equal(integrationHubAosRef('surface tab/jobs'), 'integration-hub:surface-tab-jobs')
+})
+
+test('command send semantics preserve the visible button label', () => {
+  const button = new FakeElement('button')
+  button.textContent = 'Send'
+
+  applyIntegrationHubSemanticTarget(button, {
+    id: 'command-send',
+    name: 'Send command',
+    action: 'send_command',
+  }, {
+    preserveText: true,
+  })
+
+  assert.equal(button.getAttribute('id'), 'integration-hub-command-send')
+  assert.equal(button.getAttribute('role'), null)
+  assert.equal(button.getAttribute('type'), 'button')
+  assert.equal(button.getAttribute('aria-label'), 'Send command')
+  assert.equal(button.dataset.aosRef, 'integration-hub:command-send')
+  assert.equal(button.dataset.aosAction, 'send_command')
+  assert.equal(button.dataset.aosSurface, 'integration-hub')
+  assert.equal(button.dataset.semanticTargetId, 'command-send')
+  assert.equal(button.textContent, 'Send')
+})
+
+test('command input keeps its existing DOM id for the label binding', () => {
+  const input = new FakeElement('input')
+  input.id = 'integration-hub-command'
+  input.value = 'status'
+
+  applyIntegrationHubSemanticTarget(input, {
+    id: 'command-input',
+    role: 'AXTextField',
+    name: 'Integration command',
+    action: 'edit_command',
+    value: input.value,
+  }, {
+    idPrefix: null,
+  })
+
+  assert.equal(input.getAttribute('id'), 'integration-hub-command')
+  assert.equal(input.getAttribute('role'), 'textbox')
+  assert.equal(input.getAttribute('aria-label'), 'Integration command')
+  assert.equal(input.getAttribute('aria-valuetext'), 'status')
+  assert.equal(input.dataset.aosRef, 'integration-hub:command-input')
+  assert.equal(input.dataset.aosAction, 'edit_command')
+})
+
+test('surface tabs receive tab state and AOS metadata without label changes', () => {
+  const input = new FakeElement('input')
+  input.id = 'integration-hub-command'
+  input.value = 'features'
+  const action = new FakeElement('button')
+  action.textContent = 'Send'
+  const refresh = new FakeElement('button')
+  refresh.textContent = 'Refresh'
+  const panel = new FakeElement('section')
+  const jobsTab = new FakeElement('button')
+  jobsTab.className = 'integration-hub-surface-tab active'
+  jobsTab.dataset.surface = 'jobs'
+  jobsTab.textContent = 'Jobs'
+  const activityTab = new FakeElement('button')
+  activityTab.className = 'integration-hub-surface-tab'
+  activityTab.dataset.surface = 'activity'
+  activityTab.textContent = 'Activity'
+  const root = new FakeElement('div')
+  root.controls = {
+    input,
+    action,
+    refresh,
+    panel,
+    tabs: [jobsTab, activityTab],
+  }
+
+  applyIntegrationHubSemantics(root, {
+    activeSurface: 'jobs',
+    simulateText: 'features',
+    sending: false,
+  })
+
+  assert.equal(refresh.dataset.aosAction, 'refresh_snapshot')
+  assert.equal(action.textContent, 'Send')
+  assert.equal(action.getAttribute('aria-label'), 'Send command')
+  assert.equal(panel.getAttribute('id'), 'integration-hub-surface-panel')
+  assert.equal(panel.getAttribute('role'), 'tabpanel')
+  assert.equal(jobsTab.getAttribute('role'), 'tab')
+  assert.equal(jobsTab.getAttribute('aria-selected'), 'true')
+  assert.equal(jobsTab.getAttribute('aria-controls'), 'integration-hub-surface-panel')
+  assert.equal(jobsTab.dataset.aosAction, 'select_surface')
+  assert.equal(jobsTab.dataset.aosRef, 'integration-hub:surface-tab-jobs')
+  assert.equal(jobsTab.textContent, 'Jobs')
+  assert.equal(activityTab.getAttribute('aria-selected'), 'false')
+  assert.equal(activityTab.textContent, 'Activity')
+})
+
+test('rendered integration hub stamps actionable controls with semantic metadata', (t) => {
+  const previousDocument = globalThis.document
+  const previousWindow = globalThis.window
+  const previousFetch = globalThis.fetch
+  const intervals = new Set()
+  globalThis.document = new FakeDocument()
+  globalThis.window = {
+    setInterval(handler, ms) {
+      const id = { handler, ms }
+      intervals.add(id)
+      return id
+    },
+    clearInterval(id) {
+      intervals.delete(id)
+    },
+  }
+  globalThis.fetch = () => new Promise(() => {})
+  let hub = null
+  t.after(() => {
+    hub?.teardown()
+    globalThis.document = previousDocument
+    globalThis.window = previousWindow
+    globalThis.fetch = previousFetch
+  })
+
+  hub = IntegrationHub({ pollMs: 60000 })
+  hub.restore({ activeSurface: 'activity', simulateText: 'status' })
+  const titles = []
+  const root = hub.render({ setTitle: (title) => titles.push(title) })
+
+  const input = root.querySelector('#integration-hub-command')
+  const send = root.querySelector('.integration-hub-action')
+  const refresh = root.querySelector('.integration-hub-refresh')
+  const activityTab = root.querySelectorAll('.integration-hub-surface-tab')
+    .find((button) => button.dataset.surface === 'activity')
+
+  assert.equal(input.getAttribute('id'), 'integration-hub-command')
+  assert.equal(input.dataset.aosAction, 'edit_command')
+  assert.equal(send.textContent, 'Send')
+  assert.equal(send.getAttribute('aria-label'), 'Send command')
+  assert.equal(send.dataset.aosRef, 'integration-hub:command-send')
+  assert.equal(refresh.dataset.aosAction, 'refresh_snapshot')
+  assert.equal(activityTab.getAttribute('role'), 'tab')
+  assert.equal(activityTab.getAttribute('aria-selected'), 'true')
+  assert.equal(activityTab.dataset.aosAction, 'select_surface')
+  assert.deepEqual(titles, ['Ops', 'Ops'])
+})

--- a/tests/toolkit/passive-component-semantics.test.mjs
+++ b/tests/toolkit/passive-component-semantics.test.mjs
@@ -1,0 +1,190 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import InspectorPanel from '../../packages/toolkit/components/inspector-panel/index.js'
+import LogConsole from '../../packages/toolkit/components/log-console/index.js'
+import RenderPerformance from '../../packages/toolkit/components/render-performance/index.js'
+import SpatialTelemetry from '../../packages/toolkit/components/spatial-telemetry/index.js'
+
+class FakeElement {
+  constructor(tagName = 'div') {
+    this.tagName = tagName.toUpperCase()
+    this.attributes = {}
+    this.children = []
+    this.style = {}
+    this._innerHTML = ''
+    this._textContent = ''
+    this.id = ''
+    this.className = ''
+  }
+
+  setAttribute(name, value) {
+    this.attributes[name] = String(value)
+  }
+
+  getAttribute(name) {
+    return this.attributes[name] ?? null
+  }
+
+  appendChild(child) {
+    this.children.push(child)
+    return child
+  }
+
+  removeChild(child) {
+    this.children = this.children.filter((candidate) => candidate !== child)
+    return child
+  }
+
+  get firstChild() {
+    return this.children[0] || null
+  }
+
+  get childElementCount() {
+    return this.children.length
+  }
+
+  get innerHTML() {
+    return this._innerHTML
+  }
+
+  set innerHTML(value) {
+    this._innerHTML = String(value)
+    this.children = []
+  }
+
+  get textContent() {
+    return this._textContent
+  }
+
+  set textContent(value) {
+    this._textContent = String(value)
+  }
+
+  addEventListener() {}
+  querySelectorAll() { return [] }
+}
+
+function withFakeBrowser(t) {
+  const previous = {
+    document: globalThis.document,
+    window: globalThis.window,
+    performance: globalThis.performance,
+    requestAnimationFrame: globalThis.requestAnimationFrame,
+    cancelAnimationFrame: globalThis.cancelAnimationFrame,
+    navigator: globalThis.navigator,
+  }
+
+  globalThis.document = {
+    visibilityState: 'visible',
+    createElement(tagName) {
+      return new FakeElement(tagName)
+    },
+    addEventListener() {},
+  }
+  globalThis.window = {
+    innerWidth: 800,
+    innerHeight: 600,
+    devicePixelRatio: 2,
+  }
+  globalThis.performance = {
+    now: () => 0,
+    memory: null,
+  }
+  globalThis.requestAnimationFrame = () => 1
+  globalThis.cancelAnimationFrame = () => {}
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: { hardwareConcurrency: 8 },
+  })
+
+  t.after(() => {
+    globalThis.document = previous.document
+    globalThis.window = previous.window
+    globalThis.performance = previous.performance
+    globalThis.requestAnimationFrame = previous.requestAnimationFrame
+    globalThis.cancelAnimationFrame = previous.cancelAnimationFrame
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: previous.navigator,
+    })
+  })
+}
+
+function fakeHost() {
+  const titles = []
+  return {
+    contentEl: new FakeElement('div'),
+    titles,
+    setTitle(title) {
+      titles.push(title)
+    },
+  }
+}
+
+test('InspectorPanel exposes a passive AX region', (t) => {
+  withFakeBrowser(t)
+
+  const panel = InspectorPanel()
+  const root = panel.render(fakeHost())
+
+  assert.equal(root.getAttribute('role'), 'region')
+  assert.equal(root.getAttribute('aria-label'), 'AX Inspector')
+})
+
+test('LogConsole exposes entries as an aria-live log', (t) => {
+  withFakeBrowser(t)
+
+  const log = LogConsole()
+  const root = log.render(fakeHost())
+
+  assert.equal(root.getAttribute('role'), 'log')
+  assert.equal(root.getAttribute('aria-label'), 'Log entries')
+  assert.equal(root.getAttribute('aria-live'), 'polite')
+  assert.equal(root.getAttribute('aria-relevant'), 'additions text')
+})
+
+test('RenderPerformance exposes root region and sparkline image semantics', (t) => {
+  withFakeBrowser(t)
+
+  const perf = RenderPerformance()
+  const root = perf.render(fakeHost())
+
+  assert.equal(root.getAttribute('role'), 'region')
+  assert.equal(root.getAttribute('aria-label'), 'Render Performance')
+
+  window.__renderPerformanceDebug.sample({ source: 'debug', frameMs: 16, fps: 62 })
+  assert.match(root.innerHTML, /class="perf-sparkline" role="img" aria-label="Frame-time sparkline"/)
+})
+
+test('SpatialTelemetry exposes root region, labeled tables, and log semantics', (t) => {
+  withFakeBrowser(t)
+
+  const telemetry = SpatialTelemetry()
+  const root = telemetry.render(fakeHost())
+
+  assert.equal(root.getAttribute('role'), 'region')
+  assert.equal(root.getAttribute('aria-label'), 'Spatial Telemetry')
+
+  telemetry.onMessage({
+    type: 'bootstrap',
+    payload: {
+      displays: [{
+        id: 1,
+        is_main: true,
+        bounds: { x: 0, y: 0, w: 800, h: 600 },
+        visible_bounds: { x: 0, y: 0, w: 800, h: 560 },
+        native_bounds: { x: 0, y: 0, w: 800, h: 600 },
+        native_visible_bounds: { x: 0, y: 0, w: 800, h: 560 },
+        scale_factor: 1,
+      }],
+      canvases: [{ id: 'demo', at: [10, 20, 100, 80], interactive: true }],
+      cursor: { x: 30, y: 40 },
+    },
+  })
+
+  assert.match(root.innerHTML, /<table class="telemetry-table" aria-label="Display geometry">/)
+  assert.match(root.innerHTML, /<table class="telemetry-table" aria-label="Canvas geometry">/)
+  assert.match(root.innerHTML, /<table class="telemetry-table" aria-label="Cursor position">/)
+  assert.match(root.innerHTML, /class="event-log" role="log" aria-label="Telemetry events" aria-live="polite"/)
+})

--- a/tests/toolkit/runtime-semantic-targets.test.mjs
+++ b/tests/toolkit/runtime-semantic-targets.test.mjs
@@ -7,8 +7,6 @@ import {
   normalizeSemanticTarget,
   normalizeSemanticTargets,
 } from '../../packages/toolkit/runtime/semantic-targets.js'
-import { descriptorFromElement } from '../../packages/toolkit/browser-intent-sensor/dom-crawl.js'
-import { buildLocatorCandidates } from '../../packages/toolkit/browser-intent-sensor/canonicalize.js'
 
 function dataAttrName(name) {
   return name.replace(/^data-/, '').replace(/-([a-z])/g, (_, char) => char.toUpperCase())
@@ -181,25 +179,4 @@ test('applySemanticTargetAttributes removes stale optional attrs on update', () 
   assert.equal(element.dataset.aosAction, undefined)
   assert.equal(element.dataset.aosSurface, undefined)
   assert.equal(element.dataset.aosRef, 'toggle')
-})
-
-test('helper-stamped elements expose role-name and ref browser intent descriptors', async () => {
-  const element = createSemanticTargetElement(new FakeDocument(), {
-    id: 'run',
-    role: 'AXButton',
-    name: 'Run',
-    action: 'start',
-    surface: 'run-puck',
-    frame: [4, 8, 32, 24],
-  })
-  const descriptor = descriptorFromElement(element)
-  const candidates = await buildLocatorCandidates(descriptor)
-
-  assert.equal(descriptor.role, 'button')
-  assert.equal(descriptor.name, 'Run')
-  assert.equal(descriptor.ref, 'run-puck:run')
-  assert.deepEqual(
-    candidates.map((candidate) => candidate.id),
-    ['role_name', 'css', 'ref', 'rect']
-  )
 })

--- a/tests/toolkit/runtime-semantic-targets.test.mjs
+++ b/tests/toolkit/runtime-semantic-targets.test.mjs
@@ -1,0 +1,205 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  aosRefForTarget,
+  applySemanticTargetAttributes,
+  createSemanticTargetElement,
+  normalizeSemanticTarget,
+  normalizeSemanticTargets,
+} from '../../packages/toolkit/runtime/semantic-targets.js'
+import { descriptorFromElement } from '../../packages/toolkit/browser-intent-sensor/dom-crawl.js'
+import { buildLocatorCandidates } from '../../packages/toolkit/browser-intent-sensor/canonicalize.js'
+
+function dataAttrName(name) {
+  return name.replace(/^data-/, '').replace(/-([a-z])/g, (_, char) => char.toUpperCase())
+}
+
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = tagName.toUpperCase()
+    this.attributes = new Map()
+    this.dataset = {}
+    this.style = {}
+    this.textContent = ''
+    this.disabled = false
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value))
+    if (name === 'id') this.id = String(value)
+    if (name === 'type') this.type = String(value)
+  }
+
+  removeAttribute(name) {
+    this.attributes.delete(name)
+    if (name === 'id') delete this.id
+    if (name === 'type') delete this.type
+  }
+
+  getAttribute(name) {
+    if (name.startsWith('data-')) return this.dataset[dataAttrName(name)] ?? null
+    return this.attributes.get(name) ?? null
+  }
+
+  getBoundingClientRect() {
+    return {
+      left: Number.parseFloat(this.style.left) || 0,
+      top: Number.parseFloat(this.style.top) || 0,
+      width: Number.parseFloat(this.style.width) || 0,
+      height: Number.parseFloat(this.style.height) || 0,
+    }
+  }
+}
+
+class FakeDocument {
+  createElement(tagName) {
+    return new FakeElement(tagName)
+  }
+}
+
+test('normalizeSemanticTarget maps AX roles to web roles and keeps names concise', () => {
+  const target = normalizeSemanticTarget({
+    id: 'wiki-graph',
+    role: 'AXButton',
+    label: 'Wiki Graph',
+    action: 'wikiGraph',
+    frame: [10.4, 20.6, 55.2, 44.8],
+    active: true,
+  }, {
+    surface: 'sigil-radial-menu',
+    parentCanvasId: 'avatar-main',
+  })
+
+  assert.deepEqual(target, {
+    id: 'wiki-graph',
+    role: 'button',
+    name: 'Wiki Graph',
+    action: 'wikiGraph',
+    enabled: true,
+    current: true,
+    pressed: null,
+    selected: null,
+    checked: null,
+    expanded: null,
+    value: null,
+    surface: 'sigil-radial-menu',
+    parentCanvasId: 'avatar-main',
+    aosRef: 'sigil-radial-menu:wiki-graph',
+    metadata: {},
+    frame: { x: 10, y: 21, width: 55, height: 45 },
+  })
+})
+
+test('normalizeSemanticTargets rejects targets without stable ids', () => {
+  assert.throws(
+    () => normalizeSemanticTargets([{ label: '' }]),
+    /semantic target requires id/
+  )
+})
+
+test('aosRefForTarget uses explicit refs before generated surface refs', () => {
+  assert.equal(aosRefForTarget({ id: 'save', surface: 'toolbar' }), 'toolbar:save')
+  assert.equal(aosRefForTarget({ id: 'save', aosRef: 'custom-save' }, { surface: 'toolbar' }), 'custom-save')
+})
+
+test('normalizeSemanticTarget does not default action to identity', () => {
+  const target = normalizeSemanticTarget({ id: 'plain-target', name: 'Plain Target' })
+
+  assert.equal(target.action, '')
+  assert.equal(target.aosRef, 'plain-target')
+})
+
+test('createSemanticTargetElement stamps native button semantics and metadata without visible text', () => {
+  const element = createSemanticTargetElement(new FakeDocument(), {
+    id: 'context-menu',
+    role: 'AXButton',
+    name: 'Context Menu',
+    action: 'contextMenu',
+    frame: { x: 38, y: 38, w: 56, h: 56 },
+    surface: 'sigil-radial-menu',
+  })
+
+  assert.equal(element.tagName, 'BUTTON')
+  assert.equal(element.getAttribute('role'), null)
+  assert.equal(element.getAttribute('type'), 'button')
+  assert.equal(element.getAttribute('aria-label'), 'Context Menu')
+  assert.equal(element.getAttribute('id'), 'aos-semantic-target-context-menu')
+  assert.equal(element.dataset.aosRef, 'sigil-radial-menu:context-menu')
+  assert.equal(element.dataset.aosAction, 'contextMenu')
+  assert.equal(element.dataset.aosSurface, 'sigil-radial-menu')
+  assert.equal(element.dataset.semanticTargetId, 'context-menu')
+  assert.equal(element.style.left, '38px')
+  assert.equal(element.style.top, '38px')
+  assert.equal(element.style.width, '56px')
+  assert.equal(element.style.height, '56px')
+  assert.equal(element.textContent, '')
+})
+
+test('applySemanticTargetAttributes supports non-native roles and state attrs', () => {
+  const element = new FakeElement('div')
+  applySemanticTargetAttributes(element, {
+    id: 'menu-open',
+    role: 'AXMenuItem',
+    name: 'Open',
+    action: 'open',
+    enabled: false,
+    selected: true,
+    expanded: false,
+  }, {
+    surface: 'stack-menu',
+    visibleLabel: true,
+  })
+
+  assert.equal(element.getAttribute('role'), 'menuitem')
+  assert.equal(element.getAttribute('aria-label'), 'Open')
+  assert.equal(element.getAttribute('aria-disabled'), 'true')
+  assert.equal(element.getAttribute('aria-selected'), 'true')
+  assert.equal(element.getAttribute('aria-expanded'), 'false')
+  assert.equal(element.dataset.aosRef, 'stack-menu:menu-open')
+  assert.equal(element.dataset.aosAction, 'open')
+  assert.equal(element.textContent, 'Open')
+})
+
+test('applySemanticTargetAttributes removes stale optional attrs on update', () => {
+  const element = new FakeElement('button')
+  applySemanticTargetAttributes(element, {
+    id: 'toggle',
+    name: 'Toggle',
+    pressed: true,
+    action: 'toggle',
+    surface: 'panel',
+  })
+  applySemanticTargetAttributes(element, {
+    id: 'toggle',
+    name: 'Toggle',
+    pressed: null,
+    action: '',
+    surface: '',
+  })
+
+  assert.equal(element.getAttribute('aria-pressed'), null)
+  assert.equal(element.dataset.aosAction, undefined)
+  assert.equal(element.dataset.aosSurface, undefined)
+  assert.equal(element.dataset.aosRef, 'toggle')
+})
+
+test('helper-stamped elements expose role-name and ref browser intent descriptors', async () => {
+  const element = createSemanticTargetElement(new FakeDocument(), {
+    id: 'run',
+    role: 'AXButton',
+    name: 'Run',
+    action: 'start',
+    surface: 'run-puck',
+    frame: [4, 8, 32, 24],
+  })
+  const descriptor = descriptorFromElement(element)
+  const candidates = await buildLocatorCandidates(descriptor)
+
+  assert.equal(descriptor.role, 'button')
+  assert.equal(descriptor.name, 'Run')
+  assert.equal(descriptor.ref, 'run-puck:run')
+  assert.deepEqual(
+    candidates.map((candidate) => candidate.id),
+    ['role_name', 'css', 'ref', 'rect']
+  )
+})

--- a/tests/toolkit/tabs-layout.test.mjs
+++ b/tests/toolkit/tabs-layout.test.mjs
@@ -1,6 +1,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { Tabs } from '../../packages/toolkit/panel/layouts/tabs.js';
+import {
+  Tabs,
+  panelTabAosRef,
+  panelTabSemanticTarget,
+} from '../../packages/toolkit/panel/layouts/tabs.js';
 
 function encodeMessage(message) {
   return Buffer.from(JSON.stringify(message), 'utf8').toString('base64');
@@ -47,6 +51,7 @@ class FakeElement extends FakeNode {
     this.innerHTML = '';
     this.classList = new FakeClassList(this);
     this._className = '';
+    this.disabled = false;
   }
 
   get className() {
@@ -65,6 +70,18 @@ class FakeElement extends FakeNode {
 
   setAttribute(name, value) {
     this.attributes[name] = String(value);
+    if (name === 'id') this.id = String(value);
+    if (name === 'type') this.type = String(value);
+  }
+
+  removeAttribute(name) {
+    delete this.attributes[name];
+    if (name === 'id') delete this.id;
+    if (name === 'type') delete this.type;
+  }
+
+  getAttribute(name) {
+    return this.attributes[name] ?? null;
   }
 
   addEventListener(type, handler) {
@@ -99,6 +116,27 @@ function makeContent(title) {
     },
   });
 }
+
+test('panel tab semantic targets carry stable AOS refs', () => {
+  assert.equal(panelTabAosRef('tabs smoke', 'alpha'), 'panel-tabs:tabs-smoke:alpha');
+  assert.deepEqual(panelTabSemanticTarget({
+    manifest: {
+      name: 'alpha',
+      title: 'Alpha',
+    },
+  }, 0, {
+    panelName: 'tabs smoke',
+    selected: true,
+  }), {
+    id: 'tab-alpha',
+    role: 'AXTab',
+    name: 'Alpha',
+    action: 'tabs/activate',
+    surface: 'panel-tabs',
+    aosRef: 'panel-tabs:tabs-smoke:alpha',
+    selected: true,
+  });
+});
 
 test('Tabs onActivate fires for initial mount and active-tab changes only', async (t) => {
   const previousNode = globalThis.Node;
@@ -160,6 +198,21 @@ test('Tabs onActivate fires for initial mount and active-tab changes only', asyn
   const [alphaBtn, betaBtn, gammaBtn] = tabStrip.children;
   const [alphaPanel, betaPanel, gammaPanel] = chrome.contentEl.children;
 
+  assert.equal(tabStrip.attributes.role, 'tablist');
+  assert.equal(alphaBtn.textContent, 'Alpha');
+  assert.equal(alphaBtn.attributes.role, 'tab');
+  assert.equal(alphaBtn.attributes.type, 'button');
+  assert.equal(alphaBtn.attributes['aria-label'], 'Alpha');
+  assert.equal(alphaBtn.attributes['aria-selected'], 'true');
+  assert.equal(alphaBtn.dataset.aosRef, 'panel-tabs:tabs-smoke:alpha');
+  assert.equal(alphaBtn.dataset.aosAction, 'tabs/activate');
+  assert.equal(alphaBtn.dataset.aosSurface, 'panel-tabs');
+  assert.equal(alphaBtn.dataset.semanticTargetId, 'tab-alpha');
+  assert.equal(alphaBtn.attributes['aria-controls'], alphaPanel.attributes.id);
+  assert.equal(alphaPanel.attributes['aria-labelledby'], alphaBtn.attributes.id);
+  assert.equal(betaBtn.attributes['aria-selected'], 'false');
+  assert.equal(betaBtn.dataset.aosRef, 'panel-tabs:tabs-smoke:beta');
+
   assert.equal(alphaBtn.classList.contains('active'), true);
   assert.equal(betaBtn.classList.contains('active'), false);
   assert.equal(alphaPanel.hidden, false);
@@ -174,6 +227,9 @@ test('Tabs onActivate fires for initial mount and active-tab changes only', asyn
   ]);
   assert.equal(alphaBtn.classList.contains('active'), false);
   assert.equal(betaBtn.classList.contains('active'), true);
+  assert.equal(alphaBtn.attributes['aria-selected'], 'false');
+  assert.equal(betaBtn.attributes['aria-selected'], 'true');
+  assert.equal(betaBtn.textContent, 'Beta');
   assert.equal(alphaPanel.hidden, true);
   assert.equal(betaPanel.hidden, false);
 

--- a/tests/toolkit/wiki-kb-semantics.test.mjs
+++ b/tests/toolkit/wiki-kb-semantics.test.mjs
@@ -1,0 +1,96 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  applyWikiKBSemanticTarget,
+  wikiKBAosRef,
+} from '../../packages/toolkit/components/wiki-kb/semantics.js'
+
+function dataAttrName(name) {
+  return name.replace(/^data-/, '').replace(/-([a-z])/g, (_, char) => char.toUpperCase())
+}
+
+class FakeElement {
+  constructor(tagName = 'button') {
+    this.tagName = tagName.toUpperCase()
+    this.attributes = new Map()
+    this.dataset = {}
+    this.style = {}
+    this.textContent = ''
+    this.disabled = false
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value))
+    if (name === 'id') this.id = String(value)
+    if (name === 'type') this.type = String(value)
+  }
+
+  removeAttribute(name) {
+    this.attributes.delete(name)
+    if (name === 'id') delete this.id
+    if (name === 'type') delete this.type
+  }
+
+  getAttribute(name) {
+    if (name.startsWith('data-')) return this.dataset[dataAttrName(name)] ?? null
+    return this.attributes.get(name) ?? null
+  }
+}
+
+test('wikiKBAosRef scopes refs to the Wiki KB surface', () => {
+  assert.equal(wikiKBAosRef('graph', 'depth range'), 'wiki-kb:graph:depth-range')
+  assert.equal(wikiKBAosRef('sidebar', ''), 'wiki-kb:sidebar:unknown')
+})
+
+test('applyWikiKBSemanticTarget preserves visible button text while stamping metadata', () => {
+  const button = new FakeElement('button')
+  button.textContent = 'x'
+
+  applyWikiKBSemanticTarget(button, {
+    id: 'sidebar-close',
+    name: 'Close details',
+    action: 'close_details',
+    aosRef: wikiKBAosRef('sidebar', 'close'),
+  })
+
+  assert.equal(button.getAttribute('role'), null)
+  assert.equal(button.getAttribute('type'), 'button')
+  assert.equal(button.getAttribute('aria-label'), 'Close details')
+  assert.equal(button.dataset.aosRef, 'wiki-kb:sidebar:close')
+  assert.equal(button.dataset.aosAction, 'close_details')
+  assert.equal(button.dataset.aosSurface, 'wiki-kb')
+  assert.equal(button.dataset.semanticTargetId, 'sidebar-close')
+  assert.equal(button.textContent, 'x')
+})
+
+test('applyWikiKBSemanticTarget exposes checkbox and slider state without generated ids', () => {
+  const checkbox = new FakeElement('input')
+  applyWikiKBSemanticTarget(checkbox, {
+    id: 'highlight-neighbors',
+    role: 'AXCheckBox',
+    name: 'Highlight neighbors',
+    action: 'toggle_highlight_neighbors',
+    checked: true,
+  })
+
+  assert.equal(checkbox.getAttribute('id'), null)
+  assert.equal(checkbox.getAttribute('role'), 'checkbox')
+  assert.equal(checkbox.getAttribute('aria-checked'), 'true')
+  assert.equal(checkbox.dataset.aosRef, 'wiki-kb:highlight-neighbors')
+
+  const range = new FakeElement('input')
+  range.id = 'wiki-kb-depth-input'
+  applyWikiKBSemanticTarget(range, {
+    id: 'depth',
+    role: 'AXSlider',
+    name: 'Graph depth',
+    action: 'set_depth',
+    value: '2',
+    aosRef: wikiKBAosRef('graph', 'depth'),
+  })
+
+  assert.equal(range.getAttribute('id'), 'wiki-kb-depth-input')
+  assert.equal(range.getAttribute('role'), 'slider')
+  assert.equal(range.getAttribute('aria-valuetext'), '2')
+  assert.equal(range.dataset.aosRef, 'wiki-kb:graph:depth')
+})


### PR DESCRIPTION
## Summary
- Add the AOS app accessibility surface playbook and shared semantic target helper.
- Retrofit active toolkit controls and passive telemetry surfaces with AX-style names, stable `data-aos-*` refs/actions, and state metadata.
- Add a Sigil radial menu companion surface so agents can discover/action radial items via AX without visible duplicate labels.

## Verification
- Rebased on `main` after #172 landed.
- `./aos ready` -> `ready=true mode=repo daemon=reachable tap=active`
- `bash build.sh`
- `node --test tests/toolkit/runtime-semantic-targets.test.mjs tests/toolkit/canvas-inspector-ax.test.mjs tests/toolkit/canvas-inspector-marks-render.test.mjs tests/toolkit/tabs-layout.test.mjs tests/toolkit/integration-hub-semantics.test.mjs tests/toolkit/passive-component-semantics.test.mjs tests/toolkit/wiki-kb-semantics.test.mjs tests/renderer/radial-menu-target-surface.test.mjs`
- `node --check packages/toolkit/components/canvas-inspector/index.js && node --check packages/toolkit/components/canvas-inspector/marks/render.js && node --check packages/toolkit/components/canvas-inspector/semantics.js && node --check packages/toolkit/components/inspector-panel/index.js && node --check packages/toolkit/components/integration-hub/index.js && node --check packages/toolkit/components/integration-hub/semantics.js && node --check packages/toolkit/components/log-console/index.js && node --check packages/toolkit/components/render-performance/index.js && node --check packages/toolkit/components/spatial-telemetry/index.js && node --check packages/toolkit/components/wiki-kb/index.js && node --check packages/toolkit/components/wiki-kb/semantics.js && node --check packages/toolkit/components/wiki-kb/views/graph.js && node --check packages/toolkit/panel/layouts/tabs.js && node --check packages/toolkit/runtime/index.js && node --check packages/toolkit/runtime/semantic-targets.js && node --check apps/sigil/renderer/live-modules/main.js && node --check apps/sigil/renderer/live-modules/radial-menu-target-surface.js`
- `bash -n packages/toolkit/components/wiki-kb/launch.sh && bash -n tests/sigil-avatar-interactions.sh && git diff --check origin/main...HEAD`
- `bash tests/panel-tabs-activation.sh && bash tests/wiki-kb-smoke.sh && bash tests/sigil-avatar-interactions.sh`
- `bash tests/sigil-real-input-status-avatar.sh && bash tests/sigil-context-menu-real-input.sh`

## Notes
- The clean PR branch was cherry-picked from the epic checkpoint commits and adjusted not to revive toolkit surfaces/helpers already deleted on `main`.
- The current `main` test tree does not include the older dedicated radial brain real-input helper; the radial target surface is covered by the focused renderer test and the Sigil interaction smoke, with live input covered by the status-avatar and context-menu real-input smokes above.
- Tried `./aos dev build`, but this branch binary does not have the `dev` command yet, so verification used `bash build.sh`.