### PR TITLE
Live-send Sigil vitality lab control changes

### DIFF
--- a/apps/sigil/tests/session-vitality/index.html
+++ b/apps/sigil/tests/session-vitality/index.html
@@ -369,6 +369,7 @@ const meters = document.getElementById('meters');
 const lastTelemetry = document.getElementById('last-telemetry');
 const readback = document.getElementById('readback');
 const logEl = document.getElementById('log');
+let pendingTelemetryApply = null;
 
 const params = new URLSearchParams(location.search);
 controls.targetCanvas.value = params.get('target') || DEFAULT_LAB_STATE.targetCanvasId;
@@ -473,7 +474,28 @@ function dispatchCanvasSend(delivery) {
   post('canvas.send', delivery);
 }
 
+function clearPendingTelemetryApply() {
+  if (pendingTelemetryApply === null) return;
+  clearTimeout(pendingTelemetryApply);
+  pendingTelemetryApply = null;
+}
+
+function scheduleTelemetryApply(delayMs = 120) {
+  clearPendingTelemetryApply();
+  pendingTelemetryApply = setTimeout(() => {
+    pendingTelemetryApply = null;
+    void applyTelemetry();
+  }, delayMs);
+}
+
+async function flushTelemetryApply() {
+  if (pendingTelemetryApply === null) return null;
+  clearPendingTelemetryApply();
+  return applyTelemetry();
+}
+
 async function applyTelemetry(overrides = {}) {
+  clearPendingTelemetryApply();
   const state = stateFromControls(overrides);
   const telemetry = makeTelemetry(state);
   const delivery = makeTelemetryDelivery(state, telemetry);
@@ -485,6 +507,7 @@ async function applyTelemetry(overrides = {}) {
 }
 
 async function sendLifecycle(eventName) {
+  await flushTelemetryApply();
   const state = stateFromControls();
   const event = makeLifecycleEvent(eventName, state);
   const delivery = makeLifecycleDelivery(state, event);
@@ -587,13 +610,34 @@ for (const element of [controls.targetCanvas, controls.provider, controls.delive
   element.addEventListener('input', () => syncDerivedControls());
   element.addEventListener('change', () => syncDerivedControls());
 }
-controls.mode.addEventListener('change', () => syncDerivedControls({ syncTokensFromRatio: controls.mode.value === 'tokens' }));
-controls.usedRatio.addEventListener('input', () => syncDerivedControls({ syncTokensFromRatio: true }));
-controls.usedRatio.addEventListener('change', () => syncDerivedControls({ syncTokensFromRatio: true }));
-controls.usedTokens.addEventListener('input', syncRatioFromTokenControls);
-controls.usedTokens.addEventListener('change', syncRatioFromTokenControls);
-controls.windowTokens.addEventListener('input', () => syncDerivedControls({ syncTokensFromRatio: controls.mode.value === 'tokens' }));
-controls.windowTokens.addEventListener('change', () => syncDerivedControls({ syncTokensFromRatio: controls.mode.value === 'tokens' }));
+controls.mode.addEventListener('change', () => {
+  syncDerivedControls({ syncTokensFromRatio: controls.mode.value === 'tokens' });
+  scheduleTelemetryApply(0);
+});
+controls.usedRatio.addEventListener('input', () => {
+  syncDerivedControls({ syncTokensFromRatio: true });
+  scheduleTelemetryApply();
+});
+controls.usedRatio.addEventListener('change', () => {
+  syncDerivedControls({ syncTokensFromRatio: true });
+  scheduleTelemetryApply(0);
+});
+controls.usedTokens.addEventListener('input', () => {
+  syncRatioFromTokenControls();
+  scheduleTelemetryApply();
+});
+controls.usedTokens.addEventListener('change', () => {
+  syncRatioFromTokenControls();
+  scheduleTelemetryApply(0);
+});
+controls.windowTokens.addEventListener('input', () => {
+  syncDerivedControls({ syncTokensFromRatio: controls.mode.value === 'tokens' });
+  scheduleTelemetryApply();
+});
+controls.windowTokens.addEventListener('change', () => {
+  syncDerivedControls({ syncTokensFromRatio: controls.mode.value === 'tokens' });
+  scheduleTelemetryApply(0);
+});
 document.getElementById('apply').addEventListener('click', () => { void applyTelemetry(); });
 document.getElementById('read-target').addEventListener('click', () => { void readTarget(); });
 

--- a/tests/scenarios/sigil/session-vitality/smoke.sh
+++ b/tests/scenarios/sigil/session-vitality/smoke.sh
@@ -86,6 +86,33 @@ aos_visual_avoid_sigil_avatar_overlap "$AVATAR_ID" "$INSPECTOR_ID"
 
 "$aos_bin" show eval \
   --id "$LAB_ID" \
+  --js 'const slider = document.getElementById("used-ratio"); slider.value = "0.2"; slider.dispatchEvent(new Event("input", { bubbles: true })); "ok"' >/dev/null
+
+sleep 0.5
+
+slider_snapshot="$("$aos_bin" show eval --id "$AVATAR_ID" --js 'JSON.stringify(window.__sigilDebug.snapshot().sessionVitality?.factors || null)')"
+python3 - "$slider_snapshot" <<'PY'
+import json
+import sys
+
+outer = json.loads(sys.argv[1])
+factors = json.loads(outer.get("result") or "null")
+if not isinstance(factors, dict):
+    print("FAIL: no slider session vitality factors returned", file=sys.stderr)
+    raise SystemExit(1)
+
+pressure = factors.get("pressure")
+if not (isinstance(pressure, (int, float)) and 0.19 <= pressure <= 0.21):
+    print(f"FAIL: expected slider input to live-send pressure near 0.2, got {pressure!r}", file=sys.stderr)
+    raise SystemExit(1)
+
+print(json.dumps({
+    "liveSliderPressure": pressure,
+}, sort_keys=True))
+PY
+
+"$aos_bin" show eval \
+  --id "$LAB_ID" \
   --js 'window.__sessionVitalityLab.setPreset("near-full"); window.__sessionVitalityLab.applyTelemetry(); "ok"' >/dev/null
 
 sleep 0.5


### PR DESCRIPTION
## Summary
- live-send telemetry when the Session Vitality Lab context controls change
- flush pending telemetry before lifecycle events so lifecycle buttons operate on the current form state
- extend the smoke scenario to assert slider input changes avatar pressure without pressing Apply

## Verification
- `node --input-type=module --check < apps/sigil/tests/session-vitality/lab.js && node --input-type=module --check < <(sed -n '/<script type="module">/,/<\/script>/p' apps/sigil/tests/session-vitality/index.html | sed '1d;$d') && bash -n tests/scenarios/sigil/session-vitality/smoke.sh && git diff --check`
- `node --test tests/renderer/session-vitality-lab.test.mjs tests/renderer/session-vitality.test.mjs`
- `node --test tests/renderer/*.test.mjs`
- `AOS=/Users/Michael/Code/agent-os/./aos AOS_SIGIL_AVATAR_ID=sigil-live-controls-smoke-avatar AOS_SIGIL_VITALITY_LAB_ID=sigil-live-controls-smoke-lab AOS_SIGIL_INSPECTOR_ID=sigil-live-controls-smoke-inspector AOS_SIGIL_RENDERER_URL='http://127.0.0.1:18787/sigil/renderer/index.html' AOS_SIGIL_VITALITY_LAB_URL='http://127.0.0.1:18787/sigil/tests/session-vitality/index.html?target=sigil-live-controls-smoke-avatar' bash tests/scenarios/sigil/session-vitality/smoke.sh`
