### PR TITLE
[codex] Add provider session catalog

### DIFF
--- a/apps/sigil/AGENTS.md
+++ b/apps/sigil/AGENTS.md
@@ -50,7 +50,7 @@ doc lands at `~/.config/aos/{mode}/wiki/sigil/agents/default.md`.
 | `renderer/live-modules/*.js` | Sigil-owned interaction/runtime modules: host bridge, boot sequence, PRESS/RADIAL/FAST_TRAVEL/GOTO state machine, fast-travel, display geometry helpers, overlay drawing, and hit-target lifecycle. |
 | `renderer/*.js` | Avatar visual subsystems and shared data modules (`agent-loader`, `appearance`, `birthplace-resolver`, `state`, `geometry`, `colors`, `aura`, `phenomena`, `skins`, `presets`, `fx-registry`, `omega`, `magnetic`, `lightning`, `particles`). |
 | `context-menu/` | Live avatar context menu implementation and agent playbook for menu diagnostics. |
-| `codex-terminal/` | Codex-only terminal MVP. A Sigil canvas fronts a named tmux session through a dependency-free local bridge; launch with `apps/sigil/codex-terminal/launch.sh`. tmux is preferred for durable resume/reattach, with a process fallback for machines without tmux. |
+| `codex-terminal/` | Agent Terminal evolved from the Codex-only MVP. A Sigil canvas fronts a named tmux session through a dependency-free local bridge, lists local Codex/Claude Code sessions, and resumes provider CLI commands into the terminal carrier; launch with `apps/sigil/codex-terminal/launch.sh`. tmux is preferred for durable resume/reattach, with a process fallback for machines without tmux. |
 | `studio/` | Historical URL/path for the avatar configuration surface. Do not use the old product name in new user-facing copy. |
 | `chat/` | Bidirectional conversational canvas (see Chat Canvas Protocol below). |
 | `workbench/` | Historical multi-tab surface. Do not use as the standard launch or verification path for current Sigil work unless the task explicitly targets that surface. |

--- a/apps/sigil/codex-terminal/index.html
+++ b/apps/sigil/codex-terminal/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Sigil Codex Terminal</title>
+  <title>Sigil Agent Terminal</title>
   <link rel="stylesheet" href="./node_modules/@xterm/xterm/css/xterm.css">
   <style>
     * { box-sizing: border-box; }
@@ -15,6 +15,9 @@
       color: #eff2f4;
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       -webkit-font-smoothing: antialiased;
+    }
+    button, select {
+      font: inherit;
     }
     .shell {
       position: relative;
@@ -50,10 +53,7 @@
       cursor: pointer;
       flex: 0 0 auto;
     }
-    .avatar::before {
-      content: "";
-      display: none;
-    }
+    .avatar::before,
     .avatar::after {
       content: "";
       display: none;
@@ -87,10 +87,19 @@
     }
     .status.ready { background: #32d583; }
     .status.error { background: #ff5f57; }
+    .content {
+      min-height: 0;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 238px;
+      background: #050708;
+    }
+    .shell.rail-collapsed .content {
+      grid-template-columns: minmax(0, 1fr) 42px;
+    }
     .terminal-wrap {
+      min-width: 0;
       min-height: 0;
       padding: 8px;
-      background: #050708;
       position: relative;
     }
     #terminal {
@@ -105,20 +114,203 @@
       scrollbar-width: thin;
       scrollbar-color: rgba(255,255,255,0.18) transparent;
     }
+    .rail {
+      min-width: 0;
+      min-height: 0;
+      display: grid;
+      grid-template-rows: 36px 1fr;
+      border-left: 1px solid rgba(255,255,255,0.11);
+      background: #0d1113;
+    }
+    .rail-top {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 6px;
+      padding: 6px;
+      border-bottom: 1px solid rgba(255,255,255,0.08);
+    }
+    .rail-title {
+      color: #c9d3d8;
+      font-size: 12px;
+      font-weight: 650;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+    .rail-toggle,
+    .icon-button {
+      width: 28px;
+      height: 24px;
+      display: inline-grid;
+      place-items: center;
+      border: 1px solid rgba(255,255,255,0.13);
+      border-radius: 6px;
+      background: rgba(255,255,255,0.04);
+      color: #d7e0e4;
+      cursor: pointer;
+    }
+    .rail-toggle:hover,
+    .icon-button:hover {
+      background: rgba(255,255,255,0.09);
+    }
+    .rail-content {
+      min-height: 0;
+      display: grid;
+      grid-template-rows: auto auto 1fr;
+      gap: 8px;
+      padding: 8px;
+    }
+    .shell.rail-collapsed .rail-title,
+    .shell.rail-collapsed .rail-content {
+      display: none;
+    }
+    .new-actions {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 6px;
+    }
+    .new-actions button,
+    .session-button {
+      border: 1px solid rgba(255,255,255,0.12);
+      border-radius: 7px;
+      background: rgba(255,255,255,0.045);
+      color: #edf4f6;
+      cursor: pointer;
+    }
+    .new-actions button {
+      min-height: 30px;
+      padding: 0 8px;
+      font-size: 11px;
+      font-weight: 650;
+    }
+    .new-actions button:hover,
+    .session-button:hover {
+      background: rgba(255,255,255,0.09);
+      border-color: rgba(255,255,255,0.18);
+    }
+    .filters {
+      display: grid;
+      grid-template-columns: 1fr 30px;
+      gap: 6px;
+    }
+    .sort-select {
+      grid-column: 1 / -1;
+    }
+    .filters select {
+      width: 100%;
+      min-width: 0;
+      height: 28px;
+      border: 1px solid rgba(255,255,255,0.13);
+      border-radius: 6px;
+      background: #11181b;
+      color: #dce6ea;
+      padding: 0 7px;
+      font-size: 11px;
+    }
+    .session-list {
+      min-height: 0;
+      overflow: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      padding-right: 2px;
+      scrollbar-width: thin;
+      scrollbar-color: rgba(255,255,255,0.18) transparent;
+    }
+    .session-button {
+      width: 100%;
+      min-height: 58px;
+      padding: 7px;
+      text-align: left;
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 3px;
+    }
+    .session-main {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      min-width: 0;
+    }
+    .provider-badge {
+      flex: 0 0 auto;
+      border-radius: 5px;
+      padding: 2px 5px;
+      font-size: 9px;
+      line-height: 1;
+      letter-spacing: 0;
+      color: #061013;
+      background: #89dceb;
+      font-weight: 750;
+    }
+    .provider-badge.claude-code {
+      background: #ffd166;
+    }
+    .session-name,
+    .session-meta,
+    .session-id {
+      min-width: 0;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+    .session-name {
+      color: #f3f7f8;
+      font-size: 12px;
+      font-weight: 650;
+    }
+    .session-meta,
+    .session-id,
+    .empty-state {
+      color: #8e9aa0;
+      font-size: 10.5px;
+      line-height: 1.25;
+    }
+    .empty-state {
+      padding: 8px 2px;
+    }
   </style>
 </head>
 <body>
-  <main class="shell">
+  <main class="shell" id="shell">
     <header class="header" id="dragHandle">
-      <button class="avatar" id="avatarButton" title="Return to avatar"></button>
+      <button class="avatar" id="avatarButton" title="Return to avatar" aria-label="Return to avatar"></button>
       <div class="title">
         <strong>Sigil</strong>
-        <span id="subtitle">Codex terminal</span>
+        <span id="subtitle">Agent terminal</span>
       </div>
       <span class="status" id="status"></span>
     </header>
-    <section class="terminal-wrap">
-      <div id="terminal"></div>
+    <section class="content">
+      <section class="terminal-wrap" aria-label="Agent terminal pane">
+        <div id="terminal"></div>
+      </section>
+      <aside class="rail" aria-label="Agent sessions">
+        <div class="rail-top">
+          <span class="rail-title">Sessions</span>
+          <button class="rail-toggle" id="railToggle" aria-label="Collapse sessions rail" aria-expanded="true">&gt;</button>
+        </div>
+        <div class="rail-content">
+          <div class="new-actions">
+            <button id="newCodex" type="button">New Codex</button>
+            <button id="newClaude" type="button">New Claude Code</button>
+          </div>
+          <div class="filters">
+            <select id="providerFilter" aria-label="Provider filter">
+              <option value="all">All agents</option>
+              <option value="codex">Codex</option>
+              <option value="claude-code">Claude Code</option>
+            </select>
+            <button class="icon-button" id="refreshSessions" type="button" aria-label="Refresh sessions">R</button>
+            <select class="sort-select" id="sessionSort" aria-label="Session sort">
+              <option value="last-message">Last message</option>
+              <option value="created">Created</option>
+            </select>
+          </div>
+          <div class="session-list" id="sessionList" role="list" aria-label="Recent sessions"></div>
+        </div>
+      </aside>
     </section>
   </main>
 
@@ -128,8 +320,15 @@
     const params = new URLSearchParams(location.search);
     const port = params.get('port') || '17761';
     const session = params.get('session') || 'sigil-codex-cli-agent-os';
+    let currentCwd = params.get('cwd') || '';
+    let activeLabel = 'Agent terminal';
+    const shell = document.getElementById('shell');
     const subtitle = document.getElementById('subtitle');
     const statusDot = document.getElementById('status');
+    const sessionList = document.getElementById('sessionList');
+    const providerFilter = document.getElementById('providerFilter');
+    const sessionSort = document.getElementById('sessionSort');
+    const railToggle = document.getElementById('railToggle');
     let dragging = false;
     let dragOffsetX = 0;
     let dragOffsetY = 0;
@@ -138,9 +337,14 @@
     let socket = null;
     let resizeRaf = 0;
     let lastFit = { cols: 0, rows: 0 };
+    let sessions = [];
 
     function emit(body) {
       window.webkit?.messageHandlers?.headsup?.postMessage(body);
+    }
+
+    function bridgeUrl(path) {
+      return `http://127.0.0.1:${port}${path}`;
     }
 
     function setStatus(kind, text) {
@@ -172,6 +376,169 @@
       setTimeout(resizeTerminal, 160);
     }
 
+    function providerLabel(provider) {
+      return provider === 'claude-code' ? 'Claude' : 'Codex';
+    }
+
+    function basename(filePath) {
+      const parts = String(filePath || '').split('/').filter(Boolean);
+      return parts[parts.length - 1] || filePath || 'workspace';
+    }
+
+    function shortSessionId(id) {
+      return String(id || '').slice(0, 8);
+    }
+
+    function formatTime(value) {
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) return '';
+      return date.toLocaleString([], {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      });
+    }
+
+    function sessionSortTimestamp(record) {
+      if (sessionSort.value === 'created') {
+        return record.created_at || record.updated_at || record.last_message_at;
+      }
+      return record.last_message_at || record.updated_at || record.created_at;
+    }
+
+    function compareSessionsForRail(a, b) {
+      const at = Date.parse(sessionSortTimestamp(a) || '') || 0;
+      const bt = Date.parse(sessionSortTimestamp(b) || '') || 0;
+      const recency = bt - at;
+      if (recency !== 0) return recency;
+      const provider = String(a.provider || '').localeCompare(String(b.provider || ''));
+      if (provider !== 0) return provider;
+      return String(a.session_id || '').localeCompare(String(b.session_id || ''));
+    }
+
+    function renderSessions() {
+      sessionList.replaceChildren();
+      if (!sessions.length) {
+        const empty = document.createElement('div');
+        empty.className = 'empty-state';
+        empty.textContent = 'No sessions';
+        sessionList.append(empty);
+        return;
+      }
+
+      for (const record of [...sessions].sort(compareSessionsForRail)) {
+        const item = document.createElement('button');
+        item.type = 'button';
+        item.className = 'session-button';
+        item.setAttribute('role', 'listitem');
+        item.setAttribute('aria-label', `Resume ${providerLabel(record.provider)} session ${record.session_id} in ${record.cwd}`);
+        item.addEventListener('click', () => {
+          void runAgentCommand({
+            command: record.resume_command,
+            cwd: record.cwd,
+            label: `${providerLabel(record.provider)} ${basename(record.cwd)}`,
+          });
+        });
+
+        const main = document.createElement('div');
+        main.className = 'session-main';
+        const badge = document.createElement('span');
+        badge.className = `provider-badge ${record.provider}`;
+        badge.textContent = providerLabel(record.provider);
+        const name = document.createElement('span');
+        name.className = 'session-name';
+        name.textContent = basename(record.cwd);
+        main.append(badge, name);
+
+        const meta = document.createElement('div');
+        meta.className = 'session-meta';
+        meta.textContent = [record.branch, formatTime(sessionSortTimestamp(record))].filter(Boolean).join(' / ');
+
+        const id = document.createElement('div');
+        id.className = 'session-id';
+        id.textContent = shortSessionId(record.session_id);
+
+        item.append(main, meta, id);
+        sessionList.append(item);
+      }
+    }
+
+    async function loadSessions() {
+      const query = new URLSearchParams();
+      if (currentCwd) query.set('cwd', currentCwd);
+      if (providerFilter.value !== 'all') query.append('provider', providerFilter.value);
+      try {
+        const response = await fetch(bridgeUrl(`/sessions?${query.toString()}`));
+        if (!response.ok) throw new Error(await response.text());
+        const payload = await response.json();
+        sessions = Array.isArray(payload.sessions) ? payload.sessions : [];
+      } catch (_) {
+        sessions = [];
+      }
+      renderSessions();
+    }
+
+    function connectTerminal(label = activeLabel) {
+      const previous = socket;
+      socket = null;
+      if (previous && previous.readyState !== WebSocket.CLOSED) previous.close();
+
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/terminal?session=${encodeURIComponent(session)}`);
+      socket = ws;
+      ws.addEventListener('open', () => {
+        if (socket !== ws) return;
+        setStatus('ready', `${label} - attached`);
+        window.__sigilAgentTerminal.state.attached = true;
+        terminal.clear();
+        scheduleRefit();
+        terminal.focus();
+      });
+      ws.addEventListener('message', async (event) => {
+        if (socket !== ws) return;
+        if (event.data instanceof Blob) {
+          terminal.write(await event.data.text());
+        } else {
+          terminal.write(String(event.data));
+        }
+      });
+      ws.addEventListener('close', () => {
+        if (socket !== ws) return;
+        window.__sigilAgentTerminal.state.attached = false;
+        setStatus('error', `${label} - detached`);
+      });
+      ws.addEventListener('error', () => {
+        if (socket !== ws) return;
+        setStatus('error', 'terminal bridge error');
+      });
+    }
+
+    async function runAgentCommand({ command, cwd, label }) {
+      activeLabel = label;
+      currentCwd = cwd || currentCwd;
+      setStatus('', `Starting ${label}`);
+      terminal?.clear();
+      terminal?.writeln(`Starting ${label}...`);
+      try {
+        const response = await fetch(bridgeUrl('/ensure'), {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            session,
+            cwd: currentCwd,
+            command,
+            force: true,
+          }),
+        });
+        if (!response.ok) throw new Error(await response.text());
+        connectTerminal(label);
+        void loadSessions();
+      } catch (error) {
+        setStatus('error', 'launch failed');
+        terminal?.writeln(`\r\n${error.message || String(error)}`);
+      }
+    }
+
     function bootTerminal() {
       if (!window.Terminal) {
         setStatus('error', 'xterm.js failed to load');
@@ -197,35 +564,46 @@
       terminal.open(document.getElementById('terminal'));
       scheduleRefit();
       terminal.focus();
-      terminal.writeln('Connecting to Codex tmux session...');
-
-      const ws = new WebSocket(`ws://127.0.0.1:${port}/terminal?session=${encodeURIComponent(session)}`);
-      socket = ws;
-      ws.addEventListener('open', () => {
-        setStatus('ready', `${session} - attached`);
-        window.__sigilCodexTerminal.state.attached = true;
-        terminal.clear();
-        scheduleRefit();
-        terminal.focus();
-      });
-      ws.addEventListener('message', async (event) => {
-        if (event.data instanceof Blob) {
-          terminal.write(await event.data.text());
-        } else {
-          terminal.write(String(event.data));
-        }
-      });
-      ws.addEventListener('close', () => {
-        window.__sigilCodexTerminal.state.attached = false;
-        setStatus('error', `${session} - detached`);
-      });
-      ws.addEventListener('error', () => {
-        setStatus('error', 'terminal bridge error');
-      });
+      terminal.writeln('Connecting to agent terminal...');
+      connectTerminal(activeLabel);
       terminal.onData((data) => {
-        if (ws.readyState === WebSocket.OPEN) ws.send(data);
+        if (socket?.readyState === WebSocket.OPEN) socket.send(data);
       });
     }
+
+    document.getElementById('newCodex').addEventListener('click', () => {
+      void runAgentCommand({
+        command: ['codex', '--no-alt-screen'],
+        cwd: currentCwd,
+        label: 'New Codex',
+      });
+    });
+
+    document.getElementById('newClaude').addEventListener('click', () => {
+      void runAgentCommand({
+        command: ['claude'],
+        cwd: currentCwd,
+        label: 'New Claude Code',
+      });
+    });
+
+    document.getElementById('refreshSessions').addEventListener('click', () => {
+      void loadSessions();
+    });
+
+    providerFilter.addEventListener('change', () => {
+      void loadSessions();
+    });
+
+    sessionSort.addEventListener('change', renderSessions);
+
+    railToggle.addEventListener('click', () => {
+      const collapsed = shell.classList.toggle('rail-collapsed');
+      railToggle.textContent = collapsed ? '<' : '>';
+      railToggle.setAttribute('aria-expanded', String(!collapsed));
+      railToggle.setAttribute('aria-label', collapsed ? 'Expand sessions rail' : 'Collapse sessions rail');
+      scheduleRefit();
+    });
 
     document.getElementById('avatarButton').addEventListener('click', (event) => {
       event.preventDefault();
@@ -234,7 +612,7 @@
     });
 
     document.getElementById('dragHandle').addEventListener('mousedown', (event) => {
-      if (event.target.closest('button')) return;
+      if (event.target.closest('button, select')) return;
       dragging = true;
       dragOffsetX = event.clientX;
       dragOffsetY = event.clientY;
@@ -270,26 +648,30 @@
         emit({ type: 'lifecycle.complete', payload: { action: 'resume' } });
       }
       if (msg?.type === 'codex_terminal.refit') scheduleRefit();
+      if (msg?.type === 'agent_terminal.refresh_sessions') void loadSessions();
     };
     window.focusInput = function focusInput() {
       scheduleRefit();
       terminal?.focus();
     };
-    window.__sigilCodexTerminal = {
+    window.__sigilAgentTerminal = {
       state: { attached: false },
       refit: scheduleRefit,
+      refreshSessions: loadSessions,
     };
+    window.__sigilCodexTerminal = window.__sigilAgentTerminal;
 
     emit({
       type: 'ready',
       payload: {
-        name: 'codex-terminal',
-        accepts: ['keyboard'],
+        name: 'agent-terminal',
+        accepts: ['keyboard', 'agent_terminal.refresh_sessions'],
         emits: ['ready', 'close', 'drag_start', 'move_abs', 'drag_end'],
       },
     });
 
     bootTerminal();
+    void loadSessions();
   </script>
 </body>
 </html>

--- a/apps/sigil/codex-terminal/launch.sh
+++ b/apps/sigil/codex-terminal/launch.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Launch the Codex-only Sigil terminal MVP.
+# Launch the Sigil Agent Terminal.
 
 set -euo pipefail
 
@@ -12,29 +12,37 @@ AVATAR_ID="${AVATAR_ID:-avatar-main}"
 SESSION="${SESSION:-sigil-codex-cli-agent-os}"
 PORT="${PORT:-17761}"
 CWD_TARGET="${CWD_TARGET:-$REPO_ROOT}"
-CODEX_COMMAND="${CODEX_COMMAND:-codex --no-alt-screen}"
+AGENT_COMMAND="${AGENT_COMMAND:-${CODEX_COMMAND:-codex --no-alt-screen}}"
 STATE_DIR="${HOME}/.config/aos/${MODE}/sigil"
-BRIDGE_LOG="${STATE_DIR}/codex-terminal-bridge.log"
+BRIDGE_LOG="${STATE_DIR}/agent-terminal-bridge.log"
 BRIDGE_SESSION="${BRIDGE_SESSION:-sigil-codex-bridge-${PORT}}"
 
 usage() {
-  printf 'Usage: %s [--new|--pick|--last|--restart]\n' "$0"
-  printf 'Default starts a fresh Sigil-owned Codex CLI. Use --last only when you explicitly want Codex CLI resume --last.\n'
+  printf 'Usage: %s [--new|--new-codex|--new-claude|--pick|--last|--restart]\n' "$0"
+  printf 'Default starts a fresh Sigil-owned Codex CLI. Use --new-claude for Claude Code.\n'
 }
 
 RESTART=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --new)
-      CODEX_COMMAND="codex --no-alt-screen"
+      AGENT_COMMAND="codex --no-alt-screen"
+      shift
+      ;;
+    --new-codex)
+      AGENT_COMMAND="codex --no-alt-screen"
+      shift
+      ;;
+    --new-claude)
+      AGENT_COMMAND="claude"
       shift
       ;;
     --pick)
-      CODEX_COMMAND="codex --no-alt-screen resume"
+      AGENT_COMMAND="codex --no-alt-screen resume"
       shift
       ;;
     --last)
-      CODEX_COMMAND="codex --no-alt-screen resume --last"
+      AGENT_COMMAND="codex --no-alt-screen resume --last"
       shift
       ;;
     --restart)
@@ -53,8 +61,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 ensure_content_roots() {
-  "$AOS" set content.roots.toolkit packages/toolkit >/dev/null
-  "$AOS" set content.roots.sigil apps/sigil >/dev/null
+  "$AOS" set content.roots.toolkit "$REPO_ROOT/packages/toolkit" >/dev/null
+  "$AOS" set content.roots.sigil "$REPO_ROOT/apps/sigil" >/dev/null
 }
 
 bridge_running() {
@@ -69,14 +77,14 @@ start_bridge() {
   if command -v tmux >/dev/null 2>&1; then
     tmux kill-session -t "$BRIDGE_SESSION" >/dev/null 2>&1 || true
     local bridge_cmd
-    bridge_cmd="$(python3 - "$PORT" "$SESSION" "$CWD_TARGET" "$CODEX_COMMAND" "$SCRIPT_DIR/server.mjs" "$BRIDGE_LOG" <<'PY'
+    bridge_cmd="$(python3 - "$PORT" "$SESSION" "$CWD_TARGET" "$AGENT_COMMAND" "$SCRIPT_DIR/server.mjs" "$BRIDGE_LOG" <<'PY'
 import shlex, sys
 port, session, cwd, command, server, log = sys.argv[1:]
 parts = [
-    "SIGIL_CODEX_TERMINAL_PORT=" + shlex.quote(port),
-    "SIGIL_CODEX_TMUX_SESSION=" + shlex.quote(session),
-    "SIGIL_CODEX_CWD=" + shlex.quote(cwd),
-    "SIGIL_CODEX_COMMAND=" + shlex.quote(command),
+    "SIGIL_AGENT_TERMINAL_PORT=" + shlex.quote(port),
+    "SIGIL_AGENT_TMUX_SESSION=" + shlex.quote(session),
+    "SIGIL_AGENT_CWD=" + shlex.quote(cwd),
+    "SIGIL_AGENT_COMMAND=" + shlex.quote(command),
     "node",
     shlex.quote(server),
     ">>",
@@ -89,23 +97,23 @@ PY
     : >"$BRIDGE_LOG"
     tmux new-session -d -s "$BRIDGE_SESSION" -c "$REPO_ROOT" "$bridge_cmd"
   else
-    SIGIL_CODEX_TERMINAL_PORT="$PORT" \
-    SIGIL_CODEX_TMUX_SESSION="$SESSION" \
-    SIGIL_CODEX_CWD="$CWD_TARGET" \
-    SIGIL_CODEX_COMMAND="$CODEX_COMMAND" \
+    SIGIL_AGENT_TERMINAL_PORT="$PORT" \
+    SIGIL_AGENT_TMUX_SESSION="$SESSION" \
+    SIGIL_AGENT_CWD="$CWD_TARGET" \
+    SIGIL_AGENT_COMMAND="$AGENT_COMMAND" \
       nohup node "$SCRIPT_DIR/server.mjs" >"$BRIDGE_LOG" 2>&1 &
   fi
   for _ in $(seq 1 30); do
     bridge_running && return 0
     sleep 0.1
   done
-  echo "Codex terminal bridge did not start. See $BRIDGE_LOG" >&2
+  echo "Agent terminal bridge did not start. See $BRIDGE_LOG" >&2
   return 1
 }
 
 ensure_bridge_session() {
   local payload
-  payload="$(python3 - "$SESSION" "$CWD_TARGET" "$CODEX_COMMAND" "$RESTART" <<'PY'
+  payload="$(python3 - "$SESSION" "$CWD_TARGET" "$AGENT_COMMAND" "$RESTART" <<'PY'
 import json, sys
 print(json.dumps({
     "session": sys.argv[1],
@@ -119,6 +127,14 @@ PY
     -H 'content-type: application/json' \
     -d "$payload" \
     "http://127.0.0.1:${PORT}/ensure" >/dev/null
+}
+
+urlencode() {
+  python3 - "$1" <<'PY'
+from urllib.parse import quote
+import sys
+print(quote(sys.argv[1], safe=""))
+PY
 }
 
 compute_frame() {
@@ -136,7 +152,7 @@ if not main:
     print("240,180,860,560")
     raise SystemExit
 b = main.get("visible_bounds") or main.get("visibleBounds") or main.get("bounds") or {"x": 0, "y": 0, "w": 1512, "h": 875}
-w = min(920, max(720, round(b["w"] * 0.58)))
+w = min(1140, max(920, round(b["w"] * 0.70)))
 h = min(620, max(480, round(b["h"] * 0.58)))
 x = round(b["x"] + b["w"] - w - 28)
 y = round(b["y"] + b["h"] - h - 28)
@@ -159,18 +175,20 @@ main() {
 
   "$AOS" show remove --id "$CANVAS_ID" >/dev/null 2>&1 || true
   local frame
+  local encoded_cwd
   frame="$(compute_frame)"
+  encoded_cwd="$(urlencode "$CWD_TARGET")"
   "$AOS" show create --id "$CANVAS_ID" \
     --at "$frame" \
     --interactive \
     --focus \
-    --url "aos://sigil/codex-terminal/index.html?port=${PORT}&session=${SESSION}" >/dev/null
+    --url "aos://sigil/codex-terminal/index.html?port=${PORT}&session=${SESSION}&cwd=${encoded_cwd}" >/dev/null
 
-  echo "Sigil Codex terminal launched."
+  echo "Sigil Agent terminal launched."
   echo "  canvas:  $CANVAS_ID ($frame)"
   echo "  session: $SESSION"
   echo "  bridge:  http://127.0.0.1:$PORT"
-  echo "  command: $CODEX_COMMAND"
+  echo "  command: $AGENT_COMMAND"
 }
 
 main "$@"

--- a/apps/sigil/codex-terminal/server.mjs
+++ b/apps/sigil/codex-terminal/server.mjs
@@ -4,15 +4,17 @@ import crypto from 'node:crypto';
 import { spawn, spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { listProviderSessions } from '../../../packages/host/src/session-catalog.ts';
 
-const port = Number(process.env.SIGIL_CODEX_TERMINAL_PORT || process.env.PORT || 17761);
+const port = Number(process.env.SIGIL_AGENT_TERMINAL_PORT || process.env.SIGIL_CODEX_TERMINAL_PORT || process.env.PORT || 17761);
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const ptyProxyPath = path.join(scriptDir, 'pty-proxy.py');
-const defaultSession = process.env.SIGIL_CODEX_TMUX_SESSION || 'sigil-codex-cli-agent-os';
-const defaultCwd = process.env.SIGIL_CODEX_CWD || process.cwd();
-const defaultCommand = process.env.SIGIL_CODEX_COMMAND || 'codex --no-alt-screen';
-const requestedDriver = process.env.SIGIL_CODEX_TERMINAL_DRIVER || 'auto';
+const defaultSession = process.env.SIGIL_AGENT_TMUX_SESSION || process.env.SIGIL_CODEX_TMUX_SESSION || 'sigil-codex-cli-agent-os';
+const defaultCwd = process.env.SIGIL_AGENT_CWD || process.env.SIGIL_CODEX_CWD || process.cwd();
+const defaultCommand = process.env.SIGIL_AGENT_COMMAND || process.env.SIGIL_CODEX_COMMAND || 'codex --no-alt-screen';
+const requestedDriver = process.env.SIGIL_AGENT_TERMINAL_DRIVER || process.env.SIGIL_CODEX_TERMINAL_DRIVER || 'auto';
 const processSessions = new Map();
+const sessionCommands = new Map();
 const allowedKeys = new Set([
   'Enter',
   'C-c',
@@ -62,6 +64,22 @@ function run(cmd, args, options = {}) {
     throw error;
   }
   return result.stdout || '';
+}
+
+function shellQuote(value) {
+  const textValue = String(value);
+  if (/^[A-Za-z0-9_./:=@%+-]+$/.test(textValue)) return textValue;
+  return `'${textValue.replace(/'/g, `'\\''`)}'`;
+}
+
+function commandText(value) {
+  if (Array.isArray(value)) {
+    const parts = value.map((part) => String(part)).filter(Boolean);
+    if (!parts.length) return defaultCommand;
+    return parts.map(shellQuote).join(' ');
+  }
+  if (typeof value === 'string' && value.trim()) return value.trim();
+  return defaultCommand;
 }
 
 function commandExists(command) {
@@ -123,9 +141,13 @@ function hasSession(session) {
 }
 
 function appendProcessOutput(record, chunk) {
-  record.buffer += chunk.toString('utf8');
+  const textChunk = chunk.toString('utf8');
+  record.buffer += textChunk;
   if (record.buffer.length > 240000) {
     record.buffer = record.buffer.slice(-200000);
+  }
+  for (const client of record.clients) {
+    if (!client.destroyed) client.write(wsFrame(textChunk));
   }
 }
 
@@ -149,18 +171,34 @@ function ensureProcessSession(session, cwd, command, force = false) {
     command: shellCommand,
     cwd: cwd || defaultCwd,
     buffer: `$ ${shellCommand}\n`,
+    clients: new Set(),
     exited: false,
   };
   processSessions.set(session, record);
+  sessionCommands.set(session, { command: shellCommand, cwd: cwd || defaultCwd });
   child.stdout.on('data', chunk => appendProcessOutput(record, chunk));
   child.stderr.on('data', chunk => appendProcessOutput(record, chunk));
   child.on('exit', (code, signal) => {
     record.exited = true;
-    record.buffer += `\n[process exited: ${signal || (code ?? 0)}]\n`;
+    const message = `\n[process exited: ${signal || (code ?? 0)}]\n`;
+    record.buffer += message;
+    for (const client of record.clients) {
+      if (!client.destroyed) {
+        client.write(wsFrame(message));
+        client.end();
+      }
+    }
   });
   child.on('error', error => {
     record.exited = true;
-    record.buffer += `\n[process error: ${error.message}]\n`;
+    const message = `\n[process error: ${error.message}]\n`;
+    record.buffer += message;
+    for (const client of record.clients) {
+      if (!client.destroyed) {
+        client.write(wsFrame(message));
+        client.end();
+      }
+    }
   });
   return { created: true, driver: 'process' };
 }
@@ -177,6 +215,7 @@ function ensureTmuxSession(session, cwd, command, force = false) {
   if (cwd) args.push('-c', cwd);
   args.push(command || defaultCommand);
   run('tmux', args);
+  sessionCommands.set(session, { command: command || defaultCommand, cwd: cwd || defaultCwd });
   return { created: true, driver: 'tmux' };
 }
 
@@ -296,7 +335,46 @@ function terminalCommandForSession(session) {
   if (tmuxAvailable && hasSession(session)) {
     return `tmux attach-session -t ${JSON.stringify(session)}`;
   }
-  return defaultCommand;
+  return processSessions.get(session)?.command || sessionCommands.get(session)?.command || defaultCommand;
+}
+
+function terminalCwdForSession(session) {
+  return processSessions.get(session)?.cwd || sessionCommands.get(session)?.cwd || defaultCwd;
+}
+
+function attachExistingProcessSocket(socket, session, record) {
+  terminalClients.add(socket);
+  record.clients.add(socket);
+  if (record.buffer) socket.write(wsFrame(record.buffer));
+  let incoming = Buffer.alloc(0);
+
+  function detach() {
+    terminalClients.delete(socket);
+    record.clients.delete(socket);
+  }
+
+  socket.on('data', chunk => {
+    incoming = Buffer.concat([incoming, chunk]);
+    const decoded = decodeWsFrames(incoming);
+    incoming = decoded.rest;
+    for (const frame of decoded.frames) {
+      if (frame.opcode === 8) {
+        socket.end();
+        return;
+      }
+      if (frame.opcode === 9) {
+        socket.write(wsFrame(frame.payload, 10));
+        continue;
+      }
+      if (frame.opcode === 1 || frame.opcode === 2) {
+        const payload = frame.payload.toString('utf8');
+        if (frame.opcode === 1 && payload.charCodeAt(0) === 0) continue;
+        record.child.stdin.write(frame.payload);
+      }
+    }
+  });
+  socket.on('close', detach);
+  socket.on('error', detach);
 }
 
 function attachTerminalSocket(socket, req) {
@@ -319,9 +397,15 @@ function attachTerminalSocket(socket, req) {
     '\r\n',
   ].join('\r\n'));
 
+  const existing = processSessions.get(session);
+  if (activeDriver() === 'process' && existing && !existing.exited) {
+    attachExistingProcessSocket(socket, session, existing);
+    return;
+  }
+
   const command = terminalCommandForSession(session);
   const child = spawn(pythonAvailable ? 'python3' : 'sh', pythonAvailable ? [ptyProxyPath, command] : ['-lc', command], {
-    cwd: defaultCwd,
+    cwd: terminalCwdForSession(session),
     stdio: 'pipe',
     env: { ...process.env, TERM: 'xterm-256color' },
   });
@@ -407,11 +491,26 @@ async function handle(req, res) {
       json(res, 200, {
         ok: true,
         defaultSession,
+        defaultCwd,
         driver: activeDriver(),
         tmuxAvailable,
         scriptAvailable,
         pythonAvailable,
       });
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname === '/sessions') {
+      const providerParams = url.searchParams.getAll('provider');
+      const providers = providerParams.filter((provider) => provider === 'codex' || provider === 'claude-code');
+      const sessions = listProviderSessions({
+        homeDir: process.env.SIGIL_AGENT_CATALOG_HOME,
+        codexRoot: process.env.SIGIL_AGENT_CODEX_ROOT,
+        claudeRoot: process.env.SIGIL_AGENT_CLAUDE_ROOT,
+        cwd: url.searchParams.get('cwd') || defaultCwd,
+        providers: providers.length ? providers : undefined,
+      });
+      json(res, 200, { sessions });
       return;
     }
 
@@ -431,7 +530,7 @@ async function handle(req, res) {
       const result = ensureSession(
         session,
         typeof body.cwd === 'string' ? body.cwd : defaultCwd,
-        typeof body.command === 'string' ? body.command : defaultCommand,
+        commandText(body.command),
         body.force === true,
       );
       json(res, 200, { ok: true, session, ...result });

--- a/apps/sigil/renderer/radial-menu-defaults.js
+++ b/apps/sigil/renderer/radial-menu-defaults.js
@@ -63,7 +63,7 @@ export const DEFAULT_SIGIL_RADIAL_ITEMS = [
     },
     {
         id: 'codex-terminal',
-        label: 'Codex Terminal',
+        label: 'Agent Terminal',
         action: 'codexTerminal',
         geometry: CODEX_TERMINAL_TABLET_MODEL,
     },

--- a/packages/host/src/session-catalog.ts
+++ b/packages/host/src/session-catalog.ts
@@ -1,0 +1,498 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export type ProviderSessionProvider = 'codex' | 'claude-code';
+
+export interface ProviderSessionRecord {
+  provider: ProviderSessionProvider;
+  session_id: string;
+  cwd: string;
+  branch?: string;
+  created_at?: string;
+  last_message_at?: string;
+  updated_at: string;
+  source_file: string;
+  resume_command: string[];
+}
+
+export interface SessionCatalogOptions {
+  homeDir?: string;
+  codexRoot?: string;
+  claudeRoot?: string;
+  providers?: ProviderSessionProvider[];
+  cwd?: string;
+  includeArchivedCodex?: boolean;
+  maxJsonlMetadataLines?: number;
+  maxJsonlMetadataBytes?: number;
+}
+
+interface PartialRecord {
+  provider: ProviderSessionProvider;
+  session_id?: string;
+  cwd?: string;
+  branch?: string;
+  created_at?: string;
+  last_message_at?: string;
+  updated_at?: string;
+  source_file: string;
+  resume_command?: string[];
+}
+
+const DEFAULT_JSONL_METADATA_LINES = 80;
+const DEFAULT_JSONL_METADATA_BYTES = 1024 * 1024;
+
+export function listProviderSessions(options: SessionCatalogOptions = {}): ProviderSessionRecord[] {
+  const providers = new Set(options.providers ?? ['codex', 'claude-code']);
+  const records: ProviderSessionRecord[] = [];
+
+  if (providers.has('codex')) {
+    records.push(...scanCodexSessions(options));
+  }
+  if (providers.has('claude-code')) {
+    records.push(...scanClaudeCodeSessions(options));
+  }
+
+  const filtered = options.cwd
+    ? records.filter((record) => isSameOrDescendant(record.cwd, options.cwd!))
+    : records;
+
+  return filtered.sort(compareRecordsByRecency);
+}
+
+export function scanCodexSessions(options: SessionCatalogOptions = {}): ProviderSessionRecord[] {
+  const homeDir = options.homeDir ?? os.homedir();
+  const codexRoot = options.codexRoot ?? path.join(homeDir, '.codex');
+  const includeArchived = options.includeArchivedCodex ?? true;
+  const roots = [
+    path.join(codexRoot, 'sessions'),
+    ...(includeArchived ? [path.join(codexRoot, 'archived_sessions')] : []),
+  ];
+
+  return roots
+    .flatMap((root) => walkFiles(root, (file) => path.basename(file).startsWith('rollout-') && file.endsWith('.jsonl')))
+    .map((file) => parseCodexRolloutFile(file, options))
+    .filter(isProviderSessionRecord)
+    .sort(compareRecordsByRecency);
+}
+
+export function scanClaudeCodeSessions(options: SessionCatalogOptions = {}): ProviderSessionRecord[] {
+  const homeDir = options.homeDir ?? os.homedir();
+  const claudeRoot = options.claudeRoot ?? path.join(homeDir, '.claude');
+  const projectRecords = walkFiles(
+    path.join(claudeRoot, 'projects'),
+    (file) => file.endsWith('.jsonl'),
+  ).map((file) => parseClaudeProjectFile(file, options));
+
+  const liveRecords = walkFiles(
+    path.join(claudeRoot, 'sessions'),
+    (file) => file.endsWith('.json'),
+  ).map((file) => parseClaudeLiveSessionFile(file));
+
+  const merged = new Map<string, ProviderSessionRecord>();
+  for (const record of [...projectRecords, ...liveRecords]) {
+    if (!isProviderSessionRecord(record)) continue;
+    mergeRecord(merged, record);
+  }
+  return [...merged.values()].sort(compareRecordsByRecency);
+}
+
+function parseCodexRolloutFile(file: string, options: SessionCatalogOptions): ProviderSessionRecord | undefined {
+  const stat = statFile(file);
+  if (!stat) return undefined;
+
+  const lines = readJsonlHeadLines(file, options);
+  let sessionId = codexSessionIdFromFilename(file);
+  let cwd: string | undefined;
+  let branch: string | undefined;
+  let createdAt: string | undefined;
+
+  for (const line of lines) {
+    if (!line.includes('"session_meta"')) continue;
+    const record = parseJsonObject(line);
+    if (!record) continue;
+    const payload = objectValue(record.payload);
+    if (record.type === 'session_meta' && payload) {
+      sessionId = stringValue(payload.id) ?? sessionId;
+      cwd = stringValue(payload.cwd) ?? cwd;
+      branch = stringValue(objectValue(payload.git)?.branch) ?? branch;
+      createdAt = coerceTimestamp(payload.timestamp) ?? coerceTimestamp(record.timestamp) ?? createdAt;
+      break;
+    }
+  }
+  const lastMessageAt = latestTimestampFromLines(
+    readJsonlTailLines(file, options),
+    codexMetadataPrefix,
+  ) ?? new Date(stat.mtimeMs).toISOString();
+
+  return finalizeRecord({
+    provider: 'codex',
+    session_id: sessionId,
+    cwd,
+    branch,
+    created_at: createdAt,
+    last_message_at: lastMessageAt,
+    updated_at: lastMessageAt,
+    source_file: file,
+    resume_command: sessionId ? ['codex', '--no-alt-screen', 'resume', sessionId] : undefined,
+  });
+}
+
+function parseClaudeProjectFile(file: string, options: SessionCatalogOptions): ProviderSessionRecord | undefined {
+  const stat = statFile(file);
+  if (!stat) return undefined;
+
+  const lines = readJsonlHeadLines(file, options);
+  let sessionId = path.basename(file, '.jsonl') || undefined;
+  let cwd: string | undefined;
+  let branch: string | undefined;
+  let createdAt: string | undefined;
+
+  for (const line of lines) {
+    const metadata = metadataPrefix(line);
+    sessionId = extractJsonStringField(metadata, 'sessionId') ?? sessionId;
+    cwd = extractJsonStringField(metadata, 'cwd') ?? cwd;
+    branch = extractJsonStringField(metadata, 'gitBranch')
+      ?? extractJsonStringField(metadata, 'branch')
+      ?? branch;
+    createdAt = createdAt ?? firstTimestampFromLines([line]);
+    if (sessionId && cwd) break;
+  }
+  const lastMessageAt = latestTimestampFromLines(readJsonlTailLines(file, options))
+    ?? new Date(stat.mtimeMs).toISOString();
+
+  return finalizeRecord({
+    provider: 'claude-code',
+    session_id: sessionId,
+    cwd,
+    branch,
+    created_at: createdAt,
+    last_message_at: lastMessageAt,
+    updated_at: lastMessageAt,
+    source_file: file,
+    resume_command: sessionId ? ['claude', '--resume', sessionId] : undefined,
+  });
+}
+
+function parseClaudeLiveSessionFile(file: string): ProviderSessionRecord | undefined {
+  const raw = readSmallTextFile(file, DEFAULT_JSONL_METADATA_BYTES);
+  if (raw == null) return undefined;
+
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+
+  const record = objectValue(data);
+  if (!record) return undefined;
+
+  const sessionId = stringValue(record.sessionId) ?? stringValue(record.id);
+  const createdAt = coerceTimestamp(record.startedAt)
+    ?? coerceTimestamp(record.createdAt)
+    ?? coerceTimestamp(record.created_at);
+  const lastMessageAt = coerceTimestamp(record.updatedAt)
+    ?? coerceTimestamp(record.updated_at)
+    ?? coerceTimestamp(record.lastActivity)
+    ?? fileUpdatedAt(file);
+  return finalizeRecord({
+    provider: 'claude-code',
+    session_id: sessionId,
+    cwd: stringValue(record.cwd),
+    branch: stringValue(record.gitBranch) ?? stringValue(record.branch),
+    created_at: createdAt,
+    last_message_at: lastMessageAt,
+    updated_at: lastMessageAt,
+    source_file: file,
+    resume_command: sessionId ? ['claude', '--resume', sessionId] : undefined,
+  });
+}
+
+function finalizeRecord(record: PartialRecord): ProviderSessionRecord | undefined {
+  if (!record.session_id || !record.cwd || !record.updated_at || !record.resume_command) {
+    return undefined;
+  }
+  const finalized: ProviderSessionRecord = {
+    provider: record.provider,
+    session_id: record.session_id,
+    cwd: record.cwd,
+    updated_at: record.updated_at,
+    source_file: record.source_file,
+    resume_command: record.resume_command,
+  };
+  if (record.branch) finalized.branch = record.branch;
+  if (record.created_at) finalized.created_at = record.created_at;
+  if (record.last_message_at) finalized.last_message_at = record.last_message_at;
+  return finalized;
+}
+
+function mergeRecord(records: Map<string, ProviderSessionRecord>, next: ProviderSessionRecord): void {
+  const key = `${next.provider}:${next.session_id}`;
+  const current = records.get(key);
+  if (!current) {
+    records.set(key, next);
+    return;
+  }
+
+  const nextIsNewer = Date.parse(next.updated_at) >= Date.parse(current.updated_at);
+  const newer = nextIsNewer ? next : current;
+  const older = nextIsNewer ? current : next;
+  records.set(key, {
+    ...newer,
+    cwd: newer.cwd || older.cwd,
+    branch: newer.branch ?? older.branch,
+    created_at: earliestTimestamp(newer.created_at, older.created_at),
+    last_message_at: latestTimestamp(newer.last_message_at, older.last_message_at),
+    updated_at: latestTimestamp(newer.updated_at, older.updated_at) ?? newer.updated_at,
+  });
+}
+
+function compareRecordsByRecency(a: ProviderSessionRecord, b: ProviderSessionRecord): number {
+  const recency = Date.parse(b.updated_at) - Date.parse(a.updated_at);
+  if (recency !== 0) return recency;
+  const provider = a.provider.localeCompare(b.provider);
+  if (provider !== 0) return provider;
+  return a.session_id.localeCompare(b.session_id);
+}
+
+function walkFiles(root: string, matches: (file: string) => boolean): string[] {
+  const files: string[] = [];
+  const stack = [root];
+
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(entryPath);
+      } else if (entry.isFile() && matches(entryPath)) {
+        files.push(entryPath);
+      }
+    }
+  }
+
+  return files;
+}
+
+function readJsonlHeadLines(file: string, options: SessionCatalogOptions): string[] {
+  const maxLines = options.maxJsonlMetadataLines ?? DEFAULT_JSONL_METADATA_LINES;
+  const text = readSmallTextFile(file, options.maxJsonlMetadataBytes ?? DEFAULT_JSONL_METADATA_BYTES);
+  return text?.split(/\r?\n/).filter((line) => line.trim()).slice(0, maxLines) ?? [];
+}
+
+function readJsonlTailLines(file: string, options: SessionCatalogOptions): string[] {
+  const maxLines = options.maxJsonlMetadataLines ?? DEFAULT_JSONL_METADATA_LINES;
+  const maxBytes = options.maxJsonlMetadataBytes ?? DEFAULT_JSONL_METADATA_BYTES;
+  const text = readTailTextFile(file, maxBytes);
+  return text?.split(/\r?\n/).filter((line) => line.trim()).slice(-maxLines) ?? [];
+}
+
+function readTailTextFile(file: string, maxBytes: number): string | undefined {
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(file, 'r');
+    const size = fs.fstatSync(fd).size;
+    const bytesToRead = Math.min(maxBytes, size);
+    const start = Math.max(0, size - bytesToRead);
+    const buffer = Buffer.alloc(bytesToRead);
+    const bytesRead = bytesToRead > 0 ? fs.readSync(fd, buffer, 0, bytesToRead, start) : 0;
+    let text = buffer.subarray(0, bytesRead).toString('utf8');
+    if (start > 0) {
+      const firstNewline = text.indexOf('\n');
+      text = firstNewline >= 0 ? text.slice(firstNewline + 1) : '';
+    }
+    return text;
+  } catch {
+    return undefined;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // Ignore close failures; the scanner is best-effort and read-only.
+      }
+    }
+  }
+}
+
+function readSmallTextFile(file: string, maxBytes: number): string | undefined {
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(file, 'r');
+    const bytesToRead = Math.min(maxBytes, fs.fstatSync(fd).size);
+    const buffer = Buffer.alloc(bytesToRead);
+    const bytesRead = bytesToRead > 0 ? fs.readSync(fd, buffer, 0, bytesToRead, 0) : 0;
+    return buffer.subarray(0, bytesRead).toString('utf8');
+  } catch {
+    return undefined;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // Ignore close failures; the scanner is best-effort and read-only.
+      }
+    }
+  }
+}
+
+function statFile(file: string): fs.Stats | undefined {
+  try {
+    return fs.statSync(file);
+  } catch {
+    return undefined;
+  }
+}
+
+function fileUpdatedAt(file: string): string | undefined {
+  const stat = statFile(file);
+  return stat ? new Date(stat.mtimeMs).toISOString() : undefined;
+}
+
+function codexSessionIdFromFilename(file: string): string | undefined {
+  const match = path.basename(file).match(/^rollout-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-(.+)\.jsonl$/);
+  return match?.[1];
+}
+
+function metadataPrefix(line: string): string {
+  return prefixBeforeMarkers(line, ['"message"', '"snapshot"']);
+}
+
+function codexMetadataPrefix(line: string): string {
+  return prefixBeforeMarkers(line, ['"payload"']);
+}
+
+function prefixBeforeMarkers(line: string, bodyMarkers: string[]): string {
+  const firstBodyMarker = bodyMarkers
+    .map((marker) => line.indexOf(marker))
+    .filter((index) => index >= 0)
+    .sort((a, b) => a - b)[0];
+  return firstBodyMarker == null ? line : line.slice(0, firstBodyMarker);
+}
+
+function firstTimestampFromLines(
+  lines: string[],
+  linePrefix: (line: string) => string = (line) => line,
+): string | undefined {
+  for (const line of lines) {
+    const timestamps = extractJsonTimestampFields(linePrefix(line), 'timestamp');
+    if (timestamps[0]) return timestamps[0];
+  }
+  return undefined;
+}
+
+function latestTimestampFromLines(
+  lines: string[],
+  linePrefix: (line: string) => string = (line) => line,
+): string | undefined {
+  let latest: string | undefined;
+  for (const line of lines) {
+    for (const timestamp of extractJsonTimestampFields(linePrefix(line), 'timestamp')) {
+      latest = latestTimestamp(latest, timestamp);
+    }
+  }
+  return latest;
+}
+
+function extractJsonStringField(line: string, field: string): string | undefined {
+  const escapedField = escapeRegExp(field);
+  const pattern = new RegExp(`"${escapedField}"\\s*:\\s*("(?:\\\\.|[^"\\\\])*")`, 'g');
+  let extracted: string | undefined;
+  for (const match of line.matchAll(pattern)) {
+    if (!match[1]) continue;
+    try {
+      const value = JSON.parse(match[1]) as unknown;
+      extracted = stringValue(value) ?? extracted;
+    } catch {
+      continue;
+    }
+  }
+  return extracted;
+}
+
+function extractJsonTimestampFields(line: string, field: string): string[] {
+  const escapedField = escapeRegExp(field);
+  const pattern = new RegExp(`"${escapedField}"\\s*:\\s*("(?:\\\\.|[^"\\\\])*"|-?\\d+(?:\\.\\d+)?)`, 'g');
+  const timestamps: string[] = [];
+  for (const match of line.matchAll(pattern)) {
+    if (!match[1]) continue;
+    try {
+      const raw = match[1].startsWith('"') ? JSON.parse(match[1]) as unknown : Number(match[1]);
+      const timestamp = coerceTimestamp(raw);
+      if (timestamp) timestamps.push(timestamp);
+    } catch {
+      continue;
+    }
+  }
+  return timestamps;
+}
+
+function earliestTimestamp(a: string | undefined, b: string | undefined): string | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  return Date.parse(a) <= Date.parse(b) ? a : b;
+}
+
+function latestTimestamp(a: string | undefined, b: string | undefined): string | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  return Date.parse(a) >= Date.parse(b) ? a : b;
+}
+
+function parseJsonObject(line: string): Record<string, unknown> | undefined {
+  try {
+    return objectValue(JSON.parse(line) as unknown);
+  } catch {
+    return undefined;
+  }
+}
+
+function coerceTimestamp(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const millis = value > 10_000_000_000 ? value : value * 1000;
+    const parsed = new Date(millis);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+  }
+  return undefined;
+}
+
+function isSameOrDescendant(candidate: string, root: string): boolean {
+  const normalizedCandidate = normalizeComparablePath(candidate);
+  const normalizedRoot = normalizeComparablePath(root);
+  return normalizedCandidate === normalizedRoot
+    || normalizedCandidate.startsWith(`${normalizedRoot}${path.sep}`);
+}
+
+function normalizeComparablePath(value: string): string {
+  return path.resolve(value).replace(new RegExp(`${escapeRegExp(path.sep)}+$`), '');
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function isProviderSessionRecord(record: ProviderSessionRecord | undefined): record is ProviderSessionRecord {
+  return Boolean(record);
+}
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}

--- a/packages/host/test/session-catalog.test.ts
+++ b/packages/host/test/session-catalog.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  listProviderSessions,
+  scanClaudeCodeSessions,
+  scanCodexSessions,
+} from '../src/session-catalog.ts';
+
+const CODEX_SESSION_ID = '019de3a9-2b0b-79f2-bb17-79dfb2c7a706';
+const CLAUDE_SESSION_ID = 'fe9076b7-449c-46fd-8572-0ca0f79bf07a';
+
+describe('provider session catalog', () => {
+  let root: string;
+  let homeDir: string;
+  let repoCwd: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-session-catalog-'));
+    homeDir = path.join(root, 'home');
+    repoCwd = path.join(root, 'work', 'agent-os');
+    fs.mkdirSync(repoCwd, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('discovers Codex rollout and archived sessions from configurable roots', () => {
+    const activeFile = path.join(
+      homeDir,
+      '.codex',
+      'sessions',
+      '2026',
+      '05',
+      '01',
+      `rollout-2026-05-01T09-10-08-${CODEX_SESSION_ID}.jsonl`,
+    );
+    writeJsonl(activeFile, [
+      {
+        timestamp: '2026-05-01T13:10:37.580Z',
+        type: 'session_meta',
+        payload: {
+          id: CODEX_SESSION_ID,
+          cwd: repoCwd,
+          git: { branch: 'codex/provider-session-catalog' },
+        },
+      },
+      {
+        timestamp: '2026-05-01T13:10:38.000Z',
+        type: 'response_item',
+        payload: { type: 'message', content: 'not catalog metadata' },
+      },
+    ]);
+    touch(activeFile, '2026-05-01T14:00:00.000Z');
+
+    const archivedId = '019d0e9b-f2e0-7101-94ff-007f14573560';
+    const archivedFile = path.join(
+      homeDir,
+      '.codex',
+      'archived_sessions',
+      `rollout-2026-03-21T00-16-34-${archivedId}.jsonl`,
+    );
+    writeJsonl(archivedFile, [
+      {
+        timestamp: '2026-03-21T04:16:52.954Z',
+        type: 'session_meta',
+        payload: { id: archivedId, cwd: repoCwd, git: { branch: 'main' } },
+      },
+    ]);
+    touch(archivedFile, '2026-03-21T05:00:00.000Z');
+
+    const sessions = scanCodexSessions({ homeDir });
+
+    assert.equal(sessions.length, 2);
+    assert.equal(sessions[0].session_id, CODEX_SESSION_ID);
+    assert.deepEqual(sessions[0], {
+      provider: 'codex',
+      session_id: CODEX_SESSION_ID,
+      cwd: repoCwd,
+      branch: 'codex/provider-session-catalog',
+      created_at: '2026-05-01T13:10:37.580Z',
+      last_message_at: '2026-05-01T13:10:38.000Z',
+      updated_at: '2026-05-01T13:10:38.000Z',
+      source_file: activeFile,
+      resume_command: ['codex', '--no-alt-screen', 'resume', CODEX_SESSION_ID],
+    });
+    assert.equal(sessions[1].session_id, archivedId);
+  });
+
+  it('discovers Claude Code project JSONL and live metadata sessions', () => {
+    const projectFile = path.join(
+      homeDir,
+      '.claude',
+      'projects',
+      '-tmp-work-agent-os',
+      `${CLAUDE_SESSION_ID}.jsonl`,
+    );
+    writeJsonl(projectFile, [
+      { type: 'permission-mode', sessionId: CLAUDE_SESSION_ID },
+      {
+        type: 'user',
+        uuid: '241f991d-1195-43ff-893f-948307bef527',
+        timestamp: '2026-04-13T16:58:34.648Z',
+        sessionId: CLAUDE_SESSION_ID,
+        cwd: repoCwd,
+        gitBranch: 'main',
+        message: { role: 'user', content: 'not catalog metadata' },
+      },
+      {
+        type: 'assistant',
+        timestamp: '2026-04-13T16:59:02.000Z',
+        sessionId: CLAUDE_SESSION_ID,
+        cwd: repoCwd,
+        gitBranch: 'main',
+        message: { role: 'assistant', content: 'not catalog metadata' },
+      },
+    ]);
+    touch(projectFile, '2026-04-13T17:00:00.000Z');
+
+    const liveId = 'beaf34fd-c714-4cd5-97f6-b41909d032f3';
+    const liveFile = path.join(homeDir, '.claude', 'sessions', '16990.json');
+    writeJson(liveFile, {
+      pid: 16990,
+      sessionId: liveId,
+      cwd: repoCwd,
+      status: 'running',
+      startedAt: Date.parse('2026-05-01T21:40:00.000Z'),
+      updatedAt: Date.parse('2026-05-01T21:43:46.057Z'),
+    });
+
+    const sessions = scanClaudeCodeSessions({ homeDir });
+
+    assert.deepEqual(
+      sessions.map((session) => session.session_id),
+      [liveId, CLAUDE_SESSION_ID],
+    );
+    assert.deepEqual(sessions[0], {
+      provider: 'claude-code',
+      session_id: liveId,
+      cwd: repoCwd,
+      created_at: '2026-05-01T21:40:00.000Z',
+      last_message_at: '2026-05-01T21:43:46.057Z',
+      updated_at: '2026-05-01T21:43:46.057Z',
+      source_file: liveFile,
+      resume_command: ['claude', '--resume', liveId],
+    });
+    assert.deepEqual(sessions[1], {
+      provider: 'claude-code',
+      session_id: CLAUDE_SESSION_ID,
+      cwd: repoCwd,
+      branch: 'main',
+      created_at: '2026-04-13T16:58:34.648Z',
+      last_message_at: '2026-04-13T16:59:02.000Z',
+      updated_at: '2026-04-13T16:59:02.000Z',
+      source_file: projectFile,
+      resume_command: ['claude', '--resume', CLAUDE_SESSION_ID],
+    });
+  });
+
+  it('filters sessions to the requested workspace and sorts by recency', () => {
+    const otherCwd = path.join(root, 'work', 'other');
+    fs.mkdirSync(otherCwd, { recursive: true });
+
+    writeCodexFixture(
+      path.join(homeDir, '.codex', 'sessions', '2026', '05', '01', `rollout-2026-05-01T10-00-00-${CODEX_SESSION_ID}.jsonl`),
+      CODEX_SESSION_ID,
+      repoCwd,
+      '2026-05-01T20:00:00.000Z',
+    );
+    writeCodexFixture(
+      path.join(homeDir, '.codex', 'sessions', '2026', '05', '01', 'rollout-2026-05-01T11-00-00-other-codex.jsonl'),
+      'other-codex',
+      otherCwd,
+      '2026-05-01T21:00:00.000Z',
+    );
+
+    const childCwd = path.join(repoCwd, 'packages', 'host');
+    fs.mkdirSync(childCwd, { recursive: true });
+    writeJsonl(
+      path.join(homeDir, '.claude', 'projects', '-tmp-work-agent-os-packages-host', `${CLAUDE_SESSION_ID}.jsonl`),
+      [{ type: 'user', sessionId: CLAUDE_SESSION_ID, cwd: childCwd, gitBranch: 'main' }],
+    );
+
+    const claudeFile = path.join(homeDir, '.claude', 'projects', '-tmp-work-agent-os-packages-host', `${CLAUDE_SESSION_ID}.jsonl`);
+    touch(claudeFile, '2026-05-01T22:00:00.000Z');
+
+    const sessions = listProviderSessions({ homeDir, cwd: repoCwd });
+
+    assert.deepEqual(
+      sessions.map((session) => `${session.provider}:${session.session_id}`),
+      [`claude-code:${CLAUDE_SESSION_ID}`, `codex:${CODEX_SESSION_ID}`],
+    );
+  });
+
+  it('treats provider format drift as a soft per-record failure', () => {
+    writeText(
+      path.join(homeDir, '.codex', 'sessions', '2026', '05', '01', 'rollout-2026-05-01T12-00-00-bad.jsonl'),
+      '{"timestamp":"2026-05-01T12:00:00Z","type":"session_meta","payload":',
+    );
+    writeText(
+      path.join(homeDir, '.claude', 'projects', '-tmp-work-agent-os', 'bad.jsonl'),
+      '{"type":"user","sessionId":',
+    );
+    writeText(
+      path.join(homeDir, '.claude', 'sessions', 'bad.json'),
+      '{"sessionId":',
+    );
+
+    assert.deepEqual(listProviderSessions({ homeDir }), []);
+  });
+});
+
+function writeCodexFixture(file: string, sessionId: string, cwd: string, mtime: string): void {
+  writeJsonl(file, [
+    {
+      type: 'session_meta',
+      payload: {
+        id: sessionId,
+        cwd,
+        git: { branch: 'main' },
+      },
+    },
+  ]);
+  touch(file, mtime);
+}
+
+function writeJsonl(file: string, records: unknown[]): void {
+  writeText(file, `${records.map((record) => JSON.stringify(record)).join('\n')}\n`);
+}
+
+function writeJson(file: string, value: unknown): void {
+  writeText(file, JSON.stringify(value));
+}
+
+function writeText(file: string, value: string): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, value, 'utf8');
+}
+
+function touch(file: string, iso: string): void {
+  const date = new Date(iso);
+  fs.utimesSync(file, date, date);
+}

--- a/shared/schemas/provider-session-catalog.md
+++ b/shared/schemas/provider-session-catalog.md
@@ -1,0 +1,45 @@
+# Provider Session Catalog
+
+The provider session catalog is a read-only local adapter contract for
+provider-owned agent sessions. It normalizes local Codex and Claude Code session
+metadata without making AOS or Sigil a native client for either provider
+runtime.
+
+The JSON Schema source of truth is
+[`provider-session-catalog.schema.json`](provider-session-catalog.schema.json).
+
+## Record Shape
+
+Catalog results are sorted by `updated_at` descending and shaped as:
+
+```json
+{
+  "provider": "codex",
+  "session_id": "019de3a9-2b0b-79f2-bb17-79dfb2c7a706",
+  "cwd": "/Users/Michael/Code/agent-os",
+  "branch": "codex/provider-session-catalog",
+  "created_at": "2026-05-01T13:10:37.580Z",
+  "last_message_at": "2026-05-01T13:10:38.000Z",
+  "updated_at": "2026-05-01T13:10:38.000Z",
+  "source_file": "/Users/Michael/.codex/sessions/2026/05/01/rollout-2026-05-01T09-10-08-019de3a9-2b0b-79f2-bb17-79dfb2c7a706.jsonl",
+  "resume_command": ["codex", "--no-alt-screen", "resume", "019de3a9-2b0b-79f2-bb17-79dfb2c7a706"]
+}
+```
+
+## Provider Rules
+
+Codex records come from `~/.codex/sessions/**/rollout-*.jsonl` and, where
+present, `~/.codex/archived_sessions/rollout-*.jsonl`. The adapter reads only a
+bounded JSONL head and tail. It uses `session_meta` for identity, workspace, and
+creation time, and the newest top-level JSONL timestamp for last-message
+recency. File modification time is a fallback when provider timestamps are not
+available.
+
+Claude Code records come from `~/.claude/projects/<encoded-cwd>/*.jsonl` and
+`~/.claude/sessions/*.json`. Project JSONL files provide transcript-adjacent
+metadata such as `cwd`, `gitBranch`, creation time, and last-message recency;
+live session JSON files can provide newer `startedAt` and `updatedAt` metadata.
+The adapter treats malformed or drifted files as soft per-record failures.
+
+The scanner must not mutate provider files. Provider roots are configurable for
+tests and future alternate runtime homes.

--- a/shared/schemas/provider-session-catalog.schema.json
+++ b/shared/schemas/provider-session-catalog.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-os.local/schemas/provider-session-catalog.schema.json",
+  "title": "Provider Session Catalog",
+  "description": "Read-only normalized records for local provider-owned agent sessions, sorted by recency.",
+  "type": "array",
+  "items": { "$ref": "#/$defs/providerSessionRecord" },
+  "$defs": {
+    "providerSessionRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider",
+        "session_id",
+        "cwd",
+        "updated_at",
+        "source_file",
+        "resume_command"
+      ],
+      "properties": {
+        "provider": {
+          "type": "string",
+          "enum": ["codex", "claude-code"]
+        },
+        "session_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "cwd": {
+          "type": "string",
+          "minLength": 1
+        },
+        "branch": {
+          "type": "string",
+          "minLength": 1
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "last_message_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "source_file": {
+          "type": "string",
+          "minLength": 1
+        },
+        "resume_command": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/sigil-agent-terminal-server.test.mjs
+++ b/tests/sigil-agent-terminal-server.test.mjs
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+
+describe('Sigil Agent Terminal bridge', () => {
+  let root;
+  let homeDir;
+  let repoCwd;
+  let port;
+  let child;
+  let output;
+
+  beforeEach(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'sigil-agent-terminal-'));
+    homeDir = path.join(root, 'home');
+    repoCwd = path.join(root, 'work', 'agent-os');
+    fs.mkdirSync(repoCwd, { recursive: true });
+    port = await freePort();
+    output = '';
+
+    writeJsonl(
+      path.join(homeDir, '.codex', 'sessions', '2026', '05', '01', 'rollout-2026-05-01T09-10-08-codex-session.jsonl'),
+      [
+        { timestamp: '2026-05-01T13:10:37.580Z', type: 'session_meta', payload: { id: 'codex-session', cwd: repoCwd, git: { branch: 'main' } } },
+        { timestamp: '2026-05-01T13:11:00.000Z', type: 'response_item', payload: { type: 'message' } },
+      ],
+    );
+    writeJsonl(
+      path.join(homeDir, '.claude', 'projects', '-tmp-work-agent-os', 'claude-session.jsonl'),
+      [
+        { type: 'user', timestamp: '2026-05-01T14:00:00.000Z', sessionId: 'claude-session', cwd: repoCwd, gitBranch: 'main', message: { role: 'user', content: 'fixture' } },
+        { type: 'assistant', timestamp: '2026-05-01T14:02:00.000Z', sessionId: 'claude-session', cwd: repoCwd, gitBranch: 'main', message: { role: 'assistant', content: 'fixture' } },
+      ],
+    );
+
+    child = spawn('node', ['apps/sigil/codex-terminal/server.mjs'], {
+      cwd: path.resolve('.'),
+      env: {
+        ...process.env,
+        SIGIL_AGENT_TERMINAL_PORT: String(port),
+        SIGIL_AGENT_TERMINAL_DRIVER: 'process',
+        SIGIL_AGENT_TMUX_SESSION: 'sigil-agent-terminal-test',
+        SIGIL_AGENT_CWD: repoCwd,
+        SIGIL_AGENT_COMMAND: 'node -e "setTimeout(() => {}, 100)"',
+        SIGIL_AGENT_CATALOG_HOME: homeDir,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    child.stdout.on('data', (chunk) => { output += chunk.toString('utf8'); });
+    child.stderr.on('data', (chunk) => { output += chunk.toString('utf8'); });
+
+    await waitForHealth(port, () => output);
+  });
+
+  afterEach(async () => {
+    if (child && child.exitCode == null) {
+      child.kill('SIGTERM');
+      await new Promise((resolve) => child.once('exit', resolve));
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('lists provider catalog sessions for the rail', async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/sessions?cwd=${encodeURIComponent(repoCwd)}`);
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.deepEqual(
+      payload.sessions.map((session) => `${session.provider}:${session.session_id}`).sort(),
+      ['claude-code:claude-session', 'codex:codex-session'],
+    );
+    const codexSession = payload.sessions.find((session) => session.provider === 'codex');
+    assert.equal(codexSession.created_at, '2026-05-01T13:10:37.580Z');
+    assert.equal(codexSession.last_message_at, '2026-05-01T13:11:00.000Z');
+    const claudeSession = payload.sessions.find((session) => session.provider === 'claude-code');
+    assert.equal(claudeSession.created_at, '2026-05-01T14:00:00.000Z');
+    assert.equal(claudeSession.last_message_at, '2026-05-01T14:02:00.000Z');
+
+    const codexResponse = await fetch(`http://127.0.0.1:${port}/sessions?cwd=${encodeURIComponent(repoCwd)}&provider=codex`);
+    const codexPayload = await codexResponse.json();
+    assert.deepEqual(codexPayload.sessions.map((session) => session.provider), ['codex']);
+  });
+
+  it('accepts provider resume commands as argv arrays', async () => {
+    const response = await fetch(`http://127.0.0.1:${port}/ensure`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        session: 'sigil-agent-terminal-test',
+        cwd: repoCwd,
+        command: ['node', '-e', 'setTimeout(() => {}, 50)'],
+        force: true,
+      }),
+    });
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.ok, true);
+    assert.equal(payload.driver, 'process');
+  });
+});
+
+function writeJsonl(file, records) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${records.map((record) => JSON.stringify(record)).join('\n')}\n`, 'utf8');
+}
+
+async function freePort() {
+  const server = http.createServer();
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  await new Promise((resolve) => server.close(resolve));
+  return address.port;
+}
+
+async function waitForHealth(activePort, readOutput) {
+  const url = `http://127.0.0.1:${activePort}/health`;
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+  throw new Error(`bridge did not become healthy:\n${readOutput()}`);
+}


### PR DESCRIPTION
## Summary

Closes #179 under epic #178.

This adds the provider-local session catalog for Codex and Claude Code and wires the current Sigil terminal into a provider-neutral Agent Terminal shell. The catalog stays read-only and delegates resume behavior back to provider CLIs through normalized `resume_command` arrays.

## Changes

- Add `packages/host/src/session-catalog.ts` for local Codex and Claude Code session discovery.
- Normalize provider, session id, cwd, branch, created time, last-message time, updated time, source file, and resume command.
- Add the shared provider session catalog schema and docs under `shared/schemas/`.
- Add a right-side Agent Terminal session rail with provider filtering and sorting by last message or creation time.
- Update the Sigil launch script and radial menu label from Codex Terminal toward Agent Terminal while preserving the existing path for compatibility.
- Add focused host and bridge tests for catalog discovery, filtering, timestamp extraction, and argv resume commands.

## Not Included

This intentionally does not build the undecided Sigil UI surface for #180 beyond the focused session rail needed to exercise the catalog and resume flow.

## Verification

- `npm run check` in `packages/host`
- `npm test` in `packages/host` (42 pass; Anthropic tests skipped because no API key is configured)
- `node --test --experimental-strip-types packages/host/test/session-catalog.test.ts`
- `node --test tests/sigil-agent-terminal-server.test.mjs`
- `node --test tests/renderer/radial-gesture-menu.test.mjs`
- HTML embedded script syntax check for `apps/sigil/codex-terminal/index.html`
- `bash -n apps/sigil/codex-terminal/launch.sh`
- `git diff --check`
- Live Sigil smoke against the worktree UI: 337 real sessions loaded, terminal attached, and both `Last message` and `Created` sort orders matched catalog data. Temporary `sigildev` content root, canvas, and bridge were cleaned up afterward.
