### PR TITLE
Define agent session telemetry contract

### DIFF
--- a/packages/host/src/session-telemetry.ts
+++ b/packages/host/src/session-telemetry.ts
@@ -1,0 +1,766 @@
+export type AgentSessionProvider = 'codex' | 'claude-code';
+
+export type TelemetrySourceKind =
+  | 'provider_statusline'
+  | 'provider_hook'
+  | 'provider_transcript'
+  | 'provider_app_server'
+  | 'model_catalog'
+  | 'derived'
+  | 'aos_adapter';
+
+export type TelemetrySourceStability =
+  | 'documented'
+  | 'provider-local'
+  | 'inferred'
+  | 'aos-contract';
+
+export type TelemetryPrecision = 'exact' | 'derived' | 'estimated' | 'unknown';
+
+export type TelemetryMetricUnit = 'tokens' | 'ratio' | 'percent' | 'milliseconds' | 'count';
+
+export interface TelemetrySource {
+  kind: TelemetrySourceKind;
+  provider_surface: string;
+  stability: TelemetrySourceStability;
+  precision: TelemetryPrecision;
+  provider_version?: string;
+}
+
+export interface NumericTelemetryMetric {
+  value: number;
+  unit: TelemetryMetricUnit;
+  source: TelemetrySource;
+}
+
+export interface AgentSessionIdentity {
+  provider: AgentSessionProvider;
+  session_id: string;
+  cwd?: string;
+  source_file?: string;
+}
+
+export interface AgentSessionModel {
+  id?: string;
+  display_name?: string;
+}
+
+export interface AgentSessionContextTelemetry {
+  window_tokens?: NumericTelemetryMetric;
+  used_tokens?: NumericTelemetryMetric;
+  remaining_tokens?: NumericTelemetryMetric;
+  used_ratio?: NumericTelemetryMetric;
+  remaining_ratio?: NumericTelemetryMetric;
+  tokens?: Record<string, NumericTelemetryMetric>;
+}
+
+export interface AgentSessionTelemetrySnapshot {
+  type: 'agent.session.telemetry';
+  schema_version: '2026-05-02';
+  observed_at: string;
+  session: AgentSessionIdentity;
+  model?: AgentSessionModel;
+  context?: AgentSessionContextTelemetry;
+  diagnostics?: AgentSessionTelemetryMismatch[];
+}
+
+export interface AgentSessionLifecycleEvent {
+  type: 'agent.session.lifecycle';
+  schema_version: '2026-05-02';
+  observed_at: string;
+  session: AgentSessionIdentity;
+  event:
+    | 'session_started'
+    | 'session_resumed'
+    | 'context_compaction_started'
+    | 'context_compacted'
+    | 'handoff_started'
+    | 'handoff_completed'
+    | 'session_ended';
+  trigger?: 'manual' | 'automatic' | 'provider' | 'handoff' | 'unknown';
+  pre_tokens?: NumericTelemetryMetric;
+  post_tokens?: NumericTelemetryMetric;
+  duration_ms?: NumericTelemetryMetric;
+  source: TelemetrySource;
+}
+
+export interface AgentSessionCapability {
+  id: 'check_in' | 'compact' | 'handoff' | 'resume';
+  supported: boolean;
+  source: TelemetrySource;
+  command?: string[];
+}
+
+export interface AgentSessionCapabilitiesSnapshot {
+  type: 'agent.session.capabilities';
+  schema_version: '2026-05-02';
+  observed_at: string;
+  session: AgentSessionIdentity;
+  capabilities: AgentSessionCapability[];
+}
+
+export interface AgentSessionTelemetryMismatch {
+  type: 'agent.session.telemetry_mismatch';
+  schema_version: '2026-05-02';
+  observed_at: string;
+  provider: AgentSessionProvider;
+  session_id?: string;
+  provider_version?: string;
+  source: TelemetrySourceKind;
+  provider_surface: string;
+  code: string;
+  expected: string[];
+  fallback?: string;
+  severity: 'info' | 'warn' | 'error';
+}
+
+export interface TelemetryExtractionResult {
+  snapshot?: AgentSessionTelemetrySnapshot;
+  lifecycle_events: AgentSessionLifecycleEvent[];
+  diagnostics: AgentSessionTelemetryMismatch[];
+}
+
+export interface TelemetryExtractionOptions {
+  observedAt?: string;
+  sessionId?: string;
+  cwd?: string;
+  sourceFile?: string;
+  providerVersion?: string;
+  logger?: (diagnostic: AgentSessionTelemetryMismatch) => void;
+}
+
+export const AGENT_SESSION_TELEMETRY_SCHEMA_VERSION = '2026-05-02' as const;
+
+const CLAUDE_STATUSLINE_SOURCE: Omit<TelemetrySource, 'precision' | 'provider_version'> = {
+  kind: 'provider_statusline',
+  provider_surface: 'claude.statusline.context_window',
+  stability: 'documented',
+};
+
+const CLAUDE_TRANSCRIPT_SOURCE: Omit<TelemetrySource, 'precision' | 'provider_version'> = {
+  kind: 'provider_transcript',
+  provider_surface: 'claude.transcript.message.usage',
+  stability: 'provider-local',
+};
+
+const CODEX_TRANSCRIPT_SOURCE: Omit<TelemetrySource, 'precision' | 'provider_version'> = {
+  kind: 'provider_transcript',
+  provider_surface: 'codex.transcript.event_msg.token_count',
+  stability: 'provider-local',
+};
+
+export function extractCodexTelemetryFromJsonlLines(
+  lines: string[],
+  options: TelemetryExtractionOptions = {},
+): TelemetryExtractionResult {
+  const diagnostics: AgentSessionTelemetryMismatch[] = [];
+  let sessionId = options.sessionId ?? sessionIdFromCodexRolloutPath(options.sourceFile);
+  let cwd = options.cwd;
+  let observedAt = options.observedAt;
+  let modelId: string | undefined;
+  let tokenInfo: Record<string, unknown> | undefined;
+  let fallbackWindowTokens: number | undefined;
+
+  for (const line of lines) {
+    const record = parseJsonObject(line);
+    if (!record) continue;
+    observedAt = observedAt ?? coerceTimestamp(record.timestamp);
+
+    if (record.type === 'session_meta') {
+      const payload = objectValue(record.payload);
+      sessionId = stringValue(payload?.id) ?? sessionId;
+      cwd = stringValue(payload?.cwd) ?? cwd;
+      continue;
+    }
+
+    const payload = objectValue(record.payload);
+    if (!payload) continue;
+    modelId = stringValue(payload.model) ?? modelId;
+    fallbackWindowTokens = integerValue(payload.model_context_window) ?? fallbackWindowTokens;
+
+    if (payload.type === 'token_count') {
+      const info = objectValue(payload.info);
+      if (!info) {
+        pushDiagnostic(diagnostics, options, {
+          provider: 'codex',
+          sessionId,
+          source: 'provider_transcript',
+          providerSurface: 'codex.transcript.event_msg.token_count',
+          code: 'codex_token_count_missing_info',
+          expected: ['payload.info'],
+          fallback: fallbackWindowTokens == null ? 'context_unavailable' : 'window_tokens_only',
+          severity: 'warn',
+        });
+        continue;
+      }
+      tokenInfo = info;
+      fallbackWindowTokens = integerValue(info.model_context_window) ?? fallbackWindowTokens;
+    }
+  }
+
+  if (!sessionId) {
+    pushDiagnostic(diagnostics, options, {
+      provider: 'codex',
+      source: 'provider_transcript',
+      providerSurface: 'codex.transcript',
+      code: 'missing_session_identity',
+      expected: ['session_meta.payload.id', 'rollout filename session id'],
+      fallback: 'drop_snapshot',
+      severity: 'warn',
+    });
+    return { lifecycle_events: [], diagnostics };
+  }
+
+  const source = sourceFrom(CODEX_TRANSCRIPT_SOURCE, options, 'exact');
+  const context: AgentSessionContextTelemetry = {};
+  const totalUsage = objectValue(tokenInfo?.total_token_usage);
+  const windowTokens = integerValue(tokenInfo?.model_context_window) ?? fallbackWindowTokens;
+  const usedTokens = integerValue(totalUsage?.total_tokens);
+
+  if (windowTokens != null) {
+    context.window_tokens = metric(windowTokens, 'tokens', sourceFrom(CODEX_TRANSCRIPT_SOURCE, options, 'exact'));
+  }
+  if (usedTokens != null) {
+    context.used_tokens = metric(usedTokens, 'tokens', source);
+    context.tokens = tokenMetrics(totalUsage, source);
+  } else if (tokenInfo) {
+    pushDiagnostic(diagnostics, options, {
+      provider: 'codex',
+      sessionId,
+      source: 'provider_transcript',
+      providerSurface: 'codex.transcript.event_msg.token_count',
+      code: 'codex_total_tokens_missing',
+      expected: ['payload.info.total_token_usage.total_tokens'],
+      fallback: windowTokens == null ? 'context_unavailable' : 'window_tokens_only',
+      severity: 'warn',
+    });
+  }
+
+  addDerivedContextMetrics(context, options, 'codex');
+
+  if (!hasContextMetrics(context)) {
+    pushDiagnostic(diagnostics, options, {
+      provider: 'codex',
+      sessionId,
+      source: 'provider_transcript',
+      providerSurface: 'codex.transcript',
+      code: 'codex_context_usage_unavailable',
+      expected: [
+        'payload.type=token_count',
+        'payload.info.total_token_usage.total_tokens',
+        'payload.info.model_context_window',
+      ],
+      fallback: 'context_unknown',
+      severity: 'info',
+    });
+  }
+
+  const snapshot: AgentSessionTelemetrySnapshot = {
+    type: 'agent.session.telemetry',
+    schema_version: AGENT_SESSION_TELEMETRY_SCHEMA_VERSION,
+    observed_at: observedAt ?? new Date().toISOString(),
+    session: {
+      provider: 'codex',
+      session_id: sessionId,
+    },
+  };
+  if (cwd) snapshot.session.cwd = cwd;
+  if (options.sourceFile) snapshot.session.source_file = options.sourceFile;
+  if (modelId) snapshot.model = { id: modelId };
+  if (hasContextMetrics(context)) snapshot.context = context;
+  if (diagnostics.length > 0) snapshot.diagnostics = diagnostics;
+
+  return { snapshot, lifecycle_events: [], diagnostics };
+}
+
+export function extractClaudeStatuslineTelemetry(
+  input: unknown,
+  options: TelemetryExtractionOptions = {},
+): TelemetryExtractionResult {
+  const diagnostics: AgentSessionTelemetryMismatch[] = [];
+  const record = objectValue(input);
+  if (!record) {
+    pushDiagnostic(diagnostics, options, {
+      provider: 'claude-code',
+      source: 'provider_statusline',
+      providerSurface: 'claude.statusline',
+      code: 'claude_statusline_invalid_json',
+      expected: ['object statusline payload'],
+      fallback: 'drop_snapshot',
+      severity: 'warn',
+    });
+    return { lifecycle_events: [], diagnostics };
+  }
+
+  const sessionId = options.sessionId ?? stringValue(record.session_id);
+  if (!sessionId) {
+    pushDiagnostic(diagnostics, options, {
+      provider: 'claude-code',
+      source: 'provider_statusline',
+      providerSurface: 'claude.statusline',
+      code: 'missing_session_identity',
+      expected: ['session_id'],
+      fallback: 'drop_snapshot',
+      severity: 'warn',
+    });
+    return { lifecycle_events: [], diagnostics };
+  }
+
+  const providerVersion = stringValue(record.version) ?? options.providerVersion;
+  const contextWindow = objectValue(record.context_window);
+  const context: AgentSessionContextTelemetry = {};
+  const baseSource = { ...CLAUDE_STATUSLINE_SOURCE };
+  const exactStatuslineSource = sourceFrom(baseSource, { ...options, providerVersion }, 'exact');
+
+  if (!contextWindow) {
+    pushDiagnostic(diagnostics, { ...options, providerVersion }, {
+      provider: 'claude-code',
+      sessionId,
+      source: 'provider_statusline',
+      providerSurface: 'claude.statusline',
+      code: 'claude_statusline_missing_context_window',
+      expected: ['context_window'],
+      fallback: 'context_unknown',
+      severity: 'warn',
+    });
+  } else {
+    const windowTokens = integerValue(contextWindow.context_window_size);
+    if (windowTokens != null) {
+      context.window_tokens = metric(windowTokens, 'tokens', {
+        ...exactStatuslineSource,
+        provider_surface: 'claude.statusline.context_window.context_window_size',
+      });
+    } else {
+      pushDiagnostic(diagnostics, { ...options, providerVersion }, {
+        provider: 'claude-code',
+        sessionId,
+        source: 'provider_statusline',
+        providerSurface: 'claude.statusline.context_window',
+        code: 'claude_context_window_size_missing',
+        expected: ['context_window.context_window_size'],
+        fallback: 'usage_or_percentage_only',
+        severity: 'warn',
+      });
+    }
+
+    const currentUsage = objectValue(contextWindow.current_usage);
+    if (currentUsage) {
+      const usageSource = {
+        ...exactStatuslineSource,
+        provider_surface: 'claude.statusline.context_window.current_usage',
+      };
+      context.tokens = tokenMetrics(currentUsage, usageSource);
+      const usedTokens = claudeInputSideTokens(currentUsage);
+      if (usedTokens != null) {
+        context.used_tokens = metric(usedTokens, 'tokens', {
+          ...usageSource,
+          precision: 'derived',
+        });
+      } else {
+        pushDiagnostic(diagnostics, { ...options, providerVersion }, {
+          provider: 'claude-code',
+          sessionId,
+          source: 'provider_statusline',
+          providerSurface: 'claude.statusline.context_window.current_usage',
+          code: 'claude_current_usage_token_fields_missing',
+          expected: [
+            'input_tokens',
+            'cache_creation_input_tokens',
+            'cache_read_input_tokens',
+          ],
+          fallback: 'percentage_only',
+          severity: 'warn',
+        });
+      }
+    } else if (contextWindow.current_usage === null) {
+      pushDiagnostic(diagnostics, { ...options, providerVersion }, {
+        provider: 'claude-code',
+        sessionId,
+        source: 'provider_statusline',
+        providerSurface: 'claude.statusline.context_window.current_usage',
+        code: 'claude_current_usage_not_ready',
+        expected: ['context_window.current_usage'],
+        fallback: 'percentage_or_window_only',
+        severity: 'info',
+      });
+    }
+
+    const usedPercentage = numberValue(contextWindow.used_percentage);
+    if (usedPercentage != null) {
+      context.used_ratio = metric(clampRatio(usedPercentage / 100), 'ratio', {
+        ...exactStatuslineSource,
+        provider_surface: 'claude.statusline.context_window.used_percentage',
+      });
+    }
+    const remainingPercentage = numberValue(contextWindow.remaining_percentage);
+    if (remainingPercentage != null) {
+      context.remaining_ratio = metric(clampRatio(remainingPercentage / 100), 'ratio', {
+        ...exactStatuslineSource,
+        provider_surface: 'claude.statusline.context_window.remaining_percentage',
+      });
+    }
+    if (usedPercentage == null && remainingPercentage == null && !currentUsage) {
+      pushDiagnostic(diagnostics, { ...options, providerVersion }, {
+        provider: 'claude-code',
+        sessionId,
+        source: 'provider_statusline',
+        providerSurface: 'claude.statusline.context_window',
+        code: 'claude_context_usage_fields_missing',
+        expected: [
+          'context_window.current_usage',
+          'context_window.used_percentage',
+          'context_window.remaining_percentage',
+        ],
+        fallback: windowTokens == null ? 'context_unknown' : 'window_tokens_only',
+        severity: 'warn',
+      });
+    }
+  }
+
+  addDerivedContextMetrics(context, { ...options, providerVersion }, 'claude-code');
+
+  const workspace = objectValue(record.workspace);
+  const model = objectValue(record.model);
+  const snapshot: AgentSessionTelemetrySnapshot = {
+    type: 'agent.session.telemetry',
+    schema_version: AGENT_SESSION_TELEMETRY_SCHEMA_VERSION,
+    observed_at: options.observedAt ?? new Date().toISOString(),
+    session: {
+      provider: 'claude-code',
+      session_id: sessionId,
+    },
+  };
+  const cwd = options.cwd ?? stringValue(workspace?.current_dir) ?? stringValue(record.cwd);
+  if (cwd) snapshot.session.cwd = cwd;
+  const transcriptPath = stringValue(record.transcript_path) ?? options.sourceFile;
+  if (transcriptPath) snapshot.session.source_file = transcriptPath;
+  const modelId = stringValue(model?.id) ?? stringValue(model?.name);
+  const displayName = stringValue(model?.display_name);
+  if (modelId || displayName) {
+    snapshot.model = {};
+    if (modelId) snapshot.model.id = modelId;
+    if (displayName) snapshot.model.display_name = displayName;
+  }
+  if (hasContextMetrics(context)) snapshot.context = context;
+  if (diagnostics.length > 0) snapshot.diagnostics = diagnostics;
+
+  return { snapshot, lifecycle_events: [], diagnostics };
+}
+
+export function extractClaudeTranscriptTelemetryFromJsonlLines(
+  lines: string[],
+  options: TelemetryExtractionOptions = {},
+): TelemetryExtractionResult {
+  const diagnostics: AgentSessionTelemetryMismatch[] = [];
+  const lifecycleEvents: AgentSessionLifecycleEvent[] = [];
+  let sessionId = options.sessionId;
+  let cwd = options.cwd;
+  let observedAt = options.observedAt;
+  let modelId: string | undefined;
+  let latestUsage: Record<string, unknown> | undefined;
+
+  for (const line of lines) {
+    const record = parseJsonObject(line);
+    if (!record) continue;
+    sessionId = stringValue(record.sessionId) ?? stringValue(record.session_id) ?? sessionId;
+    cwd = stringValue(record.cwd) ?? cwd;
+    observedAt = observedAt ?? coerceTimestamp(record.timestamp);
+
+    const message = objectValue(record.message);
+    modelId = stringValue(message?.model) ?? modelId;
+    const usage = objectValue(message?.usage);
+    if (usage) {
+      latestUsage = usage;
+      if (claudeInputSideTokens(usage) == null) {
+        pushDiagnostic(diagnostics, options, {
+          provider: 'claude-code',
+          sessionId,
+          source: 'provider_transcript',
+          providerSurface: 'claude.transcript.message.usage',
+          code: 'claude_transcript_usage_token_fields_missing',
+          expected: [
+            'message.usage.input_tokens',
+            'message.usage.cache_creation_input_tokens',
+            'message.usage.cache_read_input_tokens',
+          ],
+          fallback: 'usage_counters_only',
+          severity: 'warn',
+        });
+      }
+    }
+
+    const compactMetadata = objectValue(record.compactMetadata);
+    if (compactMetadata) {
+      const compactSessionId = stringValue(record.sessionId) ?? sessionId;
+      if (!compactSessionId) continue;
+      const source = sourceFrom({
+        kind: 'provider_transcript',
+        provider_surface: 'claude.transcript.compactMetadata',
+        stability: 'provider-local',
+      }, options, 'exact');
+      const lifecycleEvent: AgentSessionLifecycleEvent = {
+        type: 'agent.session.lifecycle',
+        schema_version: AGENT_SESSION_TELEMETRY_SCHEMA_VERSION,
+        observed_at: coerceTimestamp(record.timestamp) ?? observedAt ?? new Date().toISOString(),
+        session: {
+          provider: 'claude-code',
+          session_id: compactSessionId,
+        },
+        event: 'context_compacted',
+        source,
+      };
+      const compactCwd = stringValue(record.cwd) ?? cwd;
+      if (compactCwd) lifecycleEvent.session.cwd = compactCwd;
+      if (options.sourceFile) lifecycleEvent.session.source_file = options.sourceFile;
+      const trigger = normalizeCompactTrigger(stringValue(compactMetadata.trigger));
+      if (trigger) lifecycleEvent.trigger = trigger;
+      const preTokens = integerValue(compactMetadata.preTokens);
+      if (preTokens != null) lifecycleEvent.pre_tokens = metric(preTokens, 'tokens', source);
+      const postTokens = integerValue(compactMetadata.postTokens);
+      if (postTokens != null) lifecycleEvent.post_tokens = metric(postTokens, 'tokens', source);
+      const durationMs = integerValue(compactMetadata.durationMs);
+      if (durationMs != null) lifecycleEvent.duration_ms = metric(durationMs, 'milliseconds', source);
+      lifecycleEvents.push(lifecycleEvent);
+    }
+  }
+
+  if (!sessionId) {
+    pushDiagnostic(diagnostics, options, {
+      provider: 'claude-code',
+      source: 'provider_transcript',
+      providerSurface: 'claude.transcript',
+      code: 'missing_session_identity',
+      expected: ['sessionId', 'session_id'],
+      fallback: 'drop_snapshot',
+      severity: 'warn',
+    });
+    return { lifecycle_events: lifecycleEvents, diagnostics };
+  }
+
+  const context: AgentSessionContextTelemetry = {};
+  const transcriptSource = sourceFrom(CLAUDE_TRANSCRIPT_SOURCE, options, 'exact');
+  if (latestUsage) {
+    context.tokens = tokenMetrics(latestUsage, transcriptSource);
+    const usedTokens = claudeInputSideTokens(latestUsage);
+    if (usedTokens != null) {
+      context.used_tokens = metric(usedTokens, 'tokens', {
+        ...transcriptSource,
+        precision: 'derived',
+      });
+    }
+  }
+
+  const snapshot: AgentSessionTelemetrySnapshot = {
+    type: 'agent.session.telemetry',
+    schema_version: AGENT_SESSION_TELEMETRY_SCHEMA_VERSION,
+    observed_at: observedAt ?? new Date().toISOString(),
+    session: {
+      provider: 'claude-code',
+      session_id: sessionId,
+    },
+  };
+  if (cwd) snapshot.session.cwd = cwd;
+  if (options.sourceFile) snapshot.session.source_file = options.sourceFile;
+  if (modelId) snapshot.model = { id: modelId };
+  if (hasContextMetrics(context)) snapshot.context = context;
+  if (diagnostics.length > 0) snapshot.diagnostics = diagnostics;
+
+  return { snapshot, lifecycle_events: lifecycleEvents, diagnostics };
+}
+
+function addDerivedContextMetrics(
+  context: AgentSessionContextTelemetry,
+  options: TelemetryExtractionOptions,
+  provider: AgentSessionProvider,
+): void {
+  const windowTokens = context.window_tokens?.value;
+  const usedTokens = context.used_tokens?.value;
+  if (windowTokens != null && usedTokens != null) {
+    if (!context.remaining_tokens) {
+      context.remaining_tokens = metric(Math.max(0, windowTokens - usedTokens), 'tokens', derivedSource(options, provider, [
+        'context.window_tokens',
+        'context.used_tokens',
+      ]));
+    }
+    if (!context.used_ratio && windowTokens > 0) {
+      context.used_ratio = metric(clampRatio(usedTokens / windowTokens), 'ratio', derivedSource(options, provider, [
+        'context.used_tokens',
+        'context.window_tokens',
+      ]));
+    }
+    if (!context.remaining_ratio && windowTokens > 0) {
+      context.remaining_ratio = metric(clampRatio((windowTokens - usedTokens) / windowTokens), 'ratio', derivedSource(options, provider, [
+        'context.remaining_tokens',
+        'context.window_tokens',
+      ]));
+    }
+  } else if (!context.used_ratio && context.remaining_ratio) {
+    context.used_ratio = metric(1 - context.remaining_ratio.value, 'ratio', derivedSource(options, provider, [
+      'context.remaining_ratio',
+    ]));
+  } else if (!context.remaining_ratio && context.used_ratio) {
+    context.remaining_ratio = metric(1 - context.used_ratio.value, 'ratio', derivedSource(options, provider, [
+      'context.used_ratio',
+    ]));
+  }
+}
+
+function tokenMetrics(
+  usage: Record<string, unknown> | undefined,
+  source: TelemetrySource,
+): Record<string, NumericTelemetryMetric> | undefined {
+  if (!usage) return undefined;
+  const result: Record<string, NumericTelemetryMetric> = {};
+  for (const key of [
+    'input_tokens',
+    'cached_input_tokens',
+    'cache_creation_input_tokens',
+    'cache_read_input_tokens',
+    'output_tokens',
+    'reasoning_output_tokens',
+    'total_tokens',
+  ]) {
+    const value = integerValue(usage[key]);
+    if (value != null) result[key] = metric(value, 'tokens', source);
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function claudeInputSideTokens(usage: Record<string, unknown>): number | undefined {
+  const inputTokens = integerValue(usage.input_tokens);
+  const cacheCreationTokens = integerValue(usage.cache_creation_input_tokens) ?? 0;
+  const cacheReadTokens = integerValue(usage.cache_read_input_tokens) ?? 0;
+  if (inputTokens == null && integerValue(usage.cache_creation_input_tokens) == null && integerValue(usage.cache_read_input_tokens) == null) {
+    return undefined;
+  }
+  return (inputTokens ?? 0) + cacheCreationTokens + cacheReadTokens;
+}
+
+function hasContextMetrics(context: AgentSessionContextTelemetry): boolean {
+  return Boolean(
+    context.window_tokens
+      || context.used_tokens
+      || context.remaining_tokens
+      || context.used_ratio
+      || context.remaining_ratio
+      || (context.tokens && Object.keys(context.tokens).length > 0),
+  );
+}
+
+function metric(value: number, unit: TelemetryMetricUnit, source: TelemetrySource): NumericTelemetryMetric {
+  return { value, unit, source };
+}
+
+function sourceFrom(
+  source: Omit<TelemetrySource, 'precision' | 'provider_version'>,
+  options: TelemetryExtractionOptions,
+  precision: TelemetryPrecision,
+): TelemetrySource {
+  const result: TelemetrySource = {
+    ...source,
+    precision,
+  };
+  if (options.providerVersion) result.provider_version = options.providerVersion;
+  return result;
+}
+
+function derivedSource(
+  options: TelemetryExtractionOptions,
+  provider: AgentSessionProvider,
+  inputs: string[],
+): TelemetrySource {
+  return sourceFrom({
+    kind: 'derived',
+    provider_surface: `${provider}.derived(${inputs.join(',')})`,
+    stability: 'aos-contract',
+  }, options, 'derived');
+}
+
+function pushDiagnostic(
+  diagnostics: AgentSessionTelemetryMismatch[],
+  options: TelemetryExtractionOptions,
+  input: {
+    provider: AgentSessionProvider;
+    sessionId?: string;
+    source: TelemetrySourceKind;
+    providerSurface: string;
+    code: string;
+    expected: string[];
+    fallback?: string;
+    severity: 'info' | 'warn' | 'error';
+  },
+): void {
+  const diagnostic: AgentSessionTelemetryMismatch = {
+    type: 'agent.session.telemetry_mismatch',
+    schema_version: AGENT_SESSION_TELEMETRY_SCHEMA_VERSION,
+    observed_at: options.observedAt ?? new Date().toISOString(),
+    provider: input.provider,
+    source: input.source,
+    provider_surface: input.providerSurface,
+    code: input.code,
+    expected: input.expected,
+    severity: input.severity,
+  };
+  const sessionId = input.sessionId ?? options.sessionId;
+  if (sessionId) diagnostic.session_id = sessionId;
+  if (options.providerVersion) diagnostic.provider_version = options.providerVersion;
+  if (input.fallback) diagnostic.fallback = input.fallback;
+  diagnostics.push(diagnostic);
+  options.logger?.(diagnostic);
+}
+
+function normalizeCompactTrigger(value: string | undefined): AgentSessionLifecycleEvent['trigger'] | undefined {
+  if (value === 'manual') return 'manual';
+  if (value === 'auto' || value === 'automatic') return 'automatic';
+  if (value) return 'unknown';
+  return undefined;
+}
+
+function parseJsonObject(line: string): Record<string, unknown> | undefined {
+  try {
+    return objectValue(JSON.parse(line) as unknown);
+  } catch {
+    return undefined;
+  }
+}
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function integerValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : undefined;
+}
+
+function coerceTimestamp(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const millis = value > 10_000_000_000 ? value : value * 1000;
+    const parsed = new Date(millis);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+  }
+  return undefined;
+}
+
+function sessionIdFromCodexRolloutPath(file: string | undefined): string | undefined {
+  if (!file) return undefined;
+  const match = file.match(/rollout-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-(.+)\.jsonl$/);
+  return match?.[1];
+}
+
+function clampRatio(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}

--- a/packages/host/test/session-telemetry.test.ts
+++ b/packages/host/test/session-telemetry.test.ts
@@ -1,0 +1,188 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  extractClaudeStatuslineTelemetry,
+  extractClaudeTranscriptTelemetryFromJsonlLines,
+  extractCodexTelemetryFromJsonlLines,
+  type AgentSessionTelemetryMismatch,
+} from '../src/session-telemetry.ts';
+
+const OBSERVED_AT = '2026-05-02T12:00:00.000Z';
+
+describe('agent session telemetry', () => {
+  it('extracts Codex context metrics from token_count transcript events', () => {
+    const result = extractCodexTelemetryFromJsonlLines([
+      JSON.stringify({
+        timestamp: '2026-05-02T11:59:00.000Z',
+        type: 'session_meta',
+        payload: {
+          id: '019de3a9-2b0b-79f2-bb17-79dfb2c7a706',
+          cwd: '/Users/Michael/Code/agent-os',
+        },
+      }),
+      JSON.stringify({
+        timestamp: '2026-05-02T11:59:20.000Z',
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: {
+            total_token_usage: {
+              input_tokens: 33053,
+              cached_input_tokens: 3456,
+              output_tokens: 528,
+              reasoning_output_tokens: 300,
+              total_tokens: 33581,
+            },
+            model_context_window: 258400,
+          },
+        },
+      }),
+    ], {
+      observedAt: OBSERVED_AT,
+      providerVersion: 'codex-cli 0.125.0',
+      sourceFile: '/Users/Michael/.codex/sessions/rollout-test.jsonl',
+    });
+
+    assert.equal(result.diagnostics.length, 0);
+    assert.equal(result.snapshot?.session.provider, 'codex');
+    assert.equal(result.snapshot?.session.session_id, '019de3a9-2b0b-79f2-bb17-79dfb2c7a706');
+    assert.equal(result.snapshot?.context?.window_tokens?.value, 258400);
+    assert.equal(result.snapshot?.context?.used_tokens?.value, 33581);
+    assert.equal(result.snapshot?.context?.remaining_tokens?.value, 224819);
+    assert.equal(result.snapshot?.context?.used_ratio?.value, 33581 / 258400);
+    assert.equal(result.snapshot?.context?.tokens?.input_tokens.value, 33053);
+    assert.equal(result.snapshot?.context?.used_tokens?.source.stability, 'provider-local');
+    assert.equal(result.snapshot?.context?.remaining_tokens?.source.kind, 'derived');
+  });
+
+  it('extracts Claude Code exact context metrics from documented statusline JSON', () => {
+    const result = extractClaudeStatuslineTelemetry({
+      session_id: 'fe9076b7-449c-46fd-8572-0ca0f79bf07a',
+      version: '2.1.126',
+      transcript_path: '/Users/Michael/.claude/projects/agent-os/session.jsonl',
+      workspace: { current_dir: '/Users/Michael/Code/agent-os' },
+      model: { id: 'claude-opus-4-7', display_name: 'Opus' },
+      context_window: {
+        context_window_size: 200000,
+        used_percentage: 25,
+        remaining_percentage: 75,
+        current_usage: {
+          input_tokens: 30000,
+          cache_creation_input_tokens: 5000,
+          cache_read_input_tokens: 15000,
+          output_tokens: 100,
+        },
+      },
+    }, {
+      observedAt: OBSERVED_AT,
+    });
+
+    assert.equal(result.diagnostics.length, 0);
+    assert.equal(result.snapshot?.session.provider, 'claude-code');
+    assert.equal(result.snapshot?.session.cwd, '/Users/Michael/Code/agent-os');
+    assert.equal(result.snapshot?.model?.id, 'claude-opus-4-7');
+    assert.equal(result.snapshot?.context?.window_tokens?.value, 200000);
+    assert.equal(result.snapshot?.context?.used_tokens?.value, 50000);
+    assert.equal(result.snapshot?.context?.remaining_tokens?.value, 150000);
+    assert.equal(result.snapshot?.context?.used_ratio?.value, 0.25);
+    assert.equal(result.snapshot?.context?.remaining_ratio?.value, 0.75);
+    assert.equal(result.snapshot?.context?.used_ratio?.source.stability, 'documented');
+    assert.equal(result.snapshot?.context?.used_tokens?.source.provider_version, '2.1.126');
+  });
+
+  it('keeps Claude statusline telemetry partial and logs shape drift when expected fields disappear', () => {
+    const logged: AgentSessionTelemetryMismatch[] = [];
+    const result = extractClaudeStatuslineTelemetry({
+      session_id: 'fe9076b7-449c-46fd-8572-0ca0f79bf07a',
+      version: '2.1.126',
+      context_window: {
+        current_usage: {
+          input_tokens: 12,
+        },
+      },
+    }, {
+      observedAt: OBSERVED_AT,
+      logger: (diagnostic) => logged.push(diagnostic),
+    });
+
+    assert.equal(result.snapshot?.context?.used_tokens?.value, 12);
+    assert.equal(result.snapshot?.context?.window_tokens, undefined);
+    assert.equal(result.diagnostics.length, 1);
+    assert.equal(result.diagnostics[0].code, 'claude_context_window_size_missing');
+    assert.equal(result.diagnostics[0].fallback, 'usage_or_percentage_only');
+    assert.deepEqual(logged, result.diagnostics);
+  });
+
+  it('uses Claude transcript usage as provider-local fallback and emits compact lifecycle events', () => {
+    const result = extractClaudeTranscriptTelemetryFromJsonlLines([
+      JSON.stringify({
+        type: 'assistant',
+        timestamp: '2026-05-02T11:55:00.000Z',
+        sessionId: 'fe9076b7-449c-46fd-8572-0ca0f79bf07a',
+        cwd: '/Users/Michael/Code/agent-os',
+        message: {
+          role: 'assistant',
+          model: 'claude-opus-4-7',
+          usage: {
+            input_tokens: 6,
+            cache_creation_input_tokens: 11000,
+            cache_read_input_tokens: 16256,
+            output_tokens: 209,
+          },
+        },
+      }),
+      JSON.stringify({
+        timestamp: '2026-05-02T11:56:00.000Z',
+        sessionId: 'fe9076b7-449c-46fd-8572-0ca0f79bf07a',
+        cwd: '/Users/Michael/Code/agent-os',
+        compactMetadata: {
+          trigger: 'manual',
+          preTokens: 165246,
+          postTokens: 23229,
+          durationMs: 97699,
+        },
+      }),
+    ], {
+      observedAt: OBSERVED_AT,
+      sourceFile: '/Users/Michael/.claude/projects/agent-os/session.jsonl',
+    });
+
+    assert.equal(result.diagnostics.length, 0);
+    assert.equal(result.snapshot?.context?.used_tokens?.value, 27262);
+    assert.equal(result.snapshot?.context?.used_tokens?.source.stability, 'provider-local');
+    assert.equal(result.snapshot?.context?.used_tokens?.source.precision, 'derived');
+    assert.equal(result.lifecycle_events.length, 1);
+    assert.equal(result.lifecycle_events[0].event, 'context_compacted');
+    assert.equal(result.lifecycle_events[0].trigger, 'manual');
+    assert.equal(result.lifecycle_events[0].pre_tokens?.value, 165246);
+    assert.equal(result.lifecycle_events[0].post_tokens?.value, 23229);
+    assert.equal(result.lifecycle_events[0].duration_ms?.value, 97699);
+  });
+
+  it('logs transcript usage drift without dropping the session snapshot', () => {
+    const logged: AgentSessionTelemetryMismatch[] = [];
+    const result = extractClaudeTranscriptTelemetryFromJsonlLines([
+      JSON.stringify({
+        type: 'assistant',
+        timestamp: '2026-05-02T11:55:00.000Z',
+        sessionId: 'fe9076b7-449c-46fd-8572-0ca0f79bf07a',
+        message: {
+          role: 'assistant',
+          usage: {
+            tokens_in_new_shape: 100,
+          },
+        },
+      }),
+    ], {
+      observedAt: OBSERVED_AT,
+      logger: (diagnostic) => logged.push(diagnostic),
+    });
+
+    assert.equal(result.snapshot?.session.session_id, 'fe9076b7-449c-46fd-8572-0ca0f79bf07a');
+    assert.equal(result.snapshot?.context, undefined);
+    assert.equal(result.diagnostics.length, 1);
+    assert.equal(result.diagnostics[0].code, 'claude_transcript_usage_token_fields_missing');
+    assert.equal(result.diagnostics[0].severity, 'warn');
+    assert.deepEqual(logged, result.diagnostics);
+  });
+});

--- a/shared/schemas/agent-session-telemetry.md
+++ b/shared/schemas/agent-session-telemetry.md
@@ -1,0 +1,141 @@
+# Agent Session Telemetry
+
+The agent session telemetry contract is the provider-neutral envelope that AOS
+uses for live session observability. It is intentionally not a visual state
+machine. Consumers receive raw metrics, lifecycle events, action capabilities,
+and provider-shape diagnostics, then decide locally how to render or act on
+them.
+
+The JSON Schema source of truth is
+[`agent-session-telemetry.schema.json`](agent-session-telemetry.schema.json).
+
+## Event Types
+
+All records carry `schema_version`, `observed_at`, and provider/session
+identity. The current schema version is `2026-05-02`.
+
+`agent.session.telemetry` carries context-window metrics. Metrics are objects,
+not bare numbers:
+
+```json
+{
+  "window_tokens": {
+    "value": 258400,
+    "unit": "tokens",
+    "source": {
+      "kind": "provider_transcript",
+      "provider_surface": "codex.transcript.event_msg.token_count",
+      "stability": "provider-local",
+      "precision": "exact",
+      "provider_version": "codex-cli 0.125.0"
+    }
+  }
+}
+```
+
+`agent.session.lifecycle` carries raw lifecycle observations such as
+`context_compacted`, with optional `pre_tokens`, `post_tokens`, `duration_ms`,
+and `trigger`. These are event records, not renderer phases.
+
+`agent.session.capabilities` carries available actions such as `resume`,
+`compact`, `handoff`, and `check_in`. Capabilities are not context pressure
+signals. They tell consumers what can be invoked without requiring provider
+branching.
+
+`agent.session.telemetry_mismatch` is emitted when an adapter sees a provider
+surface but expected fields are missing, renamed, null at an unexpected time, or
+otherwise unusable. Mismatches are structured so logs and channels can alert AOS
+maintainers when provider versions drift.
+
+## Source And Precision
+
+Every metric has a `source` block:
+
+- `kind` says where the value came from, such as `provider_statusline`,
+  `provider_hook`, `provider_transcript`, `model_catalog`, or `derived`.
+- `provider_surface` names the concrete provider shape or AOS derivation.
+- `stability` distinguishes `documented`, `provider-local`, `inferred`, and
+  `aos-contract` sources.
+- `precision` distinguishes `exact`, `derived`, `estimated`, and `unknown`.
+- `provider_version` should be included when the adapter can observe it.
+
+Consumers must not infer confidence from provider name alone. For example,
+Claude Code statusline context fields are documented provider telemetry, while
+Claude transcript `message.usage` is provider-local fallback data.
+
+## Context Metrics
+
+The shared contract exposes raw metrics only:
+
+- `context.window_tokens`
+- `context.used_tokens`
+- `context.remaining_tokens`
+- `context.used_ratio`
+- `context.remaining_ratio`
+- `context.tokens.*` provider token counters
+
+No shared `phase` field exists. Terms such as healthy, warm, strained,
+critical, refreshed, or refreshing are app policy and should be derived by the
+consumer from raw telemetry if needed.
+
+`used_ratio` and `remaining_ratio` are numeric ratios from `0` to `1`. When a
+provider reports percentages, adapters convert them to ratios and preserve the
+provider surface in the metric source. When AOS derives a ratio from token
+counts, the metric source uses `kind: "derived"` and `stability:
+"aos-contract"`.
+
+## Provider Observability
+
+Codex currently exposes useful local usage data in transcript token-count
+events. AOS treats these as provider-local surfaces and prefers per-session
+`model_context_window` values over model catalog defaults. If a token-count event
+is present but expected fields such as
+`payload.info.total_token_usage.total_tokens` are unavailable, the adapter emits
+a mismatch and falls back to whatever partial metrics remain.
+
+Claude Code should prefer documented statusline JSON for active sessions:
+`context_window.context_window_size`, `context_window.current_usage`,
+`context_window.used_percentage`, and `context_window.remaining_percentage`.
+Statusline updates are event-driven and can also be configured with a
+`refreshInterval`. Claude hooks are useful for session lifecycle and transcript
+path discovery; they are not the primary context-usage source. Claude transcript
+`message.usage` and `compactMetadata` remain provider-local fallback inputs.
+
+Inactive sessions should not be tailed continuously by default. The catalog or
+terminal surface can scan on open, refresh, filter changes, or a slow visible
+interval. Active AOS-managed sessions can use provider statusline/hook surfaces
+when configured and provider transcript tails with debounce when no documented
+live feed is available.
+
+## Drift And Fallbacks
+
+Provider-local shapes can change without notice. Adapters must fail per metric
+or per event, not per session. A session remains visible when telemetry is
+partial or unknown.
+
+Mismatch records should include:
+
+- provider and provider version when available
+- source kind and provider surface
+- stable diagnostic code
+- expected paths
+- fallback behavior
+- severity
+
+Example:
+
+```json
+{
+  "type": "agent.session.telemetry_mismatch",
+  "schema_version": "2026-05-02",
+  "observed_at": "2026-05-02T12:00:00.000Z",
+  "provider": "claude-code",
+  "provider_version": "2.1.126",
+  "source": "provider_statusline",
+  "provider_surface": "claude.statusline.context_window",
+  "code": "claude_context_window_size_missing",
+  "expected": ["context_window.context_window_size"],
+  "fallback": "usage_or_percentage_only",
+  "severity": "warn"
+}
+```

--- a/shared/schemas/agent-session-telemetry.schema.json
+++ b/shared/schemas/agent-session-telemetry.schema.json
@@ -1,0 +1,298 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-os.local/schemas/agent-session-telemetry.schema.json",
+  "title": "Agent Session Telemetry",
+  "description": "Provider-neutral AOS envelope for agent-session context metrics, lifecycle events, capabilities, and provider-shape mismatch diagnostics.",
+  "oneOf": [
+    { "$ref": "#/$defs/telemetrySnapshot" },
+    { "$ref": "#/$defs/lifecycleEvent" },
+    { "$ref": "#/$defs/capabilitiesSnapshot" },
+    { "$ref": "#/$defs/telemetryMismatch" }
+  ],
+  "$defs": {
+    "schemaVersion": {
+      "const": "2026-05-02"
+    },
+    "provider": {
+      "type": "string",
+      "enum": ["codex", "claude-code"]
+    },
+    "sourceKind": {
+      "type": "string",
+      "enum": [
+        "provider_statusline",
+        "provider_hook",
+        "provider_transcript",
+        "provider_app_server",
+        "model_catalog",
+        "derived",
+        "aos_adapter"
+      ]
+    },
+    "sourceStability": {
+      "type": "string",
+      "enum": ["documented", "provider-local", "inferred", "aos-contract"]
+    },
+    "precision": {
+      "type": "string",
+      "enum": ["exact", "derived", "estimated", "unknown"]
+    },
+    "telemetrySource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "provider_surface", "stability", "precision"],
+      "properties": {
+        "kind": { "$ref": "#/$defs/sourceKind" },
+        "provider_surface": {
+          "type": "string",
+          "minLength": 1
+        },
+        "stability": { "$ref": "#/$defs/sourceStability" },
+        "precision": { "$ref": "#/$defs/precision" },
+        "provider_version": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "numericMetric": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "unit", "source"],
+      "properties": {
+        "value": {
+          "type": "number"
+        },
+        "unit": {
+          "type": "string",
+          "enum": ["tokens", "ratio", "percent", "milliseconds", "count"]
+        },
+        "source": { "$ref": "#/$defs/telemetrySource" }
+      }
+    },
+    "sessionIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "session_id"],
+      "properties": {
+        "provider": { "$ref": "#/$defs/provider" },
+        "session_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "cwd": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_file": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "display_name": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "anyOf": [
+        { "required": ["id"] },
+        { "required": ["display_name"] }
+      ]
+    },
+    "tokenMetrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "input_tokens": { "$ref": "#/$defs/numericMetric" },
+        "cached_input_tokens": { "$ref": "#/$defs/numericMetric" },
+        "cache_creation_input_tokens": { "$ref": "#/$defs/numericMetric" },
+        "cache_read_input_tokens": { "$ref": "#/$defs/numericMetric" },
+        "output_tokens": { "$ref": "#/$defs/numericMetric" },
+        "reasoning_output_tokens": { "$ref": "#/$defs/numericMetric" },
+        "total_tokens": { "$ref": "#/$defs/numericMetric" }
+      },
+      "minProperties": 1
+    },
+    "contextTelemetry": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "window_tokens": { "$ref": "#/$defs/numericMetric" },
+        "used_tokens": { "$ref": "#/$defs/numericMetric" },
+        "remaining_tokens": { "$ref": "#/$defs/numericMetric" },
+        "used_ratio": { "$ref": "#/$defs/numericMetric" },
+        "remaining_ratio": { "$ref": "#/$defs/numericMetric" },
+        "tokens": { "$ref": "#/$defs/tokenMetrics" }
+      },
+      "minProperties": 1
+    },
+    "telemetrySnapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "schema_version", "observed_at", "session"],
+      "properties": {
+        "type": {
+          "const": "agent.session.telemetry"
+        },
+        "schema_version": { "$ref": "#/$defs/schemaVersion" },
+        "observed_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "session": { "$ref": "#/$defs/sessionIdentity" },
+        "model": { "$ref": "#/$defs/model" },
+        "context": { "$ref": "#/$defs/contextTelemetry" },
+        "diagnostics": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/telemetryMismatch" }
+        }
+      }
+    },
+    "lifecycleEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "schema_version", "observed_at", "session", "event", "source"],
+      "properties": {
+        "type": {
+          "const": "agent.session.lifecycle"
+        },
+        "schema_version": { "$ref": "#/$defs/schemaVersion" },
+        "observed_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "session": { "$ref": "#/$defs/sessionIdentity" },
+        "event": {
+          "type": "string",
+          "enum": [
+            "session_started",
+            "session_resumed",
+            "context_compaction_started",
+            "context_compacted",
+            "handoff_started",
+            "handoff_completed",
+            "session_ended"
+          ]
+        },
+        "trigger": {
+          "type": "string",
+          "enum": ["manual", "automatic", "provider", "handoff", "unknown"]
+        },
+        "pre_tokens": { "$ref": "#/$defs/numericMetric" },
+        "post_tokens": { "$ref": "#/$defs/numericMetric" },
+        "duration_ms": { "$ref": "#/$defs/numericMetric" },
+        "source": { "$ref": "#/$defs/telemetrySource" }
+      }
+    },
+    "capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "supported", "source"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "enum": ["check_in", "compact", "handoff", "resume"]
+        },
+        "supported": {
+          "type": "boolean"
+        },
+        "source": { "$ref": "#/$defs/telemetrySource" },
+        "command": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "capabilitiesSnapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "schema_version", "observed_at", "session", "capabilities"],
+      "properties": {
+        "type": {
+          "const": "agent.session.capabilities"
+        },
+        "schema_version": { "$ref": "#/$defs/schemaVersion" },
+        "observed_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "session": { "$ref": "#/$defs/sessionIdentity" },
+        "capabilities": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/capability" }
+        }
+      }
+    },
+    "telemetryMismatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "schema_version",
+        "observed_at",
+        "provider",
+        "source",
+        "provider_surface",
+        "code",
+        "expected",
+        "severity"
+      ],
+      "properties": {
+        "type": {
+          "const": "agent.session.telemetry_mismatch"
+        },
+        "schema_version": { "$ref": "#/$defs/schemaVersion" },
+        "observed_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "provider": { "$ref": "#/$defs/provider" },
+        "session_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "provider_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": { "$ref": "#/$defs/sourceKind" },
+        "provider_surface": {
+          "type": "string",
+          "minLength": 1
+        },
+        "code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expected": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "fallback": {
+          "type": "string",
+          "minLength": 1
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["info", "warn", "error"]
+        }
+      }
+    }
+  }
+}

--- a/shared/schemas/fixtures/agent-session-telemetry/invalid/bare-context-number.json
+++ b/shared/schemas/fixtures/agent-session-telemetry/invalid/bare-context-number.json
@@ -1,0 +1,12 @@
+{
+  "type": "agent.session.telemetry",
+  "schema_version": "2026-05-02",
+  "observed_at": "2026-05-02T12:00:00.000Z",
+  "session": {
+    "provider": "claude-code",
+    "session_id": "fe9076b7-449c-46fd-8572-0ca0f79bf07a"
+  },
+  "context": {
+    "used_tokens": 42
+  }
+}

--- a/shared/schemas/fixtures/agent-session-telemetry/invalid/no-phase-signals.json
+++ b/shared/schemas/fixtures/agent-session-telemetry/invalid/no-phase-signals.json
@@ -1,0 +1,12 @@
+{
+  "type": "agent.session.telemetry",
+  "schema_version": "2026-05-02",
+  "observed_at": "2026-05-02T12:00:00.000Z",
+  "session": {
+    "provider": "codex",
+    "session_id": "019de3a9-2b0b-79f2-bb17-79dfb2c7a706"
+  },
+  "context": {
+    "phase": "healthy"
+  }
+}

--- a/shared/schemas/fixtures/agent-session-telemetry/valid/claude-compact-lifecycle.json
+++ b/shared/schemas/fixtures/agent-session-telemetry/valid/claude-compact-lifecycle.json
@@ -1,0 +1,49 @@
+{
+  "type": "agent.session.lifecycle",
+  "schema_version": "2026-05-02",
+  "observed_at": "2026-05-02T11:56:00.000Z",
+  "session": {
+    "provider": "claude-code",
+    "session_id": "fe9076b7-449c-46fd-8572-0ca0f79bf07a",
+    "cwd": "/Users/Michael/Code/agent-os",
+    "source_file": "/Users/Michael/.claude/projects/agent-os/session.jsonl"
+  },
+  "event": "context_compacted",
+  "trigger": "manual",
+  "pre_tokens": {
+    "value": 165246,
+    "unit": "tokens",
+    "source": {
+      "kind": "provider_transcript",
+      "provider_surface": "claude.transcript.compactMetadata",
+      "stability": "provider-local",
+      "precision": "exact"
+    }
+  },
+  "post_tokens": {
+    "value": 23229,
+    "unit": "tokens",
+    "source": {
+      "kind": "provider_transcript",
+      "provider_surface": "claude.transcript.compactMetadata",
+      "stability": "provider-local",
+      "precision": "exact"
+    }
+  },
+  "duration_ms": {
+    "value": 97699,
+    "unit": "milliseconds",
+    "source": {
+      "kind": "provider_transcript",
+      "provider_surface": "claude.transcript.compactMetadata",
+      "stability": "provider-local",
+      "precision": "exact"
+    }
+  },
+  "source": {
+    "kind": "provider_transcript",
+    "provider_surface": "claude.transcript.compactMetadata",
+    "stability": "provider-local",
+    "precision": "exact"
+  }
+}

--- a/shared/schemas/fixtures/agent-session-telemetry/valid/claude-mismatch.json
+++ b/shared/schemas/fixtures/agent-session-telemetry/valid/claude-mismatch.json
@@ -1,0 +1,14 @@
+{
+  "type": "agent.session.telemetry_mismatch",
+  "schema_version": "2026-05-02",
+  "observed_at": "2026-05-02T12:00:00.000Z",
+  "provider": "claude-code",
+  "session_id": "fe9076b7-449c-46fd-8572-0ca0f79bf07a",
+  "provider_version": "2.1.126",
+  "source": "provider_statusline",
+  "provider_surface": "claude.statusline.context_window",
+  "code": "claude_context_window_size_missing",
+  "expected": ["context_window.context_window_size"],
+  "fallback": "usage_or_percentage_only",
+  "severity": "warn"
+}

--- a/shared/schemas/fixtures/agent-session-telemetry/valid/codex-context.json
+++ b/shared/schemas/fixtures/agent-session-telemetry/valid/codex-context.json
@@ -1,0 +1,92 @@
+{
+  "type": "agent.session.telemetry",
+  "schema_version": "2026-05-02",
+  "observed_at": "2026-05-02T12:00:00.000Z",
+  "session": {
+    "provider": "codex",
+    "session_id": "019de3a9-2b0b-79f2-bb17-79dfb2c7a706",
+    "cwd": "/Users/Michael/Code/agent-os",
+    "source_file": "/Users/Michael/.codex/sessions/rollout-test.jsonl"
+  },
+  "context": {
+    "window_tokens": {
+      "value": 258400,
+      "unit": "tokens",
+      "source": {
+        "kind": "provider_transcript",
+        "provider_surface": "codex.transcript.event_msg.token_count",
+        "stability": "provider-local",
+        "precision": "exact",
+        "provider_version": "codex-cli 0.125.0"
+      }
+    },
+    "used_tokens": {
+      "value": 33581,
+      "unit": "tokens",
+      "source": {
+        "kind": "provider_transcript",
+        "provider_surface": "codex.transcript.event_msg.token_count",
+        "stability": "provider-local",
+        "precision": "exact",
+        "provider_version": "codex-cli 0.125.0"
+      }
+    },
+    "used_ratio": {
+      "value": 0.12995665634674923,
+      "unit": "ratio",
+      "source": {
+        "kind": "derived",
+        "provider_surface": "codex.derived(context.used_tokens,context.window_tokens)",
+        "stability": "aos-contract",
+        "precision": "derived",
+        "provider_version": "codex-cli 0.125.0"
+      }
+    },
+    "tokens": {
+      "input_tokens": {
+        "value": 33053,
+        "unit": "tokens",
+        "source": {
+          "kind": "provider_transcript",
+          "provider_surface": "codex.transcript.event_msg.token_count",
+          "stability": "provider-local",
+          "precision": "exact",
+          "provider_version": "codex-cli 0.125.0"
+        }
+      },
+      "cached_input_tokens": {
+        "value": 3456,
+        "unit": "tokens",
+        "source": {
+          "kind": "provider_transcript",
+          "provider_surface": "codex.transcript.event_msg.token_count",
+          "stability": "provider-local",
+          "precision": "exact",
+          "provider_version": "codex-cli 0.125.0"
+        }
+      },
+      "output_tokens": {
+        "value": 528,
+        "unit": "tokens",
+        "source": {
+          "kind": "provider_transcript",
+          "provider_surface": "codex.transcript.event_msg.token_count",
+          "stability": "provider-local",
+          "precision": "exact",
+          "provider_version": "codex-cli 0.125.0"
+        }
+      },
+      "total_tokens": {
+        "value": 33581,
+        "unit": "tokens",
+        "source": {
+          "kind": "provider_transcript",
+          "provider_surface": "codex.transcript.event_msg.token_count",
+          "stability": "provider-local",
+          "precision": "exact",
+          "provider_version": "codex-cli 0.125.0"
+        }
+      }
+    }
+  }
+}

--- a/shared/schemas/fixtures/agent-session-telemetry/valid/session-capabilities.json
+++ b/shared/schemas/fixtures/agent-session-telemetry/valid/session-capabilities.json
@@ -1,0 +1,23 @@
+{
+  "type": "agent.session.capabilities",
+  "schema_version": "2026-05-02",
+  "observed_at": "2026-05-02T12:00:00.000Z",
+  "session": {
+    "provider": "codex",
+    "session_id": "019de3a9-2b0b-79f2-bb17-79dfb2c7a706",
+    "cwd": "/Users/Michael/Code/agent-os"
+  },
+  "capabilities": [
+    {
+      "id": "resume",
+      "supported": true,
+      "command": ["codex", "--no-alt-screen", "resume", "019de3a9-2b0b-79f2-bb17-79dfb2c7a706"],
+      "source": {
+        "kind": "aos_adapter",
+        "provider_surface": "provider-session-catalog.resume_command",
+        "stability": "aos-contract",
+        "precision": "exact"
+      }
+    }
+  ]
+}

--- a/tests/schemas/agent-session-telemetry.test.mjs
+++ b/tests/schemas/agent-session-telemetry.test.mjs
@@ -1,0 +1,68 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+const schemaPath = path.join(repoRoot, 'shared/schemas/agent-session-telemetry.schema.json');
+const fixtureRoot = path.join(repoRoot, 'shared/schemas/fixtures/agent-session-telemetry');
+
+async function jsonFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+    .map((entry) => path.join(dir, entry.name))
+    .sort();
+}
+
+function runJsonschema(fixturePath) {
+  return spawnSync(
+    'python3',
+    [
+      '-c',
+      `
+import json, sys
+from pathlib import Path
+from jsonschema import Draft202012Validator
+
+schema = json.loads(Path(sys.argv[1]).read_text())
+instance = json.loads(Path(sys.argv[2]).read_text())
+Draft202012Validator.check_schema(schema)
+validator = Draft202012Validator(schema)
+errors = sorted(validator.iter_errors(instance), key=lambda e: list(e.path))
+if errors:
+    for error in errors[:8]:
+        print(error.message)
+    sys.exit(1)
+`,
+      schemaPath,
+      fixturePath,
+    ],
+    { encoding: 'utf8' },
+  );
+}
+
+test('valid agent-session telemetry fixtures match the canonical schema', async () => {
+  const fixtures = await jsonFiles(path.join(fixtureRoot, 'valid'));
+  assert.ok(fixtures.length >= 1, 'expected valid fixtures');
+  for (const fixture of fixtures) {
+    const result = runJsonschema(fixture);
+    assert.equal(
+      result.status,
+      0,
+      `${path.relative(repoRoot, fixture)} should validate\n${result.stdout}${result.stderr}`,
+    );
+  }
+});
+
+test('invalid agent-session telemetry fixtures are rejected by the canonical schema', async () => {
+  const fixtures = await jsonFiles(path.join(fixtureRoot, 'invalid'));
+  assert.ok(fixtures.length >= 1, 'expected invalid fixtures');
+  for (const fixture of fixtures) {
+    const result = runJsonschema(fixture);
+    assert.notEqual(result.status, 0, `${path.relative(repoRoot, fixture)} should fail validation`);
+  }
+});


### PR DESCRIPTION
Closes #181

## Summary
- add the agent-session telemetry schema and docs for raw context metrics, lifecycle events, capabilities, and provider-shape mismatch diagnostics
- add host extractors for Codex token-count transcript events, Claude Code statusline JSON, and Claude transcript fallback/compact metadata
- add fixtures and tests for exact extraction, partial fallback behavior, and rejection of app-specific phase signals

## Verification
- npm ci (packages/host)
- npm run check (packages/host)
- npm test (packages/host)
- node --test tests/schemas/agent-session-telemetry.test.mjs
- ./aos ready (from original checkout because the clean worktree does not carry the ignored ./aos binary)