### PR TITLE
Reset Sigil vitality after refresh lifecycle

### DIFF
--- a/apps/sigil/renderer/session-vitality.js
+++ b/apps/sigil/renderer/session-vitality.js
@@ -149,6 +149,10 @@ export function createSessionVitalityController(options = {}) {
         if (event?.type !== 'agent.session.lifecycle') return snapshot();
         lastLifecycleEvent = event;
         if (isRefreshLifecycleEvent(event)) {
+            if (isRefreshCompletionLifecycleEvent(event)) {
+                telemetry = null;
+                factors = { ...DEFAULT_SESSION_VITALITY_FACTORS };
+            }
             refreshStartedAt = now();
         }
         return snapshot();
@@ -200,6 +204,13 @@ function isRefreshLifecycleEvent(event) {
         'context_compaction_started',
         'context_compacted',
         'handoff_started',
+        'handoff_completed',
+    ].includes(event.event);
+}
+
+function isRefreshCompletionLifecycleEvent(event) {
+    return [
+        'context_compacted',
         'handoff_completed',
     ].includes(event.event);
 }

--- a/apps/sigil/tests/session-vitality/index.html
+++ b/apps/sigil/tests/session-vitality/index.html
@@ -491,6 +491,7 @@ async function sendLifecycle(eventName) {
   dispatchCanvasSend(delivery);
   log(`sent lifecycle ${eventName} via ${state.delivery}`);
   setTimeout(() => { void readTarget(); }, 180);
+  setTimeout(() => { void readTarget(); }, 1400);
   return event;
 }
 

--- a/tests/renderer/session-vitality.test.mjs
+++ b/tests/renderer/session-vitality.test.mjs
@@ -130,4 +130,48 @@ test('controller accepts raw telemetry and lifecycle events without shared phase
   now += 1200;
   frame = controller.tick(0, now);
   assert.equal(frame.scaleMultiplier, 1);
+  assert.equal(frame.pressure, null);
+  assert.equal(frame.auraReachMultiplier, 1);
+  assert.equal(frame.rotationMultiplier, 1);
+});
+
+test('refresh start preserves pressure until refresh completion resets visual vitality', () => {
+  let now = 2000;
+  const controller = createSessionVitalityController({
+    now: () => now,
+    refreshDurationMs: 1000,
+  });
+
+  controller.applyTelemetry({
+    type: 'agent.session.telemetry',
+    context: {
+      used_ratio: metric(0.95),
+    },
+  });
+  let frame = controller.tick(0, now);
+  assert.equal(frame.pressure, 0.95);
+  assert.ok(frame.auraReachMultiplier < 0.5);
+  assert.ok(frame.rotationMultiplier < 0.35);
+
+  controller.applyLifecycle({
+    type: 'agent.session.lifecycle',
+    event: 'context_compaction_started',
+    observed_at: '2026-05-02T12:00:00.000Z',
+  });
+  now += 100;
+  frame = controller.tick(0, now);
+  assert.equal(frame.pressure, 0.95);
+  assert.ok(frame.refreshProgress > 0);
+
+  controller.applyLifecycle({
+    type: 'agent.session.lifecycle',
+    event: 'context_compacted',
+    observed_at: '2026-05-02T12:00:01.000Z',
+  });
+  now += 1200;
+  frame = controller.tick(0, now);
+  assert.equal(frame.pressure, null);
+  assert.equal(frame.auraReachMultiplier, 1);
+  assert.equal(frame.rotationMultiplier, 1);
+  assert.equal(frame.brightnessMultiplier, 1);
 });

--- a/tests/scenarios/sigil/session-vitality/smoke.sh
+++ b/tests/scenarios/sigil/session-vitality/smoke.sh
@@ -121,4 +121,46 @@ print(json.dumps({
 }, sort_keys=True))
 PY
 
-echo "PASS: session vitality lab delivered synthetic pressure to Sigil avatar."
+"$aos_bin" show eval \
+  --id "$LAB_ID" \
+  --js 'window.__sessionVitalityLab.sendLifecycle("context_compacted"); "ok"' >/dev/null
+
+sleep 1.5
+
+reset_snapshot="$("$aos_bin" show eval --id "$AVATAR_ID" --js 'JSON.stringify(window.__sigilDebug.snapshot().sessionVitality?.factors || null)')"
+python3 - "$reset_snapshot" <<'PY'
+import json
+import sys
+
+outer = json.loads(sys.argv[1])
+factors = json.loads(outer.get("result") or "null")
+if not isinstance(factors, dict):
+    print("FAIL: no post-refresh session vitality factors returned", file=sys.stderr)
+    raise SystemExit(1)
+
+pressure = factors.get("pressure")
+aura = factors.get("auraReachMultiplier")
+rotation = factors.get("rotationMultiplier")
+brightness = factors.get("brightnessMultiplier")
+if pressure is not None:
+    print(f"FAIL: expected pressure to reset to unknown after refresh, got {pressure!r}", file=sys.stderr)
+    raise SystemExit(1)
+if aura != 1:
+    print(f"FAIL: expected full aura reach after refresh, got {aura!r}", file=sys.stderr)
+    raise SystemExit(1)
+if rotation != 1:
+    print(f"FAIL: expected normal rotation after refresh, got {rotation!r}", file=sys.stderr)
+    raise SystemExit(1)
+if brightness != 1:
+    print(f"FAIL: expected normal brightness after refresh, got {brightness!r}", file=sys.stderr)
+    raise SystemExit(1)
+
+print(json.dumps({
+    "pressure": pressure,
+    "auraReachMultiplier": aura,
+    "rotationMultiplier": rotation,
+    "brightnessMultiplier": brightness,
+}, sort_keys=True))
+PY
+
+echo "PASS: session vitality lab delivered synthetic pressure and refresh reset to Sigil avatar."


### PR DESCRIPTION
## Summary
- reset Sigil session vitality factors when refresh completion lifecycle events arrive
- keep refresh-start events pressure-aware until completion
- extend the lab readback and smoke scenario to assert post-refresh neutral vitality

## Verification
- `node --test tests/renderer/session-vitality.test.mjs`
- `node --test tests/renderer/session-vitality-lab.test.mjs`
- `node --check apps/sigil/renderer/session-vitality.js && node --check apps/sigil/tests/session-vitality/lab.js && bash -n tests/scenarios/sigil/session-vitality/smoke.sh && git diff --check`
- `node --test tests/renderer/*.test.mjs`
- `AOS=/Users/Michael/Code/agent-os/./aos AOS_SIGIL_AVATAR_ID=sigil-refresh-reset-smoke-avatar AOS_SIGIL_VITALITY_LAB_ID=sigil-refresh-reset-smoke-lab AOS_SIGIL_INSPECTOR_ID=sigil-refresh-reset-smoke-inspector AOS_SIGIL_RENDERER_URL='http://127.0.0.1:18786/sigil/renderer/index.html' AOS_SIGIL_VITALITY_LAB_URL='http://127.0.0.1:18786/sigil/tests/session-vitality/index.html?target=sigil-refresh-reset-smoke-avatar' bash tests/scenarios/sigil/session-vitality/smoke.sh`
