### PR TITLE
Bind canvas captures to AOS backing windows

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -265,6 +265,11 @@ canvases are unchanged and do not carry `segments`. Existing normal canvases
 cannot be converted into DesktopWorld surfaces with `show update`; remove and
 recreate the canvas so it boots with the segmented backing.
 
+`show list` and `show get` also expose `windowNumbers`, the native macOS window
+number or numbers backing a canvas. Perception commands use this to keep
+canvas-scoped captures and `--xray` AX traversal attached to the intended AOS
+surface instead of falling back to the frontmost app.
+
 ## `aos ops`
 
 `ops` is the source-backed operator recipe surface. It sits above primitive

--- a/packages/toolkit/runtime/canvas-lifecycle.js
+++ b/packages/toolkit/runtime/canvas-lifecycle.js
@@ -27,6 +27,8 @@ export function mergeCanvasLifecycleCanvas(existing, data) {
     cascade: data?.cascade ?? canvas.cascade ?? existing?.cascade ?? null,
     suspended: data?.suspended ?? canvas.suspended ?? existing?.suspended ?? null,
   }
+  const windowNumbers = data?.windowNumbers ?? canvas.windowNumbers ?? existing?.windowNumbers
+  if (windowNumbers !== undefined) next.windowNumbers = windowNumbers
   const segments = data?.segments ?? canvas.segments ?? existing?.segments
   if (segments !== undefined) next.segments = segments
   return next

--- a/shared/schemas/daemon-event.md
+++ b/shared/schemas/daemon-event.md
@@ -50,7 +50,7 @@ Today `snapshot:true` replays current state for `display_geometry` and
 `canvas_lifecycle` immediately after the success response. For
 `canvas_lifecycle`, the replay uses the same payload shape as live events,
 including canvas metadata such as `parent`, `track`, `interactive`, `window_level`, `scope`,
-the nested `canvas` object, and `segments` for DesktopWorld surfaces. For a
+`windowNumbers`, the nested `canvas` object, and `segments` for DesktopWorld surfaces. For a
 DesktopWorld surface, snapshot replay sends `canvas_topology_settled` before
 the synthetic `created` lifecycle event so segment-aware renderers can identify
 their topology before normal boot side effects run.
@@ -76,7 +76,7 @@ their topology before normal boot side effects run.
 | Event | Data | Trigger |
 |-------|------|---------|
 | `canvas_message` | `{id, payload}` | Canvas JS called postMessage |
-| `canvas_lifecycle` | `{canvas_id, action, at, parent?, track?, interactive, window_level?, scope?, ttl?, cascade?, suspended?, canvas}` | Canvas created/removed/updated |
+| `canvas_lifecycle` | `{canvas_id, action, at, parent?, track?, interactive, window_level?, scope?, ttl?, cascade?, suspended?, windowNumbers?, canvas}` | Canvas created/removed/updated |
 | `canvas_segment_added` | `{canvas_id, display_id, index, dw_bounds, native_bounds}` | DesktopWorld surface gained a display-backed segment |
 | `canvas_segment_removed` | `{canvas_id, display_id, index, dw_bounds, native_bounds}` | DesktopWorld surface lost a display-backed segment |
 | `canvas_segment_changed` | `{canvas_id, display_id, index, dw_bounds, native_bounds}` | DesktopWorld surface segment ordering or bounds changed |

--- a/shared/schemas/daemon-ipc.md
+++ b/shared/schemas/daemon-ipc.md
@@ -96,14 +96,19 @@ canvas layering. Valid values are `automatic`, `floating`, `status_bar`, and
 `screen_saver`; `automatic` preserves the daemon default for the canvas'
 interactive mode.
 
-DesktopWorld surfaces keep one logical canvas id while the daemon backs that id
-with one physical segment per active display. `show.list`, `show.get`, and
-`canvas_lifecycle` metadata include `segments` for these surfaces:
+`show.list`, `show.get`, and `canvas_lifecycle` metadata include
+`windowNumbers`, the native macOS window number or numbers backing a canvas.
+Normal canvases report one entry. DesktopWorld surfaces keep one logical canvas
+id while the daemon backs that id with one physical segment per active display;
+for those surfaces `windowNumbers` is ordered to match `segments`.
+`show.list`, `show.get`, and `canvas_lifecycle` metadata include `segments` for
+DesktopWorld surfaces:
 
 ```json
 {
   "id": "avatar-main",
   "track": "union",
+  "windowNumbers": [91234],
   "segments": [
     {
       "display_id": 1,

--- a/src/daemon/unified.swift
+++ b/src/daemon/unified.swift
@@ -423,6 +423,7 @@ class UnifiedDaemon {
         if let ttl = canvasInfo.ttl { payload["ttl"] = ttl }
         if let cascade = canvasInfo.cascade { payload["cascade"] = cascade }
         if let suspended = canvasInfo.suspended { payload["suspended"] = suspended }
+        if let windowNumbers = canvasInfo.windowNumbers { payload["windowNumbers"] = windowNumbers }
         if let segments = canvasInfo.segments {
             payload["segments"] = segments.map { segment in
                 [

--- a/src/display/canvas.swift
+++ b/src/display/canvas.swift
@@ -513,6 +513,7 @@ class Canvas {
             parent: parent,
             cascade: cascadeFromParent,
             suspended: suspended,
+            windowNumbers: windowNumbers,
             segments: nil
         )
     }

--- a/src/display/desktop-world-surface.swift
+++ b/src/display/desktop-world-surface.swift
@@ -292,6 +292,7 @@ final class DesktopWorldSurfaceCanvas: CanvasLike {
             parent: parent,
             cascade: cascadeFromParent,
             suspended: suspended,
+            windowNumbers: windowNumbers,
             segments: segmentMetadata()
         )
     }

--- a/src/display/protocol.swift
+++ b/src/display/protocol.swift
@@ -114,6 +114,7 @@ struct CanvasInfo: Codable {
     var parent: String?         // parent canvas ID (nil if root)
     var cascade: Bool?          // lifecycle cascade flag
     var suspended: Bool?        // true if canvas is suspended (hidden + paused)
+    var windowNumbers: [Int]?   // native window numbers backing this canvas
     var segments: [DesktopWorldSurfaceSegment]?  // present for DesktopWorldSurface canvases
 }
 

--- a/src/perceive/capture-pipeline.swift
+++ b/src/perceive/capture-pipeline.swift
@@ -621,7 +621,7 @@ func resolveCaptureSurface(opts: CaptureOptions, displays: [CaptureDisplayEntry]
             kind: "canvas",
             id: canvasID,
             globalBounds: bounds,
-            windowID: nil,
+            windowID: canvas.windowNumbers?.first ?? canvas.anchorWindow,
             segments: resolveSurfaceSegments(bounds, displays: displays)
         )
     }

--- a/tests/canvas-lifecycle-metadata-smoke.sh
+++ b/tests/canvas-lifecycle-metadata-smoke.sh
@@ -65,6 +65,12 @@ for _ in range(50):
         if parent.get("track") != "union" or child.get("parent") != "parent-canvas" or child.get("scope") != "global":
             ready = False
             break
+        if not isinstance(parent.get("windowNumbers"), list) or not parent["windowNumbers"]:
+            ready = False
+            break
+        if not isinstance(child.get("windowNumbers"), list) or not child["windowNumbers"]:
+            ready = False
+            break
     if ready:
         break
     time.sleep(0.2)

--- a/tests/capture-canvas-surface.sh
+++ b/tests/capture-canvas-surface.sh
@@ -41,11 +41,16 @@ JSON_PATH="$ARTIFACT_DIR/canvas.json"
 ./aos see capture --canvas surface-probe --perception --out "$PNG_PATH" > "$JSON_PATH"
 
 python3 - "$PNG_PATH" "$JSON_PATH" <<'PY'
-import json, pathlib, sys
+import json, pathlib, subprocess, sys
 
 png_path = pathlib.Path(sys.argv[1]).resolve()
 json_path = pathlib.Path(sys.argv[2]).resolve()
 payload = json.loads(json_path.read_text())
+show = json.loads(subprocess.check_output(["./aos", "show", "list", "--json"], text=True))
+canvas = next(c for c in show["canvases"] if c["id"] == "surface-probe")
+window_numbers = canvas.get("windowNumbers")
+assert isinstance(window_numbers, list) and len(window_numbers) == 1, canvas
+assert isinstance(window_numbers[0], int) and window_numbers[0] > 0, canvas
 
 assert len(payload.get("files") or []) == 1, payload
 assert pathlib.Path(payload["files"][0]).resolve() == png_path, payload
@@ -55,6 +60,8 @@ assert len(surfaces) == 1, payload
 surface = surfaces[0]
 assert surface["kind"] == "canvas", surface
 assert surface["id"] == "surface-probe", surface
+assert isinstance(surface.get("window_id"), int) and surface["window_id"] > 0, surface
+assert surface["window_id"] == window_numbers[0], (surface, canvas)
 assert surface["bounds_global"] == {"x": 40, "y": 40, "width": 120, "height": 80}, surface
 assert surface["displays"] == [surface["display"]], surface
 assert len(surface["segments"]) == 1, surface

--- a/tests/capture-union-canvas-surface.sh
+++ b/tests/capture-union-canvas-surface.sh
@@ -64,6 +64,9 @@ canvas = next(c for c in show["canvases"] if c["id"] == "union-probe")
 cx, cy, cw, ch = canvas["at"]
 show_segments = canvas.get("segments")
 assert show_segments is not None, canvas
+window_numbers = canvas.get("windowNumbers")
+assert isinstance(window_numbers, list) and len(window_numbers) == len(show_segments), canvas
+assert all(isinstance(wid, int) and wid > 0 for wid in window_numbers), canvas
 
 assert len(payload.get("files") or []) == 1, payload
 assert pathlib.Path(payload["files"][0]).resolve() == png_path, payload
@@ -73,6 +76,7 @@ assert len(surfaces) == 1, payload
 surface = surfaces[0]
 assert surface["kind"] == "canvas", surface
 assert surface["id"] == "union-probe", surface
+assert surface["window_id"] == window_numbers[0], (surface, canvas)
 assert surface["bounds_global"] == {"x": cx, "y": cy, "width": cw, "height": ch}, surface
 assert len(surface["segments"]) >= 2, surface
 assert len(surface["displays"]) >= 2, surface

--- a/tests/toolkit/runtime-canvas-lifecycle.test.mjs
+++ b/tests/toolkit/runtime-canvas-lifecycle.test.mjs
@@ -39,6 +39,7 @@ test('mergeCanvasLifecycleCanvas preserves rich metadata from lifecycle payloads
       track: 'union',
       cascade: true,
       suspended: false,
+      windowNumbers: [1001, 1002],
     },
   })
 
@@ -52,6 +53,7 @@ test('mergeCanvasLifecycleCanvas preserves rich metadata from lifecycle payloads
     ttl: null,
     cascade: true,
     suspended: false,
+    windowNumbers: [1001, 1002],
   })
 })
 
@@ -80,6 +82,18 @@ test('mergeCanvasLifecycleCanvas falls back to nested canvas metadata for child 
     cascade: true,
     suspended: false,
   })
+})
+
+test('mergeCanvasLifecycleCanvas preserves top-level native window numbers', () => {
+  const merged = mergeCanvasLifecycleCanvas(null, {
+    canvas_id: 'agent-panel',
+    action: 'created',
+    at: [10, 20, 300, 200],
+    interactive: true,
+    windowNumbers: [4242],
+  })
+
+  assert.deepEqual(merged.windowNumbers, [4242])
 })
 
 test('mergeCanvasLifecycleCanvas preserves DesktopWorld surface segments', () => {


### PR DESCRIPTION
## Summary
- expose native canvas backing window numbers through CanvasInfo, show list/get, and canvas lifecycle metadata
- use the backing AOS canvas window for canvas-scoped capture/xray surface resolution instead of leaving the surface window unset
- preserve windowNumbers in toolkit lifecycle normalization and document the shared daemon/API contract

Part of #161.

## Verification
- ./aos ready
- bash build.sh
- node --test tests/toolkit/runtime-canvas-lifecycle.test.mjs
- bash tests/capture-canvas-surface.sh
- bash tests/aos-semantic-targets-xray.sh
- bash tests/capture-union-canvas-surface.sh
- bash tests/canvas-lifecycle-metadata-smoke.sh
- bash tests/xray-json-shape.sh
- git diff --check

Note: running multiple isolated GUI daemon tests in parallel caused transient Screen Recording/IPC failures; sequential reruns passed.