### PR TITLE
Detect stale content roots in visual harnesses

### DIFF
--- a/tests/lib/visual-harness.sh
+++ b/tests/lib/visual-harness.sh
@@ -14,6 +14,79 @@ aos_visual_aos() {
   printf '%s\n' "${AOS:-$VISUAL_HARNESS_ROOT/aos}"
 }
 
+aos_visual_assert_live_content_root() {
+  local root_name="$1"
+  local expected_path="$2"
+  local aos_bin mode status_json verdict
+  aos_bin="$(aos_visual_aos)"
+  mode="${AOS_VISUAL_CONTENT_PREFLIGHT:-fail}"
+
+  status_json="$("$aos_bin" content status --json 2>/dev/null)" || {
+    echo "FAIL: unable to read active AOS content roots for visual harness preflight." >&2
+    echo "Expected ${root_name}: ${expected_path}" >&2
+    return 1
+  }
+
+  verdict="$(python3 - "$root_name" "$expected_path" "$status_json" <<'PY'
+import json
+import pathlib
+import sys
+
+root_name, expected_path, payload = sys.argv[1:4]
+try:
+    status = json.loads(payload)
+except Exception as error:
+    print(f"error\tinvalid content status JSON: {error}")
+    raise SystemExit(0)
+
+roots = status.get("roots") or {}
+active_path = roots.get(root_name)
+if not active_path:
+    print(f"mismatch\t{root_name}\t{expected_path}\t<missing>")
+    raise SystemExit(0)
+
+def normalize(path):
+    return str(pathlib.Path(path).expanduser().resolve(strict=False))
+
+expected = normalize(expected_path)
+active = normalize(active_path)
+if expected != active:
+    print(f"mismatch\t{root_name}\t{expected}\t{active}")
+else:
+    print(f"ok\t{root_name}\t{expected}\t{active}")
+PY
+)"
+
+  case "$verdict" in
+    ok$'\t'*)
+      return 0
+      ;;
+    error$'\t'*)
+      echo "FAIL: ${verdict#*$'\t'}" >&2
+      return 1
+      ;;
+    mismatch$'\t'*)
+      local name expected active prefix
+      IFS=$'\t' read -r _ name expected active <<<"$verdict"
+      prefix="FAIL"
+      if [[ "$mode" == "warn" ]]; then
+        prefix="WARN"
+      fi
+      echo "${prefix}: live content root mismatch for ${name}." >&2
+      echo "Expected: ${expected}" >&2
+      echo "Active:   ${active}" >&2
+      echo "The running daemon is not serving the worktree used by this visual harness." >&2
+      echo "Restart AOS after changing content.roots. If explicit HTTP URL overrides are intentional, rerun with AOS_VISUAL_CONTENT_PREFLIGHT=warn." >&2
+      [[ "$mode" == "warn" ]]
+      return $?
+      ;;
+    *)
+      echo "FAIL: unexpected visual harness content preflight result: ${verdict}" >&2
+      return 1
+      ;;
+  esac
+}
+
 aos_visual_seed_sigil() {
   local mode="${1:-repo}"
   local aos_bin
@@ -35,6 +108,8 @@ aos_visual_prepare_live_roots() {
   "$aos_bin" set content.roots.toolkit "$VISUAL_HARNESS_ROOT/packages/toolkit" >/dev/null
   "$aos_bin" set content.roots.sigil "$VISUAL_HARNESS_ROOT/apps/sigil" >/dev/null
   "$aos_bin" content wait --root toolkit --root sigil --auto-start --timeout 15s >/dev/null
+  aos_visual_assert_live_content_root toolkit "$VISUAL_HARNESS_ROOT/packages/toolkit"
+  aos_visual_assert_live_content_root sigil "$VISUAL_HARNESS_ROOT/apps/sigil"
 }
 
 aos_visual_configure_sigil_status_item() {

--- a/tests/visual-harness-content-preflight.sh
+++ b/tests/visual-harness-content-preflight.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+source "$ROOT/tests/lib/visual-harness.sh"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+fake_aos="$tmpdir/aos"
+cat >"$fake_aos" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "set" ]]; then
+  exit 0
+fi
+
+if [[ "${1:-}" == "content" && "${2:-}" == "wait" ]]; then
+  exit 0
+fi
+
+if [[ "${1:-}" == "content" && "${2:-}" == "status" ]]; then
+  python3 - <<'PY'
+import json
+import os
+
+print(json.dumps({
+    "address": "127.0.0.1",
+    "port": 65535,
+    "roots": {
+        "toolkit": os.environ["AOS_FAKE_TOOLKIT_ROOT"],
+        "sigil": os.environ["AOS_FAKE_SIGIL_ROOT"],
+    },
+}))
+PY
+  exit 0
+fi
+
+echo "unexpected fake aos invocation: $*" >&2
+exit 2
+SH
+chmod +x "$fake_aos"
+
+matching_out="$tmpdir/matching.out"
+matching_err="$tmpdir/matching.err"
+AOS="$fake_aos" \
+AOS_FAKE_TOOLKIT_ROOT="$ROOT/packages/toolkit" \
+AOS_FAKE_SIGIL_ROOT="$ROOT/apps/sigil" \
+  aos_visual_prepare_live_roots >"$matching_out" 2>"$matching_err"
+
+if [[ -s "$matching_err" ]]; then
+  echo "FAIL: expected matching content roots to be quiet" >&2
+  cat "$matching_err" >&2
+  exit 1
+fi
+
+mismatch_err="$tmpdir/mismatch.err"
+active_old_sigil="$(python3 - "$tmpdir/old-root/apps/sigil" <<'PY'
+import pathlib
+import sys
+
+print(pathlib.Path(sys.argv[1]).resolve(strict=False))
+PY
+)"
+if AOS="$fake_aos" \
+  AOS_FAKE_TOOLKIT_ROOT="$ROOT/packages/toolkit" \
+  AOS_FAKE_SIGIL_ROOT="$tmpdir/old-root/apps/sigil" \
+    aos_visual_prepare_live_roots >"$tmpdir/mismatch.out" 2>"$mismatch_err"; then
+  echo "FAIL: expected mismatched Sigil content root to fail" >&2
+  exit 1
+fi
+
+grep -Fq "FAIL: live content root mismatch for sigil" "$mismatch_err"
+grep -Fq "Expected: $ROOT/apps/sigil" "$mismatch_err"
+grep -Fq "Active:   $active_old_sigil" "$mismatch_err"
+grep -Fq "not serving the worktree" "$mismatch_err"
+
+warn_err="$tmpdir/warn.err"
+AOS="$fake_aos" \
+AOS_VISUAL_CONTENT_PREFLIGHT=warn \
+AOS_FAKE_TOOLKIT_ROOT="$tmpdir/old-root/packages/toolkit" \
+AOS_FAKE_SIGIL_ROOT="$ROOT/apps/sigil" \
+  aos_visual_prepare_live_roots >"$tmpdir/warn.out" 2>"$warn_err"
+
+grep -Fq "WARN: live content root mismatch for toolkit" "$warn_err"
+
+echo "PASS: visual harness content preflight detects stale active roots."


### PR DESCRIPTION
## Summary
- add a visual harness preflight that compares active daemon content roots with the harness worktree paths
- fail fast with expected/active roots when the daemon is serving a different checkout
- allow intentional HTTP-override runs to continue with `AOS_VISUAL_CONTENT_PREFLIGHT=warn`
- cover matching, failing, and warning behavior with a mock-AOS shell test

## Verification
- `bash -n tests/lib/visual-harness.sh && bash -n tests/visual-harness-content-preflight.sh && bash tests/visual-harness-content-preflight.sh && git diff --check`
- Expected-failure live harness check from a clean worktree against stale active daemon roots: `AOS=/Users/Michael/Code/agent-os/./aos AOS_SIGIL_AVATAR_ID=preflight-negative-avatar AOS_SIGIL_VITALITY_LAB_ID=preflight-negative-lab AOS_SIGIL_INSPECTOR_ID=preflight-negative-inspector bash tests/scenarios/sigil/session-vitality/smoke.sh` failed with `FAIL: live content root mismatch for toolkit` and restored content roots.
- HTTP override compatibility check: `AOS=/Users/Michael/Code/agent-os/./aos AOS_VISUAL_CONTENT_PREFLIGHT=warn AOS_SIGIL_AVATAR_ID=preflight-positive-avatar AOS_SIGIL_VITALITY_LAB_ID=preflight-positive-lab AOS_SIGIL_INSPECTOR_ID=preflight-positive-inspector AOS_SIGIL_RENDERER_URL='http://127.0.0.1:18788/sigil/renderer/index.html' AOS_SIGIL_VITALITY_LAB_URL='http://127.0.0.1:18788/sigil/tests/session-vitality/index.html?target=preflight-positive-avatar' bash tests/scenarios/sigil/session-vitality/smoke.sh`
