### PR TITLE
Define addressable canvas object control contract

### DIFF
--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -317,6 +317,91 @@ Subscribe side is handled for you — the canvas-inspector subscribes to
 `canvas_object.marks` via its manifest. Any canvas that subscribes will
 receive the daemon's fan-out.
 
+### Addressable Canvas Object Control
+
+`canvas_object.registry`, `canvas_object.transform.patch`, and
+`canvas_object.transform.result` define the addressable object control contract
+for reusable transform editors. This is a control contract, not a replacement
+for `canvas_object.marks`: marks are visual/debug telemetry, while registry and
+transform messages describe objects that a canvas owner explicitly exposes for
+remote control.
+
+The schema source of truth is
+[`shared/schemas/canvas-object-control.schema.json`](../../shared/schemas/canvas-object-control.schema.json)
+and the reference narrative is
+[`shared/schemas/canvas-object-control.md`](../../shared/schemas/canvas-object-control.md).
+
+Addresses use `canvas_id + object_id`:
+
+```json
+{
+  "canvas_id": "avatar-main",
+  "object_id": "radial.wiki-brain.tree"
+}
+```
+
+Registry snapshots are retained-state messages. A canvas owner publishes a full
+replacement list of addressable objects with current transform values, units,
+and capabilities:
+
+```json
+{
+  "type": "canvas_object.registry",
+  "schema_version": "2026-05-03",
+  "canvas_id": "avatar-main",
+  "objects": [
+    {
+      "object_id": "radial.wiki-brain.tree",
+      "name": "Wiki Brain Tree",
+      "kind": "three.object3d",
+      "capabilities": ["transform.read", "transform.patch"],
+      "transform": {
+        "position": { "x": 0.018, "y": -0.035, "z": 0.018 },
+        "scale": { "x": 1.32, "y": 1.42, "z": 1.2 },
+        "rotation_degrees": { "x": -11.5, "y": 0, "z": 0 }
+      },
+      "units": {
+        "position": "scene",
+        "scale": "multiplier",
+        "rotation": "degrees"
+      }
+    }
+  ]
+}
+```
+
+Transform patches are commands. Controllers send a partial transform update to
+one addressed object and correlate the owner response by `request_id`:
+
+```json
+{
+  "type": "canvas_object.transform.patch",
+  "schema_version": "2026-05-03",
+  "request_id": "req-42",
+  "target": {
+    "canvas_id": "avatar-main",
+    "object_id": "radial.wiki-brain.tree"
+  },
+  "patch": {
+    "scale": { "x": 1.4, "y": 1.5, "z": 1.25 }
+  }
+}
+```
+
+The intended v0 routing uses existing AOS canvas plumbing:
+
+- owners emit registry snapshots through toolkit `emit()` and daemon fan-out to
+  canvases subscribed to `canvas_object.registry`
+- transform editors subscribe through toolkit `subscribe()`
+- transform patches are delivered to the owning `canvas_id` with existing
+  canvas message delivery
+- owner results are direct replies or subscribed result messages, depending on
+  the controller surface
+
+Keep bus-shaped discipline at this boundary: typed messages, structured
+addresses, separate state snapshots from commands, and include `request_id` for
+mutating requests. Do not introduce a general AOS bus for this contract.
+
 The inspector's minimap cursor is operator-toggleable and starts hidden by
 default. Turning it on subscribes to `input_event` on demand and requests a
 snapshot so the current cursor dot appears immediately instead of waiting for

--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -388,7 +388,7 @@ one addressed object and correlate the owner response by `request_id`:
 }
 ```
 
-The intended v0 routing uses existing AOS canvas plumbing:
+V0 routing uses existing AOS canvas plumbing:
 
 - owners emit registry snapshots through toolkit `emit()` and daemon fan-out to
   canvases subscribed to `canvas_object.registry`

--- a/shared/schemas/canvas-object-control.md
+++ b/shared/schemas/canvas-object-control.md
@@ -90,7 +90,7 @@ capability, and patch values before applying them. Controllers should correlate
 responses by `request_id` and use the next registry snapshot as the eventual
 state authority.
 
-The initial routing should use existing AOS canvas plumbing:
+V0 runtime routing uses existing AOS canvas plumbing:
 
 - owner registry publish: toolkit `emit('canvas_object.registry', snapshot)` to
   daemon fan-out for subscribers

--- a/shared/schemas/canvas-object-control.md
+++ b/shared/schemas/canvas-object-control.md
@@ -1,0 +1,112 @@
+# Canvas Object Control
+
+The canvas object control contract describes addressable, canvas-owned objects
+that reusable AOS toolkit surfaces may inspect or request transform changes for.
+It is intentionally narrower than a generic event bus. The JSON Schema source of
+truth is
+[`canvas-object-control.schema.json`](canvas-object-control.schema.json).
+
+## Message Types
+
+`canvas_object.registry` is a latest-state snapshot. A canvas that owns
+addressable objects publishes the full set it wants controllers to see:
+
+```json
+{
+  "type": "canvas_object.registry",
+  "schema_version": "2026-05-03",
+  "canvas_id": "avatar-main",
+  "objects": [
+    {
+      "object_id": "radial.wiki-brain.tree",
+      "name": "Wiki Brain Tree",
+      "kind": "three.object3d",
+      "capabilities": ["transform.read", "transform.patch"],
+      "transform": {
+        "position": { "x": 0.018, "y": -0.035, "z": 0.018 },
+        "scale": { "x": 1.32, "y": 1.42, "z": 1.2 },
+        "rotation_degrees": { "x": -11.5, "y": 0, "z": 0 }
+      },
+      "units": {
+        "position": "scene",
+        "scale": "multiplier",
+        "rotation": "degrees"
+      }
+    }
+  ]
+}
+```
+
+`canvas_object.transform.patch` is a command. A controller targets one object by
+`canvas_id + object_id` and sends only the transform components it wants to
+change:
+
+```json
+{
+  "type": "canvas_object.transform.patch",
+  "schema_version": "2026-05-03",
+  "request_id": "req-42",
+  "target": {
+    "canvas_id": "avatar-main",
+    "object_id": "radial.wiki-brain.tree"
+  },
+  "patch": {
+    "scale": { "x": 1.4, "y": 1.5, "z": 1.25 }
+  }
+}
+```
+
+`canvas_object.transform.result` is the owner response. Owners report whether the
+patch was applied, rejected, or stale:
+
+```json
+{
+  "type": "canvas_object.transform.result",
+  "schema_version": "2026-05-03",
+  "request_id": "req-42",
+  "target": {
+    "canvas_id": "avatar-main",
+    "object_id": "radial.wiki-brain.tree"
+  },
+  "status": "applied",
+  "transform": {
+    "position": { "x": 0.018, "y": -0.035, "z": 0.018 },
+    "scale": { "x": 1.4, "y": 1.5, "z": 1.25 },
+    "rotation_degrees": { "x": -11.5, "y": 0, "z": 0 }
+  }
+}
+```
+
+## Delivery Semantics
+
+Registry snapshots are retained-state messages. Each
+`canvas_object.registry` emit fully replaces the advertised object list for its
+`canvas_id`. An empty `objects` array clears the owner's registry. Consumers must
+evict registry entries when the owning canvas is removed and should treat stale
+registries as unavailable if the owner stops publishing.
+
+Transform patches are commands, not state. The owner canvas validates the target,
+capability, and patch values before applying them. Controllers should correlate
+responses by `request_id` and use the next registry snapshot as the eventual
+state authority.
+
+The initial routing should use existing AOS canvas plumbing:
+
+- owner registry publish: toolkit `emit('canvas_object.registry', snapshot)` to
+  daemon fan-out for subscribers
+- controller registry subscribe: toolkit `subscribe(['canvas_object.registry'])`
+- transform patch delivery: toolkit/daemon canvas message delivery to the
+  owning `canvas_id`
+- transform result delivery: direct response to the requesting canvas or a
+  subscribed result stream, depending on the implementing surface
+
+The contract is bus-shaped only at the boundary: typed messages, structured
+addresses, explicit state-vs-command semantics, and correlation IDs for commands.
+It is not a request to build a general AOS bus.
+
+## Mismatch Handling
+
+Implementations should log malformed registry, patch, and result payloads with
+the message type, schema version, target address, request id when present, and
+validation failure. Contract drift should be corrected at this schema boundary
+instead of hidden in adopter-specific parsing.

--- a/shared/schemas/canvas-object-control.schema.json
+++ b/shared/schemas/canvas-object-control.schema.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-os.local/schemas/canvas-object-control.schema.json",
+  "title": "Canvas Object Control Messages",
+  "description": "Typed AOS toolkit messages for addressable canvas-owned objects and transform patch control.",
+  "oneOf": [
+    { "$ref": "#/$defs/registrySnapshot" },
+    { "$ref": "#/$defs/transformPatch" },
+    { "$ref": "#/$defs/transformResult" }
+  ],
+  "$defs": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "2026-05-03"
+    },
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "jsonObject": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "address": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["canvas_id", "object_id"],
+      "properties": {
+        "canvas_id": { "$ref": "#/$defs/nonEmptyString" },
+        "object_id": { "$ref": "#/$defs/nonEmptyString" }
+      }
+    },
+    "fullTriplet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["x", "y", "z"],
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" },
+        "z": { "type": "number" }
+      }
+    },
+    "partialTriplet": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" },
+        "z": { "type": "number" }
+      }
+    },
+    "transform": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["position", "scale", "rotation_degrees"],
+      "properties": {
+        "position": { "$ref": "#/$defs/fullTriplet" },
+        "scale": { "$ref": "#/$defs/fullTriplet" },
+        "rotation_degrees": { "$ref": "#/$defs/fullTriplet" }
+      }
+    },
+    "transformPatchValues": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "position": { "$ref": "#/$defs/partialTriplet" },
+        "scale": { "$ref": "#/$defs/partialTriplet" },
+        "rotation_degrees": { "$ref": "#/$defs/partialTriplet" }
+      },
+      "anyOf": [
+        { "required": ["position"] },
+        { "required": ["scale"] },
+        { "required": ["rotation_degrees"] }
+      ]
+    },
+    "units": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["position", "scale", "rotation"],
+      "properties": {
+        "position": {
+          "type": "string",
+          "enum": ["scene"]
+        },
+        "scale": {
+          "type": "string",
+          "enum": ["multiplier"]
+        },
+        "rotation": {
+          "type": "string",
+          "enum": ["degrees"]
+        }
+      }
+    },
+    "capability": {
+      "type": "string",
+      "enum": ["transform.read", "transform.patch"]
+    },
+    "registryObject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["object_id", "name", "kind", "capabilities", "transform", "units"],
+      "properties": {
+        "object_id": { "$ref": "#/$defs/nonEmptyString" },
+        "name": { "$ref": "#/$defs/nonEmptyString" },
+        "kind": {
+          "type": "string",
+          "enum": ["three.object3d", "canvas.object", "dom.element", "custom"]
+        },
+        "capabilities": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/capability" }
+        },
+        "transform": { "$ref": "#/$defs/transform" },
+        "units": { "$ref": "#/$defs/units" },
+        "visible": { "type": "boolean" },
+        "metadata": { "$ref": "#/$defs/jsonObject" }
+      }
+    },
+    "registrySnapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "schema_version", "canvas_id", "objects"],
+      "properties": {
+        "type": { "const": "canvas_object.registry" },
+        "schema_version": { "$ref": "#/$defs/schemaVersion" },
+        "canvas_id": { "$ref": "#/$defs/nonEmptyString" },
+        "source_id": { "$ref": "#/$defs/nonEmptyString" },
+        "observed_at": { "$ref": "#/$defs/timestamp" },
+        "objects": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/registryObject" }
+        }
+      }
+    },
+    "transformPatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "schema_version", "request_id", "target", "patch"],
+      "properties": {
+        "type": { "const": "canvas_object.transform.patch" },
+        "schema_version": { "$ref": "#/$defs/schemaVersion" },
+        "request_id": { "$ref": "#/$defs/nonEmptyString" },
+        "source_id": { "$ref": "#/$defs/nonEmptyString" },
+        "target": { "$ref": "#/$defs/address" },
+        "patch": { "$ref": "#/$defs/transformPatchValues" }
+      }
+    },
+    "transformResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "schema_version", "request_id", "target", "status"],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": { "const": "applied" }
+            }
+          },
+          "then": { "required": ["transform"] }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": { "enum": ["rejected", "stale"] }
+            }
+          },
+          "then": { "required": ["reason"] }
+        }
+      ],
+      "properties": {
+        "type": { "const": "canvas_object.transform.result" },
+        "schema_version": { "$ref": "#/$defs/schemaVersion" },
+        "request_id": { "$ref": "#/$defs/nonEmptyString" },
+        "source_id": { "$ref": "#/$defs/nonEmptyString" },
+        "target": { "$ref": "#/$defs/address" },
+        "status": {
+          "type": "string",
+          "enum": ["applied", "rejected", "stale"]
+        },
+        "reason": {
+          "type": "string",
+          "enum": [
+            "unknown_object",
+            "unsupported_capability",
+            "invalid_patch",
+            "not_ready",
+            "owner_rejected",
+            "contract_mismatch"
+          ]
+        },
+        "message": { "type": "string" },
+        "transform": { "$ref": "#/$defs/transform" }
+      }
+    }
+  }
+}

--- a/shared/schemas/fixtures/canvas-object-control/invalid/patch-without-target.json
+++ b/shared/schemas/fixtures/canvas-object-control/invalid/patch-without-target.json
@@ -1,0 +1,8 @@
+{
+  "type": "canvas_object.transform.patch",
+  "schema_version": "2026-05-03",
+  "request_id": "req-transform-1",
+  "patch": {
+    "scale": { "x": 1.4 }
+  }
+}

--- a/shared/schemas/fixtures/canvas-object-control/invalid/registry-missing-units.json
+++ b/shared/schemas/fixtures/canvas-object-control/invalid/registry-missing-units.json
@@ -1,0 +1,18 @@
+{
+  "type": "canvas_object.registry",
+  "schema_version": "2026-05-03",
+  "canvas_id": "avatar-main",
+  "objects": [
+    {
+      "object_id": "radial.wiki-brain.tree",
+      "name": "Wiki Brain Tree",
+      "kind": "three.object3d",
+      "capabilities": ["transform.read"],
+      "transform": {
+        "position": { "x": 0, "y": 0, "z": 0 },
+        "scale": { "x": 1, "y": 1, "z": 1 },
+        "rotation_degrees": { "x": 0, "y": 0, "z": 0 }
+      }
+    }
+  ]
+}

--- a/shared/schemas/fixtures/canvas-object-control/invalid/result-applied-without-transform.json
+++ b/shared/schemas/fixtures/canvas-object-control/invalid/result-applied-without-transform.json
@@ -1,0 +1,10 @@
+{
+  "type": "canvas_object.transform.result",
+  "schema_version": "2026-05-03",
+  "request_id": "req-transform-1",
+  "target": {
+    "canvas_id": "avatar-main",
+    "object_id": "radial.wiki-brain.tree"
+  },
+  "status": "applied"
+}

--- a/shared/schemas/fixtures/canvas-object-control/invalid/result-invalid-status.json
+++ b/shared/schemas/fixtures/canvas-object-control/invalid/result-invalid-status.json
@@ -1,0 +1,10 @@
+{
+  "type": "canvas_object.transform.result",
+  "schema_version": "2026-05-03",
+  "request_id": "req-transform-1",
+  "target": {
+    "canvas_id": "avatar-main",
+    "object_id": "radial.wiki-brain.tree"
+  },
+  "status": "ok"
+}

--- a/shared/schemas/fixtures/canvas-object-control/valid/registry-snapshot.json
+++ b/shared/schemas/fixtures/canvas-object-control/valid/registry-snapshot.json
@@ -1,0 +1,29 @@
+{
+  "type": "canvas_object.registry",
+  "schema_version": "2026-05-03",
+  "canvas_id": "avatar-main",
+  "source_id": "avatar-main",
+  "observed_at": "2026-05-03T12:00:00Z",
+  "objects": [
+    {
+      "object_id": "radial.wiki-brain.tree",
+      "name": "Wiki Brain Tree",
+      "kind": "three.object3d",
+      "capabilities": ["transform.read", "transform.patch"],
+      "visible": true,
+      "transform": {
+        "position": { "x": 0.018, "y": -0.035, "z": 0.018 },
+        "scale": { "x": 1.32, "y": 1.42, "z": 1.2 },
+        "rotation_degrees": { "x": -11.5, "y": 0, "z": 0 }
+      },
+      "units": {
+        "position": "scene",
+        "scale": "multiplier",
+        "rotation": "degrees"
+      },
+      "metadata": {
+        "radial_item": "wiki-graph"
+      }
+    }
+  ]
+}

--- a/shared/schemas/fixtures/canvas-object-control/valid/transform-patch.json
+++ b/shared/schemas/fixtures/canvas-object-control/valid/transform-patch.json
@@ -1,0 +1,15 @@
+{
+  "type": "canvas_object.transform.patch",
+  "schema_version": "2026-05-03",
+  "request_id": "req-transform-1",
+  "source_id": "object-transform-panel",
+  "target": {
+    "canvas_id": "avatar-main",
+    "object_id": "radial.wiki-brain.tree"
+  },
+  "patch": {
+    "position": { "y": -0.042 },
+    "scale": { "x": 1.4, "y": 1.5, "z": 1.25 },
+    "rotation_degrees": { "x": -9 }
+  }
+}

--- a/shared/schemas/fixtures/canvas-object-control/valid/transform-rejected.json
+++ b/shared/schemas/fixtures/canvas-object-control/valid/transform-rejected.json
@@ -1,0 +1,13 @@
+{
+  "type": "canvas_object.transform.result",
+  "schema_version": "2026-05-03",
+  "request_id": "req-transform-2",
+  "source_id": "avatar-main",
+  "target": {
+    "canvas_id": "avatar-main",
+    "object_id": "radial.wiki-brain.shell"
+  },
+  "status": "rejected",
+  "reason": "not_ready",
+  "message": "wiki brain shell is still loading"
+}

--- a/shared/schemas/fixtures/canvas-object-control/valid/transform-result.json
+++ b/shared/schemas/fixtures/canvas-object-control/valid/transform-result.json
@@ -1,0 +1,16 @@
+{
+  "type": "canvas_object.transform.result",
+  "schema_version": "2026-05-03",
+  "request_id": "req-transform-1",
+  "source_id": "avatar-main",
+  "target": {
+    "canvas_id": "avatar-main",
+    "object_id": "radial.wiki-brain.tree"
+  },
+  "status": "applied",
+  "transform": {
+    "position": { "x": 0.018, "y": -0.042, "z": 0.018 },
+    "scale": { "x": 1.4, "y": 1.5, "z": 1.25 },
+    "rotation_degrees": { "x": -9, "y": 0, "z": 0 }
+  }
+}

--- a/src/daemon/unified.swift
+++ b/src/daemon/unified.swift
@@ -36,6 +36,7 @@ class UnifiedDaemon {
     // Canvas-side event subscriptions: canvas ID → set of event-type names it wants.
     // Populated when a canvas posts {type: 'subscribe', payload: {events: [...]}}.
     var canvasEventSubscriptions: [String: Set<String>] = [:]
+    var canvasObjectRegistries: [String: [String: Any]] = [:]
     let canvasSubscriptionLock = NSLock()
 
     // Canvas ownership: child canvas ID → parent canvas ID.
@@ -214,6 +215,24 @@ class UnifiedDaemon {
                     markPayload["source_id"] = canvasID
                     self.forwardCanvasObjectMarks(data: markPayload)
                     return
+                case "canvas_object.registry":
+                    var registryPayload: [String: Any] = [:]
+                    if let inner = inner {
+                        for (k, v) in inner { registryPayload[k] = v }
+                    }
+                    let registryCanvasID = (registryPayload["canvas_id"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? canvasID
+                    registryPayload["canvas_id"] = registryCanvasID
+                    registryPayload["source_id"] = canvasID
+                    self.forwardCanvasObjectRegistry(canvasID: registryCanvasID, data: registryPayload)
+                    return
+                case "canvas_object.transform.result":
+                    var resultPayload: [String: Any] = [:]
+                    if let inner = inner {
+                        for (k, v) in inner { resultPayload[k] = v }
+                    }
+                    resultPayload["source_id"] = canvasID
+                    self.forwardCanvasObjectControlMessage(type: type, data: resultPayload)
+                    return
                 case "canvas_inspector.capture_bundle":
                     self.triggerCanvasInspectorSeeBundle(sourceCanvasID: canvasID, trigger: inner?["trigger"] as? String ?? "canvas")
                     return
@@ -238,6 +257,7 @@ class UnifiedDaemon {
                 let canvasID = canvasInfo.id
                 self.canvasSubscriptionLock.lock()
                 let had = self.canvasEventSubscriptions.removeValue(forKey: canvasID) != nil
+                let hadRegistry = self.canvasObjectRegistries.removeValue(forKey: canvasID) != nil
                 let children = self.canvasChildren.removeValue(forKey: canvasID) ?? []
                 // Detach this canvas from its parent's child set.
                 if let parent = self.canvasCreatedBy.removeValue(forKey: canvasID) {
@@ -253,6 +273,9 @@ class UnifiedDaemon {
                 self.canvasSubscriptionLock.unlock()
                 if had {
                     fputs("[canvas-sub] cleared subscriptions for removed canvas=\(canvasID)\n", stderr)
+                }
+                if hadRegistry {
+                    fputs("[canvas-object] cleared registry for removed canvas=\(canvasID)\n", stderr)
                 }
                 // Cascade: children with cascade=true are removed; cascade=false are orphaned.
                 for child in children {
@@ -506,6 +529,9 @@ class UnifiedDaemon {
                     payload: self.currentInputEventSnapshot()
                 )
             }
+            if requested.contains("canvas_object.registry") {
+                self.broadcastCanvasObjectRegistrySnapshot(to: canvasID)
+            }
         }
     }
 
@@ -589,15 +615,51 @@ class UnifiedDaemon {
     /// in a `{type: "canvas_object.marks", ...}` envelope since live-js
     /// canvas dispatch routes by `msg.type`.
     private func forwardCanvasObjectMarks(data: [String: Any]) {
+        forwardCanvasObjectControlMessage(type: "canvas_object.marks", data: data)
+    }
+
+    private func forwardCanvasObjectRegistry(canvasID: String, data: [String: Any]) {
+        guard let objects = data["objects"] as? [Any] else {
+            fputs("[canvas-object] registry dropped source=\(data["source_id"] ?? "?") canvas=\(canvasID) reason=missing-objects\n", stderr)
+            return
+        }
+
+        canvasSubscriptionLock.lock()
+        if objects.isEmpty {
+            canvasObjectRegistries.removeValue(forKey: canvasID)
+        } else {
+            canvasObjectRegistries[canvasID] = data
+        }
+        canvasSubscriptionLock.unlock()
+
+        forwardCanvasObjectControlMessage(type: "canvas_object.registry", data: data)
+    }
+
+    private func broadcastCanvasObjectRegistrySnapshot(to specificCanvas: String) {
+        canvasSubscriptionLock.lock()
+        let subscribed = canvasEventSubscriptions[specificCanvas]?.contains("canvas_object.registry") == true
+        let snapshots = Array(canvasObjectRegistries.values)
+        canvasSubscriptionLock.unlock()
+
+        guard subscribed, !snapshots.isEmpty else { return }
+
+        for snapshot in snapshots {
+            var msg: [String: Any] = ["type": "canvas_object.registry"]
+            for (k, v) in snapshot { msg[k] = v }
+            canvasManager.postMessageAsync(canvasID: specificCanvas, payload: msg)
+        }
+    }
+
+    private func forwardCanvasObjectControlMessage(type: String, data: [String: Any]) {
         canvasSubscriptionLock.lock()
         let targets = canvasEventSubscriptions
-            .filter { $0.value.contains("canvas_object.marks") }
+            .filter { $0.value.contains(type) }
             .map { $0.key }
         canvasSubscriptionLock.unlock()
 
         guard !targets.isEmpty else { return }
 
-        var msg: [String: Any] = ["type": "canvas_object.marks"]
+        var msg: [String: Any] = ["type": type]
         for (k, v) in data { msg[k] = v }
 
         for canvasID in targets {

--- a/tests/canvas-object-control-fanout.sh
+++ b/tests/canvas-object-control-fanout.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "$0")/lib/isolated-daemon.sh"
+
+PREFIX="aos-canvas-object-control"
+aos_test_cleanup_prefix "$PREFIX"
+
+ROOT="$(mktemp -d "${TMPDIR:-/tmp}/${PREFIX}.XXXXXX")"
+export AOS_STATE_ROOT="$ROOT"
+
+cleanup() {
+  aos_test_kill_root "$ROOT"
+  rm -rf "$ROOT"
+}
+trap cleanup EXIT
+
+aos_test_start_daemon "$ROOT" toolkit packages/toolkit \
+  || { echo "FAIL: isolated daemon did not become ready"; exit 1; }
+
+./aos show create --id object-subscriber --at 80,80,240,160 --html '
+<!doctype html><html><body>subscriber<script>
+window.received = [];
+window.headsup = {
+  receive(b64) {
+    window.received.push(JSON.parse(atob(b64)));
+  }
+};
+window.subscribe = (events, snapshot = false) => {
+  window.webkit.messageHandlers.headsup.postMessage({
+    type: "subscribe",
+    payload: { events, snapshot }
+  });
+};
+</script></body></html>' >/dev/null
+
+./aos show create --id object-producer --at 360,80,240,160 --html '
+<!doctype html><html><body>producer<script>
+window.postRegistry = (objects) => {
+  window.webkit.messageHandlers.headsup.postMessage({
+    type: "canvas_object.registry",
+    payload: {
+      schema_version: "2026-05-03",
+      canvas_id: "object-producer",
+      objects
+    }
+  });
+};
+window.postResult = () => {
+  window.webkit.messageHandlers.headsup.postMessage({
+    type: "canvas_object.transform.result",
+    payload: {
+      schema_version: "2026-05-03",
+      request_id: "req-1",
+      target: {
+        canvas_id: "object-producer",
+        object_id: "demo.cube"
+      },
+      status: "applied",
+      transform: {
+        position: { x: 1, y: 2, z: 3 },
+        scale: { x: 1, y: 1, z: 1 },
+        rotation_degrees: { x: 0, y: 45, z: 0 }
+      }
+    }
+  });
+};
+</script></body></html>' >/dev/null
+
+python3 - <<'PY'
+import json
+import subprocess
+import sys
+import time
+
+
+def eval_json(canvas_id, js):
+    out = subprocess.check_output([
+        "./aos", "show", "eval", "--id", canvas_id, "--js", js
+    ], text=True)
+    wrapped = json.loads(out)
+    return json.loads(wrapped.get("result") or "null")
+
+
+def eval_void(canvas_id, js):
+    subprocess.check_call([
+        "./aos", "show", "eval", "--id", canvas_id, "--js", js
+    ], stdout=subprocess.DEVNULL)
+
+
+def show_create(canvas_id, at, html):
+    subprocess.check_call([
+        "./aos", "show", "create", "--id", canvas_id, "--at", at, "--html", html
+    ], stdout=subprocess.DEVNULL)
+
+
+def wait_for(predicate, what, timeout=5.0):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        last = predicate()
+        if last:
+            return last
+        time.sleep(0.1)
+    print(f"FAIL: timed out waiting for {what}; last={last}", flush=True)
+    sys.exit(1)
+
+
+wait_for(
+    lambda: eval_json(
+        "object-subscriber",
+        'JSON.stringify({subscribe: typeof window.subscribe, received: Array.isArray(window.received)})'
+    ).get("subscribe") == "function",
+    "subscriber bridge setup",
+)
+wait_for(
+    lambda: eval_json(
+        "object-producer",
+        'JSON.stringify({registry: typeof window.postRegistry, result: typeof window.postResult})'
+    ).get("registry") == "function",
+    "producer bridge setup",
+)
+
+eval_void(
+    "object-subscriber",
+    'window.subscribe(["canvas_object.registry", "canvas_object.transform.result"])'
+)
+
+object_entry = {
+    "object_id": "demo.cube",
+    "name": "Demo Cube",
+    "kind": "three.object3d",
+    "capabilities": ["transform.read", "transform.patch"],
+    "transform": {
+        "position": {"x": 1, "y": 2, "z": 3},
+        "scale": {"x": 1, "y": 1, "z": 1},
+        "rotation_degrees": {"x": 0, "y": 45, "z": 0},
+    },
+    "units": {
+        "position": "scene",
+        "scale": "multiplier",
+        "rotation": "degrees",
+    },
+}
+eval_void("object-producer", f"window.postRegistry({json.dumps([object_entry])})")
+
+registry = wait_for(
+    lambda: next(
+        (
+            msg for msg in eval_json("object-subscriber", "JSON.stringify(window.received)")
+            if msg.get("type") == "canvas_object.registry"
+        ),
+        None,
+    ),
+    "registry fanout",
+)
+assert registry["canvas_id"] == "object-producer", registry
+assert registry["source_id"] == "object-producer", registry
+assert registry["objects"][0]["object_id"] == "demo.cube", registry
+print("step 1 ok - registry fanout")
+
+show_create("object-late-subscriber", "80,280,240,160", '''
+<!doctype html><html><body>late<script>
+window.received = [];
+window.headsup = {
+  receive(b64) {
+    window.received.push(JSON.parse(atob(b64)));
+  }
+};
+window.subscribe = () => {
+  window.webkit.messageHandlers.headsup.postMessage({
+    type: "subscribe",
+    payload: { events: ["canvas_object.registry"], snapshot: true }
+  });
+};
+</script></body></html>''')
+
+wait_for(
+    lambda: eval_json(
+        "object-late-subscriber",
+        'JSON.stringify({subscribe: typeof window.subscribe})'
+    ).get("subscribe") == "function",
+    "late subscriber bridge setup",
+)
+eval_void("object-late-subscriber", "window.subscribe()")
+late_registry = wait_for(
+    lambda: next(
+        (
+            msg for msg in eval_json("object-late-subscriber", "JSON.stringify(window.received)")
+            if msg.get("type") == "canvas_object.registry"
+        ),
+        None,
+    ),
+    "late registry snapshot",
+)
+assert late_registry["objects"][0]["object_id"] == "demo.cube", late_registry
+print("step 2 ok - retained registry snapshot")
+
+eval_void("object-producer", "window.postRegistry([])")
+cleared = wait_for(
+    lambda: next(
+        (
+            msg for msg in eval_json("object-subscriber", "JSON.stringify(window.received)")
+            if msg.get("type") == "canvas_object.registry" and msg.get("objects") == []
+        ),
+        None,
+    ),
+    "registry clear fanout",
+)
+assert cleared["canvas_id"] == "object-producer", cleared
+print("step 3 ok - empty registry clears")
+
+eval_void("object-subscriber", "window.received = []")
+eval_void("object-producer", "window.postResult()")
+result = wait_for(
+    lambda: next(
+        (
+            msg for msg in eval_json("object-subscriber", "JSON.stringify(window.received)")
+            if msg.get("type") == "canvas_object.transform.result"
+        ),
+        None,
+    ),
+    "transform result fanout",
+)
+assert result["request_id"] == "req-1", result
+assert result["target"]["object_id"] == "demo.cube", result
+assert result["source_id"] == "object-producer", result
+print("step 4 ok - transform result fanout")
+print("PASS")
+PY

--- a/tests/schemas/canvas-object-control.test.mjs
+++ b/tests/schemas/canvas-object-control.test.mjs
@@ -1,0 +1,68 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+const schemaPath = path.join(repoRoot, 'shared/schemas/canvas-object-control.schema.json');
+const fixtureRoot = path.join(repoRoot, 'shared/schemas/fixtures/canvas-object-control');
+
+async function jsonFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+    .map((entry) => path.join(dir, entry.name))
+    .sort();
+}
+
+function runJsonschema(fixturePath) {
+  return spawnSync(
+    'python3',
+    [
+      '-c',
+      `
+import json, sys
+from pathlib import Path
+from jsonschema import Draft202012Validator
+
+schema = json.loads(Path(sys.argv[1]).read_text())
+instance = json.loads(Path(sys.argv[2]).read_text())
+Draft202012Validator.check_schema(schema)
+validator = Draft202012Validator(schema)
+errors = sorted(validator.iter_errors(instance), key=lambda e: list(e.path))
+if errors:
+    for error in errors[:8]:
+        print(error.message)
+    sys.exit(1)
+`,
+      schemaPath,
+      fixturePath,
+    ],
+    { encoding: 'utf8' },
+  );
+}
+
+test('valid canvas object control fixtures match the canonical schema', async () => {
+  const fixtures = await jsonFiles(path.join(fixtureRoot, 'valid'));
+  assert.ok(fixtures.length >= 1, 'expected valid fixtures');
+  for (const fixture of fixtures) {
+    const result = runJsonschema(fixture);
+    assert.equal(
+      result.status,
+      0,
+      `${path.relative(repoRoot, fixture)} should validate\n${result.stdout}${result.stderr}`,
+    );
+  }
+});
+
+test('invalid canvas object control fixtures are rejected by the canonical schema', async () => {
+  const fixtures = await jsonFiles(path.join(fixtureRoot, 'invalid'));
+  assert.ok(fixtures.length >= 1, 'expected invalid fixtures');
+  for (const fixture of fixtures) {
+    const result = runJsonschema(fixture);
+    assert.notEqual(result.status, 0, `${path.relative(repoRoot, fixture)} should fail validation`);
+  }
+});


### PR DESCRIPTION
## Summary

Defines the first narrow contract for addressable canvas-owned objects and transform patch control, and adds the minimal daemon routing needed for the contract to be usable by toolkit panels and adopter canvases.

This adds:

- `shared/schemas/canvas-object-control.schema.json`
- `shared/schemas/canvas-object-control.md`
- valid and invalid schema fixtures
- focused schema tests
- toolkit API documentation for routing and semantics
- daemon fan-out for `canvas_object.registry`
- retained registry snapshot replay for late subscribers
- daemon fan-out for `canvas_object.transform.result`
- an isolated-daemon smoke for registry/result fan-out

## Scope

This preserves the long-term AOS bus aspiration as boundary discipline, but does not introduce a generic bus primitive.

The contract distinguishes:

- `canvas_object.registry` as retained latest-state object discovery
- `canvas_object.transform.patch` as a command with `request_id`
- `canvas_object.transform.result` as owner reply state

Transform patches still use existing canvas message delivery to the owning canvas; this PR does not build the toolkit panel or Sigil adopter.

## Verification

- `bash build.sh --no-restart`
- `node --test tests/schemas/canvas-object-control.test.mjs`
- `node --test tests/schemas/*.test.mjs`
- `bash -n tests/canvas-object-control-fanout.sh`
- `bash tests/canvas-object-control-fanout.sh`
- `bash tests/canvas-inspector-primitive-marks.sh`
- `git diff --check`

Closes #198.