### PR TITLE
Fix empty canvas semantic xray reads

### DIFF
--- a/src/perceive/semantic-targets.swift
+++ b/src/perceive/semantic-targets.swift
@@ -110,21 +110,38 @@ private func semanticTargetProbeJS(canvasID: String, scaleFactor: Double) -> Str
 
 func collectCanvasSemanticTargets(canvasID: String, scaleFactor: Double) -> [AOSSemanticTargetJSON]? {
     let js = semanticTargetProbeJS(canvasID: canvasID, scaleFactor: scaleFactor)
-    guard
-        let response = sendEnvelopeRequest(
-            service: "show",
-            action: "eval",
-            data: ["id": canvasID, "js": js],
-            autoStartBinary: aosExecutablePath()
-        ),
-        let decoded = decodeCanvasResponse(response),
-        decoded.error == nil,
-        let result = decoded.result,
-        !result.hasPrefix("error:")
-    else {
-        return nil
+    let maxAttempts = 5
+    let retryDelaySeconds = 0.05
+
+    for attempt in 0..<maxAttempts {
+        guard
+            let response = sendEnvelopeRequest(
+                service: "show",
+                action: "eval",
+                data: ["id": canvasID, "js": js],
+                autoStartBinary: aosExecutablePath()
+            ),
+            let decoded = decodeCanvasResponse(response),
+            decoded.error == nil,
+            let result = decoded.result,
+            !result.hasPrefix("error:")
+        else {
+            return nil
+        }
+
+        guard
+            let data = result.data(using: .utf8),
+            let targets = try? JSONDecoder().decode([AOSSemanticTargetJSON].self, from: data)
+        else {
+            return nil
+        }
+
+        if !targets.isEmpty || attempt == maxAttempts - 1 {
+            return targets
+        }
+
+        Thread.sleep(forTimeInterval: retryDelaySeconds)
     }
 
-    guard let data = result.data(using: .utf8) else { return nil }
-    return try? JSONDecoder().decode([AOSSemanticTargetJSON].self, from: data)
+    return []
 }

--- a/tests/aos-semantic-targets-xray-retry.sh
+++ b/tests/aos-semantic-targets-xray-retry.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Regression test: canvas xray retries an empty semantic target read before
+# concluding that an interactive surface has no targets.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+CANVAS_ID="semantic-target-retry-$$"
+
+cleanup() {
+  ./aos show remove --id "$CANVAS_ID" >/dev/null 2>&1 || true
+  rm -f "/tmp/${CANVAS_ID}.png"
+}
+trap cleanup EXIT
+
+./aos show create \
+  --id "$CANVAS_ID" \
+  --at 80,80,240,140 \
+  --interactive \
+  --html '<!doctype html><html><body style="margin:0;background:transparent"><button id="retry-button" data-aos-ref="contract.retry" data-aos-action="retry" data-aos-surface="contract.surface" data-semantic-target-id="retry" aria-label="Retry Action" style="position:absolute;left:20px;top:30px;width:90px;height:44px"></button><script>const originalQuerySelectorAll = document.querySelectorAll.bind(document); let semanticQueries = 0; document.querySelectorAll = (selector) => { if (String(selector).includes("[data-semantic-target-id]")) { semanticQueries += 1; if (semanticQueries === 1) return []; } return originalQuerySelectorAll(selector); };</script></body></html>' \
+  >/dev/null
+
+sleep 0.4
+
+OUT="$(./aos see capture --canvas "$CANVAS_ID" --xray --out "/tmp/${CANVAS_ID}.png" 2>/dev/null)"
+
+echo "$OUT" | jq -e --arg canvas "$CANVAS_ID" '
+  .semantic_targets
+  | map(select(
+      .canvas_id == $canvas
+      and .id == "retry"
+      and .ref == "contract.retry"
+      and .role == "button"
+      and .name == "Retry Action"
+      and .action == "retry"
+      and .surface == "contract.surface"
+      and .enabled == true
+    ))
+  | length == 1
+' >/dev/null || {
+  echo "FAIL: expected semantic_targets retry entry not found" >&2
+  echo "$OUT" | jq '.semantic_targets' >&2
+  exit 1
+}
+
+echo "PASS"


### PR DESCRIPTION
## Summary

Fixes #185.

- retry successful-but-empty canvas semantic target evals before returning an empty xray target list
- preserve nil/error behavior for failed eval or decode paths
- add a focused regression where the first semantic DOM query is intentionally empty and the retry must recover the target

## Verification

- `bash build.sh`
- `./aos ready`
- `bash tests/aos-semantic-targets-xray-retry.sh`
- `bash tests/aos-semantic-targets-xray.sh`
- narrow live Sigil drag probe with temporary `sigildev` root: radial child DOM and xray both reported `agent-terminal`, `context-menu`, and `wiki-graph`

## Notes

The full `tests/scenarios/sigil/radial-menu/real-input.sh` was not used as the final harness from this worktree because its visual harness rewrites canonical `sigil`/`toolkit` content roots to the worktree. The narrower probe kept canonical roots restored after execution and exercised the same radial child xray path.