### PR TITLE
Fix repo permission marker readiness across worktrees

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -613,6 +613,11 @@ Consumers:
   post). If the CLI grant is present but the daemon reports stale or missing
   daemon-owned grants, setup returns degraded with remove/re-add guidance
   instead of silently declaring onboarding complete.
+- The permissions onboarding marker is mode-scoped and proves the operator has
+  completed the setup flow for that runtime mode. The marker's recorded
+  `bundle_path` is diagnostic only: in repo mode, readiness does not fail solely
+  because another worktree last wrote the marker when the current CLI grants and
+  daemon input tap are verified green.
 - `aos status --json` exposes `runtime.input_tap` (full block) plus the
   legacy flat `runtime.input_tap_status` / `runtime.input_tap_attempts`.
 - `aos status` text mode includes `tap=<status>` in the one-line summary.

--- a/src/commands/operator.swift
+++ b/src/commands/operator.swift
@@ -930,12 +930,30 @@ private func currentGitStatus() -> GitStatusState? {
 }
 
 private func currentPermissionsState() -> PermissionsState {
-    PermissionsState(
+    if testAssumePermissionsGranted() {
+        return PermissionsState(
+            accessibility: true,
+            screen_recording: true,
+            listen_access: true,
+            post_access: true
+        )
+    }
+
+    return PermissionsState(
         accessibility: AXIsProcessTrusted(),
         screen_recording: preflightScreenRecordingAccess(),
         listen_access: preflightListenEventAccess(),
         post_access: preflightPostEventAccess()
     )
+}
+
+private func testAssumePermissionsGranted() -> Bool {
+    // Test-only hook for isolated-state mock daemon tests. Requiring an
+    // explicit state root keeps real repo/installed runtime checks bound to
+    // the macOS TCC preflight APIs.
+    let env = ProcessInfo.processInfo.environment
+    return env["AOS_TEST_ASSUME_PERMISSIONS_GRANTED"] == "1" &&
+        aosHasExplicitStateRootOverride()
 }
 
 private func currentPermissionRequirements(permissions: PermissionsState) -> [PermissionRequirement] {
@@ -974,12 +992,13 @@ private func currentPermissionsSetupState(permissions: PermissionsState) -> Perm
     let bundlePath = marker?["bundle_path"] as? String
     let completedAt = marker?["completed_at"] as? String
     let bundleMatchesCurrent = bundlePath == nil ? false : bundlePath == currentBundlePath
+    let mode = aosCurrentRuntimeMode()
     let setupCompleted = permissions.accessibility &&
         permissions.screen_recording &&
         permissions.listen_access &&
         permissions.post_access &&
         marker != nil &&
-        bundleMatchesCurrent
+        (bundleMatchesCurrent || mode == .repo)
 
     return PermissionsSetupState(
         marker_exists: marker != nil,
@@ -1084,7 +1103,7 @@ private func permissionsCheckCommand(args: [String], usage: String) {
     }
     if !setup.marker_exists {
         notes.append("Permission onboarding has not been completed for this runtime identity.")
-    } else if !setup.bundle_matches_current {
+    } else if !setup.bundle_matches_current && !setup.setup_completed {
         notes.append("Permission onboarding marker belongs to a different app bundle path.")
     }
     if let command = setup.recommended_command {

--- a/tests/permissions-marker-worktree.sh
+++ b/tests/permissions-marker-worktree.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT"
+
+PREFIX="aos-permissions-marker-worktree"
+STATE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/${PREFIX}.XXXXXX")"
+export AOS_STATE_ROOT="$STATE_ROOT"
+export AOS_TEST_ASSUME_PERMISSIONS_GRANTED=1
+export AOS_TEST_SKIP_READY_SERVICE_START=1
+
+SOCK="$STATE_ROOT/repo/sock"
+MARKER="$STATE_ROOT/repo/permissions-onboarding.json"
+mkdir -p "$(dirname "$SOCK")"
+
+cleanup() {
+  if [[ -n "${MOCK_PID:-}" ]] && kill -0 "$MOCK_PID" 2>/dev/null; then
+    kill "$MOCK_PID" 2>/dev/null || true
+    wait "$MOCK_PID" 2>/dev/null || true
+  fi
+  rm -rf "$STATE_ROOT"
+}
+trap cleanup EXIT
+
+python3 tests/lib/mock-daemon.py \
+    --socket "$SOCK" \
+    --tap-status active \
+    --listen-access true \
+    --post-access true \
+    --accessibility true \
+    >"$STATE_ROOT/mock.stdout" 2>"$STATE_ROOT/mock.stderr" &
+MOCK_PID=$!
+
+for _ in $(seq 1 20); do
+  if [[ -S "$SOCK" ]]; then break; fi
+  sleep 0.1
+done
+if ! [[ -S "$SOCK" ]]; then
+  echo "FAIL: mock daemon did not bind socket $SOCK"
+  exit 1
+fi
+
+python3 - "$MARKER" <<'PY'
+import json
+import pathlib
+import sys
+
+marker = pathlib.Path(sys.argv[1])
+marker.write_text(json.dumps({
+    "bundle_path": "/tmp/aos-other-worktree",
+    "completed_at": "2026-04-30T00:00:00Z",
+    "permissions": {
+        "accessibility": True,
+        "screen_recording": True,
+        "listen_access": True,
+        "post_access": True,
+    },
+}, indent=2, sort_keys=True), encoding="utf-8")
+PY
+
+OUT="$(./aos permissions check --json)"
+echo "$OUT" | python3 -c '
+import json, sys
+d = json.loads(sys.stdin.read())
+setup = d.get("setup", {})
+assert d.get("status") == "ok", d
+assert d.get("ready_for_testing") is True, d
+assert d.get("ready_source") == "daemon", d
+assert setup.get("marker_exists") is True, setup
+assert setup.get("bundle_matches_current") is False, setup
+assert setup.get("setup_completed") is True, setup
+notes = "\n".join(d.get("notes", []))
+assert "different app bundle path" not in notes, notes
+'
+echo "PASS: permissions check accepts live-verified cross-worktree marker"
+
+OUT="$(./aos ready --json)"
+echo "$OUT" | python3 -c '
+import json, sys
+d = json.loads(sys.stdin.read())
+assert d.get("ready") is True, d
+assert d.get("phase") == "ready", d
+assert d.get("diagnosis") == "ready", d
+blockers = {b.get("id") for b in d.get("blockers", [])}
+assert "permissions_onboarding" not in blockers, d
+setup = d.get("permissions_setup", {})
+assert setup.get("bundle_matches_current") is False, setup
+assert setup.get("setup_completed") is True, setup
+'
+echo "PASS: ready does not block on cross-worktree marker path"
+
+rm -f "$MARKER"
+set +e
+OUT="$(./aos ready --json)"
+RC=$?
+set -e
+echo "$OUT" | python3 -c '
+import json, sys
+d = json.loads(sys.stdin.read())
+assert d.get("ready") is False, d
+assert d.get("phase") == "setup_required", d
+assert d.get("diagnosis") == "permissions_onboarding_required", d
+blockers = {b.get("id") for b in d.get("blockers", [])}
+assert "permissions_onboarding" in blockers, d
+'
+if [[ "$RC" -eq 0 ]]; then
+  echo "FAIL: ready exited 0 without any onboarding marker"
+  exit 1
+fi
+echo "PASS: ready still requires an onboarding marker"
+
+echo "PASS"


### PR DESCRIPTION
## Summary
- Treat repo-mode permission onboarding marker `bundle_path` mismatches as diagnostic once live CLI grants are present.
- Keep installed-mode marker matching strict, and keep requiring an onboarding marker when none exists.
- Add an isolated mock-daemon regression for cross-worktree marker readiness and document the repo-mode behavior.

Fixes #171.

## Verification
- `bash build.sh`
- `bash tests/permissions-marker-worktree.sh`
- `bash tests/input-tap-readiness.sh`
- `bash tests/input-tap-readiness-legacy.sh`
- `git diff --check origin/main...HEAD`

## Notes
- Tried `./aos dev build`, but this `origin/main` binary does not have the `dev` command yet, so verification used `bash build.sh`.
- The build completed; its post-build readiness probe still reported the existing shared daemon ownership/socket degradation, unrelated to the isolated regression tests.