### PR TITLE
Add canvas owner metadata

### DIFF
--- a/packages/toolkit/runtime/canvas-lifecycle.js
+++ b/packages/toolkit/runtime/canvas-lifecycle.js
@@ -31,5 +31,7 @@ export function mergeCanvasLifecycleCanvas(existing, data) {
   if (windowNumbers !== undefined) next.windowNumbers = windowNumbers
   const segments = data?.segments ?? canvas.segments ?? existing?.segments
   if (segments !== undefined) next.segments = segments
+  const owner = data?.owner ?? canvas.owner ?? existing?.owner
+  if (owner !== undefined) next.owner = owner
   return next
 }

--- a/shared/schemas/daemon-event.md
+++ b/shared/schemas/daemon-event.md
@@ -50,7 +50,7 @@ Today `snapshot:true` replays current state for `display_geometry` and
 `canvas_lifecycle` immediately after the success response. For
 `canvas_lifecycle`, the replay uses the same payload shape as live events,
 including canvas metadata such as `parent`, `track`, `interactive`, `window_level`, `scope`,
-`windowNumbers`, the nested `canvas` object, and `segments` for DesktopWorld surfaces. For a
+`owner`, `windowNumbers`, the nested `canvas` object, and `segments` for DesktopWorld surfaces. For a
 DesktopWorld surface, snapshot replay sends `canvas_topology_settled` before
 the synthetic `created` lifecycle event so segment-aware renderers can identify
 their topology before normal boot side effects run.
@@ -76,7 +76,7 @@ their topology before normal boot side effects run.
 | Event | Data | Trigger |
 |-------|------|---------|
 | `canvas_message` | `{id, payload}` | Canvas JS called postMessage |
-| `canvas_lifecycle` | `{canvas_id, action, at, parent?, track?, interactive, window_level?, scope?, ttl?, cascade?, suspended?, windowNumbers?, canvas}` | Canvas created/removed/updated |
+| `canvas_lifecycle` | `{canvas_id, action, at, parent?, track?, interactive, window_level?, scope?, ttl?, cascade?, suspended?, owner?, windowNumbers?, canvas}` | Canvas created/removed/updated |
 | `canvas_segment_added` | `{canvas_id, display_id, index, dw_bounds, native_bounds}` | DesktopWorld surface gained a display-backed segment |
 | `canvas_segment_removed` | `{canvas_id, display_id, index, dw_bounds, native_bounds}` | DesktopWorld surface lost a display-backed segment |
 | `canvas_segment_changed` | `{canvas_id, display_id, index, dw_bounds, native_bounds}` | DesktopWorld surface segment ordering or bounds changed |

--- a/shared/schemas/daemon-ipc.md
+++ b/shared/schemas/daemon-ipc.md
@@ -96,6 +96,15 @@ canvas layering. Valid values are `automatic`, `floating`, `status_bar`, and
 `screen_saver`; `automatic` preserves the daemon default for the canvas'
 interactive mode.
 
+The official `aos show create` client attaches optional `owner` metadata to
+new canvases. This is diagnostic caller metadata, not a permission boundary or
+lease scheduler. The daemon stores it with the canvas, child canvases inherit it
+when they are created through a parent canvas, and it is exposed through
+`show.list`, `show.get`, and `canvas_lifecycle` so consumers can quickly identify
+which agent/session/worktree produced a visible surface. Current fields are
+`consumer_id`, `harness`, `pid`, `cwd`, optional `worktree_root`, and
+`runtime_mode`.
+
 `show.list`, `show.get`, and `canvas_lifecycle` metadata include
 `windowNumbers`, the native macOS window number or numbers backing a canvas.
 Normal canvases report one entry. DesktopWorld surfaces keep one logical canvas
@@ -107,6 +116,14 @@ DesktopWorld surfaces:
 ```json
 {
   "id": "avatar-main",
+  "owner": {
+    "consumer_id": "codex-abc123",
+    "harness": "codex",
+    "pid": 4242,
+    "cwd": "/Users/Michael/Code/agent-os-worktrees/example",
+    "worktree_root": "/Users/Michael/Code/agent-os-worktrees/example",
+    "runtime_mode": "repo"
+  },
   "track": "union",
   "windowNumbers": [91234],
   "segments": [

--- a/shared/schemas/daemon-request.schema.json
+++ b/shared/schemas/daemon-request.schema.json
@@ -113,7 +113,8 @@
         "surface": { "type": "string", "enum": ["desktop-world"] },
         "parent": { "type": "string" },
         "cascade": { "type": "boolean" },
-        "suspended": { "type": "boolean" }
+        "suspended": { "type": "boolean" },
+        "owner": { "$ref": "#/$defs/CanvasOwnerInfo" }
       },
       "oneOf": [
         { "required": ["at"], "not": { "required": ["surface"] } },
@@ -134,6 +135,19 @@
           }
         }
       ],
+      "additionalProperties": true
+    },
+    "CanvasOwnerInfo": {
+      "type": "object",
+      "required": ["consumer_id", "harness", "pid", "cwd", "runtime_mode"],
+      "properties": {
+        "consumer_id": { "type": "string", "minLength": 1 },
+        "harness": { "type": "string", "minLength": 1 },
+        "pid": { "type": "integer", "minimum": 1 },
+        "cwd": { "type": "string", "minLength": 1 },
+        "worktree_root": { "type": ["string", "null"] },
+        "runtime_mode": { "enum": ["repo", "installed"] }
+      },
       "additionalProperties": true
     },
     "ShowUpdateData": {

--- a/src/daemon/unified.swift
+++ b/src/daemon/unified.swift
@@ -424,6 +424,7 @@ class UnifiedDaemon {
         if let cascade = canvasInfo.cascade { payload["cascade"] = cascade }
         if let suspended = canvasInfo.suspended { payload["suspended"] = suspended }
         if let windowNumbers = canvasInfo.windowNumbers { payload["windowNumbers"] = windowNumbers }
+        if let owner = canvasInfo.owner, let ownerObject = encodedObject(owner) { payload["owner"] = ownerObject }
         if let segments = canvasInfo.segments {
             payload["segments"] = segments.map { segment in
                 [

--- a/src/display/canvas.swift
+++ b/src/display/canvas.swift
@@ -304,6 +304,7 @@ class Canvas {
     var suspended: Bool = false
     var cascadeFromParent: Bool = true
     var parent: String?
+    var owner: CanvasOwnerInfo?
 
     /// Direct create/update into a mixed-DPI straddling rect can still land at
     /// `frame + externalScreen.frame.origin` for specific ratios, while
@@ -514,7 +515,8 @@ class Canvas {
             cascade: cascadeFromParent,
             suspended: suspended,
             windowNumbers: windowNumbers,
-            segments: nil
+            segments: nil,
+            owner: owner
         )
     }
 }
@@ -987,13 +989,17 @@ class CanvasManager {
             canvas = single
         }
         canvas.cascadeFromParent = req.cascade ?? true
+        canvas.owner = req.owner
         // Explicit parent from request (implicit parent set by daemon layer)
         if let explicitParent = req.parent {
-            guard canvases[explicitParent] != nil else {
+            guard let parentCanvas = canvases[explicitParent] else {
                 canvas.close()
                 return .fail("Parent canvas '\(explicitParent)' not found", code: "PARENT_NOT_FOUND")
             }
             canvas.parent = explicitParent
+            if canvas.owner == nil {
+                canvas.owner = parentCanvas.owner
+            }
         }
         // Born suspended: if explicitly requested, or if parent is suspended
         // and cascade is true, start hidden while still allowing the web view

--- a/src/display/client.swift
+++ b/src/display/client.swift
@@ -43,6 +43,8 @@ class DaemonClient {
         if let sus = request.suspended { dataDict["suspended"] = sus }
         if let ch = request.channel { dataDict["channel"] = ch }
         if let d = request.data { dataDict["data"] = d }
+        let owner = request.owner ?? (request.action == "create" ? CanvasOwnerInfo.currentCLI() : nil)
+        if let ownerDict = owner?.dictionary() { dataDict["owner"] = ownerDict }
 
         guard let response = sendEnvelopeRequest(service: service, action: action, data: dataDict) else {
             return CanvasResponse.fail("IPC failure", code: "INTERNAL")

--- a/src/display/desktop-world-surface.swift
+++ b/src/display/desktop-world-surface.swift
@@ -17,6 +17,7 @@ protocol CanvasLike: AnyObject {
     var suspended: Bool { get set }
     var cascadeFromParent: Bool { get set }
     var parent: String? { get set }
+    var owner: CanvasOwnerInfo? { get set }
     var onMessage: ((Any) -> Void)? { get set }
     var onTTLExpired: (() -> Void)? { get set }
     var remainingTTL: Double? { get }
@@ -156,6 +157,7 @@ final class DesktopWorldSurfaceCanvas: CanvasLike {
     var suspended: Bool = false
     var cascadeFromParent: Bool = true
     var parent: String? = nil
+    var owner: CanvasOwnerInfo? = nil
     var onTTLExpired: (() -> Void)?
     var onMessage: ((Any) -> Void)? {
         didSet {
@@ -293,7 +295,8 @@ final class DesktopWorldSurfaceCanvas: CanvasLike {
             cascade: cascadeFromParent,
             suspended: suspended,
             windowNumbers: windowNumbers,
-            segments: segmentMetadata()
+            segments: segmentMetadata(),
+            owner: owner
         )
     }
 

--- a/src/display/protocol.swift
+++ b/src/display/protocol.swift
@@ -77,6 +77,7 @@ struct CanvasRequest: Codable {
     var suspended: Bool?        // create hidden/suspended without showing a window first
     var channel: String?        // channel name (legacy relay path for "post" action)
     var data: String?           // JSON string payload (for "post" action)
+    var owner: CanvasOwnerInfo? = nil // optional caller/session metadata for daemon-owned resources
 
     enum CodingKeys: String, CodingKey {
         case action, id, at, offset, html, url, interactive, focus, ttl, js, scope
@@ -84,11 +85,51 @@ struct CanvasRequest: Codable {
         case anchorWindow = "anchor_window"
         case anchorChannel = "anchor_channel"
         case autoProject = "auto_project"
-        case track, surface, parent, cascade, suspended, channel, data
+        case track, surface, parent, cascade, suspended, channel, data, owner
     }
 }
 
 // MARK: - Response (Daemon → CLI)
+
+struct CanvasOwnerInfo: Codable, Equatable {
+    let consumerID: String
+    let harness: String
+    let pid: Int
+    let cwd: String
+    let worktreeRoot: String?
+    let runtimeMode: String
+
+    enum CodingKeys: String, CodingKey {
+        case consumerID = "consumer_id"
+        case harness
+        case pid
+        case cwd
+        case worktreeRoot = "worktree_root"
+        case runtimeMode = "runtime_mode"
+    }
+}
+
+extension CanvasOwnerInfo {
+    static func currentCLI() -> CanvasOwnerInfo {
+        let cwd = FileManager.default.currentDirectoryPath
+        return CanvasOwnerInfo(
+            consumerID: aosCurrentSessionKey(),
+            harness: aosCurrentSessionHarness(),
+            pid: Int(getpid()),
+            cwd: cwd,
+            worktreeRoot: aosRepoRootFromBases([cwd]),
+            runtimeMode: aosCurrentRuntimeMode().rawValue
+        )
+    }
+
+    func dictionary() -> [String: Any]? {
+        guard let data = try? JSONEncoder().encode(self),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return object
+    }
+}
 
 struct CanvasResponse: Codable {
     var status: String?         // "success" on success
@@ -116,6 +157,7 @@ struct CanvasInfo: Codable {
     var suspended: Bool?        // true if canvas is suspended (hidden + paused)
     var windowNumbers: [Int]?   // native window numbers backing this canvas
     var segments: [DesktopWorldSurfaceSegment]?  // present for DesktopWorldSurface canvases
+    var owner: CanvasOwnerInfo? // optional caller/session metadata that created the canvas
 }
 
 // MARK: - Encode/Decode Helpers

--- a/tests/canvas-owner-metadata.sh
+++ b/tests/canvas-owner-metadata.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "$0")/lib/isolated-daemon.sh"
+
+PREFIX="aos-canvas-owner-metadata"
+aos_test_cleanup_prefix "$PREFIX"
+
+ROOT="$(mktemp -d "${TMPDIR:-/tmp}/${PREFIX}.XXXXXX")"
+export AOS_STATE_ROOT="$ROOT"
+unset AOS_REPO_ROOT
+
+cleanup() {
+  ./aos show remove-all >/dev/null 2>&1 || true
+  aos_test_kill_root "$ROOT"
+  rm -rf "$ROOT"
+}
+trap cleanup EXIT
+
+aos_test_start_daemon "$ROOT" \
+  || { echo "FAIL: isolated daemon did not become ready"; exit 1; }
+
+ID="owner-metadata-$$"
+SESSION_ID="owner-session-$$"
+HARNESS="owner-harness"
+
+AOS_SESSION_ID="$SESSION_ID" \
+AOS_SESSION_HARNESS="$HARNESS" \
+./aos show create \
+  --id "$ID" \
+  --at 20,20,80,60 \
+  --html '<!doctype html><html><body>owner</body></html>' >/dev/null
+
+python3 - "$ID" "$SESSION_ID" "$HARNESS" "$PWD" "$ROOT" <<'PY'
+import json
+import pathlib
+import socket
+import subprocess
+import sys
+import time
+
+canvas_id, session_id, harness, cwd, state_root = sys.argv[1:]
+child_id = f"{canvas_id}-child"
+sock_path = pathlib.Path(state_root) / "repo" / "sock"
+
+def send_envelope(action, data):
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.settimeout(3)
+    sock.connect(str(sock_path))
+    sock.sendall(json.dumps({
+        "v": 1,
+        "service": "show",
+        "action": action,
+        "data": data,
+    }).encode() + b"\n")
+    buffer = b""
+    while b"\n" not in buffer:
+        chunk = sock.recv(65536)
+        if not chunk:
+            break
+        buffer += chunk
+    sock.close()
+    if not buffer:
+        raise SystemExit(f"FAIL: no response for show.{action}")
+    return json.loads(buffer.split(b"\n", 1)[0])
+
+def canvas_from_list():
+    payload = json.loads(subprocess.check_output(["./aos", "show", "list", "--json"], text=True))
+    for canvas in payload.get("canvases", []):
+        if canvas.get("id") == canvas_id:
+            return canvas
+    return None
+
+deadline = time.time() + 5
+canvas = None
+while time.time() < deadline:
+    canvas = canvas_from_list()
+    if canvas:
+        break
+    time.sleep(0.1)
+if not canvas:
+    raise SystemExit(f"FAIL: canvas {canvas_id!r} missing from show list")
+
+owner = canvas.get("owner")
+if not isinstance(owner, dict):
+    raise SystemExit(f"FAIL: owner metadata missing from show list: {canvas}")
+
+assert owner.get("consumer_id") == session_id, owner
+assert owner.get("harness") == harness, owner
+assert owner.get("cwd") == cwd, owner
+assert owner.get("worktree_root") == cwd, owner
+assert owner.get("runtime_mode") == "repo", owner
+assert isinstance(owner.get("pid"), int) and owner["pid"] > 0, owner
+
+response = send_envelope("create", {
+    "id": child_id,
+    "parent": canvas_id,
+    "at": [120, 20, 80, 60],
+    "html": "<!doctype html><html><body>child</body></html>",
+})
+assert response.get("status") in ("ok", "success"), response
+
+payload = json.loads(subprocess.check_output(["./aos", "show", "list", "--json"], text=True))
+child = next((canvas for canvas in payload.get("canvases", []) if canvas.get("id") == child_id), None)
+if not child:
+    raise SystemExit(f"FAIL: child canvas {child_id!r} missing from show list")
+assert child.get("parent") == canvas_id, child
+assert child.get("owner") == owner, child
+
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.settimeout(3)
+sock.connect(str(sock_path))
+sock.sendall(json.dumps({
+    "action": "subscribe",
+    "events": ["canvas_lifecycle"],
+    "snapshot": True,
+}).encode() + b"\n")
+
+buffer = b""
+deadline = time.time() + 5
+lifecycle = None
+while time.time() < deadline:
+    if b"\n" not in buffer:
+        chunk = sock.recv(65536)
+        if not chunk:
+            break
+        buffer += chunk
+    while b"\n" in buffer:
+        line, buffer = buffer.split(b"\n", 1)
+        if not line:
+            continue
+        message = json.loads(line)
+        data = message.get("data") if message.get("event") == "canvas_lifecycle" else None
+        if data and data.get("canvas_id") == canvas_id:
+            lifecycle = data
+            break
+    if lifecycle:
+        break
+
+if lifecycle is None:
+    raise SystemExit("FAIL: canvas_lifecycle snapshot did not include the created canvas")
+
+assert lifecycle.get("owner") == owner, lifecycle
+assert lifecycle.get("canvas", {}).get("owner") == owner, lifecycle
+PY
+
+./aos show remove --id "$ID" >/dev/null
+
+echo "PASS"

--- a/tests/toolkit/runtime-canvas-lifecycle.test.mjs
+++ b/tests/toolkit/runtime-canvas-lifecycle.test.mjs
@@ -96,6 +96,27 @@ test('mergeCanvasLifecycleCanvas preserves top-level native window numbers', () 
   assert.deepEqual(merged.windowNumbers, [4242])
 })
 
+test('mergeCanvasLifecycleCanvas preserves owner metadata', () => {
+  const owner = {
+    consumer_id: 'codex-thread-123',
+    harness: 'codex',
+    pid: 4242,
+    cwd: '/worktrees/agent-a',
+    worktree_root: '/worktrees/agent-a',
+    runtime_mode: 'repo',
+  }
+
+  const merged = mergeCanvasLifecycleCanvas(null, {
+    canvas_id: 'agent-panel',
+    action: 'created',
+    at: [10, 20, 300, 200],
+    interactive: true,
+    owner,
+  })
+
+  assert.deepEqual(merged.owner, owner)
+})
+
 test('mergeCanvasLifecycleCanvas preserves DesktopWorld surface segments', () => {
   const segments = [
     { display_id: 1, index: 0, dw_bounds: [0, 0, 100, 100], native_bounds: [0, 0, 100, 100] },


### PR DESCRIPTION
Summary:
- Attach automatic owner metadata to CLI-created canvases using existing AOS session/runtime hints.
- Store owner metadata on normal and DesktopWorld canvases, inherit it for child canvases, and expose it through show list and canvas lifecycle payloads.
- Document the optional owner shape and add focused toolkit and isolated-daemon coverage.

Verification:
- AOS_REPO_ROOT="/Users/Michael/Code/agent-os-worktrees/canvas-owner-metadata" /Users/Michael/Code/agent-os/./aos dev build --force --no-restart
- tests/canvas-owner-metadata.sh
- node --test tests/toolkit/runtime-canvas-lifecycle.test.mjs
- python3 -m json.tool shared/schemas/daemon-request.schema.json >/dev/null
- git diff --check