### PR TITLE
[codex] Expose AOS canvas semantic targets

### DIFF
--- a/apps/sigil/AGENTS.md
+++ b/apps/sigil/AGENTS.md
@@ -54,8 +54,8 @@ doc lands at `~/.config/aos/{mode}/wiki/sigil/agents/default.md`.
 | `studio/` | Historical URL/path for the avatar configuration surface. Do not use the old product name in new user-facing copy. |
 | `chat/` | Bidirectional conversational canvas (see Chat Canvas Protocol below). |
 | `workbench/` | Historical multi-tab surface. Do not use as the standard launch or verification path for current Sigil work unless the task explicitly targets that surface. |
-| `renderer/hit-area.html` | Minimal interactive child canvas the renderer spawns at the avatar's position so clicks/drags on the dot land somewhere while the parent canvas stays click-through. |
-| `renderer/radial-menu-surface.html` | Minimal interactive child canvas the renderer spawns around live radial-menu items so `aos see --xray` can discover labeled item targets and `aos do` can act on them. |
+| `renderer/hit-area.html` | Minimal interactive child canvas the renderer spawns at the avatar's position so clicks/drags on the dot land somewhere while the parent canvas stays click-through. Exposes the avatar as an AOS semantic target via `aos see capture --canvas <hit-id> --xray`. |
+| `renderer/radial-menu-surface.html` | Minimal interactive child canvas the renderer spawns around live radial-menu items so `aos see capture --canvas <radial-id> --xray` can discover labeled item targets and `aos do` can act on them. |
 | `renderer/appearance.js` / `renderer/state.js` | Runtime appearance and interaction config, including Sigil's radial gesture menu defaults. |
 | `seed/wiki/sigil/` | Seed source for the default agent wiki doc. |
 | `sigilctl-seed.sh` | Wraps `aos wiki seed` for the Sigil namespace. |

--- a/apps/sigil/renderer/hit-area.html
+++ b/apps/sigil/renderer/hit-area.html
@@ -3,10 +3,42 @@
 <head>
 <meta charset="utf-8">
 <style>
-html, body { margin: 0; width: 100%; height: 100%; background: transparent; overflow: hidden; cursor: pointer; }
+html,
+body {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    background: transparent;
+    overflow: hidden;
+    cursor: pointer;
+}
+
+.avatar-hit-target {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    padding: 0;
+    background: transparent;
+    appearance: none;
+    cursor: pointer;
+}
+
+.avatar-hit-target:focus-visible {
+    outline: 3px solid rgba(140, 248, 255, 0.95);
+    outline-offset: -3px;
+}
 </style>
 </head>
 <body>
+<button
+    id="sigil-avatar-hit-target"
+    class="avatar-hit-target"
+    type="button"
+    aria-label="Sigil avatar"
+    data-aos-surface="sigil.avatar"
+    data-semantic-target-id="avatar"></button>
 <script>
 // Minimal absorber page. Exists where canvas.update puts it so clicks land
 // here instead of passing through to the desktop.
@@ -15,6 +47,12 @@ const HIT_SOURCE = 'sigil-hit';
 const HIT_PARAMS = new URLSearchParams(window.location.search);
 const HIT_PARENT_ID = HIT_PARAMS.get('parent') || 'avatar-main';
 const HIT_ID = HIT_PARAMS.get('id') || null;
+const HIT_ELEMENT = document.getElementById('sigil-avatar-hit-target');
+
+if (HIT_ELEMENT) {
+    HIT_ELEMENT.dataset.aosRef = HIT_ID || 'sigil-avatar-hit';
+    HIT_ELEMENT.dataset.aosParentCanvas = HIT_PARENT_ID;
+}
 
 function emit(kind, event) {
     const rect = document.body.getBoundingClientRect();

--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -191,6 +191,7 @@ Shorthand capture is supported:
 aos see main
 aos see external 1
 aos see capture --canvas canvas-inspector --perception
+aos see capture --canvas sigil-radial-menu --xray
 aos see capture --region 1172,442,320,480 --perception
 ```
 
@@ -201,6 +202,18 @@ Useful capture modifiers include:
 - `--canvas <id>` / `--channel <id>` for surface-relative captures
 - `--exclude-window <CGWindowID>` to omit specific windows from a display/region capture
 - `--perception` to attach spatial metadata alongside the image payload
+
+`--xray` returns AX-derived interactive elements in `elements`. For AOS-owned
+canvas captures, `aos see capture --canvas <id> --xray` also runs a fixed
+semantic target probe inside that canvas and returns `semantic_targets`. Those
+entries project standard DOM/AX/ARIA facts plus thin AOS ownership metadata such
+as `canvas_id`, `data-aos-ref`, `data-aos-action`, `data-aos-surface`, and
+`data-semantic-target-id`. The probe does not use caller-supplied JavaScript;
+`show eval` remains a developer diagnostic bridge, not the agent perception
+contract.
+
+See [`shared/schemas/aos-semantic-targets.md`](../../shared/schemas/aos-semantic-targets.md)
+for the response shape.
 
 `--perception` augments the capture response with:
 

--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -364,9 +364,13 @@ Supported include toggles today:
 - `xray`
 
 `xray` writes an additional `xray.json` artifact containing the AX-derived
-element list from `aos see capture --xray`. This config shape is intentionally
-under `see` so future `see` bundle/record presets can grow beside the current
-inspector export path instead of being trapped in inspector-only settings.
+element list from `aos see capture --xray`. Canvas-id captures can also include
+`semantic_targets`, the fixed AOS projection of toolkit-stamped DOM/AX/ARIA
+target metadata. Current region-based inspector bundle exports remain AX-only
+unless their runner switches to `--canvas <id>`. This config shape is
+intentionally under `see` so future `see` bundle/record presets can grow beside
+the current inspector export path instead of being trapped in inspector-only
+settings.
 
 ### Spatial Telemetry
 

--- a/docs/recipes/aos-app-accessibility-surfaces.md
+++ b/docs/recipes/aos-app-accessibility-surfaces.md
@@ -29,6 +29,12 @@ The accessibility surface should still behave like a Mac app: `aos see --xray`
 can discover it, and `aos do` can operate it through the daemon route when the
 runtime is ready.
 
+For AOS-owned canvases, `aos see capture --canvas <id> --xray` also exposes a
+`semantic_targets` array. Treat that as a projection of the same standard facts,
+not a separate agent language: role and name come from AX/ARIA, bounds come from
+the DOM frame, state comes from ARIA/native disabled/value state, and AOS
+metadata supplies ownership and routing identity.
+
 ## Labels And Names
 
 Keep visible labels and semantic names separate.
@@ -109,7 +115,8 @@ before claiming runtime verification. In installed mode, use the installed
 For representative controls, verify:
 
 - `./aos see --xray` exposes the expected role, semantic name, frame, state, and
-  action.
+  action. For AOS-owned canvases, check `semantic_targets` for stable refs,
+  surface id, parent canvas id, and action id.
 - `./aos do` can operate the control through the daemon/AOS route, not only
   through app-local JavaScript or a synthetic unit test.
 - Screenshots show the intended visual design, with no duplicate agent labels

--- a/packages/gateway/sdk/aos-sdk.d.ts
+++ b/packages/gateway/sdk/aos-sdk.d.ts
@@ -19,6 +19,7 @@ declare const aos: {
   /** Capture a screenshot, optionally with accessibility tree. */
   capture(opts?: {
     display?: string;
+    canvas?: string;
     window?: boolean;
     xray?: boolean;
     base64?: boolean;
@@ -28,6 +29,17 @@ declare const aos: {
     status: string; base64?: string; elements?: Array<{
       role: string; label?: string; value?: string;
       frame: { x: number; y: number; width: number; height: number };
+    }>; semantic_targets?: Array<{
+      canvas_id?: string; id?: string; ref?: string;
+      role: string; name?: string; action?: string;
+      surface?: string; parent_canvas?: string; enabled: boolean;
+      bounds: { x: number; y: number; width: number; height: number };
+      center: { x: number; y: number };
+      state?: {
+        current?: string; pressed?: boolean; selected?: boolean;
+        checked?: boolean; expanded?: boolean; disabled?: boolean;
+        value?: string;
+      };
     }>; path?: string;
   }>;
 

--- a/packages/gateway/src/aos-proxy.ts
+++ b/packages/gateway/src/aos-proxy.ts
@@ -87,13 +87,15 @@ export async function getCursor(): Promise<{ x: number; y: number; app?: string;
 
 export async function capture(opts?: {
   display?: string;
+  canvas?: string;
   window?: boolean;
   xray?: boolean;
   base64?: boolean;
   format?: 'png' | 'jpg';
   out?: string;
-}): Promise<{ status: string; base64?: string; elements?: unknown[]; path?: string }> {
+}): Promise<{ status: string; base64?: string; elements?: unknown[]; semantic_targets?: unknown[]; path?: string }> {
   const args = ['see', 'capture', opts?.display ?? 'user_active'];
+  if (opts?.canvas) args.push('--canvas', opts.canvas);
   if (opts?.window) args.push('--window');
   if (opts?.xray) args.push('--xray');
   if (opts?.base64) args.push('--base64');

--- a/shared/schemas/aos-semantic-targets.md
+++ b/shared/schemas/aos-semantic-targets.md
@@ -1,0 +1,71 @@
+# AOS Semantic Targets
+
+Version: `0.1.0`
+
+`semantic_targets` is the AOS-owned canvas target projection emitted by:
+
+```bash
+aos see capture --canvas <canvas-id> --xray
+```
+
+This is not a new UI language. It is a machine-readable projection of facts the
+canvas already owns:
+
+- role, name, state, and disabled/value semantics from standard AX/ARIA/native
+  controls
+- bounds and center from the element's DOM frame in the capture image's local
+  coordinate space
+- AOS ownership metadata from `data-aos-ref`, `data-aos-action`,
+  `data-aos-surface`, `data-semantic-target-id`, and `data-aos-parent-canvas`
+
+The CLI gathers this data through a fixed internal probe. Agents should prefer
+this field for AOS-owned canvases and reserve `show eval` for developer
+diagnostics.
+
+## Shape
+
+```json
+{
+  "semantic_targets": [
+    {
+      "canvas_id": "sigil-radial-menu",
+      "id": "wiki-graph",
+      "ref": "sigil-radial-item-wiki-graph",
+      "role": "button",
+      "name": "Wiki Graph",
+      "action": "wiki-graph",
+      "surface": "sigil-radial-menu",
+      "parent_canvas": "avatar-main",
+      "enabled": true,
+      "bounds": { "x": 40, "y": 24, "width": 56, "height": 56 },
+      "center": { "x": 68, "y": 52 },
+      "state": { "current": "true" }
+    }
+  ]
+}
+```
+
+## Field Notes
+
+`canvas_id` is the canvas requested by `--canvas`.
+
+`id` is the stable local target id, normally `data-semantic-target-id` or the DOM
+id.
+
+`ref` is the canonical AOS object reference from `data-aos-ref`.
+
+`role` is the explicit DOM role when present, otherwise the closest native
+control role.
+
+`name` is the accessible name, usually `aria-label`, not an implementation id.
+
+`action` is the AOS action id from `data-aos-action`.
+
+`surface` and `parent_canvas` identify the AOS surface relationship without
+polluting the accessible name.
+
+`bounds` and `center` use the same local image coordinate space as capture/xray
+output for that canvas.
+
+`state` is present only when the control exposes state such as `current`,
+`pressed`, `selected`, `checked`, `expanded`, `disabled`, or `value`.

--- a/src/perceive/capture-pipeline.swift
+++ b/src/perceive/capture-pipeline.swift
@@ -2068,6 +2068,7 @@ func captureCommand(args: [String]) async {
     var responseClickX: Int? = nil
     var responseClickY: Int? = nil
     var responseElements: [AXElementJSON]? = nil
+    var responseSemanticTargets: [AOSSemanticTargetJSON]? = nil
     var responseAnnotations: [AnnotationJSON]? = nil
     var responseWindow: CaptureWindowJSON? = nil
     var responseSurfaces: [CaptureSurfaceJSON] = []
@@ -2175,6 +2176,9 @@ func captureCommand(args: [String]) async {
                 )
             } else {
                 responseElements = xrayFrontmostApp(mapper: mapper, imageSize: imageSize)
+            }
+            if surface.kind == "canvas", let canvasID = surface.id {
+                responseSemanticTargets = collectCanvasSemanticTargets(canvasID: canvasID, scaleFactor: captureScale)
             }
         }
 
@@ -2448,6 +2452,7 @@ func captureCommand(args: [String]) async {
         resp.click_y = responseClickY
         resp.warning = responseWarning
         resp.elements = responseElements
+        resp.semantic_targets = responseSemanticTargets
         resp.annotations = responseAnnotations
         if !responseSurfaces.isEmpty {
             resp.surfaces = responseSurfaces

--- a/src/perceive/models.swift
+++ b/src/perceive/models.swift
@@ -168,7 +168,7 @@ struct SpatialTopology: Encodable {
 // MARK: - Capture Pipeline Cursor Output Models
 // These use different struct names to avoid collision with the aos cursor command models.
 
-struct CursorJSON: Encodable {
+struct CursorJSON: Codable {
     let x: Int
     let y: Int
 }
@@ -215,7 +215,7 @@ struct SelectionResponse: Encodable {
 
 // MARK: - Capture Pipeline AX Output Models
 
-struct BoundsJSON: Encodable {
+struct BoundsJSON: Codable {
     let x: Int
     let y: Int
     let width: Int
@@ -231,6 +231,33 @@ struct AXElementJSON: Encodable {
     let context_path: [String]
     let bounds: BoundsJSON?
     let ref: String?
+}
+
+// MARK: - AOS-owned Canvas Semantic Target Output
+
+struct AOSSemanticTargetStateJSON: Codable {
+    let current: String?
+    let pressed: Bool?
+    let selected: Bool?
+    let checked: Bool?
+    let expanded: Bool?
+    let disabled: Bool?
+    let value: String?
+}
+
+struct AOSSemanticTargetJSON: Codable {
+    let canvas_id: String?
+    let id: String?
+    let ref: String?
+    let role: String
+    let name: String?
+    let action: String?
+    let surface: String?
+    let parent_canvas: String?
+    let enabled: Bool
+    let bounds: BoundsJSON
+    let center: CursorJSON
+    let state: AOSSemanticTargetStateJSON?
 }
 
 // MARK: - Annotation Output Model (annotation.schema.json v0.1.0)
@@ -296,13 +323,14 @@ struct SuccessResponse: Encodable {
     var click_y: Int?
     var warning: String?
     var elements: [AXElementJSON]?
+    var semantic_targets: [AOSSemanticTargetJSON]?
     var annotations: [AnnotationJSON]?
     var window: CaptureWindowJSON?
     var surfaces: [CaptureSurfaceJSON]?
     var perceptions: [CapturePerceptionJSON]?
 
     enum CodingKeys: String, CodingKey {
-        case status, files, base64, cursor, bounds, click_x, click_y, warning, elements, annotations, window, surfaces, perceptions
+        case status, files, base64, cursor, bounds, click_x, click_y, warning, elements, semantic_targets, annotations, window, surfaces, perceptions
     }
 
     func encode(to encoder: Encoder) throws {
@@ -316,6 +344,7 @@ struct SuccessResponse: Encodable {
         if let cy = click_y { try c.encode(cy, forKey: .click_y) }
         if let w = warning { try c.encode(w, forKey: .warning) }
         if let e = elements { try c.encode(e, forKey: .elements) }
+        if let st = semantic_targets { try c.encode(st, forKey: .semantic_targets) }
         if let a = annotations { try c.encode(a, forKey: .annotations) }
         if let win = window { try c.encode(win, forKey: .window) }
         if let s = surfaces { try c.encode(s, forKey: .surfaces) }

--- a/src/perceive/semantic-targets.swift
+++ b/src/perceive/semantic-targets.swift
@@ -1,0 +1,130 @@
+// semantic-targets.swift — Fixed AOS-owned canvas semantic target projection.
+
+import Foundation
+
+private func jsonStringLiteral(_ value: String) -> String {
+    guard
+        let data = try? JSONSerialization.data(withJSONObject: [value], options: []),
+        let arrayLiteral = String(data: data, encoding: .utf8),
+        arrayLiteral.count >= 2
+    else {
+        return "\"\""
+    }
+    return String(arrayLiteral.dropFirst().dropLast())
+}
+
+private func semanticTargetProbeJS(canvasID: String, scaleFactor: Double) -> String {
+    let encodedCanvasID = jsonStringLiteral(canvasID)
+    let scale = String(scaleFactor)
+    return """
+    (() => {
+      const canvasId = \(encodedCanvasID);
+      const scale = Number(\(scale)) || 1;
+      const selector = [
+        '[data-aos-ref]',
+        '[data-aos-action]',
+        '[data-aos-surface]',
+        '[data-semantic-target-id]',
+        '[data-aos-parent-canvas]'
+      ].join(',');
+
+      const clean = (value) => String(value ?? '').replace(/\\s+/g, ' ').trim();
+      const attr = (el, name) => clean(el.getAttribute(name));
+      const data = (el, name) => clean(el.dataset ? el.dataset[name] : '');
+      const boolAttr = (el, name) => {
+        const value = attr(el, name);
+        if (!value || value === 'undefined' || value === 'mixed') return null;
+        return value === 'true';
+      };
+      const nativeRole = (el) => {
+        const tag = clean(el.tagName).toLowerCase();
+        const type = attr(el, 'type').toLowerCase();
+        if (tag === 'button') return 'button';
+        if (tag === 'a' && attr(el, 'href')) return 'link';
+        if (tag === 'input') {
+          if (type === 'checkbox') return 'checkbox';
+          if (type === 'radio') return 'radio';
+          if (type === 'range') return 'slider';
+          if (type === 'search') return 'searchbox';
+          return 'textbox';
+        }
+        if (tag === 'textarea') return 'textbox';
+        if (tag === 'select') return 'combobox';
+        return 'generic';
+      };
+      const targetName = (el, id, ref) => clean(
+        attr(el, 'aria-label')
+        || attr(el, 'title')
+        || clean(el.innerText)
+        || clean(el.textContent)
+        || id
+        || ref
+      );
+      const stateFor = (el, disabled) => {
+        const state = {};
+        const current = attr(el, 'aria-current');
+        if (current && current !== 'false') state.current = current;
+        for (const key of ['pressed', 'selected', 'checked', 'expanded']) {
+          const value = boolAttr(el, `aria-${key}`);
+          if (value !== null) state[key] = value;
+        }
+        const value = attr(el, 'aria-valuetext') || attr(el, 'aria-valuenow') || (el.value !== undefined ? clean(el.value) : '');
+        if (value) state.value = value;
+        if (disabled) state.disabled = true;
+        return Object.keys(state).length ? state : null;
+      };
+
+      return JSON.stringify(Array.from(document.querySelectorAll(selector)).map((el) => {
+        const rect = el.getBoundingClientRect();
+        if (!Number.isFinite(rect.width) || !Number.isFinite(rect.height) || rect.width <= 0 || rect.height <= 0) return null;
+        const id = data(el, 'semanticTargetId') || attr(el, 'data-semantic-target-id') || attr(el, 'id');
+        const ref = data(el, 'aosRef') || attr(el, 'data-aos-ref');
+        const disabled = el.matches?.(':disabled') || attr(el, 'aria-disabled') === 'true';
+        const bounds = {
+          x: Math.round(rect.left * scale),
+          y: Math.round(rect.top * scale),
+          width: Math.max(1, Math.round(rect.width * scale)),
+          height: Math.max(1, Math.round(rect.height * scale)),
+        };
+        return {
+          canvas_id: canvasId,
+          id: id || null,
+          ref: ref || null,
+          role: attr(el, 'role') || nativeRole(el),
+          name: targetName(el, id, ref) || null,
+          action: data(el, 'aosAction') || attr(el, 'data-aos-action') || null,
+          surface: data(el, 'aosSurface') || attr(el, 'data-aos-surface') || null,
+          parent_canvas: data(el, 'aosParentCanvas') || attr(el, 'data-aos-parent-canvas') || null,
+          enabled: !disabled,
+          bounds,
+          center: {
+            x: Math.round(bounds.x + bounds.width / 2),
+            y: Math.round(bounds.y + bounds.height / 2),
+          },
+          state: stateFor(el, disabled),
+        };
+      }).filter(Boolean));
+    })()
+    """
+}
+
+func collectCanvasSemanticTargets(canvasID: String, scaleFactor: Double) -> [AOSSemanticTargetJSON]? {
+    let js = semanticTargetProbeJS(canvasID: canvasID, scaleFactor: scaleFactor)
+    guard
+        let response = sendEnvelopeRequest(
+            service: "show",
+            action: "eval",
+            data: ["id": canvasID, "js": js],
+            autoStartBinary: aosExecutablePath()
+        ),
+        let decoded = decodeCanvasResponse(response),
+        decoded.error == nil,
+        let result = decoded.result,
+        !result.hasPrefix("error:")
+    else {
+        return nil
+    }
+
+    guard let data = result.data(using: .utf8) else { return nil }
+    return try? JSONDecoder().decode([AOSSemanticTargetJSON].self, from: data)
+}

--- a/tests/aos-semantic-targets-xray.sh
+++ b/tests/aos-semantic-targets-xray.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Smoke test: AOS-owned canvas xray includes fixed semantic target projection
+# from standard DOM/ARIA plus thin AOS data attributes.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+CANVAS_ID="semantic-target-smoke-$$"
+
+cleanup() {
+  ./aos show remove --id "$CANVAS_ID" >/dev/null 2>&1 || true
+  rm -f "/tmp/${CANVAS_ID}.png"
+}
+trap cleanup EXIT
+
+./aos show create \
+  --id "$CANVAS_ID" \
+  --at 80,80,240,140 \
+  --interactive \
+  --html '<!doctype html><html><body style="margin:0;background:transparent"><button id="primary-button" data-aos-ref="contract.primary" data-aos-action="commit" data-aos-surface="contract.surface" data-semantic-target-id="primary" data-aos-parent-canvas="contract-parent" aria-label="Primary Action" aria-pressed="true" style="position:absolute;left:20px;top:30px;width:90px;height:44px"></button></body></html>' \
+  >/dev/null
+
+sleep 0.4
+
+OUT="$(./aos see capture --canvas "$CANVAS_ID" --xray --out "/tmp/${CANVAS_ID}.png" 2>/dev/null)"
+
+echo "$OUT" | jq -e --arg canvas "$CANVAS_ID" '
+  .semantic_targets
+  | map(select(
+      .canvas_id == $canvas
+      and .id == "primary"
+      and .ref == "contract.primary"
+      and .role == "button"
+      and .name == "Primary Action"
+      and .action == "commit"
+      and .surface == "contract.surface"
+      and .parent_canvas == "contract-parent"
+      and .enabled == true
+      and .state.pressed == true
+      and (.bounds.width | type == "number")
+      and .bounds.width > 0
+      and (.center.x | type == "number")
+    ))
+  | length == 1
+' >/dev/null || {
+  echo "FAIL: expected semantic_targets entry not found" >&2
+  echo "$OUT" | jq '.semantic_targets' >&2
+  exit 1
+}
+
+echo "PASS"

--- a/tests/renderer/hit-target.test.mjs
+++ b/tests/renderer/hit-target.test.mjs
@@ -1,5 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
 import { createHitTargetController } from '../../apps/sigil/renderer/live-modules/hit-target.js'
 
 test('Sigil hit target requests the above-menu window level', async () => {
@@ -77,4 +78,16 @@ test('Sigil hit target skips redundant frame updates', async () => {
   assert.equal(creates.length, 1)
   assert.equal(updates.length, 1)
   assert.deepEqual(updates[0], { id: 'sigil-hit-test', frame: [60, 60, 80, 80] })
+})
+
+test('Sigil hit area exposes avatar semantics without visible label text', async () => {
+  const html = await readFile(new URL('../../apps/sigil/renderer/hit-area.html', import.meta.url), 'utf8')
+
+  assert.match(html, /id="sigil-avatar-hit-target"/)
+  assert.match(html, /aria-label="Sigil avatar"/)
+  assert.match(html, /data-aos-surface="sigil\.avatar"/)
+  assert.match(html, /data-semantic-target-id="avatar"/)
+  assert.match(html, /dataset\.aosRef = HIT_ID/)
+  assert.match(html, /dataset\.aosParentCanvas = HIT_PARENT_ID/)
+  assert.doesNotMatch(html, />\s*Sigil avatar\s*<\/button>/)
 })

--- a/tests/sigil-avatar-interactions.sh
+++ b/tests/sigil-avatar-interactions.sh
@@ -42,6 +42,7 @@ aos_test_start_daemon "$ROOT" toolkit packages/toolkit sigil apps/sigil \
 python3 - <<'PY'
 import json
 import math
+import os
 import subprocess
 import time
 
@@ -65,7 +66,51 @@ def canvas_ids():
     return {canvas["id"] for canvas in payload.get("canvases", [])}
 
 
-def wait_until(predicate, timeout=5.0, interval=0.05):
+def see_canvas(canvas_id):
+    safe_id = "".join(char if char.isalnum() or char in "-_" else "-" for char in canvas_id)
+    out_path = f"/tmp/aos-sigil-semantic-{safe_id}-{os.getpid()}.png"
+    try:
+        return json.loads(run("see", "capture", "--canvas", canvas_id, "--xray", "--out", out_path))
+    finally:
+        try:
+            os.remove(out_path)
+        except FileNotFoundError:
+            pass
+
+
+def semantic_target(canvas_id, target_id):
+    payload = see_canvas(canvas_id)
+    for target in payload.get("semantic_targets") or []:
+        if target.get("id") == target_id:
+            return {"payload": payload, "target": target}
+    return None
+
+
+def native_desktop_bounds(displays):
+    rects = [display.get("native_bounds") for display in displays if display.get("native_bounds")]
+    if not rects:
+        return {"x": 0, "y": 0}
+    min_x = min(rect.get("x", 0) for rect in rects)
+    min_y = min(rect.get("y", 0) for rect in rects)
+    return {"x": min_x, "y": min_y}
+
+
+def semantic_target_world_point(surface_snapshot, capture_payload, target, displays):
+    frame = surface_snapshot.get("frame") or [0, 0, 0, 0]
+    surface = (capture_payload.get("surfaces") or [{}])[0]
+    scale = surface.get("capture_scale_factor") or 1
+    native_point = {
+        "x": frame[0] + target["center"]["x"] / scale,
+        "y": frame[1] + target["center"]["y"] / scale,
+    }
+    origin = native_desktop_bounds(displays)
+    return {
+        "x": native_point["x"] - origin["x"],
+        "y": native_point["y"] - origin["y"],
+    }
+
+
+def wait_until(predicate, timeout=5.0, interval=0.05, label="condition"):
     deadline = time.time() + timeout
     last = None
     while time.time() < deadline:
@@ -73,7 +118,7 @@ def wait_until(predicate, timeout=5.0, interval=0.05):
         if last is not None:
             return last
         time.sleep(interval)
-    raise SystemExit(f"FAIL: timed out waiting for condition; last={last!r}")
+    raise SystemExit(f"FAIL: timed out waiting for {label}; last={last!r}")
 
 
 snapshot = show_eval_json("JSON.stringify(window.__sigilDebug.snapshot())")
@@ -81,6 +126,16 @@ hit_target_id = snapshot["hitTargetId"]
 assert snapshot["hitTargetReady"] is True, snapshot
 assert hit_target_id in canvas_ids(), f"missing hit target canvas {hit_target_id}"
 assert snapshot["avatarVisible"] is True, snapshot
+
+hit_semantic = wait_until(lambda: semantic_target(hit_target_id, "avatar"), timeout=5.0, label="avatar hit semantic target")
+hit_target = hit_semantic["target"]
+assert hit_target["ref"] == hit_target_id, hit_target
+assert hit_target["role"] == "button", hit_target
+assert hit_target["name"] == "Sigil avatar", hit_target
+assert hit_target["surface"] == "sigil.avatar", hit_target
+assert hit_target["parent_canvas"] == "avatar-main", hit_target
+assert hit_target["enabled"] is True, hit_target
+assert hit_target["bounds"]["width"] > 0 and hit_target["bounds"]["height"] > 0, hit_target
 
 hover_state = show_eval_json(
     """(() => {
@@ -170,7 +225,7 @@ drag_state = show_eval_json(
 )
 assert drag_state["state"] == "RADIAL", drag_state
 assert drag_state["radialGestureMenu"]["phase"] == "radial", drag_state
-wait_until(
+radial_ready = wait_until(
     lambda: (
         lambda snap: snap
         if snap.get("radialGestureVisuals", {}).get("visible") is True
@@ -181,6 +236,28 @@ wait_until(
         else None
     )(show_eval_json("JSON.stringify(window.__sigilDebug.snapshot())")),
     timeout=3.0,
+    label="radial target surface ready",
+)
+radial_surface = radial_ready["radialTargetSurface"]
+radial_surface_id = radial_surface["id"]
+radial_context_semantic = wait_until(lambda: semantic_target(radial_surface_id, "context-menu"), timeout=3.0, label="radial context semantic target")
+radial_targets = radial_context_semantic["payload"].get("semantic_targets") or []
+radial_target_ids = {target.get("id") for target in radial_targets}
+assert {"context-menu", "wiki-graph"}.issubset(radial_target_ids), radial_targets
+context_target = radial_context_semantic["target"]
+assert context_target["ref"] == "sigil-radial-item-context-menu", context_target
+assert context_target["role"] == "button", context_target
+assert context_target["name"] == "Context Menu", context_target
+assert context_target["action"] == "contextMenu", context_target
+assert context_target["surface"] == radial_surface_id, context_target
+assert context_target["parent_canvas"] == "avatar-main", context_target
+
+displays = show_eval_json("JSON.stringify(window.liveJs.displays)")
+context_point = semantic_target_world_point(
+    radial_surface,
+    radial_context_semantic["payload"],
+    context_target,
+    displays,
 )
 
 canceled = show_eval_json(
@@ -192,16 +269,14 @@ canceled = show_eval_json(
 assert canceled["state"] == "IDLE", canceled
 
 radial_context = show_eval_json(
-    """(() => {
+    f"""(() => {{
       const p = window.liveJs.avatarPos
-      window.__sigilDebug.dispatchDesktop({ type: 'left_mouse_down', x: p.x, y: p.y })
-      window.__sigilDebug.dispatchDesktop({ type: 'left_mouse_dragged', x: p.x + 18, y: p.y })
-      const radial = window.__sigilDebug.snapshot().radialGestureMenu
-      const item = radial.items.find((candidate) => candidate.id === 'context-menu')
-      window.__sigilDebug.dispatchDesktop({ type: 'left_mouse_dragged', x: item.center.x, y: item.center.y })
-      window.__sigilDebug.dispatchDesktop({ type: 'left_mouse_up', x: item.center.x, y: item.center.y })
+      window.__sigilDebug.dispatchDesktop({{ type: 'left_mouse_down', x: p.x, y: p.y }})
+      window.__sigilDebug.dispatchDesktop({{ type: 'left_mouse_dragged', x: p.x + 18, y: p.y }})
+      window.__sigilDebug.dispatchDesktop({{ type: 'left_mouse_dragged', x: {context_point['x']}, y: {context_point['y']} }})
+      window.__sigilDebug.dispatchDesktop({{ type: 'left_mouse_up', x: {context_point['x']}, y: {context_point['y']} }})
       return JSON.stringify(window.__sigilDebug.snapshot())
-    })()"""
+    }})()"""
 )
 assert radial_context["state"] == "IDLE", radial_context
 assert radial_context["contextMenu"]["open"] is True, radial_context


### PR DESCRIPTION
## Summary

Adds a #163 vertical slice for AOS-owned canvas perception and Sigil consumption:

- emits `semantic_targets` from `aos see capture --canvas <id> --xray` using a fixed internal probe over existing DOM/AX/ARIA facts and toolkit `data-aos-*` metadata
- keeps native/browser xray `elements` shape unchanged
- documents the public response shape under `shared/schemas/aos-semantic-targets.md` and updates app/toolkit accessibility guidance
- extends the gateway capture wrapper/types for canvas captures and `semantic_targets`
- exposes the Sigil avatar hit child canvas as a semantic `Sigil avatar` target without visible label text
- updates the Sigil avatar/radial interaction scenario to assert hit and radial child canvas targets through `aos see` semantics before using debug paths for synthetic input

This intentionally avoids a new semantic language: roles, names, state, and bounds come from standard accessibility/DOM sources, while AOS metadata supplies stable ownership and routing identity.

## Validation

- `bash build.sh`
- `./aos ready`
- `bash tests/aos-semantic-targets-xray.sh`
- `bash tests/xray-json-shape.sh`
- `node --test tests/toolkit/runtime-semantic-targets.test.mjs`
- `node --test tests/renderer/hit-target.test.mjs tests/renderer/radial-menu-target-surface.test.mjs`
- `bash tests/sigil-avatar-interactions.sh`
- `bash -n tests/aos-semantic-targets-xray.sh`
- `bash -n tests/sigil-avatar-interactions.sh`
- `npm ci && npm run build` in `packages/gateway`

Part of #163.