### PR TITLE
Add Sigil session vitality lab

### DIFF
--- a/apps/sigil/tests/session-vitality/README.md
+++ b/apps/sigil/tests/session-vitality/README.md
@@ -1,0 +1,46 @@
+# Sigil Session Vitality Lab
+
+This is a manual visual test harness for Sigil's session telemetry expression.
+It sends synthetic `agent.session.telemetry` and `agent.session.lifecycle`
+events to a running Sigil avatar canvas, then reads back
+`window.__sigilDebug.snapshot().sessionVitality`.
+
+Launch manually from repo mode:
+
+```bash
+./aos ready
+./aos set content.roots.toolkit packages/toolkit
+./aos set content.roots.sigil apps/sigil
+./aos show remove --id avatar-main 2>/dev/null || true
+./aos show create --id avatar-main --url 'aos://sigil/renderer/index.html' --track union
+./aos show wait --id avatar-main --js '!!window.__sigilDebug?.snapshot'
+./aos show create \
+  --id sigil-session-vitality-lab \
+  --url 'aos://sigil/tests/session-vitality/index.html?target=avatar-main' \
+  --at 80,80,760,720 \
+  --interactive \
+  --focus
+```
+
+Run the automated smoke:
+
+```bash
+bash tests/scenarios/sigil/session-vitality/smoke.sh
+```
+
+In a clean git worktree without a local `./aos` binary, point the scenario at
+the built repo binary:
+
+```bash
+AOS=/path/to/agent-os/aos bash tests/scenarios/sigil/session-vitality/smoke.sh
+```
+
+For unmerged worktree verification against a temporary static server, override
+the canvas URLs:
+
+```bash
+AOS=/path/to/agent-os/aos \
+AOS_SIGIL_RENDERER_URL='http://127.0.0.1:18784/sigil/renderer/index.html' \
+AOS_SIGIL_VITALITY_LAB_URL='http://127.0.0.1:18784/sigil/tests/session-vitality/index.html?target=sigil-session-vitality-avatar' \
+bash tests/scenarios/sigil/session-vitality/smoke.sh
+```

--- a/apps/sigil/tests/session-vitality/index.html
+++ b/apps/sigil/tests/session-vitality/index.html
@@ -1,0 +1,626 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Sigil Session Vitality Lab</title>
+<style>
+:root {
+  color-scheme: dark;
+  --bg: #080b0f;
+  --panel: #10161d;
+  --panel-2: #0c1117;
+  --line: rgba(255,255,255,0.12);
+  --muted: #8a98a5;
+  --text: #e8eef2;
+  --accent: #8ef0ff;
+  --warn: #ffd166;
+  --hot: #ff6b6b;
+  --ok: #36d399;
+}
+
+* { box-sizing: border-box; }
+
+html,
+body {
+  margin: 0;
+  width: 100%;
+  min-height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font: 13px/1.4 -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+}
+
+body {
+  display: grid;
+  grid-template-rows: 42px minmax(0, 1fr);
+}
+
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--line);
+  background: #151b22;
+  cursor: grab;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+header strong {
+  font-size: 13px;
+  font-weight: 650;
+}
+
+header span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+main {
+  display: grid;
+  grid-template-columns: minmax(320px, 420px) minmax(360px, 1fr);
+  min-height: 0;
+}
+
+section {
+  min-width: 0;
+  min-height: 0;
+  padding: 12px;
+}
+
+section + section {
+  border-left: 1px solid var(--line);
+  background: var(--panel-2);
+}
+
+h2 {
+  margin: 0 0 10px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  color: var(--accent);
+}
+
+.group {
+  border-top: 1px solid var(--line);
+  padding-top: 12px;
+  margin-top: 12px;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 132px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+label,
+.label {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+input,
+select,
+button {
+  font: inherit;
+}
+
+input,
+select {
+  width: 100%;
+  min-width: 0;
+  height: 30px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #070a0e;
+  color: var(--text);
+  padding: 4px 8px;
+}
+
+input[type="range"] {
+  height: 24px;
+  padding: 0;
+}
+
+.inline {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 54px;
+  gap: 8px;
+  align-items: center;
+}
+
+.value {
+  text-align: right;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
+
+.buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+button {
+  height: 30px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #18212a;
+  color: var(--text);
+  padding: 0 10px;
+  cursor: pointer;
+}
+
+button:hover { background: #202c36; }
+button.primary {
+  border-color: rgba(142,240,255,0.55);
+  background: rgba(38,123,140,0.36);
+}
+
+.meters {
+  display: grid;
+  gap: 8px;
+}
+
+.meter {
+  display: grid;
+  grid-template-columns: 150px minmax(120px, 1fr) 64px;
+  gap: 8px;
+  align-items: center;
+}
+
+.track {
+  height: 8px;
+  border-radius: 99px;
+  overflow: hidden;
+  background: rgba(255,255,255,0.1);
+}
+
+.fill {
+  width: 0%;
+  height: 100%;
+  background: var(--accent);
+}
+
+.fill.warn { background: var(--warn); }
+.fill.hot { background: var(--hot); }
+.fill.ok { background: var(--ok); }
+
+pre {
+  margin: 0;
+  min-height: 118px;
+  max-height: 260px;
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: #05070a;
+  padding: 10px;
+  color: #cbd5df;
+  font: 12px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace;
+  white-space: pre-wrap;
+}
+
+.log {
+  max-height: 160px;
+}
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--muted);
+}
+
+.dot.ok { background: var(--ok); }
+.dot.error { background: var(--hot); }
+
+@media (max-width: 820px) {
+  main { grid-template-columns: 1fr; }
+  section + section {
+    border-left: 0;
+    border-top: 1px solid var(--line);
+  }
+  .row { grid-template-columns: 1fr; gap: 4px; }
+}
+</style>
+</head>
+<body>
+<header>
+  <strong>Sigil Session Vitality Lab</strong>
+  <span class="status"><span id="host-dot" class="dot"></span><span id="host-status">starting</span></span>
+</header>
+
+<main>
+  <section>
+    <h2>Session Signal</h2>
+    <div class="row">
+      <label for="target-canvas">Target canvas</label>
+      <input id="target-canvas" value="avatar-main">
+    </div>
+    <div class="row">
+      <label for="provider">Provider</label>
+      <select id="provider">
+        <option value="codex">Codex</option>
+        <option value="claude-code">Claude Code</option>
+        <option value="synthetic">Synthetic</option>
+      </select>
+    </div>
+    <div class="row">
+      <label for="delivery">Delivery</label>
+      <select id="delivery">
+        <option value="agent-terminal">Agent Terminal envelope</option>
+        <option value="direct">Direct session event</option>
+      </select>
+    </div>
+    <div class="row">
+      <label for="metric-mode">Metrics</label>
+      <select id="metric-mode">
+        <option value="ratio">used + remaining ratios</option>
+        <option value="used_ratio">used ratio only</option>
+        <option value="remaining_ratio">remaining ratio only</option>
+        <option value="tokens">token counts</option>
+        <option value="unknown">unknown</option>
+      </select>
+    </div>
+    <div class="row">
+      <label for="precision">Precision</label>
+      <select id="precision">
+        <option value="exact">exact</option>
+        <option value="derived">derived</option>
+        <option value="estimated">estimated</option>
+      </select>
+    </div>
+    <div class="row">
+      <label for="used-ratio">Context used</label>
+      <div class="inline">
+        <input id="used-ratio" type="range" min="0" max="1" step="0.01" value="0.5">
+        <span id="used-ratio-value" class="value">50%</span>
+      </div>
+    </div>
+    <div class="row">
+      <label for="used-tokens">Used tokens</label>
+      <input id="used-tokens" type="number" min="0" step="1000" value="50000">
+    </div>
+    <div class="row">
+      <label for="window-tokens">Window tokens</label>
+      <input id="window-tokens" type="number" min="1" step="1000" value="100000">
+    </div>
+
+    <div class="group">
+      <h2>Presets</h2>
+      <div id="preset-buttons" class="buttons"></div>
+    </div>
+
+    <div class="group">
+      <h2>Lifecycle</h2>
+      <div id="lifecycle-buttons" class="buttons"></div>
+    </div>
+
+    <div class="group buttons">
+      <button id="apply" class="primary" type="button">Apply telemetry</button>
+      <button id="read-target" type="button">Read target</button>
+    </div>
+  </section>
+
+  <section>
+    <h2>Target Factors</h2>
+    <div id="meters" class="meters"></div>
+
+    <div class="group">
+      <h2>Last Telemetry</h2>
+      <pre id="last-telemetry">No telemetry sent</pre>
+    </div>
+
+    <div class="group">
+      <h2>Readback</h2>
+      <pre id="readback">No readback yet</pre>
+    </div>
+
+    <div class="group">
+      <h2>Log</h2>
+      <pre id="log" class="log"></pre>
+    </div>
+  </section>
+</main>
+
+<script type="module">
+import {
+  DEFAULT_LAB_STATE,
+  LIFECYCLE_EVENTS,
+  PRESSURE_PRESETS,
+  clampRatio,
+  makeLifecycleDelivery,
+  makeLifecycleEvent,
+  makeTelemetry,
+  makeTelemetryDelivery,
+  normalizeLabState,
+  summarizeSessionVitality,
+} from './lab.js';
+
+const pending = new Map();
+const controls = {
+  targetCanvas: document.getElementById('target-canvas'),
+  provider: document.getElementById('provider'),
+  delivery: document.getElementById('delivery'),
+  mode: document.getElementById('metric-mode'),
+  precision: document.getElementById('precision'),
+  usedRatio: document.getElementById('used-ratio'),
+  usedRatioValue: document.getElementById('used-ratio-value'),
+  usedTokens: document.getElementById('used-tokens'),
+  windowTokens: document.getElementById('window-tokens'),
+};
+const hostDot = document.getElementById('host-dot');
+const hostStatus = document.getElementById('host-status');
+const presetButtons = document.getElementById('preset-buttons');
+const lifecycleButtons = document.getElementById('lifecycle-buttons');
+const meters = document.getElementById('meters');
+const lastTelemetry = document.getElementById('last-telemetry');
+const readback = document.getElementById('readback');
+const logEl = document.getElementById('log');
+
+const params = new URLSearchParams(location.search);
+controls.targetCanvas.value = params.get('target') || DEFAULT_LAB_STATE.targetCanvasId;
+controls.delivery.value = params.get('delivery') || DEFAULT_LAB_STATE.delivery;
+controls.provider.value = params.get('provider') || DEFAULT_LAB_STATE.provider;
+
+function post(type, payload) {
+  window.webkit?.messageHandlers?.headsup?.postMessage(
+    payload === undefined ? { type } : { type, payload },
+  );
+}
+
+function request(type, payload, timeoutMs = 3000) {
+  const request_id = 'vitality-lab-' + Math.random().toString(36).slice(2, 10);
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      pending.delete(request_id);
+      reject(new Error(`TIMEOUT: ${type}`));
+    }, timeoutMs);
+    pending.set(request_id, { resolve, reject, timer });
+    post(type, { ...payload, request_id });
+  });
+}
+
+function setHostStatus(kind, text) {
+  hostDot.className = 'dot ' + (kind || '');
+  hostStatus.textContent = text;
+}
+
+function log(message) {
+  const time = new Date().toISOString().slice(11, 19);
+  logEl.textContent = `${time} ${message}\n${logEl.textContent}`;
+}
+
+window.headsup = window.headsup || {};
+window.headsup.receive = function receive(b64) {
+  let msg;
+  try {
+    msg = JSON.parse(atob(b64));
+  } catch (error) {
+    log(`decode error: ${error}`);
+    return;
+  }
+
+  if (msg?.type === 'canvas.response' && msg.request_id) {
+    const entry = pending.get(msg.request_id);
+    if (!entry) return;
+    pending.delete(msg.request_id);
+    clearTimeout(entry.timer);
+    if (msg.status === 'ok') entry.resolve(msg);
+    else entry.reject(new Error(`${msg.code || 'ERROR'}: ${msg.message || 'unknown'}`));
+  }
+};
+
+function stateFromControls(overrides = {}) {
+  return normalizeLabState({
+    provider: controls.provider.value,
+    sessionId: 'session-vitality-lab-' + controls.provider.value,
+    mode: controls.mode.value,
+    usedRatio: controls.usedRatio.value,
+    usedTokens: controls.usedTokens.value,
+    windowTokens: controls.windowTokens.value,
+    precision: controls.precision.value,
+    delivery: controls.delivery.value,
+    targetCanvasId: controls.targetCanvas.value,
+    ...overrides,
+  });
+}
+
+function syncDerivedControls({ syncTokensFromRatio = false } = {}) {
+  const ratio = clampRatio(controls.usedRatio.value);
+  controls.usedRatioValue.textContent = `${Math.round(ratio * 100)}%`;
+  if (syncTokensFromRatio && controls.mode.value === 'tokens') {
+    const windowTokens = Math.max(1, Number(controls.windowTokens.value) || DEFAULT_LAB_STATE.windowTokens);
+    controls.usedTokens.value = Math.round(windowTokens * ratio);
+  }
+  renderTelemetryPreview();
+}
+
+function syncRatioFromTokenControls() {
+  if (controls.mode.value === 'tokens') {
+    const usedTokens = Math.max(0, Number(controls.usedTokens.value) || 0);
+    const windowTokens = Math.max(1, Number(controls.windowTokens.value) || DEFAULT_LAB_STATE.windowTokens);
+    controls.usedRatio.value = clampRatio(usedTokens / windowTokens);
+  }
+  syncDerivedControls();
+}
+
+function renderTelemetryPreview() {
+  lastTelemetry.textContent = JSON.stringify(makeTelemetry(stateFromControls()), null, 2);
+}
+
+function setPreset(id) {
+  const preset = PRESSURE_PRESETS.find((item) => item.id === id) || PRESSURE_PRESETS[0];
+  controls.mode.value = preset.mode;
+  controls.usedRatio.value = preset.usedRatio;
+  syncDerivedControls();
+  return stateFromControls();
+}
+
+function dispatchCanvasSend(delivery) {
+  post('canvas.send', delivery);
+}
+
+async function applyTelemetry(overrides = {}) {
+  const state = stateFromControls(overrides);
+  const telemetry = makeTelemetry(state);
+  const delivery = makeTelemetryDelivery(state, telemetry);
+  dispatchCanvasSend(delivery);
+  lastTelemetry.textContent = JSON.stringify(telemetry, null, 2);
+  log(`sent telemetry ${state.mode} ${Math.round(state.usedRatio * 100)}% via ${state.delivery}`);
+  setTimeout(() => { void readTarget(); }, 180);
+  return telemetry;
+}
+
+async function sendLifecycle(eventName) {
+  const state = stateFromControls();
+  const event = makeLifecycleEvent(eventName, state);
+  const delivery = makeLifecycleDelivery(state, event);
+  dispatchCanvasSend(delivery);
+  log(`sent lifecycle ${eventName} via ${state.delivery}`);
+  setTimeout(() => { void readTarget(); }, 180);
+  return event;
+}
+
+async function readTarget() {
+  const target = controls.targetCanvas.value || DEFAULT_LAB_STATE.targetCanvasId;
+  try {
+    const response = await request('canvas.eval', {
+      id: target,
+      js: 'JSON.stringify(window.__sigilDebug?.snapshot?.().sessionVitality ?? null)',
+    }, 4000);
+    const parsed = parseReadback(response.result);
+    renderFactors(parsed);
+    readback.textContent = JSON.stringify(parsed, null, 2);
+    log(`read ${target}`);
+    return parsed;
+  } catch (error) {
+    readback.textContent = String(error);
+    renderFactors(null);
+    log(`read failed: ${error.message || error}`);
+    return null;
+  }
+}
+
+function parseReadback(value) {
+  if (typeof value !== 'string') return value ?? null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function renderFactors(snapshot) {
+  const summary = summarizeSessionVitality(snapshot);
+  const specs = [
+    ['pressure', summary.pressure, 'hot'],
+    ['remainingRatio', summary.remainingRatio, 'ok'],
+    ['confidence', summary.confidence, 'ok'],
+    ['auraReachMultiplier', summary.auraReachMultiplier, 'warn'],
+    ['auraIntensityMultiplier', summary.auraIntensityMultiplier, 'warn'],
+    ['rotationMultiplier', summary.rotationMultiplier, 'warn'],
+    ['brightnessMultiplier', summary.brightnessMultiplier, 'warn'],
+    ['flickerAmount', summary.flickerAmount, 'hot'],
+    ['scaleMultiplier', summary.scaleMultiplier, 'accent'],
+    ['refreshProgress', summary.refreshProgress, 'accent'],
+  ];
+  meters.innerHTML = '';
+  for (const [name, value, tone] of specs) {
+    const row = document.createElement('div');
+    row.className = 'meter';
+    const label = document.createElement('div');
+    label.className = 'label';
+    label.textContent = name;
+    const track = document.createElement('div');
+    track.className = 'track';
+    const fill = document.createElement('div');
+    fill.className = `fill ${tone === 'accent' ? '' : tone}`;
+    const normalized = value == null ? 0 : Math.max(0, Math.min(1.35, Number(value))) / 1.35;
+    fill.style.width = `${Math.round(normalized * 100)}%`;
+    track.append(fill);
+    const number = document.createElement('div');
+    number.className = 'value';
+    number.textContent = value == null ? '-' : value.toFixed(3);
+    row.append(label, track, number);
+    meters.append(row);
+  }
+}
+
+function renderButtons() {
+  for (const preset of PRESSURE_PRESETS) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = preset.label;
+    button.addEventListener('click', () => {
+      setPreset(preset.id);
+      void applyTelemetry();
+    });
+    presetButtons.append(button);
+  }
+
+  for (const eventName of LIFECYCLE_EVENTS) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = eventName.replaceAll('_', ' ');
+    button.addEventListener('click', () => {
+      void sendLifecycle(eventName);
+    });
+    lifecycleButtons.append(button);
+  }
+}
+
+for (const element of [controls.targetCanvas, controls.provider, controls.delivery, controls.precision]) {
+  element.addEventListener('input', () => syncDerivedControls());
+  element.addEventListener('change', () => syncDerivedControls());
+}
+controls.mode.addEventListener('change', () => syncDerivedControls({ syncTokensFromRatio: controls.mode.value === 'tokens' }));
+controls.usedRatio.addEventListener('input', () => syncDerivedControls({ syncTokensFromRatio: true }));
+controls.usedRatio.addEventListener('change', () => syncDerivedControls({ syncTokensFromRatio: true }));
+controls.usedTokens.addEventListener('input', syncRatioFromTokenControls);
+controls.usedTokens.addEventListener('change', syncRatioFromTokenControls);
+controls.windowTokens.addEventListener('input', () => syncDerivedControls({ syncTokensFromRatio: controls.mode.value === 'tokens' }));
+controls.windowTokens.addEventListener('change', () => syncDerivedControls({ syncTokensFromRatio: controls.mode.value === 'tokens' }));
+document.getElementById('apply').addEventListener('click', () => { void applyTelemetry(); });
+document.getElementById('read-target').addEventListener('click', () => { void readTarget(); });
+
+renderButtons();
+syncDerivedControls();
+renderFactors(null);
+setHostStatus(window.webkit?.messageHandlers?.headsup ? 'ok' : 'error', window.webkit?.messageHandlers?.headsup ? 'host ready' : 'host unavailable');
+const manifest = {
+  name: 'sigil-session-vitality-lab',
+  accepts: ['agent.session.telemetry', 'agent.session.lifecycle'],
+  emits: ['canvas.send', 'canvas.eval'],
+};
+window.headsup.manifest = manifest;
+post('ready', manifest);
+
+window.__sessionVitalityLab = {
+  snapshot() {
+    return {
+      state: stateFromControls(),
+      telemetry: makeTelemetry(stateFromControls()),
+      readback: parseReadback(readback.textContent),
+    };
+  },
+  setPreset,
+  applyTelemetry,
+  sendLifecycle,
+  readTarget,
+};
+</script>
+</body>
+</html>

--- a/apps/sigil/tests/session-vitality/lab.js
+++ b/apps/sigil/tests/session-vitality/lab.js
@@ -1,0 +1,189 @@
+export const PRESSURE_PRESETS = Object.freeze([
+    { id: 'unknown', label: 'Unknown', mode: 'unknown', usedRatio: 0 },
+    { id: 'low', label: '20%', mode: 'ratio', usedRatio: 0.2 },
+    { id: 'middle', label: '50%', mode: 'ratio', usedRatio: 0.5 },
+    { id: 'high', label: '80%', mode: 'ratio', usedRatio: 0.8 },
+    { id: 'near-full', label: '95%', mode: 'ratio', usedRatio: 0.95 },
+]);
+
+export const LIFECYCLE_EVENTS = Object.freeze([
+    'context_compaction_started',
+    'context_compacted',
+    'handoff_started',
+    'handoff_completed',
+]);
+
+export const DEFAULT_LAB_STATE = Object.freeze({
+    provider: 'codex',
+    sessionId: 'session-vitality-lab',
+    mode: 'ratio',
+    usedRatio: 0.5,
+    usedTokens: 50000,
+    windowTokens: 100000,
+    precision: 'exact',
+    delivery: 'agent-terminal',
+    targetCanvasId: 'avatar-main',
+    terminalCanvasId: 'sigil-codex-terminal',
+});
+
+export function clampRatio(value) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) return 0;
+    return Math.max(0, Math.min(1, number));
+}
+
+export function clampTokenCount(value) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) return 0;
+    return Math.max(0, Math.round(number));
+}
+
+export function normalizeLabState(input = {}) {
+    const usedRatio = clampRatio(input.usedRatio ?? input.used_ratio ?? DEFAULT_LAB_STATE.usedRatio);
+    let windowTokens = clampTokenCount(input.windowTokens ?? input.window_tokens ?? DEFAULT_LAB_STATE.windowTokens);
+    let usedTokens = clampTokenCount(input.usedTokens ?? input.used_tokens ?? DEFAULT_LAB_STATE.usedTokens);
+    if (windowTokens <= 0) windowTokens = DEFAULT_LAB_STATE.windowTokens;
+    usedTokens = Math.min(usedTokens, windowTokens);
+
+    return {
+        ...DEFAULT_LAB_STATE,
+        ...input,
+        provider: String(input.provider || DEFAULT_LAB_STATE.provider),
+        sessionId: String(input.sessionId || input.session_id || DEFAULT_LAB_STATE.sessionId),
+        mode: String(input.mode || DEFAULT_LAB_STATE.mode),
+        usedRatio,
+        usedTokens,
+        windowTokens,
+        precision: normalizePrecision(input.precision || DEFAULT_LAB_STATE.precision),
+        delivery: String(input.delivery || DEFAULT_LAB_STATE.delivery),
+        targetCanvasId: String(input.targetCanvasId || input.target_canvas_id || DEFAULT_LAB_STATE.targetCanvasId),
+        terminalCanvasId: String(input.terminalCanvasId || input.terminal_canvas_id || DEFAULT_LAB_STATE.terminalCanvasId),
+    };
+}
+
+export function makeMetric(value, unit, state = {}) {
+    const normalized = normalizeLabState(state);
+    return {
+        value,
+        unit,
+        source: {
+            kind: 'manual_fixture',
+            provider_surface: 'sigil-session-vitality-lab',
+            stability: 'synthetic',
+            precision: normalized.precision,
+        },
+    };
+}
+
+export function makeTelemetry(input = {}, observedAt = new Date().toISOString()) {
+    const state = normalizeLabState(input);
+    const context = {};
+    const usedRatio = clampRatio(state.usedRatio);
+    const remainingRatio = clampRatio(1 - usedRatio);
+
+    if (state.mode === 'ratio') {
+        context.used_ratio = makeMetric(usedRatio, 'ratio', state);
+        context.remaining_ratio = makeMetric(remainingRatio, 'ratio', state);
+    } else if (state.mode === 'used_ratio') {
+        context.used_ratio = makeMetric(usedRatio, 'ratio', state);
+    } else if (state.mode === 'remaining_ratio') {
+        context.remaining_ratio = makeMetric(remainingRatio, 'ratio', state);
+    } else if (state.mode === 'tokens') {
+        context.used_tokens = makeMetric(state.usedTokens, 'tokens', state);
+        context.window_tokens = makeMetric(state.windowTokens, 'tokens', state);
+    }
+
+    return {
+        type: 'agent.session.telemetry',
+        provider: state.provider,
+        session_id: state.sessionId,
+        observed_at: observedAt,
+        context,
+        diagnostics: [],
+    };
+}
+
+export function makeLifecycleEvent(event, input = {}, observedAt = new Date().toISOString()) {
+    const state = normalizeLabState(input);
+    return {
+        type: 'agent.session.lifecycle',
+        provider: state.provider,
+        session_id: state.sessionId,
+        observed_at: observedAt,
+        event,
+        source: {
+            kind: 'manual_fixture',
+            provider_surface: 'sigil-session-vitality-lab',
+            stability: 'synthetic',
+            precision: 'exact',
+        },
+    };
+}
+
+export function makeTelemetryDelivery(input = {}, telemetry = makeTelemetry(input)) {
+    const state = normalizeLabState(input);
+    if (state.delivery === 'direct') {
+        return {
+            target: state.targetCanvasId,
+            message: telemetry,
+        };
+    }
+    return {
+        target: state.targetCanvasId,
+        message: {
+            type: 'canvas_message',
+            id: state.terminalCanvasId,
+            payload: {
+                type: 'agent_terminal.session_telemetry',
+                payload: { telemetry },
+            },
+        },
+    };
+}
+
+export function makeLifecycleDelivery(input = {}, event = makeLifecycleEvent('context_compacted', input)) {
+    const state = normalizeLabState(input);
+    if (state.delivery === 'direct') {
+        return {
+            target: state.targetCanvasId,
+            message: event,
+        };
+    }
+    return {
+        target: state.targetCanvasId,
+        message: {
+            type: 'canvas_message',
+            id: state.terminalCanvasId,
+            payload: {
+                type: 'agent_terminal.session_telemetry',
+                payload: { lifecycle_events: [event] },
+            },
+        },
+    };
+}
+
+export function summarizeSessionVitality(snapshot) {
+    const factors = snapshot?.factors || snapshot || {};
+    return {
+        confidence: finiteOrNull(factors.confidence),
+        pressure: finiteOrNull(factors.pressure),
+        usedRatio: finiteOrNull(factors.usedRatio),
+        remainingRatio: finiteOrNull(factors.remainingRatio),
+        auraReachMultiplier: finiteOrNull(factors.auraReachMultiplier),
+        auraIntensityMultiplier: finiteOrNull(factors.auraIntensityMultiplier),
+        rotationMultiplier: finiteOrNull(factors.rotationMultiplier),
+        brightnessMultiplier: finiteOrNull(factors.brightnessMultiplier),
+        flickerAmount: finiteOrNull(factors.flickerAmount),
+        scaleMultiplier: finiteOrNull(factors.scaleMultiplier),
+        refreshProgress: finiteOrNull(factors.refreshProgress),
+    };
+}
+
+function normalizePrecision(value) {
+    return ['exact', 'derived', 'estimated'].includes(value) ? value : 'exact';
+}
+
+function finiteOrNull(value) {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : null;
+}

--- a/tests/renderer/session-vitality-lab.test.mjs
+++ b/tests/renderer/session-vitality-lab.test.mjs
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  makeLifecycleDelivery,
+  makeLifecycleEvent,
+  makeTelemetry,
+  makeTelemetryDelivery,
+  normalizeLabState,
+  summarizeSessionVitality,
+} from '../../apps/sigil/tests/session-vitality/lab.js';
+
+test('session vitality lab builds ratio telemetry with provenance', () => {
+  const telemetry = makeTelemetry({
+    provider: 'codex',
+    mode: 'ratio',
+    usedRatio: 0.82,
+    precision: 'derived',
+  }, '2026-05-02T12:00:00.000Z');
+
+  assert.equal(telemetry.type, 'agent.session.telemetry');
+  assert.equal(telemetry.provider, 'codex');
+  assert.equal(telemetry.context.used_ratio.value, 0.82);
+  assert.equal(telemetry.context.remaining_ratio.value, 0.18000000000000005);
+  assert.equal(telemetry.context.used_ratio.source.provider_surface, 'sigil-session-vitality-lab');
+  assert.equal(telemetry.context.used_ratio.source.precision, 'derived');
+});
+
+test('session vitality lab can emit token-only telemetry', () => {
+  const telemetry = makeTelemetry({
+    mode: 'tokens',
+    usedTokens: 75000,
+    windowTokens: 100000,
+  });
+
+  assert.equal(telemetry.context.used_ratio, undefined);
+  assert.equal(telemetry.context.remaining_ratio, undefined);
+  assert.equal(telemetry.context.used_tokens.value, 75000);
+  assert.equal(telemetry.context.window_tokens.value, 100000);
+});
+
+test('session vitality lab can emit unknown telemetry', () => {
+  const telemetry = makeTelemetry({ mode: 'unknown' });
+
+  assert.deepEqual(telemetry.context, {});
+});
+
+test('session vitality lab wraps telemetry in the Agent Terminal envelope by default', () => {
+  const telemetry = makeTelemetry({ usedRatio: 0.9 });
+  const delivery = makeTelemetryDelivery({
+    targetCanvasId: 'avatar-main',
+    terminalCanvasId: 'sigil-codex-terminal',
+  }, telemetry);
+
+  assert.equal(delivery.target, 'avatar-main');
+  assert.equal(delivery.message.type, 'canvas_message');
+  assert.equal(delivery.message.id, 'sigil-codex-terminal');
+  assert.equal(delivery.message.payload.type, 'agent_terminal.session_telemetry');
+  assert.equal(delivery.message.payload.payload.telemetry, telemetry);
+});
+
+test('session vitality lab supports direct session event delivery', () => {
+  const telemetry = makeTelemetry({ usedRatio: 0.9 });
+  const delivery = makeTelemetryDelivery({
+    delivery: 'direct',
+    targetCanvasId: 'avatar-main',
+  }, telemetry);
+
+  assert.equal(delivery.target, 'avatar-main');
+  assert.equal(delivery.message, telemetry);
+});
+
+test('session vitality lab wraps lifecycle events for Agent Terminal delivery', () => {
+  const event = makeLifecycleEvent('context_compacted', {
+    provider: 'claude-code',
+  }, '2026-05-02T12:00:00.000Z');
+  const delivery = makeLifecycleDelivery({
+    targetCanvasId: 'avatar-main',
+  }, event);
+
+  assert.equal(event.type, 'agent.session.lifecycle');
+  assert.equal(event.provider, 'claude-code');
+  assert.equal(delivery.message.payload.payload.lifecycle_events[0], event);
+});
+
+test('session vitality lab normalizes ratios and token counts', () => {
+  const state = normalizeLabState({
+    usedRatio: 12,
+    usedTokens: 200000,
+    windowTokens: 100000,
+    precision: 'not-real',
+  });
+
+  assert.equal(state.usedRatio, 1);
+  assert.equal(state.usedTokens, 100000);
+  assert.equal(state.windowTokens, 100000);
+  assert.equal(state.precision, 'exact');
+});
+
+test('session vitality lab summarizes renderer vitality snapshots', () => {
+  const summary = summarizeSessionVitality({
+    factors: {
+      pressure: 0.88,
+      remainingRatio: 0.12,
+      confidence: 1,
+      scaleMultiplier: 'bad',
+    },
+  });
+
+  assert.equal(summary.pressure, 0.88);
+  assert.equal(summary.remainingRatio, 0.12);
+  assert.equal(summary.confidence, 1);
+  assert.equal(summary.scaleMultiplier, null);
+});

--- a/tests/scenarios/sigil/session-vitality/smoke.sh
+++ b/tests/scenarios/sigil/session-vitality/smoke.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "$0")/../../../lib/visual-harness.sh"
+
+AVATAR_ID="${AOS_SIGIL_AVATAR_ID:-sigil-session-vitality-avatar}"
+LAB_ID="${AOS_SIGIL_VITALITY_LAB_ID:-sigil-session-vitality-lab}"
+INSPECTOR_ID="${AOS_SIGIL_INSPECTOR_ID:-sigil-session-vitality-inspector}"
+HIT_ID="sigil-hit-$AVATAR_ID"
+RADIAL_ID="sigil-radial-menu-$AVATAR_ID"
+RENDERER_URL="${AOS_SIGIL_RENDERER_URL:-aos://sigil/renderer/index.html}"
+LAB_URL="${AOS_SIGIL_VITALITY_LAB_URL:-aos://sigil/tests/session-vitality/index.html?target=$AVATAR_ID}"
+
+aos_bin="$(aos_visual_aos)"
+
+config_get_string() {
+  "$aos_bin" config get "$1" --json 2>/dev/null | python3 -c '
+import json
+import sys
+try:
+    value = json.load(sys.stdin)
+except Exception:
+    value = ""
+print("" if value is None else str(value))
+' 2>/dev/null || true
+}
+
+OLD_TOOLKIT_ROOT="$(config_get_string content.roots.toolkit)"
+OLD_SIGIL_ROOT="$(config_get_string content.roots.sigil)"
+
+restore_roots() {
+  if [[ -n "$OLD_TOOLKIT_ROOT" ]]; then
+    "$aos_bin" set content.roots.toolkit "$OLD_TOOLKIT_ROOT" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$OLD_SIGIL_ROOT" ]]; then
+    "$aos_bin" set content.roots.sigil "$OLD_SIGIL_ROOT" >/dev/null 2>&1 || true
+  fi
+}
+
+cleanup() {
+  aos_visual_remove_canvas "$LAB_ID"
+  aos_visual_remove_canvas "$RADIAL_ID"
+  aos_visual_remove_canvas "$HIT_ID"
+  aos_visual_remove_canvas "$AVATAR_ID"
+  aos_visual_remove_canvas "$INSPECTOR_ID"
+  restore_roots
+}
+trap cleanup EXIT
+
+echo "INFO: launching Sigil session vitality lab smoke with active repo daemon."
+"$aos_bin" ready >/dev/null
+aos_visual_prepare_live_roots
+aos_visual_seed_sigil repo
+
+aos_visual_remove_canvas "$LAB_ID"
+aos_visual_remove_canvas "$RADIAL_ID"
+aos_visual_remove_canvas "$HIT_ID"
+aos_visual_remove_canvas "$AVATAR_ID"
+aos_visual_remove_canvas "$INSPECTOR_ID"
+
+aos_visual_launch_canvas_inspector "$INSPECTOR_ID"
+if [[ "$RENDERER_URL" == "aos://sigil/renderer/index.html" ]]; then
+  aos_visual_launch_sigil_avatar "$AVATAR_ID"
+else
+  "$aos_bin" show create \
+    --id "$AVATAR_ID" \
+    --url "$RENDERER_URL" \
+    --track union >/dev/null
+fi
+aos_visual_wait_sigil_avatar_ready "$AVATAR_ID"
+aos_visual_show_sigil_avatar "$AVATAR_ID"
+aos_visual_place_sigil_avatar_for_manual_test "$AVATAR_ID"
+aos_visual_avoid_sigil_avatar_overlap "$AVATAR_ID" "$INSPECTOR_ID"
+
+"$aos_bin" show create \
+  --id "$LAB_ID" \
+  --url "$LAB_URL" \
+  --at 80,80,760,720 \
+  --interactive \
+  --focus >/dev/null
+
+"$aos_bin" show wait \
+  --id "$LAB_ID" \
+  --js '!!window.__sessionVitalityLab && window.headsup?.manifest?.name === "sigil-session-vitality-lab"' \
+  --timeout 8s >/dev/null
+
+"$aos_bin" show eval \
+  --id "$LAB_ID" \
+  --js 'window.__sessionVitalityLab.setPreset("near-full"); window.__sessionVitalityLab.applyTelemetry(); "ok"' >/dev/null
+
+sleep 0.5
+
+snapshot="$("$aos_bin" show eval --id "$AVATAR_ID" --js 'JSON.stringify(window.__sigilDebug.snapshot().sessionVitality?.factors || null)')"
+python3 - "$snapshot" <<'PY'
+import json
+import sys
+
+outer = json.loads(sys.argv[1])
+factors = json.loads(outer.get("result") or "null")
+if not isinstance(factors, dict):
+    print("FAIL: no session vitality factors returned", file=sys.stderr)
+    raise SystemExit(1)
+
+pressure = factors.get("pressure")
+aura = factors.get("auraReachMultiplier")
+rotation = factors.get("rotationMultiplier")
+if not (isinstance(pressure, (int, float)) and pressure >= 0.94):
+    print(f"FAIL: expected pressure >= 0.94, got {pressure!r}", file=sys.stderr)
+    raise SystemExit(1)
+if not (isinstance(aura, (int, float)) and aura < 0.5):
+    print(f"FAIL: expected compressed aura reach, got {aura!r}", file=sys.stderr)
+    raise SystemExit(1)
+if not (isinstance(rotation, (int, float)) and rotation < 0.35):
+    print(f"FAIL: expected slowed rotation, got {rotation!r}", file=sys.stderr)
+    raise SystemExit(1)
+
+print(json.dumps({
+    "pressure": pressure,
+    "auraReachMultiplier": aura,
+    "rotationMultiplier": rotation,
+}, sort_keys=True))
+PY
+
+echo "PASS: session vitality lab delivered synthetic pressure to Sigil avatar."


### PR DESCRIPTION
## Summary

- Add a dedicated Sigil test harness at `apps/sigil/tests/session-vitality/` for synthetic session pressure and lifecycle events.
- Cover the harness telemetry/envelope builders with focused Node tests.
- Add an AOS smoke scenario that launches a disposable avatar plus lab, sends synthetic pressure through the lab, and verifies non-neutral avatar vitality factors.

## Verification

- `node --test tests/renderer/session-vitality-lab.test.mjs`
- `node --test tests/renderer/*.test.mjs`
- `node --check apps/sigil/tests/session-vitality/lab.js`
- `bash -n tests/scenarios/sigil/session-vitality/smoke.sh`
- `git diff --check`
- `AOS=/Users/Michael/Code/agent-os/./aos AOS_SIGIL_RENDERER_URL='http://127.0.0.1:18784/sigil/renderer/index.html' AOS_SIGIL_VITALITY_LAB_URL='http://127.0.0.1:18784/sigil/tests/session-vitality/index.html?target=sigil-session-vitality-avatar' bash tests/scenarios/sigil/session-vitality/smoke.sh`

The URL overrides were only needed because this was verified from an unmerged clean worktree while the live daemon content root still pointed at the original checkout.