### PR TITLE
Add AOS dev workflow router

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,11 +127,17 @@ spec at `docs/superpowers/specs/2026-04-15-tell-hear-coordination-verbs-design.m
 - Treat `doctor`, `daemon-snapshot`, and `clean` as deeper follow-up tools, not
   the first move. `./aos ready` is the explicit daemon bring-up and readiness
   gate; startup hooks should stay lightweight and avoid hidden runtime mutation.
+- Before choosing a rebuild, package test, canvas reload, or runtime readiness
+  loop, ask the dev workflow router: `./aos dev recommend --json`. The router is
+  manifest-backed by `docs/dev/workflow-rules.json`; update that manifest and
+  schema when routing policy changes instead of scattering new session rules.
 
-- Do not default to `bash build.sh` before every test or verification step.
+- Do not default to rebuilding before every test or verification step.
   Rebuild `./aos` only when the work changes Swift sources in `src/` or
   `shared/swift/ipc/`, or when the command/test you are about to run executes
-  `./aos` directly.
+  `./aos` directly. Use `./aos dev build --no-restart` for repo builds so the
+  signing/TCC implication stays visible; call `bash build.sh` directly only when
+  `./aos` cannot run or you are fixing the build surface itself.
 - Pure Node/TypeScript/package workflows should stay in their local loop unless
   they explicitly depend on a fresh `./aos` binary. Examples: `packages/gateway`
   build/test, `packages/host` test, and pure `node --test` suites under

--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -19,6 +19,7 @@ Start here:
 
 ```bash
 ./aos ready
+./aos dev recommend --json
 ./aos help <command> [--json]
 ./aos introspect review
 ```
@@ -28,6 +29,12 @@ managed daemon and exits non-zero when AOS is not ready. Use `./aos status` for
 a read-only runtime snapshot after that. Use `doctor`, `daemon-snapshot`, and
 `clean` when you need deeper diagnostics or explicit cleanup, not as the default
 first move.
+
+Use `./aos dev classify --json` and `./aos dev recommend --json` to route repo
+changes through the manifest-backed developer workflow before choosing a build,
+test, canvas reload, or readiness loop. Use `./aos dev build --no-restart`
+instead of raw `bash build.sh` unless `./aos` is missing or the build surface is
+itself under repair.
 
 ## Contract
 
@@ -91,6 +98,7 @@ The current top-level commands are:
 | `aos serve` | Unified daemon |
 | `aos service` | launchd lifecycle for the daemon |
 | `aos runtime` | packaged runtime utilities |
+| `aos dev` | repo development workflow classification, recommendations, and build wrapper |
 | `aos permissions` | preflight and onboarding |
 | `aos doctor` | detailed runtime and permission diagnostics |
 | `aos clean` | explicit stale daemon / canvas cleanup |
@@ -117,6 +125,23 @@ Typical consumer loop:
 2. Decide externally.
 3. Use `aos do` or `aos show`.
 4. Re-perceive if needed.
+
+### Repo Development Workflow
+
+`aos dev` is the developer workflow router for this repo. `classify` and
+`recommend` are read-only and do not start the daemon.
+
+```bash
+./aos dev classify --json
+./aos dev recommend --json
+./aos dev recommend --paths src/main.swift,packages/toolkit/runtime/canvas.js --json
+./aos dev build --no-restart
+```
+
+`classify` reports changed files, matched rules, classes, actions, and whether
+the set is hot-swappable or TCC-sensitive. `recommend` adds ordered commands
+and verification steps. The rules live in `docs/dev/workflow-rules.json` and
+are validated by `shared/schemas/dev-workflow-rules.schema.json`.
 
 ### 2. Create a Persistent Canvas
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -1,0 +1,12 @@
+# AOS Dev Workflow Router
+
+`workflow-rules.json` is the source of truth for `./aos dev classify` and
+`./aos dev recommend`. Keep it provider-neutral and repo-wide: route platform
+layers, package loops, schema tests, and local-contract delegation, but do not
+encode app-specific playbooks here.
+
+Validate routing changes with:
+
+```bash
+node --test tests/schemas/dev-workflow-rules.test.mjs
+```

--- a/docs/dev/workflow-rules.json
+++ b/docs/dev/workflow-rules.json
@@ -1,0 +1,305 @@
+{
+  "$schema": "../../shared/schemas/dev-workflow-rules.schema.json",
+  "schema_version": 1,
+  "summary": "Repo development workflow routing rules for changed files.",
+  "rules": [
+    {
+      "id": "app-subtree-local-contract",
+      "summary": "App subtree changes delegate app-specific workflow details to the nearest local contract.",
+      "patterns": [
+        "apps/**"
+      ],
+      "classes": [
+        "app",
+        "local_contract"
+      ],
+      "actions": [
+        "read_local_contract"
+      ],
+      "hot_swappable": true,
+      "tcc_identity_sensitive": false,
+      "commands": [],
+      "verification": [],
+      "notes": [
+        "Repo-wide routing should not encode app-specific behavior; read the nearest subtree AGENTS.md or local playbook before choosing app tests."
+      ]
+    },
+    {
+      "id": "swift-core",
+      "summary": "Unified aos binary or Swift IPC sources changed.",
+      "patterns": [
+        "src/**/*.swift",
+        "shared/swift/ipc/**/*.swift"
+      ],
+      "classes": [
+        "swift",
+        "aos_binary"
+      ],
+      "actions": [
+        "swift_build"
+      ],
+      "hot_swappable": false,
+      "tcc_identity_sensitive": true,
+      "commands": [
+        {
+          "id": "dev-build",
+          "command": "./aos dev build --no-restart",
+          "reason": "Swift source changes require a current repo-mode ./aos binary. The dev wrapper preserves the signing/TCC warning surface."
+        }
+      ],
+      "verification": [
+        {
+          "id": "ready",
+          "command": "./aos ready",
+          "reason": "Verify the rebuilt binary and managed daemon still agree on repo-mode readiness."
+        }
+      ]
+    },
+    {
+      "id": "toolkit-components",
+      "summary": "Reusable toolkit component or runtime browser code changed.",
+      "patterns": [
+        "packages/toolkit/components/**",
+        "packages/toolkit/panel/**",
+        "packages/toolkit/runtime/**"
+      ],
+      "classes": [
+        "toolkit",
+        "web_surface"
+      ],
+      "actions": [
+        "component_reload",
+        "focused_toolkit_test"
+      ],
+      "hot_swappable": true,
+      "tcc_identity_sensitive": false,
+      "commands": [],
+      "verification": [
+        {
+          "id": "toolkit-test",
+          "command": "node --test tests/toolkit/*.test.mjs",
+          "reason": "Use focused toolkit/runtime tests for pure browser-surface changes."
+        },
+        {
+          "id": "show-wait",
+          "command": "./aos show wait --id <canvas-id> --timeout 5s",
+          "reason": "When manually verifying a canvas-backed component, wait for the affected canvas instead of rebuilding the binary."
+        }
+      ]
+    },
+    {
+      "id": "browser-intent-sensor",
+      "summary": "Browser intent sensor or JS adapter path changed.",
+      "patterns": [
+        "packages/toolkit/browser-intent-sensor/**"
+      ],
+      "classes": [
+        "toolkit",
+        "browser_intent_sensor"
+      ],
+      "actions": [
+        "focused_js_test"
+      ],
+      "hot_swappable": true,
+      "tcc_identity_sensitive": false,
+      "commands": [
+        {
+          "id": "browser-intent-test",
+          "command": "node --test packages/toolkit/browser-intent-sensor",
+          "reason": "Browser intent sensor changes stay in the JavaScript test loop unless an adapter contract changes."
+        }
+      ],
+      "verification": []
+    },
+    {
+      "id": "schemas",
+      "summary": "Shared schema contracts changed.",
+      "patterns": [
+        "shared/schemas/**"
+      ],
+      "classes": [
+        "schema"
+      ],
+      "actions": [
+        "schema_test"
+      ],
+      "hot_swappable": true,
+      "tcc_identity_sensitive": false,
+      "commands": [
+        {
+          "id": "schema-tests",
+          "command": "node --test tests/schemas/*.test.mjs",
+          "reason": "Schema changes should run schema validation tests without daemon restart."
+        }
+      ],
+      "verification": []
+    },
+    {
+      "id": "dev-workflow-manifest",
+      "summary": "Developer workflow router manifest or tests changed.",
+      "patterns": [
+        "docs/dev/workflow-rules.json",
+        "shared/schemas/dev-workflow-rules.schema.json",
+        "shared/schemas/fixtures/dev-workflow-rules/**",
+        "tests/schemas/dev-workflow-rules.test.mjs"
+      ],
+      "classes": [
+        "dev_workflow",
+        "schema"
+      ],
+      "actions": [
+        "schema_test"
+      ],
+      "hot_swappable": true,
+      "tcc_identity_sensitive": false,
+      "commands": [
+        {
+          "id": "dev-workflow-schema-test",
+          "command": "node --test tests/schemas/dev-workflow-rules.test.mjs",
+          "reason": "Validate the router manifest and fixtures against the schema."
+        }
+      ],
+      "verification": []
+    },
+    {
+      "id": "package-gateway",
+      "summary": "Gateway package TypeScript changed.",
+      "patterns": [
+        "packages/gateway/**"
+      ],
+      "classes": [
+        "package",
+        "gateway"
+      ],
+      "actions": [
+        "package_test"
+      ],
+      "hot_swappable": true,
+      "tcc_identity_sensitive": false,
+      "commands": [
+        {
+          "id": "gateway-test",
+          "command": "cd packages/gateway && npm test",
+          "reason": "Gateway changes stay in the package-local TypeScript test loop."
+        }
+      ],
+      "verification": []
+    },
+    {
+      "id": "package-host",
+      "summary": "Host package TypeScript changed.",
+      "patterns": [
+        "packages/host/**"
+      ],
+      "classes": [
+        "package",
+        "host"
+      ],
+      "actions": [
+        "package_test"
+      ],
+      "hot_swappable": true,
+      "tcc_identity_sensitive": false,
+      "commands": [
+        {
+          "id": "host-test",
+          "command": "cd packages/host && npm test",
+          "reason": "Host changes stay in the package-local TypeScript test loop."
+        }
+      ],
+      "verification": []
+    },
+    {
+      "id": "command-contract-docs",
+      "summary": "CLI/API contract documentation changed.",
+      "patterns": [
+        "docs/api/**/*.md",
+        "docs/api/*.md"
+      ],
+      "classes": [
+        "docs",
+        "command_contract"
+      ],
+      "actions": [
+        "help_contract"
+      ],
+      "hot_swappable": true,
+      "tcc_identity_sensitive": false,
+      "commands": [
+        {
+          "id": "help-contract",
+          "command": "bash tests/help-contract.sh",
+          "reason": "Public CLI docs must stay aligned with discoverable help and parser contracts."
+        }
+      ],
+      "verification": []
+    },
+    {
+      "id": "docs-only",
+      "summary": "Docs, plans, or recipes changed.",
+      "patterns": [
+        "AGENTS.md",
+        "CLAUDE.md",
+        "**/AGENTS.md",
+        "**/CLAUDE.md",
+        "docs/**/*.md",
+        "recipes/**",
+        "README.md"
+      ],
+      "classes": [
+        "docs"
+      ],
+      "actions": [
+        "docs_review"
+      ],
+      "hot_swappable": true,
+      "tcc_identity_sensitive": false,
+      "commands": [],
+      "verification": [],
+      "notes": [
+        "Docs-only changes do not require runtime verification unless they change command contracts or executable examples."
+      ]
+    },
+    {
+      "id": "tests",
+      "summary": "Test harnesses or scenarios changed.",
+      "patterns": [
+        "tests/**"
+      ],
+      "classes": [
+        "tests"
+      ],
+      "actions": [
+        "focused_test"
+      ],
+      "hot_swappable": true,
+      "tcc_identity_sensitive": false,
+      "commands": [],
+      "verification": [
+        {
+          "id": "focused-test",
+          "command": "bash <changed-test>",
+          "reason": "Run the changed shell scenario or the smallest adjacent test set."
+        }
+      ]
+    }
+  ],
+  "fallback": {
+    "id": "unclassified",
+    "summary": "No workflow rule matched the changed path.",
+    "patterns": [],
+    "classes": [
+      "unclassified"
+    ],
+    "actions": [
+      "inspect_manually"
+    ],
+    "hot_swappable": true,
+    "tcc_identity_sensitive": false,
+    "commands": [],
+    "verification": [],
+    "notes": [
+      "No manifest rule matched this path; inspect the nearest AGENTS.md or CLAUDE.md before choosing a verification loop."
+    ]
+  }
+}

--- a/docs/recipes/agent-entry-paths-and-verification.md
+++ b/docs/recipes/agent-entry-paths-and-verification.md
@@ -32,6 +32,12 @@ repo files, running tests, restarting canvases, reading logs, or committing a
 checkpoint. Treat these as elevated privileges, not as capabilities that normal
 app agents automatically inherit.
 
+For repo workflow routing, prefer `./aos dev recommend --json` before choosing
+between a Swift rebuild, package-local test, schema test, canvas reload, or
+readiness loop. The source of truth is `docs/dev/workflow-rules.json`; update
+that manifest and `shared/schemas/dev-workflow-rules.schema.json` when routing
+policy changes.
+
 ### Testing
 
 Use the smallest stable test harness that exercises the changed behavior. Prefer

--- a/shared/schemas/dev-workflow-rules.schema.json
+++ b/shared/schemas/dev-workflow-rules.schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/michaelblum/agent-os/shared/schemas/dev-workflow-rules.schema.json",
+  "title": "AOS Dev Workflow Rules",
+  "description": "Manifest contract for classifying repo changes into deterministic developer workflow actions.",
+  "type": "object",
+  "required": ["schema_version", "rules", "fallback"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "schema_version": { "type": "integer", "minimum": 1 },
+    "summary": { "type": "string" },
+    "rules": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/rule" }
+    },
+    "fallback": { "$ref": "#/$defs/rule" }
+  },
+  "$defs": {
+    "rule": {
+      "type": "object",
+      "required": [
+        "id",
+        "summary",
+        "patterns",
+        "classes",
+        "actions",
+        "hot_swappable",
+        "tcc_identity_sensitive",
+        "commands",
+        "verification"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$"
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "patterns": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "classes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]*$"
+          },
+          "uniqueItems": true
+        },
+        "actions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]*$"
+          },
+          "uniqueItems": true
+        },
+        "hot_swappable": { "type": "boolean" },
+        "tcc_identity_sensitive": { "type": "boolean" },
+        "commands": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/step" },
+          "uniqueItems": true
+        },
+        "verification": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/step" },
+          "uniqueItems": true
+        },
+        "notes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "step": {
+      "type": "object",
+      "required": ["command", "reason"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]*$"
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/shared/schemas/fixtures/dev-workflow-rules/invalid/missing-actions.json
+++ b/shared/schemas/fixtures/dev-workflow-rules/invalid/missing-actions.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "rules": [
+    {
+      "id": "bad-rule",
+      "summary": "Missing actions should fail.",
+      "patterns": ["src/**/*.swift"],
+      "classes": ["swift"],
+      "hot_swappable": false,
+      "tcc_identity_sensitive": true,
+      "commands": [],
+      "verification": []
+    }
+  ],
+  "fallback": {
+    "id": "unclassified",
+    "summary": "No rule matched.",
+    "patterns": [],
+    "classes": ["unclassified"],
+    "actions": ["inspect_manually"],
+    "hot_swappable": true,
+    "tcc_identity_sensitive": false,
+    "commands": [],
+    "verification": []
+  }
+}

--- a/shared/schemas/fixtures/dev-workflow-rules/valid/minimal.json
+++ b/shared/schemas/fixtures/dev-workflow-rules/valid/minimal.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "../../../dev-workflow-rules.schema.json",
+  "schema_version": 1,
+  "summary": "Minimal valid workflow manifest.",
+  "rules": [
+    {
+      "id": "swift-core",
+      "summary": "Swift changed.",
+      "patterns": ["src/**/*.swift"],
+      "classes": ["swift"],
+      "actions": ["swift_build"],
+      "hot_swappable": false,
+      "tcc_identity_sensitive": true,
+      "commands": [
+        {
+          "id": "dev-build",
+          "command": "./aos dev build --no-restart",
+          "reason": "Swift changes require a build."
+        }
+      ],
+      "verification": []
+    }
+  ],
+  "fallback": {
+    "id": "unclassified",
+    "summary": "No rule matched.",
+    "patterns": [],
+    "classes": ["unclassified"],
+    "actions": ["inspect_manually"],
+    "hot_swappable": true,
+    "tcc_identity_sensitive": false,
+    "commands": [],
+    "verification": []
+  }
+}

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -7,22 +7,23 @@ Unified binary for macOS perception, display, action, and voice.
 ## Build
 
 ```bash
-bash build.sh
+./aos dev build --no-restart
 ```
 
 Only rebuild when you changed Swift in `src/` or `shared/swift/ipc/`, or when
 the next verification step runs `./aos` directly. Do not rebuild before pure
 Node-based tests or package-local workflows.
 
-When an automated flow needs to rebuild and then immediately run an `./aos`
-command, prefer:
+When you are unsure which loop applies, ask the router first:
 
 ```bash
-scripts/aos-after-build -- ./aos status --json
+./aos dev recommend --json
 ```
 
-That wrapper waits for any in-flight rebuild, refreshes the binary if needed,
-then runs the `./aos` command.
+Use raw `bash build.sh` only when `./aos` is missing or the build surface itself
+is being repaired. `scripts/aos-after-build` still exists for serialized
+automation around an in-flight build, but the normal developer control surface is
+`./aos dev build`.
 
 Examples that usually do **not** need `bash build.sh`:
 

--- a/src/commands/dev.swift
+++ b/src/commands/dev.swift
@@ -1,0 +1,637 @@
+// dev.swift - repo development workflow router and build wrapper
+
+import Foundation
+
+private struct DevWorkflowManifest: Decodable {
+    let schemaVersion: Int
+    let summary: String?
+    let rules: [DevWorkflowRule]
+    let fallback: DevWorkflowRule?
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case summary
+        case rules
+        case fallback
+    }
+}
+
+private struct DevWorkflowRule: Decodable {
+    let id: String
+    let summary: String
+    let patterns: [String]
+    let classes: [String]
+    let actions: [String]
+    let hotSwappable: Bool?
+    let tccIdentitySensitive: Bool?
+    let commands: [DevWorkflowStep]?
+    let verification: [DevWorkflowStep]?
+    let notes: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case summary
+        case patterns
+        case classes
+        case actions
+        case hotSwappable = "hot_swappable"
+        case tccIdentitySensitive = "tcc_identity_sensitive"
+        case commands
+        case verification
+        case notes
+    }
+}
+
+private struct DevWorkflowStep: Decodable {
+    let id: String?
+    let command: String
+    let reason: String
+}
+
+private struct DevOptions {
+    var json = false
+    var repo: String?
+    var base: String?
+    var manifest: String?
+    var files: [String] = []
+}
+
+private struct DevClassifiedFile {
+    let path: String
+    let rules: [DevWorkflowRule]
+}
+
+private struct DevAggregatedStep {
+    let id: String?
+    let command: String
+    let reason: String
+    var sourceRules: [String]
+
+    func toJSON() -> [String: Any] {
+        var out: [String: Any] = [
+            "command": command,
+            "reason": reason,
+            "source_rules": sourceRules,
+        ]
+        if let id = id, !id.isEmpty {
+            out["id"] = id
+        }
+        return out
+    }
+}
+
+func devCommand(args: [String]) {
+    guard let sub = args.first else {
+        printCommandHelp(["dev"], json: false)
+        exit(0)
+    }
+
+    if sub == "--help" || sub == "-h" {
+        printCommandHelp(["dev"], json: args.contains("--json"))
+        exit(0)
+    }
+
+    let subArgs = Array(args.dropFirst())
+    if subArgs.contains("--help") || subArgs.contains("-h") {
+        printCommandHelp(["dev", sub], json: subArgs.contains("--json"))
+        exit(0)
+    }
+
+    switch sub {
+    case "classify":
+        devClassifyCommand(args: subArgs)
+    case "recommend":
+        devRecommendCommand(args: subArgs)
+    case "build":
+        devBuildCommand(args: subArgs)
+    default:
+        exitError("Unknown dev subcommand: \(sub)", code: "UNKNOWN_SUBCOMMAND")
+    }
+}
+
+private func devClassifyCommand(args: [String]) {
+    let options = parseDevOptions(args)
+    let result = buildDevClassification(options: options)
+    if options.json {
+        printDevJSON(result)
+    } else {
+        printDevClassificationText(result)
+    }
+}
+
+private func devRecommendCommand(args: [String]) {
+    let options = parseDevOptions(args)
+    let classification = buildDevClassification(options: options)
+    let result = buildDevRecommendation(from: classification)
+    if options.json {
+        printDevJSON(result)
+    } else {
+        printDevRecommendationText(result)
+    }
+}
+
+private func devBuildCommand(args: [String]) {
+    let asJSON = args.contains("--json")
+    let passthrough = args.filter { $0 != "--help" && $0 != "-h" && $0 != "--json" }
+    for arg in passthrough {
+        if !["--release", "--force", "--no-restart"].contains(arg) {
+            exitError("Unknown dev build argument: \(arg)", code: "UNKNOWN_FLAG")
+        }
+    }
+
+    let repoRoot = findAgentOSRepoRoot()
+    let buildScript = (repoRoot as NSString).appendingPathComponent("build.sh")
+    guard FileManager.default.fileExists(atPath: buildScript) else {
+        exitError("Missing build script: \(buildScript)", code: "MISSING_BUILD_SCRIPT")
+    }
+
+    let permissionNote = "aos dev build wraps build.sh; rebuilt repo binaries may require a fresh macOS Accessibility/Input Monitoring grant if readiness later reports stale TCC identity."
+    let result = runProcessCapturingOutput("/bin/bash", arguments: [buildScript] + passthrough, cwd: repoRoot)
+
+    if asJSON {
+        printDevJSON([
+            "status": result.exitCode == 0 ? "success" : "error",
+            "command": (["bash", "build.sh"] + passthrough).joined(separator: " "),
+            "exit_code": Int(result.exitCode),
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "permission_note": permissionNote,
+            "next": "./aos ready",
+        ])
+    } else {
+        FileHandle.standardError.write(Data("\(permissionNote)\n".utf8))
+        if !result.stdout.isEmpty {
+            print(result.stdout, terminator: result.stdout.hasSuffix("\n") ? "" : "\n")
+        }
+        if !result.stderr.isEmpty, let data = result.stderr.data(using: .utf8) {
+            FileHandle.standardError.write(data)
+        }
+        if result.exitCode == 0 {
+            print("Next: ./aos ready")
+        }
+    }
+    exit(result.exitCode)
+}
+
+private func runProcessCapturingOutput(_ executable: String, arguments: [String], cwd: String? = nil) -> ProcessOutput {
+    let process = Process()
+    let tempDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+    let token = UUID().uuidString
+    let stdoutURL = tempDir.appendingPathComponent("aos-dev-build-\(token).out")
+    let stderrURL = tempDir.appendingPathComponent("aos-dev-build-\(token).err")
+    FileManager.default.createFile(atPath: stdoutURL.path, contents: nil)
+    FileManager.default.createFile(atPath: stderrURL.path, contents: nil)
+    guard let stdout = try? FileHandle(forWritingTo: stdoutURL),
+          let stderr = try? FileHandle(forWritingTo: stderrURL) else {
+        return ProcessOutput(exitCode: 1, stdout: "", stderr: "Could not create temporary build output files")
+    }
+    defer {
+        try? stdout.close()
+        try? stderr.close()
+        try? FileManager.default.removeItem(at: stdoutURL)
+        try? FileManager.default.removeItem(at: stderrURL)
+    }
+
+    process.executableURL = URL(fileURLWithPath: executable)
+    process.arguments = arguments
+    if let cwd {
+        process.currentDirectoryURL = URL(fileURLWithPath: cwd)
+    }
+    process.standardOutput = stdout
+    process.standardError = stderr
+
+    do {
+        try process.run()
+    } catch {
+        return ProcessOutput(exitCode: 1, stdout: "", stderr: "\(error)")
+    }
+
+    process.waitUntilExit()
+    try? stdout.synchronize()
+    try? stderr.synchronize()
+
+    return ProcessOutput(
+        exitCode: process.terminationStatus,
+        stdout: (try? String(contentsOf: stdoutURL, encoding: .utf8)) ?? "",
+        stderr: (try? String(contentsOf: stderrURL, encoding: .utf8)) ?? ""
+    )
+}
+
+private func parseDevOptions(_ args: [String]) -> DevOptions {
+    var options = DevOptions()
+    var i = 0
+    while i < args.count {
+        let arg = args[i]
+        switch arg {
+        case "--json":
+            options.json = true
+            i += 1
+        case "--repo":
+            guard i + 1 < args.count else {
+                exitError("--repo requires a path", code: "MISSING_ARG")
+            }
+            options.repo = args[i + 1]
+            i += 2
+        case "--base":
+            guard i + 1 < args.count else {
+                exitError("--base requires a ref", code: "MISSING_ARG")
+            }
+            options.base = args[i + 1]
+            i += 2
+        case "--manifest":
+            guard i + 1 < args.count else {
+                exitError("--manifest requires a path", code: "MISSING_ARG")
+            }
+            options.manifest = args[i + 1]
+            i += 2
+        case "--paths":
+            guard i + 1 < args.count else {
+                exitError("--paths requires a comma-separated path list", code: "MISSING_ARG")
+            }
+            options.files.append(contentsOf: args[i + 1].split(separator: ",").map(String.init).filter { !$0.isEmpty })
+            i += 2
+        case "--files":
+            i += 1
+            var consumed = false
+            while i < args.count && !args[i].hasPrefix("--") {
+                options.files.append(args[i])
+                consumed = true
+                i += 1
+            }
+            if !consumed {
+                exitError("--files requires at least one path", code: "MISSING_ARG")
+            }
+        default:
+            if arg.hasPrefix("--") {
+                exitError("Unknown dev flag: \(arg)", code: "UNKNOWN_FLAG")
+            }
+            options.files.append(arg)
+            i += 1
+        }
+    }
+    return options
+}
+
+private func buildDevClassification(options: DevOptions) -> [String: Any] {
+    let repoRoot = resolveRepoRoot(options.repo)
+    let manifestPath = resolveManifestPath(options.manifest, repoRoot: repoRoot)
+    let manifest = loadDevWorkflowManifest(path: manifestPath)
+    let changed = resolveChangedFiles(options: options, repoRoot: repoRoot)
+    let files = uniquePreservingOrder(changed.files.map { normalizeRepoRelativePath($0, repoRoot: repoRoot) })
+        .filter { !$0.isEmpty }
+
+    let classified = files.map { path -> DevClassifiedFile in
+        let matches = manifest.rules.filter { rule in
+            rule.patterns.contains { globMatches(pattern: $0, path: path) }
+        }
+        if matches.isEmpty, let fallback = manifest.fallback {
+            return DevClassifiedFile(path: path, rules: [fallback])
+        }
+        return DevClassifiedFile(path: path, rules: matches)
+    }
+
+    let aggregate = aggregateDevWorkflow(classified)
+    return [
+        "status": "success",
+        "manifest": normalizeRepoRelativePath(manifestPath, repoRoot: repoRoot),
+        "manifest_schema_version": manifest.schemaVersion,
+        "repo": repoRoot,
+        "diff_base": changed.base as Any,
+        "changed_files": files,
+        "files": classified.map { classifiedFileJSON($0) },
+        "summary": aggregate,
+    ]
+}
+
+private func buildDevRecommendation(from classification: [String: Any]) -> [String: Any] {
+    let summary = classification["summary"] as? [String: Any] ?? [:]
+    let commands = summary["commands"] as? [[String: Any]] ?? []
+    let verification = summary["verification"] as? [[String: Any]] ?? []
+    let notes = summary["notes"] as? [String] ?? []
+
+    return [
+        "status": "success",
+        "manifest": classification["manifest"] ?? "docs/dev/workflow-rules.json",
+        "repo": classification["repo"] ?? FileManager.default.currentDirectoryPath,
+        "diff_base": classification["diff_base"] ?? NSNull(),
+        "changed_files": classification["changed_files"] ?? [],
+        "next_commands": commands,
+        "verification": verification,
+        "notes": notes,
+        "summary": summary,
+    ]
+}
+
+private func aggregateDevWorkflow(_ files: [DevClassifiedFile]) -> [String: Any] {
+    let allRules = files.flatMap { $0.rules }
+    let ruleIDs = uniquePreservingOrder(allRules.map { $0.id })
+    let classes = uniquePreservingOrder(allRules.flatMap { $0.classes })
+    let actions = uniquePreservingOrder(allRules.flatMap { $0.actions })
+    let hotSwappable = !allRules.contains { ($0.hotSwappable ?? true) == false }
+    let tccSensitive = allRules.contains { ($0.tccIdentitySensitive ?? false) == true }
+    let commands = aggregateSteps(allRules.flatMap { rule in
+        (rule.commands ?? []).map { (step: $0, ruleID: rule.id) }
+    })
+    let verification = aggregateSteps(allRules.flatMap { rule in
+        (rule.verification ?? []).map { (step: $0, ruleID: rule.id) }
+    })
+    let notes = uniquePreservingOrder(allRules.flatMap { $0.notes ?? [] })
+
+    return [
+        "changed_file_count": files.count,
+        "rule_ids": ruleIDs,
+        "classes": classes,
+        "actions": actions,
+        "hot_swappable": hotSwappable,
+        "requires_swift_build": actions.contains("swift_build"),
+        "tcc_identity_sensitive": tccSensitive,
+        "commands": commands.map { $0.toJSON() },
+        "verification": verification.map { $0.toJSON() },
+        "notes": notes,
+    ]
+}
+
+private func aggregateSteps(_ input: [(step: DevWorkflowStep, ruleID: String)]) -> [DevAggregatedStep] {
+    var order: [String] = []
+    var map: [String: DevAggregatedStep] = [:]
+    for item in input {
+        let command = item.step.command
+        if command.isEmpty {
+            continue
+        }
+        if var existing = map[command] {
+            if !existing.sourceRules.contains(item.ruleID) {
+                existing.sourceRules.append(item.ruleID)
+            }
+            map[command] = existing
+        } else {
+            order.append(command)
+            map[command] = DevAggregatedStep(
+                id: item.step.id,
+                command: command,
+                reason: item.step.reason,
+                sourceRules: [item.ruleID])
+        }
+    }
+    return order.compactMap { map[$0] }
+}
+
+private func classifiedFileJSON(_ file: DevClassifiedFile) -> [String: Any] {
+    let classes = uniquePreservingOrder(file.rules.flatMap { $0.classes })
+    let actions = uniquePreservingOrder(file.rules.flatMap { $0.actions })
+    return [
+        "path": file.path,
+        "rules": file.rules.map { $0.id },
+        "classes": classes,
+        "actions": actions,
+        "hot_swappable": !file.rules.contains { ($0.hotSwappable ?? true) == false },
+        "tcc_identity_sensitive": file.rules.contains { ($0.tccIdentitySensitive ?? false) == true },
+    ]
+}
+
+private func resolveRepoRoot(_ requested: String?) -> String {
+    let start = NSString(string: requested ?? FileManager.default.currentDirectoryPath).expandingTildeInPath
+    if let root = runGit(["rev-parse", "--show-toplevel"], cwd: start).stdoutLines.first, !root.isEmpty {
+        return NSString(string: root).standardizingPath
+    }
+    return NSString(string: start).standardizingPath
+}
+
+private func resolveManifestPath(_ requested: String?, repoRoot: String) -> String {
+    if let requested = requested {
+        let expanded = NSString(string: requested).expandingTildeInPath
+        if expanded.hasPrefix("/") {
+            return NSString(string: expanded).standardizingPath
+        }
+        return NSString(string: (repoRoot as NSString).appendingPathComponent(expanded)).standardizingPath
+    }
+    return (repoRoot as NSString).appendingPathComponent("docs/dev/workflow-rules.json")
+}
+
+private func loadDevWorkflowManifest(path: String) -> DevWorkflowManifest {
+    guard let data = FileManager.default.contents(atPath: path) else {
+        exitError("Missing dev workflow manifest: \(path)", code: "MISSING_MANIFEST")
+    }
+    do {
+        return try JSONDecoder().decode(DevWorkflowManifest.self, from: data)
+    } catch {
+        exitError("Invalid dev workflow manifest \(path): \(error)", code: "INVALID_MANIFEST")
+    }
+}
+
+private func resolveChangedFiles(options: DevOptions, repoRoot: String) -> (files: [String], base: String?) {
+    if !options.files.isEmpty {
+        return (options.files, "explicit")
+    }
+
+    if let base = options.base {
+        let diff = gitDiffFiles(base: base, repoRoot: repoRoot, strict: true)
+        let untracked = gitStatusFiles(repoRoot: repoRoot, untrackedOnly: true)
+        return (uniquePreservingOrder(diff + untracked), base)
+    }
+
+    let dirty = gitStatusFiles(repoRoot: repoRoot, untrackedOnly: false)
+    if !dirty.isEmpty {
+        return (dirty, "working-tree")
+    }
+
+    if runGit(["rev-parse", "--verify", "--quiet", "origin/main"], cwd: repoRoot).status == 0,
+       let mergeBase = runGit(["merge-base", "HEAD", "origin/main"], cwd: repoRoot).stdoutLines.first,
+       !mergeBase.isEmpty {
+        return (gitDiffFiles(base: mergeBase, repoRoot: repoRoot), mergeBase)
+    }
+
+    if let upstream = runGit(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], cwd: repoRoot).stdoutLines.first,
+       !upstream.isEmpty,
+       let mergeBase = runGit(["merge-base", "HEAD", upstream], cwd: repoRoot).stdoutLines.first,
+       !mergeBase.isEmpty {
+        return (gitDiffFiles(base: mergeBase, repoRoot: repoRoot), mergeBase)
+    }
+
+    return (gitDiffFiles(base: "HEAD", repoRoot: repoRoot), "HEAD")
+}
+
+private func gitDiffFiles(base: String, repoRoot: String, strict: Bool = false) -> [String] {
+    let result = runGit(["diff", "--name-only", "-z", "--diff-filter=ACDMRTUXB", base, "--"], cwd: repoRoot)
+    guard result.status == 0 else {
+        if strict {
+            let detail = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            exitError("Invalid dev workflow diff base '\(base)'\(detail.isEmpty ? "." : ": \(detail)")", code: "INVALID_BASE_REF")
+        }
+        return []
+    }
+    return splitNul(result.stdout)
+}
+
+private func gitStatusFiles(repoRoot: String, untrackedOnly: Bool) -> [String] {
+    let result = runGit(["status", "--porcelain=v1", "-z", "--untracked-files=all"], cwd: repoRoot)
+    guard result.status == 0 else { return [] }
+    let parts = splitNul(result.stdout)
+    var out: [String] = []
+    var i = 0
+    while i < parts.count {
+        let record = parts[i]
+        guard record.count >= 4 else {
+            i += 1
+            continue
+        }
+        let status = String(record.prefix(2))
+        let pathStart = record.index(record.startIndex, offsetBy: 3)
+        let path = String(record[pathStart...])
+        let isUntracked = status == "??"
+        if status.contains("R") || status.contains("C") {
+            if i + 1 < parts.count {
+                if !untrackedOnly || isUntracked {
+                    out.append(path)
+                }
+                i += 2
+                continue
+            }
+        }
+        if !untrackedOnly || isUntracked {
+            out.append(path)
+        }
+        i += 1
+    }
+    return uniquePreservingOrder(out)
+}
+
+private func runGit(_ args: [String], cwd: String) -> (status: Int32, stdout: String, stderr: String, stdoutLines: [String]) {
+    let proc = Process()
+    proc.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    proc.arguments = ["-C", cwd] + args
+    let out = Pipe()
+    let err = Pipe()
+    proc.standardOutput = out
+    proc.standardError = err
+    do {
+        try proc.run()
+    } catch {
+        return (127, "", error.localizedDescription, [])
+    }
+    proc.waitUntilExit()
+    let outData = out.fileHandleForReading.readDataToEndOfFile()
+    let errData = err.fileHandleForReading.readDataToEndOfFile()
+    let stdout = String(data: outData, encoding: .utf8) ?? ""
+    let stderr = String(data: errData, encoding: .utf8) ?? ""
+    let lines = stdout.split(whereSeparator: \.isNewline).map(String.init)
+    return (proc.terminationStatus, stdout, stderr, lines)
+}
+
+private func splitNul(_ value: String) -> [String] {
+    value.split(separator: "\u{0}", omittingEmptySubsequences: true).map(String.init)
+}
+
+private func normalizeRepoRelativePath(_ value: String, repoRoot: String) -> String {
+    let expanded = NSString(string: value).expandingTildeInPath
+    let standardized = NSString(string: expanded).standardizingPath
+    let root = NSString(string: repoRoot).standardizingPath
+    if standardized == root {
+        return "."
+    }
+    let prefix = root.hasSuffix("/") ? root : root + "/"
+    if standardized.hasPrefix(prefix) {
+        return String(standardized.dropFirst(prefix.count))
+    }
+    if value.hasPrefix("./") {
+        return String(value.dropFirst(2))
+    }
+    return value
+}
+
+private func globMatches(pattern: String, path: String) -> Bool {
+    if pattern == "**" {
+        return true
+    }
+    let regex = "^" + globToRegex(pattern) + "$"
+    return path.range(of: regex, options: .regularExpression) != nil
+}
+
+private func globToRegex(_ pattern: String) -> String {
+    let chars = Array(pattern)
+    var out = ""
+    var i = 0
+    while i < chars.count {
+        let ch = chars[i]
+        if ch == "*" {
+            if i + 1 < chars.count && chars[i + 1] == "*" {
+                if i + 2 < chars.count && chars[i + 2] == "/" {
+                    out += "(?:.*/)?"
+                    i += 3
+                } else {
+                    out += ".*"
+                    i += 2
+                }
+            } else {
+                out += "[^/]*"
+                i += 1
+            }
+        } else if ch == "?" {
+            out += "[^/]"
+            i += 1
+        } else {
+            out += NSRegularExpression.escapedPattern(for: String(ch))
+            i += 1
+        }
+    }
+    return out
+}
+
+private func uniquePreservingOrder(_ input: [String]) -> [String] {
+    var seen = Set<String>()
+    var out: [String] = []
+    for item in input where !item.isEmpty {
+        if seen.insert(item).inserted {
+            out.append(item)
+        }
+    }
+    return out
+}
+
+private func printDevJSON(_ payload: [String: Any]) {
+    guard JSONSerialization.isValidJSONObject(payload),
+          let data = try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys]),
+          let text = String(data: data, encoding: .utf8) else {
+        exitError("Unable to serialize dev workflow response", code: "SERIALIZATION_FAILED")
+    }
+    print(text)
+}
+
+private func printDevClassificationText(_ payload: [String: Any]) {
+    let files = payload["changed_files"] as? [String] ?? []
+    let summary = payload["summary"] as? [String: Any] ?? [:]
+    print("Changed files: \(files.count)")
+    print("Classes: \((summary["classes"] as? [String] ?? []).joined(separator: ", "))")
+    print("Actions: \((summary["actions"] as? [String] ?? []).joined(separator: ", "))")
+    if (summary["tcc_identity_sensitive"] as? Bool) == true {
+        print("Risk: tcc_identity_sensitive")
+    }
+}
+
+private func printDevRecommendationText(_ payload: [String: Any]) {
+    let commands = payload["next_commands"] as? [[String: Any]] ?? []
+    let verification = payload["verification"] as? [[String: Any]] ?? []
+    let notes = payload["notes"] as? [String] ?? []
+
+    if commands.isEmpty {
+        print("Next commands: none")
+    } else {
+        print("Next commands:")
+        for item in commands {
+            print("- \(item["command"] as? String ?? "")")
+        }
+    }
+
+    if verification.isEmpty {
+        print("Verification: none")
+    } else {
+        print("Verification:")
+        for item in verification {
+            print("- \(item["command"] as? String ?? "")")
+        }
+    }
+
+    for note in notes {
+        print("Note: \(note)")
+    }
+}

--- a/src/main.swift
+++ b/src/main.swift
@@ -62,6 +62,8 @@ struct AOS {
             serviceCommand(args: Array(args.dropFirst()))
         case "runtime":
             runtimeCommand(args: Array(args.dropFirst()))
+        case "dev":
+            devCommand(args: Array(args.dropFirst()))
         case "status":
             statusCommand(args: Array(args.dropFirst()))
         case "ready":

--- a/src/shared/command-help.swift
+++ b/src/shared/command-help.swift
@@ -179,6 +179,7 @@ func printFullRegistryText() {
         "serve",
         "service",
         "runtime",
+        "dev",
         "permissions",
         "doctor",
         "clean",

--- a/src/shared/command-registry-data.swift
+++ b/src/shared/command-registry-data.swift
@@ -1068,6 +1068,55 @@ func buildCommandRegistry() -> [CommandDescriptor] {
             examples: ["aos runtime display-union", "aos runtime display-union --native"])
     ]))
 
+    // ── dev ───────────────────────────────────────────────
+    reg.append(CommandDescriptor(path: ["dev"], summary: "Repo development workflow router and build surface", forms: [
+        InvocationForm(id: "dev-classify", usage: "aos dev classify [--paths <path,...>] [--manifest <path>] [--base <ref>] [--json] [path...]",
+            args: [
+                flag("paths", "--paths", "Comma-separated changed paths to classify"),
+                flag("files", "--files", "Space-separated changed paths to classify", variadic: true),
+                flag("manifest", "--manifest", "Workflow rules manifest path", default: .string("docs/dev/workflow-rules.json")),
+                flag("base", "--base", "Git ref to diff against instead of working-tree status"),
+                flag("repo", "--repo", "Repository root path"),
+                flag("json", "--json", "Emit machine-readable classification", type: .bool),
+                pos("path", "Changed path", required: false, variadic: true)
+            ],
+            stdin: nil, constraints: nil,
+            execution: execReadOnly(),
+            output: outJSONFlag,
+            examples: [
+                "aos dev classify --json",
+                "aos dev classify --paths src/main.swift,packages/toolkit/runtime/canvas.js --json"
+            ]),
+        InvocationForm(id: "dev-recommend", usage: "aos dev recommend [--paths <path,...>] [--manifest <path>] [--base <ref>] [--json] [path...]",
+            args: [
+                flag("paths", "--paths", "Comma-separated changed paths to classify before recommending"),
+                flag("files", "--files", "Space-separated changed paths to classify before recommending", variadic: true),
+                flag("manifest", "--manifest", "Workflow rules manifest path", default: .string("docs/dev/workflow-rules.json")),
+                flag("base", "--base", "Git ref to diff against instead of working-tree status"),
+                flag("repo", "--repo", "Repository root path"),
+                flag("json", "--json", "Emit machine-readable recommendation", type: .bool),
+                pos("path", "Changed path", required: false, variadic: true)
+            ],
+            stdin: nil, constraints: nil,
+            execution: execReadOnly(),
+            output: outJSONFlag,
+            examples: [
+                "aos dev recommend --json",
+                "aos dev recommend src/commands/dev.swift --json"
+            ]),
+        InvocationForm(id: "dev-build", usage: "aos dev build [--release] [--force] [--no-restart] [--json]",
+            args: [
+                flag("release", "--release", "Build optimized release binary", type: .bool),
+                flag("force", "--force", "Force rebuild even when inputs appear current", type: .bool),
+                flag("no-restart", "--no-restart", "Do not restart the managed daemon after building", type: .bool),
+                flag("json", "--json", "Emit machine-readable build result", type: .bool)
+            ],
+            stdin: nil, constraints: nil,
+            execution: execMutating(),
+            output: outJSONFlag,
+            examples: ["aos dev build --no-restart", "aos dev build --no-restart --json"])
+    ]))
+
     // ── status ────────────────────────────────────────────
     reg.append(CommandDescriptor(path: ["status"], summary: "Primary runtime/session status entrypoint", forms: [
         InvocationForm(id: "status", usage: "aos status [--json]",

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,17 +1,26 @@
 # Test Targets
 
-Use the smallest loop that matches the change. Do not rebuild `./aos` by
-default before every verification step.
+Use the smallest loop that matches the change. Start with the manifest-backed
+router when the right loop is not obvious:
+
+```bash
+./aos dev recommend --json
+```
+
+Do not rebuild `./aos` by default before every verification step.
 
 For the repo-wide entry-path model behind these choices, see
 `docs/recipes/agent-entry-paths-and-verification.md`.
 
 ## Rebuild `./aos` First
 
-Rebuild with `bash build.sh` when both of these are true:
+Rebuild with `./aos dev build --no-restart` when both of these are true:
 
 - the work changed Swift sources in `src/` or `shared/swift/ipc/`
 - the command or test you are about to run executes `./aos`
+
+Use raw `bash build.sh` only when `./aos` is missing or the build command itself
+is being repaired.
 
 If you are chaining build + `./aos` verification from automation, prefer:
 

--- a/tests/dev-workflow-router.sh
+++ b/tests/dev-workflow-router.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+FAILS=0
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1" >&2; FAILS=$((FAILS + 1)); }
+
+if OUT="$(./aos dev classify --json --paths src/main.swift,packages/toolkit/runtime/canvas.js,shared/schemas/input-event-v2.schema.json,docs/recipes/example.md 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+summary = data["summary"]
+assert data["status"] == "success"
+assert data["diff_base"] == "explicit"
+assert "swift-core" in summary["rule_ids"], summary
+assert "toolkit-components" in summary["rule_ids"], summary
+assert "schemas" in summary["rule_ids"], summary
+assert "docs-only" in summary["rule_ids"], summary
+assert summary["requires_swift_build"] is True, summary
+assert summary["tcc_identity_sensitive"] is True, summary
+assert summary["hot_swappable"] is False, summary
+assert any(item["command"] == "./aos dev build --no-restart" for item in summary["commands"]), summary
+assert any(item["command"] == "./aos ready" for item in summary["verification"]), summary
+PY
+then
+    pass "dev classify aggregates manifest-backed workflow classes"
+else
+    fail "dev classify did not report expected aggregate classes"
+fi
+
+if OUT="$(./aos dev recommend --json --files docs/recipes/example.md 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert data["next_commands"] == [], data
+assert data["verification"] == [], data
+assert data["notes"], data
+assert data["summary"]["rule_ids"] == ["docs-only"], data
+PY
+then
+    pass "dev recommend keeps docs-only changes out of runtime loops"
+else
+    fail "dev recommend docs-only routing drifted"
+fi
+
+if OUT="$(./aos dev classify --json --files unknown/path.txt 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert data["summary"]["rule_ids"] == ["unclassified"], data
+assert data["summary"]["actions"] == ["inspect_manually"], data
+PY
+then
+    pass "dev classify reports unmatched paths through fallback"
+else
+    fail "dev classify fallback routing drifted"
+fi
+
+if OUT="$(./aos dev classify --json --files apps/example/feature.js 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert data["summary"]["rule_ids"] == ["app-subtree-local-contract"], data
+assert data["summary"]["actions"] == ["read_local_contract"], data
+assert "nearest subtree AGENTS.md" in data["summary"]["notes"][0], data
+assert "sigil" not in json.dumps(data).lower(), data
+PY
+then
+    pass "dev classify routes app subtree changes to local contracts"
+else
+    fail "dev classify app local-contract routing drifted"
+fi
+
+if OUT="$(./aos dev recommend --json --files docs/api/aos.md 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+summary = data["summary"]
+assert "command-contract-docs" in summary["rule_ids"], data
+assert any(item["command"] == "bash tests/help-contract.sh" for item in data["next_commands"]), data
+PY
+then
+    pass "dev recommend routes command-contract docs to help verification"
+else
+    fail "dev recommend command-contract docs routing drifted"
+fi
+
+if ERR="$(./aos dev recommend --json --base definitely-not-a-ref 2>&1 >/dev/null)"; then
+    fail "dev recommend should reject invalid --base refs"
+elif echo "$ERR" | grep -q '"code" : "INVALID_BASE_REF"'; then
+    pass "dev recommend rejects invalid --base refs"
+else
+    fail "dev recommend invalid --base error mismatch: $ERR"
+fi
+
+if OUT="$(./aos help dev --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+forms = {form["id"]: form for form in data["forms"]}
+assert {"dev-classify", "dev-recommend", "dev-build"} <= set(forms), forms
+tokens = {arg.get("token") for arg in forms["dev-classify"]["args"]}
+assert "--paths" in tokens, tokens
+PY
+then
+    pass "dev help exposes classify/recommend/build"
+else
+    fail "dev help missing workflow router forms"
+fi
+
+echo
+if [[ "$FAILS" -eq 0 ]]; then
+    echo "dev-workflow-router: all checks passed"
+    exit 0
+fi
+
+echo "dev-workflow-router: $FAILS failure(s)"
+exit 1

--- a/tests/schemas/dev-workflow-rules.test.mjs
+++ b/tests/schemas/dev-workflow-rules.test.mjs
@@ -1,0 +1,92 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+const schemaPath = path.join(repoRoot, 'shared/schemas/dev-workflow-rules.schema.json');
+const canonicalPath = path.join(repoRoot, 'docs/dev/workflow-rules.json');
+const fixtureRoot = path.join(repoRoot, 'shared/schemas/fixtures/dev-workflow-rules');
+
+async function jsonFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+    .map((entry) => path.join(dir, entry.name))
+    .sort();
+}
+
+function validate(instancePath) {
+  return spawnSync(
+    'python3',
+    [
+      '-c',
+      `
+import json, sys
+from pathlib import Path
+from jsonschema import Draft202012Validator
+
+schema = json.loads(Path(sys.argv[1]).read_text())
+instance = json.loads(Path(sys.argv[2]).read_text())
+Draft202012Validator.check_schema(schema)
+validator = Draft202012Validator(schema)
+errors = sorted(validator.iter_errors(instance), key=lambda e: list(e.path))
+if errors:
+    for error in errors[:8]:
+        print(error.message)
+    sys.exit(1)
+`,
+      schemaPath,
+      instancePath,
+    ],
+    { encoding: 'utf8' },
+  );
+}
+
+test('canonical dev workflow manifest matches the schema', () => {
+  const result = validate(canonicalPath);
+  assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+});
+
+test('valid dev workflow fixtures match the schema', async () => {
+  const fixtures = await jsonFiles(path.join(fixtureRoot, 'valid'));
+  assert.ok(fixtures.length >= 1, 'expected valid fixtures');
+  for (const fixture of fixtures) {
+    const result = validate(fixture);
+    assert.equal(
+      result.status,
+      0,
+      `${path.relative(repoRoot, fixture)} should validate\n${result.stdout}${result.stderr}`,
+    );
+  }
+});
+
+test('invalid dev workflow fixtures are rejected by the schema', async () => {
+  const fixtures = await jsonFiles(path.join(fixtureRoot, 'invalid'));
+  assert.ok(fixtures.length >= 1, 'expected invalid fixtures');
+  for (const fixture of fixtures) {
+    const result = validate(fixture);
+    assert.notEqual(result.status, 0, `${path.relative(repoRoot, fixture)} should fail validation`);
+  }
+});
+
+test('canonical rules preserve the expected V0 routing contracts', async () => {
+  const manifest = JSON.parse(await fs.readFile(canonicalPath, 'utf8'));
+  const rules = new Map(manifest.rules.map((rule) => [rule.id, rule]));
+
+  assert.equal(rules.get('swift-core')?.tcc_identity_sensitive, true);
+  assert.equal(
+    rules.get('swift-core')?.commands?.[0]?.command,
+    './aos dev build --no-restart',
+  );
+  assert.equal(
+    rules.get('command-contract-docs')?.commands?.[0]?.command,
+    'bash tests/help-contract.sh',
+  );
+  assert.equal(rules.get('toolkit-components')?.hot_swappable, true);
+  assert.equal(rules.get('schemas')?.commands?.[0]?.command, 'node --test tests/schemas/*.test.mjs');
+  assert.ok(rules.get('app-subtree-local-contract')?.notes?.[0]?.includes('nearest subtree AGENTS.md'));
+});


### PR DESCRIPTION
## Summary
- Adds `./aos dev classify`, `./aos dev recommend`, and `./aos dev build` as the repo developer workflow control surface.
- Adds `docs/dev/workflow-rules.json` plus `shared/schemas/dev-workflow-rules.schema.json` and fixtures.
- Updates agent/dev docs so rebuild, package test, schema test, canvas reload, and readiness routing start from the manifest-backed router.

Closes #160.

## Verification
- `bash build.sh --no-restart` (bootstrap because this worktree had no `./aos` binary)
- `./aos dev build --no-restart --json`
- `bash tests/dev-workflow-router.sh`
- `node --test tests/schemas/*.test.mjs`
- `bash tests/help-contract.sh`
- `git diff --check`

Note: I did not run `./aos ready` from this temporary worktree to avoid switching the repo-mode daemon/TCC marker away from the active root checkout; the new dev classify/recommend paths are daemon-free.
