### PR TITLE
Drive Sigil avatar vitality from session telemetry

### DIFF
--- a/apps/sigil/codex-terminal/index.html
+++ b/apps/sigil/codex-terminal/index.html
@@ -641,6 +641,7 @@
       } else {
         appendText(diagnosticSection, 'empty-state', 'No diagnostics');
       }
+      emit({ type: 'agent_terminal.session_telemetry', payload });
     }
 
     function selectSession(record, { loadTelemetry = true } = {}) {

--- a/apps/sigil/renderer/aura.js
+++ b/apps/sigil/renderer/aura.js
@@ -77,10 +77,13 @@ export function computeAuraPosition() {
 
 export function animateAura(dt) {
     const { auraPos, auraScaleMult } = computeAuraPosition();
+    const vitality = state.sessionVitality || {};
+    const reachMultiplier = Number.isFinite(vitality.auraReachMultiplier) ? vitality.auraReachMultiplier : 1;
+    const intensityMultiplier = Number.isFinite(vitality.auraIntensityMultiplier) ? vitality.auraIntensityMultiplier : 1;
 
     state.auraSpike *= state.auraSpikeDecay;
-    const baseScale = state.auraBaseScale * state.auraReach * state.z_depth;
-    const pulseOffset = Math.sin(Date.now() * state.auraPulseRate) * (state.auraPulseAmplitude * state.auraReach) * state.z_depth;
+    const baseScale = state.auraBaseScale * state.auraReach * reachMultiplier * state.z_depth;
+    const pulseOffset = Math.sin(Date.now() * state.auraPulseRate) * (state.auraPulseAmplitude * state.auraReach * reachMultiplier) * state.z_depth;
     const spikeBonus = baseScale * (state.spikeMultiplier - 1.0) * state.auraSpike;
     const reachScale = baseScale + pulseOffset + spikeBonus;
 
@@ -99,7 +102,7 @@ export function animateAura(dt) {
         state.coreSprite.visible = true;
         state.coreSprite.position.copy(auraPos);
 
-        let iFactor = state.auraIntensity / 3.0;
+        let iFactor = (state.auraIntensity * intensityMultiplier) / 3.0;
         let ciScale = (0.2 + 1.8 * iFactor) * state.z_depth * auraScaleMult * state.appScale;
         state.coreSprite.scale.set(ciScale, ciScale, 1);
         state.coreSprite.material.opacity = 1.0 - state.auraCoreFade * iFactor;

--- a/apps/sigil/renderer/live-modules/main.js
+++ b/apps/sigil/renderer/live-modules/main.js
@@ -40,6 +40,7 @@ import { createRadialMenuTargetSurface } from './radial-menu-target-surface.js';
 import { createSigilRadialGestureVisuals } from './radial-gesture-visuals.js';
 import { createSigilContextMenu } from '../../context-menu/menu.js';
 import { loadAgent } from '../agent-loader.js';
+import { createSessionVitalityController } from '../session-vitality.js';
 
 const host = createHostRuntime();
 const interactionTrace = createInteractionTrace({
@@ -95,6 +96,7 @@ const liveJs = {
     contextMenu: { open: false, bounds: null, stack: null },
     utilityCanvases: new Map(),
     defaultAvatarSave: { dirty: false, saving: false, lastSavedAt: null, lastError: null },
+    sessionVitality: null,
     appearanceVersion: 0,
     appliedAppearanceVersion: null,
     lastPublishedAppearanceVersion: null,
@@ -129,6 +131,9 @@ const renderLoop = createRenderLoopScheduler(requestAnimationFrame);
 let radialGestureVisuals = null;
 let lastRenderPerformanceFrameAt = null;
 let lastRenderPerformanceSampleAt = 0;
+const sessionVitality = createSessionVitalityController({
+    now: () => performance.now(),
+});
 const DEFAULT_AGENT_WIKI_PATH = 'sigil/agents/default';
 const DEFAULT_AGENT_WIKI_URL = `/wiki/${DEFAULT_AGENT_WIKI_PATH}.md`;
 const INPUT_POINTER_EVENT_TYPES = new Set([
@@ -1665,6 +1670,42 @@ function originFromMessage(msg = {}) {
     return nativeToDesktopWorldPoint({ x, y }, liveJs.displays) ?? { x, y, valid: true };
 }
 
+function publishSessionVitalitySnapshot() {
+    const snapshot = sessionVitality.snapshot();
+    liveJs.sessionVitality = snapshot;
+    state.sessionVitality = snapshot.factors;
+    scheduleRenderFrame();
+    return snapshot;
+}
+
+function handleSessionTelemetryEnvelope(envelope = {}) {
+    let changed = false;
+    const telemetry = envelope.type === 'agent.session.telemetry'
+        ? envelope
+        : envelope.telemetry;
+    if (telemetry?.type === 'agent.session.telemetry') {
+        sessionVitality.applyTelemetry(telemetry);
+        changed = true;
+    }
+
+    const lifecycle = envelope.type === 'agent.session.lifecycle'
+        ? [envelope]
+        : (Array.isArray(envelope.lifecycle_events) ? envelope.lifecycle_events : []);
+    for (const event of lifecycle) {
+        if (event?.type !== 'agent.session.lifecycle') continue;
+        sessionVitality.applyLifecycle(event);
+        if (['context_compaction_started', 'context_compacted', 'handoff_started', 'handoff_completed'].includes(event.event)) {
+            state.auraSpike = Math.max(state.auraSpike || 0, 1);
+        }
+        changed = true;
+    }
+
+    if (changed) {
+        publishSessionVitalitySnapshot();
+    }
+    return changed;
+}
+
 function handleHostMessage(rawMsg) {
     const msg = normalizeMessage(rawMsg);
     if (
@@ -1692,6 +1733,11 @@ function handleHostMessage(rawMsg) {
         });
     }
     if (!shouldProcessGlobalDaemonEvent(msg)) return;
+
+    if (msg.type === 'agent.session.telemetry' || msg.type === 'agent.session.lifecycle') {
+        handleSessionTelemetryEnvelope(msg);
+        return;
+    }
 
     if (msg.type === 'canvas_lifecycle') {
         const canvasId = msg.canvas_id || msg.canvas?.id;
@@ -1836,6 +1882,10 @@ function handleHostMessage(rawMsg) {
         if (msg.payload?.type === 'agent_terminal.avatar_toggle'
             || msg.payload?.type === 'codex_terminal.avatar_toggle') {
             void toggleUtilityCanvas('agent-terminal');
+            return;
+        }
+        if (msg.payload?.type === 'agent_terminal.session_telemetry') {
+            handleSessionTelemetryEnvelope(msg.payload.payload || {});
         }
         return;
     }
@@ -2039,6 +2089,9 @@ function animate() {
     if (fastTravelState?.avatarPos?.valid) {
         renderAvatarPos = fastTravelState.avatarPos;
     }
+    const vitalityFrame = sessionVitality.tick(dt, performance.now());
+    state.sessionVitality = vitalityFrame;
+    liveJs.sessionVitality = sessionVitality.snapshot();
 
     const visualActive = liveJs.avatarVisible
         || !!visibilityTransition.active
@@ -2054,6 +2107,7 @@ function animate() {
         const projected = projectAvatarToScene(renderAvatarPos.x, renderAvatarPos.y);
         state.polyGroup.position.copy(projected);
         state.pointLight.position.copy(state.polyGroup.position);
+        state.pointLight.intensity = 2 * (Number.isFinite(vitalityFrame.brightnessMultiplier) ? vitalityFrame.brightnessMultiplier : 1);
         window.__sigilRenderDebug = {
             desktopWorld: {
                 x: Math.round(renderAvatarPos.x),
@@ -2068,8 +2122,11 @@ function animate() {
     }
 
     if (!state.isPaused) {
-        state.polyGroup.rotation.y += 0.005;
-        state.polyGroup.rotation.x += 0.002;
+        const rotationMultiplier = Number.isFinite(vitalityFrame.rotationMultiplier)
+            ? vitalityFrame.rotationMultiplier
+            : 1;
+        state.polyGroup.rotation.y += 0.005 * rotationMultiplier;
+        state.polyGroup.rotation.x += 0.002 * rotationMultiplier;
     }
 
     const hoverTarget = liveJs.avatarHover && liveJs.avatarVisible && liveJs.currentState === 'IDLE' ? 1 : 0;
@@ -2123,7 +2180,8 @@ function animate() {
         window.__sigilBootFirstFrameAt = Date.now();
         recordBoot('boot:firstFrame', { boot_elapsed_ms: bootElapsedMs() });
     }
-    state.polyGroup.scale.setScalar(state.baseScale * state.z_depth * state.appScale * (1 + liveJs.avatarHoverProgress * 0.055));
+    const vitalityScale = Number.isFinite(vitalityFrame.scaleMultiplier) ? vitalityFrame.scaleMultiplier : 1;
+    state.polyGroup.scale.setScalar(state.baseScale * state.z_depth * state.appScale * vitalityScale * (1 + liveJs.avatarHoverProgress * 0.055));
     if (desktopWorldSurface?.isPrimary) {
         desktopWorldSurface.publishState(surfaceRenderSnapshot(renderAvatarPos));
     }
@@ -2175,6 +2233,7 @@ window.__sigilDebug = {
                 enabled: interactionTrace.snapshot().enabled,
             },
             avatarVisible: liveJs.avatarVisible,
+            sessionVitality: liveJs.sessionVitality,
             hitTargetId: hitTarget.hit.id,
             hitTargetReady: hitTarget.hit.ready,
             hitTargetFrame: hitTarget.hit.frame,

--- a/apps/sigil/renderer/session-vitality.js
+++ b/apps/sigil/renderer/session-vitality.js
@@ -1,0 +1,213 @@
+const DEFAULT_REFRESH_DURATION_MS = 1200;
+
+export const DEFAULT_SESSION_VITALITY_FACTORS = Object.freeze({
+    confidence: 0,
+    pressure: null,
+    usedRatio: null,
+    remainingRatio: null,
+    auraReachMultiplier: 1,
+    auraIntensityMultiplier: 1,
+    rotationMultiplier: 1,
+    brightnessMultiplier: 1,
+    flickerAmount: 0,
+    scaleMultiplier: 1,
+    refreshProgress: null,
+});
+
+function clamp01(value) {
+    if (!Number.isFinite(value)) return null;
+    return Math.max(0, Math.min(1, value));
+}
+
+function smoothstep(value) {
+    const x = clamp01(value);
+    if (x == null) return 0;
+    return x * x * (3 - (2 * x));
+}
+
+function lerp(a, b, t) {
+    return a + ((b - a) * t);
+}
+
+function easeOutBack(value) {
+    const x = clamp01(value) ?? 0;
+    const c1 = 1.45;
+    const c3 = c1 + 1;
+    return 1 + (c3 * Math.pow(x - 1, 3)) + (c1 * Math.pow(x - 1, 2));
+}
+
+function metricValue(metric) {
+    const value = Number(metric?.value);
+    return Number.isFinite(value) ? value : null;
+}
+
+export function contextRatiosFromTelemetry(telemetry) {
+    const context = telemetry?.context;
+    if (!context || typeof context !== 'object') {
+        return { usedRatio: null, remainingRatio: null, confidence: 0 };
+    }
+
+    const usedRatioMetric = context.used_ratio;
+    const remainingRatioMetric = context.remaining_ratio;
+    let usedRatio = clamp01(metricValue(usedRatioMetric));
+    let remainingRatio = clamp01(metricValue(remainingRatioMetric));
+    const confidenceMetrics = [];
+    if (usedRatio != null) confidenceMetrics.push(usedRatioMetric);
+    if (remainingRatio != null) confidenceMetrics.push(remainingRatioMetric);
+
+    const usedTokens = metricValue(context.used_tokens);
+    const windowTokens = metricValue(context.window_tokens);
+    if (usedRatio == null && usedTokens != null && windowTokens > 0) {
+        usedRatio = clamp01(usedTokens / windowTokens);
+        confidenceMetrics.push(context.used_tokens, context.window_tokens);
+    }
+    if (remainingRatio == null && usedRatio != null) {
+        remainingRatio = clamp01(1 - usedRatio);
+    }
+    if (usedRatio == null && remainingRatio != null) {
+        usedRatio = clamp01(1 - remainingRatio);
+    }
+
+    if (usedRatio == null && remainingRatio == null) {
+        return { usedRatio: null, remainingRatio: null, confidence: 0 };
+    }
+
+    return {
+        usedRatio,
+        remainingRatio,
+        confidence: sourceConfidence(confidenceMetrics),
+    };
+}
+
+export function factorsFromTelemetry(telemetry) {
+    const ratios = contextRatiosFromTelemetry(telemetry);
+    if (ratios.usedRatio == null) return { ...DEFAULT_SESSION_VITALITY_FACTORS };
+
+    const pressure = ratios.usedRatio;
+    const pressureCurve = smoothstep((pressure - 0.42) / 0.56);
+    const highPressure = smoothstep((pressure - 0.72) / 0.24);
+
+    return {
+        confidence: ratios.confidence,
+        pressure,
+        usedRatio: ratios.usedRatio,
+        remainingRatio: ratios.remainingRatio,
+        auraReachMultiplier: lerp(1, 0.34, pressureCurve),
+        auraIntensityMultiplier: lerp(1, 0.58, highPressure),
+        rotationMultiplier: pressure >= 0.97 ? 0 : lerp(1, 0.18, pressureCurve),
+        brightnessMultiplier: lerp(1, 0.72, highPressure),
+        flickerAmount: lerp(0, 0.24, highPressure),
+        scaleMultiplier: 1,
+        refreshProgress: null,
+    };
+}
+
+export function refreshFactors(elapsedMs, durationMs = DEFAULT_REFRESH_DURATION_MS) {
+    const progress = clamp01(elapsedMs / durationMs) ?? 1;
+    if (progress >= 1) {
+        return { active: false, scaleMultiplier: 1, auraReachBoost: 0, progress: 1 };
+    }
+    if (progress < 0.36) {
+        const collapse = smoothstep(progress / 0.36);
+        return {
+            active: true,
+            scaleMultiplier: lerp(1, 0.18, collapse),
+            auraReachBoost: lerp(0.15, 0.75, collapse),
+            progress,
+        };
+    }
+    const rebound = easeOutBack((progress - 0.36) / 0.64);
+    return {
+        active: true,
+        scaleMultiplier: Math.max(0.18, 0.18 + (rebound * 0.88)),
+        auraReachBoost: Math.max(0, lerp(0.75, 0, smoothstep((progress - 0.36) / 0.64))),
+        progress,
+    };
+}
+
+export function createSessionVitalityController(options = {}) {
+    const now = typeof options.now === 'function' ? options.now : () => performance.now();
+    const refreshDurationMs = Math.max(120, Number(options.refreshDurationMs) || DEFAULT_REFRESH_DURATION_MS);
+    let telemetry = null;
+    let factors = { ...DEFAULT_SESSION_VITALITY_FACTORS };
+    let refreshStartedAt = null;
+    let lastLifecycleEvent = null;
+
+    function recompute() {
+        factors = factorsFromTelemetry(telemetry);
+        return factors;
+    }
+
+    function applyTelemetry(nextTelemetry) {
+        if (nextTelemetry?.type !== 'agent.session.telemetry') return snapshot();
+        telemetry = nextTelemetry;
+        recompute();
+        return snapshot();
+    }
+
+    function applyLifecycle(event) {
+        if (event?.type !== 'agent.session.lifecycle') return snapshot();
+        lastLifecycleEvent = event;
+        if (isRefreshLifecycleEvent(event)) {
+            refreshStartedAt = now();
+        }
+        return snapshot();
+    }
+
+    function tick(elapsedMs = 0, nowMs = now()) {
+        let next = { ...factors };
+        if (refreshStartedAt != null) {
+            const refresh = refreshFactors(Math.max(0, nowMs - refreshStartedAt), refreshDurationMs);
+            if (refresh.active) {
+                next = {
+                    ...next,
+                    auraReachMultiplier: Math.max(next.auraReachMultiplier, next.auraReachMultiplier + refresh.auraReachBoost),
+                    brightnessMultiplier: Math.max(next.brightnessMultiplier, 1 + (refresh.auraReachBoost * 0.14)),
+                    scaleMultiplier: refresh.scaleMultiplier,
+                    refreshProgress: refresh.progress,
+                };
+            } else {
+                refreshStartedAt = null;
+            }
+        }
+        if (next.flickerAmount > 0) {
+            const wave = Math.sin(nowMs * 0.037) * Math.sin(nowMs * 0.071 + 0.7);
+            next.brightnessMultiplier *= 1 - (next.flickerAmount * Math.max(0, wave));
+        }
+        return next;
+    }
+
+    function snapshot() {
+        return {
+            telemetry,
+            factors: { ...factors },
+            refreshing: refreshStartedAt != null,
+            lastLifecycleEvent,
+        };
+    }
+
+    recompute();
+    return {
+        applyTelemetry,
+        applyLifecycle,
+        tick,
+        snapshot,
+    };
+}
+
+function isRefreshLifecycleEvent(event) {
+    return [
+        'context_compaction_started',
+        'context_compacted',
+        'handoff_started',
+        'handoff_completed',
+    ].includes(event.event);
+}
+
+function sourceConfidence(metrics = []) {
+    const presentMetrics = metrics.filter(Boolean);
+    if (presentMetrics.some((metric) => metric?.source?.precision === 'estimated')) return 0.55;
+    if (presentMetrics.some((metric) => metric?.source?.precision === 'derived')) return 0.78;
+    if (presentMetrics.some((metric) => metric?.source?.precision === 'exact')) return 1;
+    return 0.65;
+}

--- a/apps/sigil/renderer/state.js
+++ b/apps/sigil/renderer/state.js
@@ -325,7 +325,22 @@ const defaults = {
     segmentProgress: 0,
 
     // Force aura visible flag
-    forceAuraVisible: false
+    forceAuraVisible: false,
+
+    // Session telemetry expression (Sigil-local, derived from raw AOS metrics)
+    sessionVitality: {
+        confidence: 0,
+        pressure: null,
+        usedRatio: null,
+        remainingRatio: null,
+        auraReachMultiplier: 1,
+        auraIntensityMultiplier: 1,
+        rotationMultiplier: 1,
+        brightnessMultiplier: 1,
+        flickerAmount: 0,
+        scaleMultiplier: 1,
+        refreshProgress: null,
+    }
 };
 
 const state = { ...defaults };

--- a/tests/renderer/session-vitality.test.mjs
+++ b/tests/renderer/session-vitality.test.mjs
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  contextRatiosFromTelemetry,
+  createSessionVitalityController,
+  factorsFromTelemetry,
+  refreshFactors,
+} from '../../apps/sigil/renderer/session-vitality.js';
+
+function metric(value, source = {}) {
+  return {
+    value,
+    unit: 'ratio',
+    source: {
+      kind: 'provider_statusline',
+      provider_surface: 'test',
+      stability: 'documented',
+      precision: 'exact',
+      ...source,
+    },
+  };
+}
+
+test('unknown context telemetry stays neutral', () => {
+  const factors = factorsFromTelemetry({
+    type: 'agent.session.telemetry',
+    context: {},
+  });
+
+  assert.equal(factors.pressure, null);
+  assert.equal(factors.confidence, 0);
+  assert.equal(factors.auraReachMultiplier, 1);
+  assert.equal(factors.rotationMultiplier, 1);
+  assert.equal(factors.scaleMultiplier, 1);
+});
+
+test('context ratios derive from raw ratio metrics before visual factors', () => {
+  const telemetry = {
+    type: 'agent.session.telemetry',
+    context: {
+      used_ratio: metric(0.84),
+    },
+  };
+
+  const ratios = contextRatiosFromTelemetry(telemetry);
+  assert.equal(ratios.usedRatio, 0.84);
+  assert.equal(ratios.remainingRatio, 0.16000000000000003);
+  assert.equal(ratios.confidence, 1);
+
+  const factors = factorsFromTelemetry(telemetry);
+  assert.equal(factors.pressure, 0.84);
+  assert.ok(factors.auraReachMultiplier < 1);
+  assert.ok(factors.auraIntensityMultiplier < 1);
+  assert.ok(factors.rotationMultiplier < 1);
+  assert.ok(factors.flickerAmount > 0);
+});
+
+test('context ratios can derive from token counts when ratios are absent', () => {
+  const ratios = contextRatiosFromTelemetry({
+    type: 'agent.session.telemetry',
+    context: {
+      used_tokens: metric(75, { precision: 'derived' }),
+      window_tokens: metric(100),
+    },
+  });
+
+  assert.equal(ratios.usedRatio, 0.75);
+  assert.equal(ratios.remainingRatio, 0.25);
+  assert.equal(ratios.confidence, 0.78);
+});
+
+test('context confidence follows the metric used for pressure', () => {
+  const ratios = contextRatiosFromTelemetry({
+    type: 'agent.session.telemetry',
+    context: {
+      used_ratio: metric(0.5),
+      used_tokens: metric(80, { precision: 'estimated' }),
+      window_tokens: metric(100, { precision: 'estimated' }),
+    },
+  });
+
+  assert.equal(ratios.usedRatio, 0.5);
+  assert.equal(ratios.confidence, 1);
+});
+
+test('refresh lifecycle produces collapse and rebound scale factors', () => {
+  const collapse = refreshFactors(240, 1200);
+  assert.equal(collapse.active, true);
+  assert.ok(collapse.scaleMultiplier < 1);
+  assert.ok(collapse.auraReachBoost > 0);
+
+  const rebound = refreshFactors(840, 1200);
+  assert.equal(rebound.active, true);
+  assert.ok(rebound.scaleMultiplier > collapse.scaleMultiplier);
+
+  const complete = refreshFactors(1400, 1200);
+  assert.equal(complete.active, false);
+  assert.equal(complete.scaleMultiplier, 1);
+});
+
+test('controller accepts raw telemetry and lifecycle events without shared phase names', () => {
+  let now = 1000;
+  const controller = createSessionVitalityController({
+    now: () => now,
+    refreshDurationMs: 1000,
+  });
+
+  controller.applyTelemetry({
+    type: 'agent.session.telemetry',
+    context: {
+      remaining_ratio: metric(0.1),
+    },
+  });
+  let frame = controller.tick(0, now);
+  assert.equal(frame.usedRatio, 0.9);
+  assert.ok(frame.rotationMultiplier < 0.5);
+  assert.equal('phase' in frame, false);
+
+  controller.applyLifecycle({
+    type: 'agent.session.lifecycle',
+    event: 'context_compacted',
+    observed_at: '2026-05-02T12:00:00.000Z',
+  });
+  now += 250;
+  frame = controller.tick(0, now);
+  assert.ok(frame.scaleMultiplier < 1);
+  assert.notEqual(frame.refreshProgress, null);
+
+  now += 1200;
+  frame = controller.tick(0, now);
+  assert.equal(frame.scaleMultiplier, 1);
+});


### PR DESCRIPTION
## Summary

- Add a Sigil-local session vitality controller that derives numeric visual factors from raw `agent.session.telemetry` context metrics and refresh lifecycle events.
- Wire Agent Terminal session inspector telemetry into the avatar renderer through a canvas message envelope.
- Apply vitality factors to aura reach/intensity, point-light brightness, avatar rotation, and refresh collapse/rebound scale without shared phase names.

Closes #182

## Verification

- `node --test tests/renderer/session-vitality.test.mjs`
- `node --check apps/sigil/renderer/session-vitality.js && node --check apps/sigil/renderer/live-modules/main.js && node --check apps/sigil/renderer/aura.js`
- `node --test tests/sigil-agent-terminal-server.test.mjs`
- `node --test tests/renderer/*.test.mjs`
- `git diff --check`
- `/Users/Michael/Code/agent-os/./aos ready`
- AOS/Sigil runtime smoke: launched a temporary Sigil renderer canvas from the clean worktree through an isolated local static server, dispatched an Agent Terminal telemetry envelope, and verified `__sigilDebug.snapshot().sessionVitality.factors` reported `pressure: 0.88`, `remainingRatio: 0.12`, and non-neutral aura/rotation/brightness multipliers.