### PR TITLE
Add Sigil radial real-input harness

### DIFF
--- a/apps/sigil/AGENTS.md
+++ b/apps/sigil/AGENTS.md
@@ -97,6 +97,24 @@ or tooltips into the user-facing composition. See
 `docs/recipes/aos-app-accessibility-surfaces.md` for the repo-wide app and
 toolkit contract.
 
+### Radial Menu Real-Input Verification
+
+For Sigil radial menu, avatar hit target, status-item launch, or physical
+pointer behavior, use the canonical real-input scenario before inventing an ad
+hoc canvas path:
+
+```bash
+AOS_REAL_INPUT_OK=1 bash tests/scenarios/sigil/radial-menu/real-input.sh
+```
+
+This scenario uses the active repo daemon and the visible AOS status item,
+opens Sigil through the human-facing path, opens the radial menu with real
+cursor movement and drag input, verifies the radial child surface through AOS
+semantic targets, and removes its canvases on exit. Synthetic renderer tests and
+`show eval` probes remain appropriate for focused state-machine or DOM logic,
+but they are not enough to close regressions that only appear through actual
+mouse input.
+
 ### Content Server
 
 The AOS daemon serves Sigil's HTML surfaces over localhost. Configure in `~/.config/aos/{mode}/config.json`:

--- a/apps/sigil/context-menu/README.md
+++ b/apps/sigil/context-menu/README.md
@@ -59,9 +59,15 @@ falling back to screenshots.
 For user-input regressions, spot-check with actual AOS events:
 
 ```bash
+AOS_REAL_INPUT_OK=1 bash tests/scenarios/sigil/radial-menu/real-input.sh
 bash tests/sigil-real-input-status-avatar.sh
 bash tests/sigil-context-menu-real-input.sh
 ```
+
+`tests/scenarios/sigil/radial-menu/real-input.sh` is the default radial-menu
+entry path. It uses the live repo status item, opens the radial menu with real
+drag input, and verifies the radial menu child surface through AOS semantic
+targets before any screenshot or pixel fallback.
 
 `tests/sigil-real-input-status-avatar.sh` is the default entry-path smoke. It
 uses the status item as the user would: locate the AOS status item, click it

--- a/docs/recipes/agent-entry-paths-and-verification.md
+++ b/docs/recipes/agent-entry-paths-and-verification.md
@@ -130,8 +130,10 @@ starting point.
 5. Pick the smallest test loop that matches the changed behavior.
 6. For visual/display work, launch the relevant diagnostics instead of relying
    on memory or screenshots alone.
-7. For real-input bugs, capture or run at least one real-input verification.
-8. If the task touches runtime knowledge, check whether the AOS wiki needs to be
+7. When a repo-owned scenario harness exists for the behavior, use that harness
+   before inventing an ad hoc verification path.
+8. For real-input bugs, capture or run at least one real-input verification.
+9. If the task touches runtime knowledge, check whether the AOS wiki needs to be
    read or updated in addition to repo docs or code.
-9. If a lesson should survive the session, place it using the placement rules
+10. If a lesson should survive the session, place it using the placement rules
    above before handing the work back.

--- a/tests/README.md
+++ b/tests/README.md
@@ -90,6 +90,23 @@ Visual Sigil scenarios should default to launching `canvas-inspector` beside the
 surface under test unless the test is specifically measuring canvas lifecycle,
 window count, or placement without auxiliary canvases.
 
+For Sigil radial-menu, avatar hit-target, status-item launch, or physical
+pointer behavior, use the canonical live real-input scenario before creating an
+ad hoc canvas or relying only on renderer debug state:
+
+```bash
+AOS_REAL_INPUT_OK=1 bash tests/scenarios/sigil/radial-menu/real-input.sh
+```
+
+It requires an active repo daemon, exactly one visible AOS status item, and an
+idle keyboard/mouse. It opens Sigil through the status item, uses real cursor
+movement and drag input to reveal the radial menu, verifies the radial child
+surface through AOS semantic targets, and removes `avatar-main`,
+`sigil-hit-avatar-main`, `sigil-radial-menu-avatar-main`, and
+`sigil-radial-harness-inspector` on exit. If the run fails, use the structured
+diagnostics it prints before escalating to screenshots, pixel checks, or HITL
+inspection.
+
 For live or manual Sigil checks after source edits, do not trust an already-open
 `avatar-main` unless its debug runtime snapshot proves it was reloaded after the
 change. Relaunch the surface or use `tests/lib/visual-harness.sh`; stale

--- a/tests/lib/sigil/radial-menu.sh
+++ b/tests/lib/sigil/radial-menu.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+
+SIGIL_RADIAL_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SIGIL_RADIAL_LIB_DIR/../visual-harness.sh"
+
+aos_sigil_radial_verify_real_input() {
+  local avatar_id="${1:-avatar-main}"
+  local aos_bin
+  aos_bin="$(aos_visual_aos)"
+
+  python3 - "$aos_bin" "$avatar_id" <<'PY'
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+aos, avatar_id = sys.argv[1:3]
+
+
+def run(*args):
+    return subprocess.check_output([aos, *args], text=True, stderr=subprocess.STDOUT)
+
+
+def run_json(*args):
+    return json.loads(run(*args))
+
+
+def eval_json(js):
+    payload = run_json("show", "eval", "--id", avatar_id, "--js", js)
+    if payload.get("status") != "success":
+        raise SystemExit(f"FAIL: show eval failed: {payload}")
+    return json.loads(payload.get("result") or "null")
+
+
+def wait_until(predicate, timeout=6.0, interval=0.08, label="condition"):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        last = predicate()
+        if last is not None:
+            return last
+        time.sleep(interval)
+    raise SystemExit(f"FAIL: timed out waiting for {label}; last={last!r}")
+
+
+def point_arg(point):
+    return f"{round(point['x'])},{round(point['y'])}"
+
+
+def distance(a, b):
+    dx = float(a["x"]) - float(b["x"])
+    dy = float(a["y"]) - float(b["y"])
+    return (dx * dx + dy * dy) ** 0.5
+
+
+def cursor_point():
+    payload = run_json("see", "cursor")
+    cursor = payload.get("cursor") or {}
+    return {"x": cursor.get("x", 0), "y": cursor.get("y", 0)}
+
+
+def hit_target_probe():
+    return eval_json(
+        """(() => {
+          const snap = window.__sigilDebug?.snapshot?.() || {};
+          return JSON.stringify({
+            avatarVisible: snap.avatarVisible,
+            hitTargetReady: snap.hitTargetReady,
+            hitTargetInteractive: snap.hitTargetInteractive,
+            hitTargetFrame: snap.hitTargetFrame,
+            avatarPos: snap.avatarPos,
+            state: snap.state || null
+          });
+        })()"""
+    )
+
+
+def radial_surface_probe():
+    return eval_json(
+        """(() => {
+          const snap = window.__sigilDebug?.snapshot?.() || {};
+          const surface = snap.radialTargetSurface || null;
+          return JSON.stringify({
+            state: snap.state || null,
+            phase: snap.radialGestureMenu?.phase || null,
+            visuals: snap.radialGestureVisuals || null,
+            surface,
+            targetIds: (surface?.targets || []).map((target) => target.id)
+          });
+        })()"""
+    )
+
+
+def radial_surface_capture(surface_id):
+    fd, path = tempfile.mkstemp(prefix="aos-sigil-radial-", suffix=".png")
+    os.close(fd)
+    try:
+        return run_json("see", "capture", "--canvas", surface_id, "--xray", "--out", path)
+    finally:
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+
+
+def semantic_target_map(payload):
+    result = {}
+    for target in payload.get("semantic_targets") or []:
+        target_id = target.get("id")
+        if target_id:
+            result[target_id] = target
+    return result
+
+
+def element_names(payload):
+    names = []
+    for element in payload.get("elements") or []:
+        for key in ("title", "label", "value"):
+            value = element.get(key)
+            if isinstance(value, str) and value:
+                names.append(value)
+    return names
+
+
+def verify_radial_semantics(surface):
+    surface_id = surface["surface"]["id"]
+    payload = radial_surface_capture(surface_id)
+    targets = semantic_target_map(payload)
+    required = {"context-menu", "wiki-graph"}
+    if not required.issubset(targets):
+        raise SystemExit("FAIL: radial semantic targets missing: " + json.dumps({
+            "required": sorted(required),
+            "targetIds": sorted(targets),
+            "surface": surface,
+            "payloadTargets": payload.get("semantic_targets") or [],
+        }, sort_keys=True))
+
+    context = targets["context-menu"]
+    wiki = targets["wiki-graph"]
+    assertions = [
+        (context.get("ref") == "sigil-radial-item-context-menu", "context menu ref", context),
+        (context.get("role") == "button", "context menu role", context),
+        (context.get("name") == "Context Menu", "context menu name", context),
+        (context.get("action") == "contextMenu", "context menu action", context),
+        (context.get("surface") == surface_id, "context menu surface", context),
+        (context.get("parent_canvas") == avatar_id, "context menu parent", context),
+        (wiki.get("ref") == "sigil-radial-item-wiki-graph", "wiki graph ref", wiki),
+        (wiki.get("role") == "button", "wiki graph role", wiki),
+        (wiki.get("name") == "Wiki Graph", "wiki graph name", wiki),
+        (wiki.get("surface") == surface_id, "wiki graph surface", wiki),
+        (wiki.get("parent_canvas") == avatar_id, "wiki graph parent", wiki),
+    ]
+    for ok, label, target in assertions:
+        if not ok:
+            raise SystemExit(f"FAIL: radial semantic target failed {label}: " + json.dumps(target, sort_keys=True))
+
+    semantic_names = [target.get("name") for target in targets.values() if isinstance(target.get("name"), str)]
+    if any(name.startswith("Sigil radial item:") for name in semantic_names):
+        raise SystemExit("FAIL: radial item semantic names should be command names only: " + json.dumps(semantic_names))
+
+    names = element_names(payload)
+    return {
+        "status": payload.get("status"),
+        "surface": surface_id,
+        "targetIds": sorted(targets),
+        "semanticNames": sorted(semantic_names),
+        "xrayNames": names,
+        "buttonCount": sum(1 for element in payload.get("elements") or [] if element.get("role") == "AXButton"),
+    }
+
+
+eval_json("window.__sigilDebug?.armInteractionTrace?.('radial-real-input-harness'); JSON.stringify(true)")
+
+last_stable = {"probe": None, "count": 0}
+
+
+def stable_hit_target():
+    probe = hit_target_probe()
+    frame = probe.get("hitTargetFrame")
+    if not probe.get("avatarVisible") or not probe.get("hitTargetReady") or not probe.get("hitTargetInteractive") or not frame:
+        last_stable["probe"] = probe
+        last_stable["count"] = 0
+        return None
+
+    previous = (last_stable.get("probe") or {}).get("hitTargetFrame")
+    if previous and all(abs(float(frame[i]) - float(previous[i])) <= 1.0 for i in range(4)):
+        last_stable["count"] += 1
+    else:
+        last_stable["count"] = 1
+    last_stable["probe"] = probe
+    if last_stable["count"] >= 4:
+        return probe
+    return None
+
+
+initial = wait_until(stable_hit_target, timeout=6.0, interval=0.08, label="stable Sigil hit target")
+frame = initial.get("hitTargetFrame")
+if not frame:
+    raise SystemExit(f"FAIL: avatar not ready for radial real-input check: {initial}")
+
+start = {"x": frame[0] + frame[2] / 2, "y": frame[1] + frame[3] / 2}
+target = {"x": start["x"] + 24, "y": start["y"]}
+
+hover = subprocess.run(
+    [aos, "do", "hover", point_arg(start)],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    text=True,
+    timeout=8,
+)
+if hover.returncode != 0:
+    raise SystemExit(f"FAIL: cursor preposition failed: {hover.stdout}")
+
+pre_drag_cursor = cursor_point()
+if distance(pre_drag_cursor, start) > 8:
+    raise SystemExit("FAIL: cursor preposition did not land on radial hit target: " + json.dumps({
+        "start": start,
+        "cursor": pre_drag_cursor,
+        "initial": initial,
+        "hover": hover.stdout.strip(),
+    }, sort_keys=True))
+
+drag = subprocess.Popen(
+    [aos, "do", "drag", point_arg(start), point_arg(target), "--speed", "6"],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    text=True,
+)
+
+surface = None
+semantic_proof = None
+proof_error = None
+stdout = ""
+drag_timeout_error = None
+drag_timeout = max(6.0, distance(start, target) / 6.0 + 2.0)
+
+try:
+    surface = wait_until(
+        lambda: (
+            lambda probe: probe
+            if (
+                probe.get("state") == "RADIAL"
+                and probe.get("phase") == "radial"
+                and (probe.get("surface") or {}).get("ready") is True
+                and (probe.get("surface") or {}).get("interactive") is True
+                and {"context-menu", "wiki-graph"}.issubset(set(probe.get("targetIds") or []))
+                and (probe.get("visuals") or {}).get("visible") is True
+            )
+            else None
+        )(radial_surface_probe()),
+        timeout=4.0,
+        interval=0.08,
+        label="AOS radial menu target surface",
+    )
+    semantic_proof = verify_radial_semantics(surface)
+except SystemExit as error:
+    proof_error = str(error)
+finally:
+    try:
+        stdout, _ = drag.communicate(timeout=drag_timeout)
+    except subprocess.TimeoutExpired:
+        drag.kill()
+        stdout, _ = drag.communicate()
+        drag_timeout_error = f"real drag did not finish within {drag_timeout:.1f}s"
+
+diagnostics = {
+    "initial": initial,
+    "surface": surface,
+    "semanticProof": semantic_proof,
+    "start": start,
+    "target": target,
+    "preDragCursor": pre_drag_cursor,
+    "hover": hover.stdout.strip(),
+    "drag": stdout.strip(),
+    "lastProbe": radial_surface_probe(),
+}
+
+if proof_error:
+    diagnostics["proofError"] = proof_error
+    raise SystemExit("FAIL: radial semantic proof failed: " + json.dumps(diagnostics, sort_keys=True))
+if drag_timeout_error:
+    diagnostics["dragTimeoutError"] = drag_timeout_error
+    raise SystemExit("FAIL: real drag did not finish cleanly: " + json.dumps(diagnostics, sort_keys=True))
+if drag.returncode != 0:
+    diagnostics["dragReturnCode"] = drag.returncode
+    raise SystemExit("FAIL: real drag command failed: " + json.dumps(diagnostics, sort_keys=True))
+
+try:
+    drag_payload = json.loads(stdout) if stdout.strip().startswith("{") else stdout.strip()
+except json.JSONDecodeError:
+    drag_payload = stdout.strip()
+
+print("PASS", json.dumps({
+    "initial": initial,
+    "surface": surface,
+    "semanticProof": semantic_proof,
+    "preDragCursor": pre_drag_cursor,
+    "drag": drag_payload,
+}, sort_keys=True))
+PY
+}

--- a/tests/lib/visual-harness.sh
+++ b/tests/lib/visual-harness.sh
@@ -32,8 +32,8 @@ aos_visual_prepare_live_roots() {
   local aos_bin
   aos_bin="$(aos_visual_aos)"
 
-  "$aos_bin" set content.roots.toolkit packages/toolkit >/dev/null
-  "$aos_bin" set content.roots.sigil apps/sigil >/dev/null
+  "$aos_bin" set content.roots.toolkit "$VISUAL_HARNESS_ROOT/packages/toolkit" >/dev/null
+  "$aos_bin" set content.roots.sigil "$VISUAL_HARNESS_ROOT/apps/sigil" >/dev/null
   "$aos_bin" content wait --root toolkit --root sigil --auto-start --timeout 15s >/dev/null
 }
 
@@ -42,8 +42,8 @@ aos_visual_configure_sigil_status_item() {
   local aos_bin
   aos_bin="$(aos_visual_aos)"
 
-  "$aos_bin" set content.roots.toolkit packages/toolkit >/dev/null
-  "$aos_bin" set content.roots.sigil apps/sigil >/dev/null
+  "$aos_bin" set content.roots.toolkit "$VISUAL_HARNESS_ROOT/packages/toolkit" >/dev/null
+  "$aos_bin" set content.roots.sigil "$VISUAL_HARNESS_ROOT/apps/sigil" >/dev/null
   "$aos_bin" set status_item.enabled true >/dev/null
   "$aos_bin" set status_item.toggle_id "$avatar_id" >/dev/null
   "$aos_bin" set status_item.toggle_url 'aos://sigil/renderer/index.html' >/dev/null
@@ -52,18 +52,74 @@ aos_visual_configure_sigil_status_item() {
 
 aos_visual_remove_canvas() {
   local canvas_id="$1"
-  local aos_bin
+  local aos_bin timeout
   aos_bin="$(aos_visual_aos)"
+  timeout="${2:-3}"
 
   "$aos_bin" show remove --id "$canvas_id" >/dev/null 2>&1 || true
+  python3 - "$aos_bin" "$canvas_id" "$timeout" <<'PY' >/dev/null 2>&1 || true
+import json
+import subprocess
+import sys
+import time
+
+aos, canvas_id, timeout = sys.argv[1], sys.argv[2], float(sys.argv[3])
+deadline = time.time() + timeout
+
+while time.time() < deadline:
+    try:
+        payload = json.loads(subprocess.check_output([aos, "show", "list", "--json"], text=True, stderr=subprocess.DEVNULL))
+    except Exception:
+        raise SystemExit(0)
+    ids = {canvas.get("id") for canvas in payload.get("canvases") or []}
+    if canvas_id not in ids:
+        raise SystemExit(0)
+    time.sleep(0.1)
+PY
 }
 
 aos_visual_launch_canvas_inspector() {
   local inspector_id="${1:-canvas-inspector}"
-  local aos_bin
+  local aos_bin panel_w panel_h display_json x y
   aos_bin="$(aos_visual_aos)"
+  panel_w="${AOS_CANVAS_INSPECTOR_W:-320}"
+  panel_h="${AOS_CANVAS_INSPECTOR_H:-480}"
 
-  CANVAS_ID="$inspector_id" AOS="$aos_bin" bash "$VISUAL_HARNESS_ROOT/packages/toolkit/components/canvas-inspector/launch.sh" >/dev/null
+  aos_visual_remove_canvas "$inspector_id" 5
+  "$aos_bin" set content.roots.toolkit "$VISUAL_HARNESS_ROOT/packages/toolkit" >/dev/null
+  "$aos_bin" content wait --root toolkit --auto-start --timeout 15s >/dev/null
+
+  display_json="$("$aos_bin" graph displays --json 2>/dev/null || echo '{"data":{"displays":[]}}')"
+  read -r x y <<EOF
+$(PANEL_W="$panel_w" PANEL_H="$panel_h" python3 -c "
+import json, os, sys
+
+payload = json.load(sys.stdin)
+displays = payload.get('data', {}).get('displays', payload.get('displays', payload if isinstance(payload, list) else []))
+main = next((display for display in displays if display.get('is_main')), displays[0] if displays else None)
+rect = (main or {}).get('visible_bounds') or (main or {}).get('bounds') or {}
+x = int(rect.get('x', 0))
+y = int(rect.get('y', 0))
+w = int(rect.get('w', 1920))
+h = int(rect.get('h', 1080))
+panel_w = int(os.environ['PANEL_W'])
+panel_h = int(os.environ['PANEL_H'])
+print(max(x, x + w - panel_w), max(y, y + h - panel_h))
+" <<<"$display_json" 2>/dev/null || echo "1600 500")
+EOF
+
+  "$aos_bin" show create --id "$inspector_id" \
+    --at "$x,$y,$panel_w,$panel_h" \
+    --interactive \
+    --scope global \
+    --url 'aos://toolkit/components/canvas-inspector/index.html' >/dev/null
+
+  "$aos_bin" show wait --id "$inspector_id" --manifest canvas-inspector --timeout 5s >/dev/null
+  "$aos_bin" show wait \
+    --id "$inspector_id" \
+    --manifest canvas-inspector \
+    --js '!!document.querySelector(".tree-row.canvas.self .canvas-dims") && !!document.querySelector(".minimap-display")' \
+    --timeout 5s >/dev/null
 }
 
 aos_visual_launch_sigil_avatar() {
@@ -118,6 +174,47 @@ aos_visual_show_sigil_avatar_via_real_status_click() {
     echo "FAIL: daemon pid missing for real status-item click" >&2
     return 1
   }
+
+  click_aos_status_item_real "$pid" "$aos_bin"
+  aos_visual_wait_sigil_avatar_ready "$avatar_id"
+  "$aos_bin" show wait \
+    --id "$avatar_id" \
+    --js 'window.__sigilDebug && window.__sigilDebug.snapshot().avatarVisible === true && window.__sigilDebug.snapshot().hitTargetInteractive === true' \
+    --timeout 5s >/dev/null
+}
+
+aos_visual_single_status_item_pid() {
+  local matches_json
+  matches_json="$(aos_status_item_matches_json)" || return 1
+
+  python3 - "$matches_json" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+matches = payload.get("matches") or []
+if len(matches) != 1:
+    print(
+        f"FAIL: expected exactly one AOS status item, found {len(matches)}: "
+        f"{json.dumps(matches, sort_keys=True)}",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+pid = matches[0].get("pid")
+if not pid:
+    print(f"FAIL: AOS status item match is missing pid: {matches[0]}", file=sys.stderr)
+    raise SystemExit(1)
+
+print(pid)
+PY
+}
+
+aos_visual_show_sigil_avatar_via_live_status_click() {
+  local avatar_id="${1:-avatar-main}"
+  local aos_bin pid
+  aos_bin="$(aos_visual_aos)"
+  pid="$(aos_visual_single_status_item_pid)"
 
   click_aos_status_item_real "$pid" "$aos_bin"
   aos_visual_wait_sigil_avatar_ready "$avatar_id"
@@ -271,6 +368,24 @@ aos_visual_launch_sigil_with_inspector_via_status_item() {
   aos_visual_remove_canvas "$inspector_id"
   aos_visual_launch_canvas_inspector "$inspector_id"
   aos_visual_show_sigil_avatar_via_real_status_click "$state_root" "$avatar_id"
+  if [[ "$placement" == "manual-visible" ]]; then
+    aos_visual_place_sigil_avatar_for_manual_test "$avatar_id"
+  fi
+  aos_visual_avoid_sigil_avatar_overlap "$avatar_id" "$inspector_id"
+}
+
+aos_visual_launch_sigil_with_inspector_via_live_status_item() {
+  local avatar_id="${1:-avatar-main}"
+  local inspector_id="${2:-canvas-inspector}"
+  local placement="${3:-default}"
+
+  aos_visual_configure_sigil_status_item "$avatar_id"
+  aos_visual_remove_canvas "$avatar_id"
+  aos_visual_remove_canvas "sigil-hit-$avatar_id"
+  aos_visual_remove_canvas "sigil-radial-menu-$avatar_id"
+  aos_visual_remove_canvas "$inspector_id"
+  aos_visual_launch_canvas_inspector "$inspector_id"
+  aos_visual_show_sigil_avatar_via_live_status_click "$avatar_id"
   if [[ "$placement" == "manual-visible" ]]; then
     aos_visual_place_sigil_avatar_for_manual_test "$avatar_id"
   fi

--- a/tests/scenarios/sigil/radial-menu/real-input.sh
+++ b/tests/scenarios/sigil/radial-menu/real-input.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "$0")/../../../lib/sigil/radial-menu.sh"
+
+AVATAR_ID="${AOS_SIGIL_AVATAR_ID:-avatar-main}"
+INSPECTOR_ID="${AOS_SIGIL_INSPECTOR_ID:-sigil-radial-harness-inspector}"
+RADIAL_ID="sigil-radial-menu-$AVATAR_ID"
+HIT_ID="sigil-hit-$AVATAR_ID"
+
+if [[ "${AOS_REAL_INPUT_OK:-}" != "1" ]]; then
+  echo "SKIP: this scenario uses real mouse input. Re-run with AOS_REAL_INPUT_OK=1 when the keyboard and mouse are idle."
+  exit 77
+fi
+
+cleanup() {
+  aos_visual_remove_canvas "$RADIAL_ID"
+  aos_visual_remove_canvas "$HIT_ID"
+  aos_visual_remove_canvas "$AVATAR_ID"
+  aos_visual_remove_canvas "$INSPECTOR_ID"
+}
+trap cleanup EXIT
+
+echo "INFO: this scenario uses real mouse input through the active repo daemon. Keep the keyboard and mouse idle."
+"$(aos_visual_aos)" ready >/dev/null
+aos_visual_prepare_live_roots
+aos_visual_seed_sigil repo
+aos_visual_configure_sigil_status_item "$AVATAR_ID"
+cleanup
+
+aos_visual_launch_sigil_with_inspector_via_live_status_item "$AVATAR_ID" "$INSPECTOR_ID" manual-visible
+aos_sigil_radial_verify_real_input "$AVATAR_ID"


### PR DESCRIPTION
## Summary
- add a live Sigil radial-menu real-input scenario gated by `AOS_REAL_INPUT_OK=1`
- add Sigil-specific radial proof that opens the menu with real hover/drag input and verifies AOS semantic targets through `see capture --xray`
- harden visual harness live-status-item launch, absolute content roots, and canvas cleanup
- document the Sigil-scoped default harness path without adding root-level Sigil policy

Part of #161.

## Verification
- `bash build.sh`
- `./aos permissions setup --once && ./aos ready`
- `AOS_REAL_INPUT_OK=1 bash tests/scenarios/sigil/radial-menu/real-input.sh`
- `bash -n tests/lib/visual-harness.sh tests/lib/sigil/radial-menu.sh tests/scenarios/sigil/radial-menu/real-input.sh tests/sigil-real-input-status-avatar.sh tests/sigil-context-menu-real-input.sh`
- `bash tests/scenarios/sigil/radial-menu/real-input.sh` exits 77 when real input is not explicitly allowed
- `node --test tests/renderer/radial-menu-target-surface.test.mjs tests/toolkit/runtime-semantic-targets.test.mjs`
- `git diff --check`

Dogfood note: running the scenario with a stale root-branch `aos` binary reached the real drag but failed with empty `semantic_targets`; rebuilding/running the current worktree binary passed. This confirms the harness catches stale perception binaries instead of silently falling back to screenshots.