### PR TITLE
Add Agent Terminal session inspector

### DIFF
--- a/apps/sigil/codex-terminal/index.html
+++ b/apps/sigil/codex-terminal/index.html
@@ -90,7 +90,7 @@
     .content {
       min-height: 0;
       display: grid;
-      grid-template-columns: minmax(0, 1fr) 238px;
+      grid-template-columns: minmax(0, 1fr) 340px;
       background: #050708;
     }
     .shell.rail-collapsed .content {
@@ -157,7 +157,7 @@
     .rail-content {
       min-height: 0;
       display: grid;
-      grid-template-rows: auto auto 1fr;
+      grid-template-rows: auto auto minmax(108px, 1fr) minmax(168px, 0.9fr);
       gap: 8px;
       padding: 8px;
     }
@@ -188,6 +188,10 @@
     .session-button:hover {
       background: rgba(255,255,255,0.09);
       border-color: rgba(255,255,255,0.18);
+    }
+    .session-button.selected {
+      border-color: rgba(137,220,235,0.58);
+      background: rgba(137,220,235,0.1);
     }
     .filters {
       display: grid;
@@ -270,6 +274,92 @@
     .empty-state {
       padding: 8px 2px;
     }
+    .inspector {
+      min-width: 0;
+      min-height: 0;
+      display: grid;
+      grid-template-rows: 28px 1fr;
+      border-top: 1px solid rgba(255,255,255,0.09);
+      padding-top: 8px;
+    }
+    .inspector-top {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+    }
+    .inspector-title {
+      color: #c9d3d8;
+      font-size: 12px;
+      font-weight: 650;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+    .inspector-body {
+      min-height: 0;
+      overflow: auto;
+      padding-right: 2px;
+      scrollbar-width: thin;
+      scrollbar-color: rgba(255,255,255,0.18) transparent;
+    }
+    .inspector-section {
+      display: grid;
+      gap: 5px;
+      padding: 7px 0;
+      border-top: 1px solid rgba(255,255,255,0.06);
+    }
+    .inspector-section:first-child {
+      border-top: 0;
+      padding-top: 0;
+    }
+    .inspector-heading {
+      color: #f3f7f8;
+      font-size: 11px;
+      font-weight: 700;
+      line-height: 1.2;
+    }
+    .inspector-row {
+      display: grid;
+      grid-template-columns: minmax(72px, 0.42fr) minmax(0, 1fr);
+      gap: 8px;
+      align-items: baseline;
+      min-width: 0;
+      font-size: 10.5px;
+      line-height: 1.25;
+    }
+    .inspector-key {
+      color: #849198;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+    .inspector-value {
+      color: #dce6ea;
+      min-width: 0;
+      overflow-wrap: anywhere;
+      font-family: "SF Mono", Menlo, Consolas, monospace;
+    }
+    .inspector-source {
+      color: #8e9aa0;
+      font-size: 9.5px;
+      line-height: 1.25;
+      overflow-wrap: anywhere;
+    }
+    .diagnostic {
+      display: grid;
+      gap: 2px;
+      padding: 6px;
+      border: 1px solid rgba(255,209,102,0.2);
+      border-radius: 6px;
+      background: rgba(255,209,102,0.055);
+    }
+    .diagnostic.warn .inspector-heading {
+      color: #ffd166;
+    }
+    .diagnostic.error .inspector-heading {
+      color: #ff8f87;
+    }
   </style>
 </head>
 <body>
@@ -309,6 +399,13 @@
             </select>
           </div>
           <div class="session-list" id="sessionList" role="list" aria-label="Recent sessions"></div>
+          <section class="inspector" aria-label="Session inspector">
+            <div class="inspector-top">
+              <span class="inspector-title">Inspector</span>
+              <button class="icon-button" id="refreshInspector" type="button" aria-label="Refresh inspector">I</button>
+            </div>
+            <div class="inspector-body" id="sessionInspector"></div>
+          </section>
         </div>
       </aside>
     </section>
@@ -326,6 +423,7 @@
     const subtitle = document.getElementById('subtitle');
     const statusDot = document.getElementById('status');
     const sessionList = document.getElementById('sessionList');
+    const sessionInspector = document.getElementById('sessionInspector');
     const providerFilter = document.getElementById('providerFilter');
     const sessionSort = document.getElementById('sessionSort');
     const railToggle = document.getElementById('railToggle');
@@ -338,6 +436,8 @@
     let resizeRaf = 0;
     let lastFit = { cols: 0, rows: 0 };
     let sessions = [];
+    let selectedSession = null;
+    let inspectorRequest = 0;
 
     function emit(body) {
       window.webkit?.messageHandlers?.headsup?.postMessage(body);
@@ -400,6 +500,183 @@
       });
     }
 
+    function formatNumber(value) {
+      if (typeof value !== 'number' || !Number.isFinite(value)) return 'unknown';
+      return new Intl.NumberFormat().format(value);
+    }
+
+    function formatRatio(value) {
+      if (typeof value !== 'number' || !Number.isFinite(value)) return 'unknown';
+      return `${Math.round(value * 1000) / 10}%`;
+    }
+
+    function appendText(parent, className, text, title) {
+      const element = document.createElement('div');
+      element.className = className;
+      element.textContent = text;
+      if (title) element.title = title;
+      parent.append(element);
+      return element;
+    }
+
+    function appendRow(parent, key, value, title) {
+      const row = document.createElement('div');
+      row.className = 'inspector-row';
+      appendText(row, 'inspector-key', key);
+      appendText(row, 'inspector-value', value || 'unknown', title);
+      parent.append(row);
+      return row;
+    }
+
+    function appendSection(parent, heading) {
+      const section = document.createElement('section');
+      section.className = 'inspector-section';
+      appendText(section, 'inspector-heading', heading);
+      parent.append(section);
+      return section;
+    }
+
+    function metricDisplay(metric) {
+      if (!metric || typeof metric !== 'object') return 'unknown';
+      if (metric.unit === 'ratio') return formatRatio(metric.value);
+      return `${formatNumber(metric.value)} ${metric.unit || ''}`.trim();
+    }
+
+    function sourceDisplay(metric) {
+      const source = metric?.source;
+      if (!source) return '';
+      return [source.stability, source.precision, source.kind, source.provider_version]
+        .filter(Boolean)
+        .join(' / ');
+    }
+
+    function appendMetric(parent, key, metric) {
+      appendRow(parent, key, metricDisplay(metric), metric?.source?.provider_surface);
+      const source = sourceDisplay(metric);
+      if (source) appendText(parent, 'inspector-source', source, metric?.source?.provider_surface);
+    }
+
+    function renderInspectorEmpty(text = 'Select a session') {
+      sessionInspector.replaceChildren();
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
+      empty.textContent = text;
+      sessionInspector.append(empty);
+    }
+
+    function renderInspectorLoading(record) {
+      sessionInspector.replaceChildren();
+      const section = appendSection(sessionInspector, 'Session');
+      appendRow(section, 'provider', providerLabel(record.provider));
+      appendRow(section, 'id', record.session_id);
+      appendRow(section, 'cwd', record.cwd, record.cwd);
+      appendText(sessionInspector, 'empty-state', 'Loading telemetry...');
+    }
+
+    function renderInspector(record, payload) {
+      sessionInspector.replaceChildren();
+      const sourceSession = payload?.session || record;
+      const telemetry = payload?.telemetry || null;
+      const context = telemetry?.context || null;
+      const diagnostics = [
+        ...(Array.isArray(payload?.diagnostics) ? payload.diagnostics : []),
+        ...(Array.isArray(telemetry?.diagnostics) ? telemetry.diagnostics : []),
+      ];
+      const lifecycleEvents = Array.isArray(payload?.lifecycle_events) ? payload.lifecycle_events : [];
+
+      const sessionSection = appendSection(sessionInspector, 'Session');
+      appendRow(sessionSection, 'provider', providerLabel(sourceSession.provider));
+      appendRow(sessionSection, 'id', sourceSession.session_id);
+      appendRow(sessionSection, 'cwd', sourceSession.cwd, sourceSession.cwd);
+      appendRow(sessionSection, 'branch', sourceSession.branch || 'unknown');
+      appendRow(sessionSection, 'source', sourceSession.source_file || 'unknown', sourceSession.source_file);
+      if (telemetry?.model?.id || telemetry?.model?.display_name) {
+        appendRow(sessionSection, 'model', telemetry.model.display_name || telemetry.model.id);
+      }
+
+      const contextSection = appendSection(sessionInspector, 'Context');
+      if (context) {
+        appendMetric(contextSection, 'window', context.window_tokens);
+        appendMetric(contextSection, 'used', context.used_tokens);
+        appendMetric(contextSection, 'remaining', context.remaining_tokens);
+        appendMetric(contextSection, 'used ratio', context.used_ratio);
+        appendMetric(contextSection, 'remaining ratio', context.remaining_ratio);
+      } else {
+        appendText(contextSection, 'empty-state', 'Unknown');
+      }
+
+      if (context?.tokens) {
+        const tokenSection = appendSection(sessionInspector, 'Token Counters');
+        for (const key of Object.keys(context.tokens).sort()) {
+          appendMetric(tokenSection, key.replace(/_/g, ' '), context.tokens[key]);
+        }
+      }
+
+      if (lifecycleEvents.length) {
+        const lifecycleSection = appendSection(sessionInspector, 'Lifecycle');
+        for (const event of lifecycleEvents.slice(-3)) {
+          appendRow(lifecycleSection, event.event, event.trigger || event.observed_at);
+          if (event.pre_tokens) appendMetric(lifecycleSection, 'pre', event.pre_tokens);
+          if (event.post_tokens) appendMetric(lifecycleSection, 'post', event.post_tokens);
+        }
+      }
+
+      const diagnosticSection = appendSection(sessionInspector, 'Diagnostics');
+      if (diagnostics.length) {
+        const seen = new Set();
+        for (const diagnostic of diagnostics) {
+          const key = `${diagnostic.code}:${diagnostic.provider_surface}:${diagnostic.fallback || ''}`;
+          if (seen.has(key)) continue;
+          seen.add(key);
+          const item = document.createElement('div');
+          item.className = `diagnostic ${diagnostic.severity || ''}`;
+          appendText(item, 'inspector-heading', diagnostic.code || 'diagnostic');
+          appendText(item, 'inspector-source', [
+            diagnostic.severity,
+            diagnostic.provider_surface,
+            diagnostic.fallback ? `fallback: ${diagnostic.fallback}` : '',
+          ].filter(Boolean).join(' / '));
+          diagnosticSection.append(item);
+        }
+      } else {
+        appendText(diagnosticSection, 'empty-state', 'No diagnostics');
+      }
+    }
+
+    function selectSession(record, { loadTelemetry = true } = {}) {
+      selectedSession = record || null;
+      renderSessions();
+      if (!record) {
+        renderInspectorEmpty();
+        return;
+      }
+      renderInspectorLoading(record);
+      if (loadTelemetry) void loadInspector(record);
+    }
+
+    async function loadInspector(record = selectedSession) {
+      if (!record) {
+        renderInspectorEmpty();
+        return;
+      }
+      const requestId = ++inspectorRequest;
+      const query = new URLSearchParams();
+      query.set('provider', record.provider);
+      query.set('session_id', record.session_id);
+      if (currentCwd) query.set('cwd', currentCwd);
+      try {
+        const response = await fetch(bridgeUrl(`/session-inspector?${query.toString()}`));
+        if (!response.ok) throw new Error(await response.text());
+        const payload = await response.json();
+        if (requestId === inspectorRequest) renderInspector(record, payload);
+      } catch (error) {
+        if (requestId !== inspectorRequest) return;
+        sessionInspector.replaceChildren();
+        const section = appendSection(sessionInspector, 'Inspector');
+        appendText(section, 'empty-state', error.message || String(error));
+      }
+    }
+
     function sessionSortTimestamp(record) {
       if (sessionSort.value === 'created') {
         return record.created_at || record.updated_at || record.last_message_at;
@@ -431,9 +708,14 @@
         const item = document.createElement('button');
         item.type = 'button';
         item.className = 'session-button';
+        if (selectedSession?.provider === record.provider && selectedSession?.session_id === record.session_id) {
+          item.classList.add('selected');
+          item.setAttribute('aria-current', 'true');
+        }
         item.setAttribute('role', 'listitem');
         item.setAttribute('aria-label', `Resume ${providerLabel(record.provider)} session ${record.session_id} in ${record.cwd}`);
         item.addEventListener('click', () => {
+          selectSession(record, { loadTelemetry: true });
           void runAgentCommand({
             command: record.resume_command,
             cwd: record.cwd,
@@ -476,6 +758,20 @@
       } catch (_) {
         sessions = [];
       }
+      if (selectedSession) {
+        const replacement = sessions.find((record) => (
+          record.provider === selectedSession.provider && record.session_id === selectedSession.session_id
+        ));
+        if (replacement) selectedSession = replacement;
+      }
+      if (!selectedSession && sessions.length) {
+        selectedSession = [...sessions].sort(compareSessionsForRail)[0];
+        void loadInspector(selectedSession);
+      } else if (selectedSession) {
+        void loadInspector(selectedSession);
+      } else {
+        renderInspectorEmpty('No session selected');
+      }
       renderSessions();
     }
 
@@ -516,6 +812,7 @@
     async function runAgentCommand({ command, cwd, label }) {
       activeLabel = label;
       currentCwd = cwd || currentCwd;
+      if (!selectedSession) renderInspectorEmpty('Telemetry pending');
       setStatus('', `Starting ${label}`);
       terminal?.clear();
       terminal?.writeln(`Starting ${label}...`);
@@ -572,6 +869,7 @@
     }
 
     document.getElementById('newCodex').addEventListener('click', () => {
+      selectSession(null);
       void runAgentCommand({
         command: ['codex', '--no-alt-screen'],
         cwd: currentCwd,
@@ -580,6 +878,7 @@
     });
 
     document.getElementById('newClaude').addEventListener('click', () => {
+      selectSession(null);
       void runAgentCommand({
         command: ['claude'],
         cwd: currentCwd,
@@ -589,6 +888,10 @@
 
     document.getElementById('refreshSessions').addEventListener('click', () => {
       void loadSessions();
+    });
+
+    document.getElementById('refreshInspector').addEventListener('click', () => {
+      void loadInspector();
     });
 
     providerFilter.addEventListener('change', () => {

--- a/apps/sigil/codex-terminal/server.mjs
+++ b/apps/sigil/codex-terminal/server.mjs
@@ -5,6 +5,7 @@ import { spawn, spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { listProviderSessions } from '../../../packages/host/src/session-catalog.ts';
+import { buildSessionInspector } from './session-inspector.mjs';
 
 const port = Number(process.env.SIGIL_AGENT_TERMINAL_PORT || process.env.SIGIL_CODEX_TERMINAL_PORT || process.env.PORT || 17761);
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
@@ -342,6 +343,18 @@ function terminalCwdForSession(session) {
   return processSessions.get(session)?.cwd || sessionCommands.get(session)?.cwd || defaultCwd;
 }
 
+function sessionCatalogForUrl(url) {
+  const providerParams = url.searchParams.getAll('provider');
+  const providers = providerParams.filter((provider) => provider === 'codex' || provider === 'claude-code');
+  return listProviderSessions({
+    homeDir: process.env.SIGIL_AGENT_CATALOG_HOME,
+    codexRoot: process.env.SIGIL_AGENT_CODEX_ROOT,
+    claudeRoot: process.env.SIGIL_AGENT_CLAUDE_ROOT,
+    cwd: url.searchParams.get('cwd') || defaultCwd,
+    providers: providers.length ? providers : undefined,
+  });
+}
+
 function attachExistingProcessSocket(socket, session, record) {
   terminalClients.add(socket);
   record.clients.add(socket);
@@ -501,16 +514,27 @@ async function handle(req, res) {
     }
 
     if (req.method === 'GET' && url.pathname === '/sessions') {
-      const providerParams = url.searchParams.getAll('provider');
-      const providers = providerParams.filter((provider) => provider === 'codex' || provider === 'claude-code');
-      const sessions = listProviderSessions({
-        homeDir: process.env.SIGIL_AGENT_CATALOG_HOME,
-        codexRoot: process.env.SIGIL_AGENT_CODEX_ROOT,
-        claudeRoot: process.env.SIGIL_AGENT_CLAUDE_ROOT,
-        cwd: url.searchParams.get('cwd') || defaultCwd,
-        providers: providers.length ? providers : undefined,
-      });
+      const sessions = sessionCatalogForUrl(url);
       json(res, 200, { sessions });
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname === '/session-inspector') {
+      const provider = url.searchParams.get('provider');
+      const sessionId = url.searchParams.get('session_id');
+      if (!provider || !sessionId) {
+        text(res, 400, 'provider and session_id are required');
+        return;
+      }
+      const sessions = sessionCatalogForUrl(url);
+      const record = sessions.find((candidate) => (
+        candidate.provider === provider && candidate.session_id === sessionId
+      ));
+      if (!record) {
+        text(res, 404, `session not found: ${provider}:${sessionId}`);
+        return;
+      }
+      json(res, 200, buildSessionInspector(record));
       return;
     }
 

--- a/apps/sigil/codex-terminal/session-inspector.mjs
+++ b/apps/sigil/codex-terminal/session-inspector.mjs
@@ -1,0 +1,166 @@
+import fs from 'node:fs';
+import {
+  extractClaudeTranscriptTelemetryFromJsonlLines,
+  extractCodexTelemetryFromJsonlLines,
+} from '../../../packages/host/src/session-telemetry.ts';
+
+const DEFAULT_TAIL_BYTES = 2 * 1024 * 1024;
+const DEFAULT_TAIL_LINES = 1200;
+const SCHEMA_VERSION = '2026-05-02';
+
+export function buildSessionInspector(record, options = {}) {
+  const observedAt = options.observedAt || new Date().toISOString();
+  const session = sessionSummary(record);
+  const diagnostics = [];
+  const lifecycleEvents = [];
+  let snapshot;
+
+  if (!record || typeof record !== 'object') {
+    diagnostics.push(adapterDiagnostic({
+      observedAt,
+      provider: 'codex',
+      code: 'invalid_session_record',
+      expected: ['provider session catalog record'],
+      fallback: 'telemetry_unknown',
+      severity: 'warn',
+    }));
+    return { session: null, telemetry: null, lifecycle_events: lifecycleEvents, diagnostics };
+  }
+
+  if (!record.source_file) {
+    diagnostics.push(adapterDiagnostic({
+      observedAt,
+      provider: record.provider,
+      sessionId: record.session_id,
+      code: 'missing_source_file',
+      expected: ['provider-session-catalog.source_file'],
+      fallback: 'telemetry_unknown',
+      severity: 'warn',
+    }));
+    return { session, telemetry: null, lifecycle_events: lifecycleEvents, diagnostics };
+  }
+
+  const lines = readJsonlTailLines(record.source_file, {
+    maxBytes: options.maxBytes ?? DEFAULT_TAIL_BYTES,
+    maxLines: options.maxLines ?? DEFAULT_TAIL_LINES,
+  });
+  if (!lines) {
+    diagnostics.push(adapterDiagnostic({
+      observedAt,
+      provider: record.provider,
+      sessionId: record.session_id,
+      code: 'source_file_unreadable',
+      expected: ['readable provider-session-catalog.source_file'],
+      fallback: 'telemetry_unknown',
+      severity: 'warn',
+    }));
+    return { session, telemetry: null, lifecycle_events: lifecycleEvents, diagnostics };
+  }
+
+  const extractionOptions = {
+    observedAt,
+    sessionId: record.session_id,
+    cwd: record.cwd,
+    sourceFile: record.source_file,
+    providerVersion: options.providerVersion,
+  };
+
+  if (record.provider === 'codex') {
+    const result = extractCodexTelemetryFromJsonlLines(lines, extractionOptions);
+    snapshot = result.snapshot;
+    diagnostics.push(...result.diagnostics);
+    lifecycleEvents.push(...result.lifecycle_events);
+  } else if (record.provider === 'claude-code') {
+    const result = extractClaudeTranscriptTelemetryFromJsonlLines(lines, extractionOptions);
+    snapshot = result.snapshot;
+    diagnostics.push(...result.diagnostics);
+    lifecycleEvents.push(...result.lifecycle_events);
+  } else {
+    diagnostics.push(adapterDiagnostic({
+      observedAt,
+      provider: record.provider,
+      sessionId: record.session_id,
+      code: 'unsupported_provider',
+      expected: ['codex', 'claude-code'],
+      fallback: 'telemetry_unknown',
+      severity: 'warn',
+    }));
+  }
+
+  return {
+    session,
+    telemetry: snapshot || null,
+    lifecycle_events: lifecycleEvents,
+    diagnostics,
+  };
+}
+
+function sessionSummary(record) {
+  if (!record || typeof record !== 'object') return null;
+  const summary = {
+    provider: String(record.provider || ''),
+    session_id: String(record.session_id || ''),
+    cwd: String(record.cwd || ''),
+    updated_at: String(record.updated_at || ''),
+  };
+  for (const key of ['branch', 'created_at', 'last_message_at', 'source_file']) {
+    if (typeof record[key] === 'string' && record[key]) summary[key] = record[key];
+  }
+  if (Array.isArray(record.resume_command)) {
+    summary.resume_command = record.resume_command.map((part) => String(part));
+  }
+  return summary;
+}
+
+function readJsonlTailLines(file, options) {
+  let fd;
+  try {
+    fd = fs.openSync(file, 'r');
+    const size = fs.fstatSync(fd).size;
+    const bytesToRead = Math.min(options.maxBytes, size);
+    const start = Math.max(0, size - bytesToRead);
+    const buffer = Buffer.alloc(bytesToRead);
+    const bytesRead = bytesToRead > 0 ? fs.readSync(fd, buffer, 0, bytesToRead, start) : 0;
+    let text = buffer.subarray(0, bytesRead).toString('utf8');
+    if (start > 0) {
+      const firstNewline = text.indexOf('\n');
+      text = firstNewline >= 0 ? text.slice(firstNewline + 1) : '';
+    }
+    return text.split(/\r?\n/).filter((line) => line.trim()).slice(-options.maxLines);
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // Best-effort read-only inspector.
+      }
+    }
+  }
+}
+
+function adapterDiagnostic({
+  observedAt,
+  provider,
+  sessionId,
+  code,
+  expected,
+  fallback,
+  severity,
+}) {
+  const diagnostic = {
+    type: 'agent.session.telemetry_mismatch',
+    schema_version: SCHEMA_VERSION,
+    observed_at: observedAt,
+    provider: provider === 'claude-code' ? 'claude-code' : 'codex',
+    source: 'aos_adapter',
+    provider_surface: 'agent-terminal.session-inspector',
+    code,
+    expected,
+    fallback,
+    severity,
+  };
+  if (sessionId) diagnostic.session_id = String(sessionId);
+  return diagnostic;
+}

--- a/tests/sigil-agent-terminal-server.test.mjs
+++ b/tests/sigil-agent-terminal-server.test.mjs
@@ -26,14 +26,64 @@ describe('Sigil Agent Terminal bridge', () => {
       path.join(homeDir, '.codex', 'sessions', '2026', '05', '01', 'rollout-2026-05-01T09-10-08-codex-session.jsonl'),
       [
         { timestamp: '2026-05-01T13:10:37.580Z', type: 'session_meta', payload: { id: 'codex-session', cwd: repoCwd, git: { branch: 'main' } } },
-        { timestamp: '2026-05-01T13:11:00.000Z', type: 'response_item', payload: { type: 'message' } },
+        {
+          timestamp: '2026-05-01T13:11:00.000Z',
+          type: 'event_msg',
+          payload: {
+            type: 'token_count',
+            info: {
+              total_token_usage: {
+                input_tokens: 12000,
+                cached_input_tokens: 2000,
+                output_tokens: 400,
+                total_tokens: 12400,
+              },
+              model_context_window: 258400,
+            },
+          },
+        },
+      ],
+    );
+    writeJsonl(
+      path.join(homeDir, '.codex', 'sessions', '2026', '05', '01', 'rollout-2026-05-01T10-00-00-codex-drift.jsonl'),
+      [
+        { timestamp: '2026-05-01T13:20:00.000Z', type: 'session_meta', payload: { id: 'codex-drift', cwd: repoCwd, git: { branch: 'main' } } },
+        { timestamp: '2026-05-01T13:21:00.000Z', type: 'event_msg', payload: { type: 'token_count' } },
       ],
     );
     writeJsonl(
       path.join(homeDir, '.claude', 'projects', '-tmp-work-agent-os', 'claude-session.jsonl'),
       [
         { type: 'user', timestamp: '2026-05-01T14:00:00.000Z', sessionId: 'claude-session', cwd: repoCwd, gitBranch: 'main', message: { role: 'user', content: 'fixture' } },
-        { type: 'assistant', timestamp: '2026-05-01T14:02:00.000Z', sessionId: 'claude-session', cwd: repoCwd, gitBranch: 'main', message: { role: 'assistant', content: 'fixture' } },
+        {
+          type: 'assistant',
+          timestamp: '2026-05-01T14:02:00.000Z',
+          sessionId: 'claude-session',
+          cwd: repoCwd,
+          gitBranch: 'main',
+          message: {
+            role: 'assistant',
+            content: 'fixture',
+            model: 'claude-opus-4-7',
+            usage: {
+              input_tokens: 6,
+              cache_creation_input_tokens: 11000,
+              cache_read_input_tokens: 16256,
+              output_tokens: 209,
+            },
+          },
+        },
+        {
+          timestamp: '2026-05-01T14:03:00.000Z',
+          sessionId: 'claude-session',
+          cwd: repoCwd,
+          compactMetadata: {
+            trigger: 'manual',
+            preTokens: 165246,
+            postTokens: 23229,
+            durationMs: 97699,
+          },
+        },
       ],
     );
 
@@ -70,18 +120,58 @@ describe('Sigil Agent Terminal bridge', () => {
     const payload = await response.json();
     assert.deepEqual(
       payload.sessions.map((session) => `${session.provider}:${session.session_id}`).sort(),
-      ['claude-code:claude-session', 'codex:codex-session'],
+      ['claude-code:claude-session', 'codex:codex-drift', 'codex:codex-session'],
     );
-    const codexSession = payload.sessions.find((session) => session.provider === 'codex');
+    const codexSession = payload.sessions.find((session) => session.session_id === 'codex-session');
     assert.equal(codexSession.created_at, '2026-05-01T13:10:37.580Z');
     assert.equal(codexSession.last_message_at, '2026-05-01T13:11:00.000Z');
     const claudeSession = payload.sessions.find((session) => session.provider === 'claude-code');
     assert.equal(claudeSession.created_at, '2026-05-01T14:00:00.000Z');
-    assert.equal(claudeSession.last_message_at, '2026-05-01T14:02:00.000Z');
+    assert.equal(claudeSession.last_message_at, '2026-05-01T14:03:00.000Z');
 
     const codexResponse = await fetch(`http://127.0.0.1:${port}/sessions?cwd=${encodeURIComponent(repoCwd)}&provider=codex`);
     const codexPayload = await codexResponse.json();
-    assert.deepEqual(codexPayload.sessions.map((session) => session.provider), ['codex']);
+    assert.deepEqual(codexPayload.sessions.map((session) => session.provider), ['codex', 'codex']);
+  });
+
+  it('returns sanitized session inspector telemetry for selected sessions', async () => {
+    const codexResponse = await fetch(
+      `http://127.0.0.1:${port}/session-inspector?cwd=${encodeURIComponent(repoCwd)}&provider=codex&session_id=codex-session`,
+    );
+    assert.equal(codexResponse.status, 200);
+    const codexPayload = await codexResponse.json();
+    assert.equal(codexPayload.session.provider, 'codex');
+    assert.equal(codexPayload.telemetry.context.window_tokens.value, 258400);
+    assert.equal(codexPayload.telemetry.context.used_tokens.value, 12400);
+    assert.equal(codexPayload.telemetry.context.remaining_tokens.value, 246000);
+    assert.equal(codexPayload.telemetry.context.used_tokens.source.stability, 'provider-local');
+    assert.deepEqual(codexPayload.diagnostics, []);
+
+    const claudeResponse = await fetch(
+      `http://127.0.0.1:${port}/session-inspector?cwd=${encodeURIComponent(repoCwd)}&provider=claude-code&session_id=claude-session`,
+    );
+    assert.equal(claudeResponse.status, 200);
+    const claudePayload = await claudeResponse.json();
+    assert.equal(claudePayload.session.provider, 'claude-code');
+    assert.equal(claudePayload.telemetry.model.id, 'claude-opus-4-7');
+    assert.equal(claudePayload.telemetry.context.used_tokens.value, 27262);
+    assert.equal(claudePayload.telemetry.context.used_tokens.source.precision, 'derived');
+    assert.equal(claudePayload.lifecycle_events[0].event, 'context_compacted');
+    assert.equal(claudePayload.lifecycle_events[0].pre_tokens.value, 165246);
+    assert.equal(JSON.stringify(claudePayload).includes('fixture'), false);
+  });
+
+  it('surfaces provider drift diagnostics in the session inspector', async () => {
+    const response = await fetch(
+      `http://127.0.0.1:${port}/session-inspector?cwd=${encodeURIComponent(repoCwd)}&provider=codex&session_id=codex-drift`,
+    );
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.session.session_id, 'codex-drift');
+    assert.equal(payload.telemetry.context, undefined);
+    assert.equal(payload.diagnostics[0].type, 'agent.session.telemetry_mismatch');
+    assert.equal(payload.diagnostics[0].code, 'codex_token_count_missing_info');
+    assert.equal(payload.diagnostics[0].fallback, 'context_unavailable');
   });
 
   it('accepts provider resume commands as argv arrays', async () => {


### PR DESCRIPTION
Closes #188

## Summary
- add a read-only Session Inspector panel to Agent Terminal beside the session rail
- expose a bridge `/session-inspector` endpoint that reads the selected catalog session source file and returns sanitized telemetry, lifecycle events, and diagnostics
- reuse the #181 session telemetry extractors for Codex token-count events and Claude transcript fallback/compact metadata
- cover exact Codex/Claude telemetry, sanitized output, and provider-drift diagnostics in the Agent Terminal bridge tests

## Verification
- npm ci (packages/host)
- npm run check (packages/host)
- npm test (packages/host)
- node --test tests/sigil-agent-terminal-server.test.mjs tests/schemas/agent-session-telemetry.test.mjs
- inline Agent Terminal script syntax check via node/vm
- ./aos ready (from original checkout because the clean worktree does not carry the ignored ./aos binary)