### PR TITLE
Add toolkit object transform panel

### DIFF
--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -72,6 +72,7 @@ Current reusable toolkit components include:
 - `aos://toolkit/components/spatial-telemetry/index.html` - live coordinate tables + event log for display, canvas, cursor, and object-mark debugging
 - `aos://toolkit/components/render-performance/index.html` - live framerate, frame-time, and coarse renderer telemetry panel
 - `aos://toolkit/components/wiki-kb/index.html` - wiki graph browser with force-graph and mind-map views
+- `aos://toolkit/components/object-transform-panel/index.html` - addressable canvas object transform editor for position/scale/rotation triplets
 
 ### Inline Canvas Stats
 
@@ -401,6 +402,28 @@ V0 routing uses existing AOS canvas plumbing:
 Keep bus-shaped discipline at this boundary: typed messages, structured
 addresses, separate state snapshots from commands, and include `request_id` for
 mutating requests. Do not introduce a general AOS bus for this contract.
+
+### Object Transform Panel
+
+`object-transform-panel` is the reusable controller for the addressable canvas
+object control contract. It subscribes to `canvas_object.registry` and
+`canvas_object.transform.result`, renders advertised objects by
+`canvas_id + object_id`, and emits transform edits through existing
+`canvas.send` routing to the owning canvas. The panel does not inspect another
+canvas or assume the object is backed by Three.js.
+
+Default launcher:
+
+```bash
+bash packages/toolkit/components/object-transform-panel/launch.sh
+```
+
+Machine-readable state is exposed for agents via:
+
+```bash
+./aos show eval --id object-transform-panel \
+  --js 'JSON.stringify(window.__objectTransformPanelState)'
+```
 
 The inspector's minimap cursor is operator-toggleable and starts hidden by
 default. Turning it on subscribes to `input_event` on demand and requests a

--- a/packages/toolkit/components/object-transform-panel/index.html
+++ b/packages/toolkit/components/object-transform-panel/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../_base/theme.css">
+<link rel="stylesheet" href="../../panel/defaults.css">
+<link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+<script type="module">
+import { mountPanel, Single } from '../../panel/index.js'
+import ObjectTransformPanel from './index.js'
+
+mountPanel({ title: 'Object Transform', layout: Single(ObjectTransformPanel) })
+</script>
+</body>
+</html>

--- a/packages/toolkit/components/object-transform-panel/index.js
+++ b/packages/toolkit/components/object-transform-panel/index.js
@@ -1,0 +1,282 @@
+import { emit, esc } from '../../runtime/bridge.js';
+import {
+  TRANSFORM_GROUPS,
+  VECTOR_AXES,
+  applyRegistryMessage,
+  applyTransformResultMessage,
+  buildTripletPatchMessage,
+  canPatchObject,
+  createObjectTransformState,
+  formatTripletValue,
+  objectAddressLabel,
+  patchDeliveryForTarget,
+  selectObject,
+  selectedObject,
+  sortedObjectEntries,
+  updateEntryTransformDraft,
+} from './model.js';
+import {
+  objectRowAttrs,
+  tripletInputAttrs,
+} from './semantics.js';
+
+const BASE_TITLE = 'Object Transform';
+
+let requestCounter = 0;
+
+function nextRequestId() {
+  requestCounter += 1;
+  return `object-transform-${Date.now().toString(36)}-${requestCounter}`;
+}
+
+function shortStatus(result) {
+  if (!result) return 'No transform result yet';
+  const detail = result.message || result.reason || objectAddressLabel({ canvas_id: result.target.canvas_id, object_id: result.target.object_id });
+  return `${result.status}: ${detail}`;
+}
+
+function unitForGroup(entry, group) {
+  const def = TRANSFORM_GROUPS.find((candidate) => candidate.key === group);
+  return entry?.units?.[def?.unitKey] || '';
+}
+
+function renderObjectList(entries, selectedKey) {
+  if (entries.length === 0) {
+    return '<div class="object-transform-empty">Waiting for addressable objects</div>';
+  }
+  return (
+    `<div class="object-transform-list" role="listbox" aria-label="Addressable objects">`
+      + entries.map((entry) => {
+        const selected = entry.key === selectedKey;
+        const visible = entry.visible === null ? '' : `<span>${entry.visible ? 'visible' : 'hidden'}</span>`;
+        return (
+          `<button type="button" class="object-transform-row${selected ? ' selected' : ''}" data-object-key="${esc(entry.key)}" ${objectRowAttrs(entry, selected)}>`
+            + `<strong>${esc(entry.name)}</strong>`
+            + `<small>${esc(entry.canvas_id)} / ${esc(entry.object_id)}</small>`
+            + `<em>${esc(entry.kind)}${visible}</em>`
+          + `</button>`
+        );
+      }).join('')
+    + `</div>`
+  );
+}
+
+function renderTriplet(entry, groupDef) {
+  const triplet = entry.transform[groupDef.key];
+  const unit = unitForGroup(entry, groupDef.key);
+  return (
+    `<fieldset class="object-transform-triplet" data-transform-group="${esc(groupDef.key)}">`
+      + `<legend><span>${esc(groupDef.label)}</span><em>${esc(unit)}</em></legend>`
+      + `<div class="object-transform-triplet-grid">`
+        + VECTOR_AXES.map((axis) => {
+          const value = formatTripletValue(triplet[axis]);
+          return (
+            `<label>`
+              + `<span>${axis.toUpperCase()}</span>`
+              + `<input class="object-transform-input" type="number" step="0.001" inputmode="decimal" value="${esc(value)}" `
+                + `data-transform-group="${esc(groupDef.key)}" data-transform-axis="${esc(axis)}" `
+                + `${tripletInputAttrs(entry, groupDef.key, axis, value)}>`
+            + `</label>`
+          );
+        }).join('')
+      + `</div>`
+    + `</fieldset>`
+  );
+}
+
+function renderEditor(entry, state) {
+  if (!entry) {
+    return (
+      `<div class="object-transform-editor empty">`
+        + `<div class="object-transform-empty">Select an advertised object to edit its transform</div>`
+      + `</div>`
+    );
+  }
+
+  const patchable = canPatchObject(entry);
+  const capabilityText = patchable ? 'patchable' : 'read only';
+  return (
+    `<div class="object-transform-editor">`
+      + `<header class="object-transform-target">`
+        + `<div>`
+          + `<strong>${esc(entry.name)}</strong>`
+          + `<span>${esc(objectAddressLabel(entry))}</span>`
+        + `</div>`
+        + `<em class="${patchable ? 'ok' : 'warn'}">${esc(capabilityText)}</em>`
+      + `</header>`
+      + `<div class="object-transform-triplets">`
+        + TRANSFORM_GROUPS.map((group) => renderTriplet(entry, group)).join('')
+      + `</div>`
+      + `<div class="object-transform-status ${esc(state.lastResult?.status || '')}" role="status" aria-live="polite">`
+        + `${esc(shortStatus(state.lastResult))}`
+      + `</div>`
+    + `</div>`
+  );
+}
+
+function renderSnapshot(state) {
+  const entries = sortedObjectEntries(state);
+  const selected = selectedObject(state);
+  return (
+    `<div class="object-transform-body">`
+      + `<aside class="object-transform-sidebar">`
+        + `<header><span>Objects</span><strong>${entries.length}</strong></header>`
+        + renderObjectList(entries, state.selectedKey)
+      + `</aside>`
+      + renderEditor(selected, state)
+    + `</div>`
+  );
+}
+
+export default function ObjectTransformPanel() {
+  let host = null;
+  let root = null;
+  const state = createObjectTransformState();
+
+  function syncDebugState() {
+    window.__objectTransformPanelState = {
+      objects: sortedObjectEntries(state),
+      selected: selectedObject(state),
+      lastResult: state.lastResult,
+      errors: [...state.errors],
+      pending: [...state.pendingByRequest.keys()],
+    };
+  }
+
+  function updateTitle() {
+    if (!host) return;
+    const count = sortedObjectEntries(state).length;
+    const selected = selectedObject(state);
+    host.setTitle(`${BASE_TITLE} - ${count}${selected ? ` - ${selected.name}` : ''}`);
+  }
+
+  function rerender() {
+    if (!root) return;
+    root.innerHTML = renderSnapshot(state);
+    updateTitle();
+    syncDebugState();
+  }
+
+  function emitTripletPatch(group, values) {
+    const entry = selectedObject(state);
+    if (!entry) return null;
+    try {
+      const patch = buildTripletPatchMessage(entry, group, values, { requestId: nextRequestId() });
+      state.pendingByRequest.set(patch.request_id, {
+        key: entry.key,
+        group,
+        sent_at: Date.now(),
+      });
+      state.objectsByKey.set(entry.key, updateEntryTransformDraft(entry, group, values));
+      const delivery = patchDeliveryForTarget(entry, patch);
+      emit(delivery.type, delivery.payload);
+      state.lastResult = {
+        request_id: patch.request_id,
+        target: patch.target,
+        key: entry.key,
+        status: 'pending',
+        reason: '',
+        message: 'waiting for owner',
+        transform: null,
+      };
+      rerender();
+      return patch;
+    } catch (error) {
+      state.errors.push(error.message);
+      state.lastResult = {
+        request_id: '',
+        target: { canvas_id: entry.canvas_id, object_id: entry.object_id },
+        key: entry.key,
+        status: 'rejected',
+        reason: 'invalid_patch',
+        message: error.message,
+        transform: null,
+      };
+      rerender();
+      return null;
+    }
+  }
+
+  function tripletValuesFromDom(group) {
+    const values = {};
+    for (const axis of VECTOR_AXES) {
+      const input = root.querySelector?.(`.object-transform-input[data-transform-group="${group}"][data-transform-axis="${axis}"]`);
+      if (input) values[axis] = input.value;
+    }
+    return values;
+  }
+
+  function handleClick(event) {
+    const row = event.target?.closest?.('[data-object-key]');
+    if (!row) return;
+    selectObject(state, row.dataset.objectKey);
+    rerender();
+  }
+
+  function handleChange(event) {
+    const input = event.target?.closest?.('.object-transform-input');
+    if (!input) return;
+    const group = input.dataset.transformGroup;
+    if (!group) return;
+    emitTripletPatch(group, tripletValuesFromDom(group));
+  }
+
+  function handleMessage(msg) {
+    if (msg.type === 'canvas_object.registry') {
+      applyRegistryMessage(state, msg);
+      rerender();
+      return;
+    }
+    if (msg.type === 'canvas_object.transform.result') {
+      applyTransformResultMessage(state, msg);
+      rerender();
+    }
+  }
+
+  return {
+    manifest: {
+      name: 'object-transform-panel',
+      title: BASE_TITLE,
+      accepts: ['canvas_object.registry', 'canvas_object.transform.result'],
+      emits: ['canvas.send'],
+      channelPrefix: 'object-transform',
+      requires: ['canvas_object.registry', 'canvas_object.transform.result'],
+      defaultSize: { w: 620, h: 420 },
+    },
+
+    render(host_) {
+      host = host_;
+      host.contentEl.style.overflow = 'hidden';
+      root = document.createElement('div');
+      root.className = 'object-transform-root';
+      root.setAttribute('role', 'region');
+      root.setAttribute('aria-label', BASE_TITLE);
+      root.addEventListener('click', handleClick);
+      root.addEventListener('change', handleChange);
+      window.__objectTransformPanelDebug = {
+        applyRegistry(message) {
+          applyRegistryMessage(state, message);
+          rerender();
+          return window.__objectTransformPanelState;
+        },
+        applyResult(message) {
+          applyTransformResultMessage(state, message);
+          rerender();
+          return window.__objectTransformPanelState;
+        },
+        select(key) {
+          selectObject(state, key);
+          rerender();
+          return selectedObject(state);
+        },
+        emitTriplet(group, values) {
+          return emitTripletPatch(group, values);
+        },
+      };
+      rerender();
+      return root;
+    },
+
+    onMessage: handleMessage,
+  };
+}

--- a/packages/toolkit/components/object-transform-panel/launch.sh
+++ b/packages/toolkit/components/object-transform-panel/launch.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# launch.sh - Create the addressable object transform panel.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null || pwd)"
+AOS="${AOS:-$ROOT/aos}"
+CANVAS_ID="${CANVAS_ID:-object-transform-panel}"
+PANEL_W="${AOS_OBJECT_TRANSFORM_PANEL_W:-620}"
+PANEL_H="${AOS_OBJECT_TRANSFORM_PANEL_H:-420}"
+
+if [[ ! -x "$AOS" ]]; then
+  echo "aos binary not found at $AOS" >&2
+  exit 1
+fi
+
+"$AOS" set content.roots.toolkit packages/toolkit >/dev/null
+"$AOS" content wait --root toolkit --auto-start --timeout 15s >/dev/null
+
+DISPLAY_JSON="$("$AOS" graph displays --json 2>/dev/null || echo '{"data":{"displays":[]}}')"
+GEOMETRY="$(
+  echo "$DISPLAY_JSON" | PANEL_W="$PANEL_W" PANEL_H="$PANEL_H" python3 -c '
+import json, os, sys
+
+payload = json.load(sys.stdin)
+displays = payload.get("data", {}).get("displays", payload.get("displays", [])) if isinstance(payload, dict) else payload
+main = next((entry for entry in displays if entry.get("is_main")), displays[0] if displays else None)
+rect = (main or {}).get("visible_bounds") or (main or {}).get("bounds") or {}
+x = int(rect.get("x", 0))
+y = int(rect.get("y", 0))
+w = int(rect.get("w", 1728))
+h = int(rect.get("h", 1117))
+panel_w = int(os.environ["PANEL_W"])
+panel_h = int(os.environ["PANEL_H"])
+print(x + max(0, w - panel_w - 16), y + 48, panel_w, panel_h)
+' 2>/dev/null || echo "0 48 $PANEL_W $PANEL_H"
+)"
+
+read -r X Y W H <<<"$GEOMETRY"
+
+"$AOS" show remove --id "$CANVAS_ID" 2>/dev/null || true
+"$AOS" show create \
+  --id "$CANVAS_ID" \
+  --at "$X,$Y,$W,$H" \
+  --interactive \
+  --scope global \
+  --url 'aos://toolkit/components/object-transform-panel/index.html' >/dev/null
+
+"$AOS" show wait \
+  --id "$CANVAS_ID" \
+  --manifest object-transform-panel \
+  --js 'typeof window.__objectTransformPanelState === "object"' \
+  --timeout 5s >/dev/null
+
+echo "Object transform panel launched at ${X},${Y} (${W}x${H})"

--- a/packages/toolkit/components/object-transform-panel/model.js
+++ b/packages/toolkit/components/object-transform-panel/model.js
@@ -1,0 +1,297 @@
+export const SCHEMA_VERSION = '2026-05-03';
+
+export const TRANSFORM_GROUPS = [
+  { key: 'position', label: 'Position', unitKey: 'position' },
+  { key: 'scale', label: 'Scale', unitKey: 'scale' },
+  { key: 'rotation_degrees', label: 'Rotation', unitKey: 'rotation' },
+];
+
+export const VECTOR_AXES = ['x', 'y', 'z'];
+
+const DEFAULT_TRANSFORM = Object.freeze({
+  position: Object.freeze({ x: 0, y: 0, z: 0 }),
+  scale: Object.freeze({ x: 1, y: 1, z: 1 }),
+  rotation_degrees: Object.freeze({ x: 0, y: 0, z: 0 }),
+});
+
+const DEFAULT_UNITS = Object.freeze({
+  position: 'scene',
+  scale: 'multiplier',
+  rotation: 'degrees',
+});
+
+function text(value, fallback = '') {
+  const normalized = String(value ?? '').replace(/\s+/g, ' ').trim();
+  return normalized || fallback;
+}
+
+function finiteNumber(value, fallback = null) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function cloneTriplet(triplet) {
+  return {
+    x: finiteNumber(triplet?.x, 0),
+    y: finiteNumber(triplet?.y, 0),
+    z: finiteNumber(triplet?.z, 0),
+  };
+}
+
+function normalizeTriplet(value, fallback) {
+  const base = fallback || { x: 0, y: 0, z: 0 };
+  return {
+    x: finiteNumber(value?.x, base.x),
+    y: finiteNumber(value?.y, base.y),
+    z: finiteNumber(value?.z, base.z),
+  };
+}
+
+function normalizePartialTriplet(value) {
+  const triplet = {};
+  for (const axis of VECTOR_AXES) {
+    if (value?.[axis] === undefined || value?.[axis] === '') continue;
+    const n = finiteNumber(value[axis], null);
+    if (n == null) continue;
+    triplet[axis] = n;
+  }
+  return triplet;
+}
+
+function normalizeTransform(value = {}) {
+  return {
+    position: normalizeTriplet(value.position, DEFAULT_TRANSFORM.position),
+    scale: normalizeTriplet(value.scale, DEFAULT_TRANSFORM.scale),
+    rotation_degrees: normalizeTriplet(value.rotation_degrees, DEFAULT_TRANSFORM.rotation_degrees),
+  };
+}
+
+function normalizeUnits(value = {}) {
+  return {
+    position: text(value.position, DEFAULT_UNITS.position),
+    scale: text(value.scale, DEFAULT_UNITS.scale),
+    rotation: text(value.rotation, DEFAULT_UNITS.rotation),
+  };
+}
+
+function unwrapMessage(message = {}) {
+  if (message?.payload && typeof message.payload === 'object') {
+    return { ...message.payload, type: message.payload.type || message.type };
+  }
+  return message || {};
+}
+
+export function objectAddressKey(canvasId, objectId) {
+  return `${encodeURIComponent(text(canvasId, 'unknown'))}::${encodeURIComponent(text(objectId, 'unknown'))}`;
+}
+
+export function objectAddressLabel(entry) {
+  if (!entry) return 'No object selected';
+  return `${entry.canvas_id} / ${entry.object_id}`;
+}
+
+export function createObjectTransformState() {
+  return {
+    objectsByKey: new Map(),
+    selectedKey: null,
+    lastResult: null,
+    errors: [],
+    pendingByRequest: new Map(),
+  };
+}
+
+export function normalizeRegistryMessage(message = {}) {
+  const payload = unwrapMessage(message);
+  if (payload.type && payload.type !== 'canvas_object.registry') {
+    return { ok: false, error: `unexpected message type ${payload.type}` };
+  }
+
+  const canvasId = text(payload.canvas_id);
+  if (!canvasId) return { ok: false, error: 'registry missing canvas_id' };
+  if (!Array.isArray(payload.objects)) return { ok: false, error: 'registry missing objects array' };
+
+  const objects = [];
+  for (const object of payload.objects) {
+    const objectId = text(object?.object_id);
+    if (!objectId) continue;
+    const key = objectAddressKey(canvasId, objectId);
+    objects.push({
+      key,
+      canvas_id: canvasId,
+      object_id: objectId,
+      name: text(object.name, objectId),
+      kind: text(object.kind, 'custom'),
+      capabilities: Array.isArray(object.capabilities)
+        ? object.capabilities.filter((item) => typeof item === 'string')
+        : [],
+      transform: normalizeTransform(object.transform),
+      units: normalizeUnits(object.units),
+      visible: object.visible === undefined ? null : !!object.visible,
+      metadata: object.metadata && typeof object.metadata === 'object' ? { ...object.metadata } : {},
+    });
+  }
+
+  return {
+    ok: true,
+    registry: {
+      type: 'canvas_object.registry',
+      schema_version: text(payload.schema_version, SCHEMA_VERSION),
+      canvas_id: canvasId,
+      source_id: text(payload.source_id),
+      objects,
+    },
+  };
+}
+
+export function sortedObjectEntries(state) {
+  return [...(state?.objectsByKey?.values?.() || [])].sort((a, b) => {
+    const canvasOrder = a.canvas_id.localeCompare(b.canvas_id);
+    if (canvasOrder !== 0) return canvasOrder;
+    return a.name.localeCompare(b.name) || a.object_id.localeCompare(b.object_id);
+  });
+}
+
+export function selectedObject(state) {
+  if (!state?.selectedKey) return null;
+  return state.objectsByKey.get(state.selectedKey) || null;
+}
+
+export function selectObject(state, key) {
+  if (!state || !state.objectsByKey.has(key)) return null;
+  state.selectedKey = key;
+  return selectedObject(state);
+}
+
+function pickNextSelection(state) {
+  const entries = sortedObjectEntries(state);
+  state.selectedKey = entries[0]?.key || null;
+}
+
+export function applyRegistryMessage(state, message = {}) {
+  const normalized = normalizeRegistryMessage(message);
+  if (!normalized.ok) {
+    state.errors.push(normalized.error);
+    while (state.errors.length > 12) state.errors.shift();
+    return normalized;
+  }
+
+  const { registry } = normalized;
+  for (const [key, entry] of [...state.objectsByKey.entries()]) {
+    if (entry.canvas_id === registry.canvas_id) state.objectsByKey.delete(key);
+  }
+  for (const object of registry.objects) {
+    state.objectsByKey.set(object.key, object);
+  }
+  if (!state.selectedKey || !state.objectsByKey.has(state.selectedKey)) pickNextSelection(state);
+  return normalized;
+}
+
+export function normalizeTransformResultMessage(message = {}) {
+  const payload = unwrapMessage(message);
+  if (payload.type && payload.type !== 'canvas_object.transform.result') {
+    return { ok: false, error: `unexpected message type ${payload.type}` };
+  }
+  const requestId = text(payload.request_id);
+  const canvasId = text(payload.target?.canvas_id);
+  const objectId = text(payload.target?.object_id);
+  const status = text(payload.status);
+  if (!requestId) return { ok: false, error: 'result missing request_id' };
+  if (!canvasId || !objectId) return { ok: false, error: 'result missing target address' };
+  if (!['applied', 'rejected', 'stale'].includes(status)) return { ok: false, error: `invalid result status ${status}` };
+  return {
+    ok: true,
+    result: {
+      type: 'canvas_object.transform.result',
+      schema_version: text(payload.schema_version, SCHEMA_VERSION),
+      request_id: requestId,
+      target: { canvas_id: canvasId, object_id: objectId },
+      key: objectAddressKey(canvasId, objectId),
+      status,
+      reason: text(payload.reason),
+      message: text(payload.message),
+      transform: payload.transform ? normalizeTransform(payload.transform) : null,
+    },
+  };
+}
+
+export function applyTransformResultMessage(state, message = {}) {
+  const normalized = normalizeTransformResultMessage(message);
+  if (!normalized.ok) {
+    state.errors.push(normalized.error);
+    while (state.errors.length > 12) state.errors.shift();
+    return normalized;
+  }
+
+  const { result } = normalized;
+  state.lastResult = result;
+  state.pendingByRequest.delete(result.request_id);
+  if (result.status === 'applied' && result.transform && state.objectsByKey.has(result.key)) {
+    const entry = state.objectsByKey.get(result.key);
+    state.objectsByKey.set(result.key, {
+      ...entry,
+      transform: result.transform,
+    });
+  }
+  return normalized;
+}
+
+export function canPatchObject(entry) {
+  return !!entry?.capabilities?.includes?.('transform.patch');
+}
+
+export function buildTripletPatchMessage(entry, group, values, options = {}) {
+  if (!entry) throw new Error('target entry is required');
+  if (!TRANSFORM_GROUPS.some((candidate) => candidate.key === group)) {
+    throw new Error(`unknown transform group ${group}`);
+  }
+  if (!canPatchObject(entry)) throw new Error(`object ${entry.object_id} does not advertise transform.patch`);
+
+  const triplet = normalizePartialTriplet(values);
+  if (Object.keys(triplet).length === 0) throw new Error('patch requires at least one numeric axis');
+  const requestId = text(options.requestId, `object-transform-${Date.now().toString(36)}`);
+
+  return {
+    type: 'canvas_object.transform.patch',
+    schema_version: SCHEMA_VERSION,
+    request_id: requestId,
+    target: {
+      canvas_id: entry.canvas_id,
+      object_id: entry.object_id,
+    },
+    patch: {
+      [group]: triplet,
+    },
+  };
+}
+
+export function patchDeliveryForTarget(entry, patchMessage) {
+  if (!entry) throw new Error('target entry is required');
+  return {
+    type: 'canvas.send',
+    payload: {
+      target: entry.canvas_id,
+      message: patchMessage,
+    },
+  };
+}
+
+export function updateEntryTransformDraft(entry, group, values) {
+  if (!entry) return null;
+  const current = entry.transform || DEFAULT_TRANSFORM;
+  return {
+    ...entry,
+    transform: {
+      ...current,
+      [group]: {
+        ...cloneTriplet(current[group]),
+        ...normalizePartialTriplet(values),
+      },
+    },
+  };
+}
+
+export function formatTripletValue(value) {
+  const n = finiteNumber(value, 0);
+  if (Math.abs(n) >= 1000 || (Math.abs(n) > 0 && Math.abs(n) < 0.001)) return String(n);
+  return Number.parseFloat(n.toFixed(4)).toString();
+}

--- a/packages/toolkit/components/object-transform-panel/semantics.js
+++ b/packages/toolkit/components/object-transform-panel/semantics.js
@@ -1,0 +1,62 @@
+import { normalizeSemanticTarget } from '../../runtime/semantic-targets.js';
+
+const SURFACE = 'object-transform-panel';
+
+function escAttr(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function boolAttr(value) {
+  return value ? 'true' : 'false';
+}
+
+function semanticAttrString(target = {}, options = {}) {
+  const normalized = normalizeSemanticTarget({
+    ...target,
+    surface: SURFACE,
+  });
+  const attrs = [
+    ['aria-label', normalized.name],
+    ['data-aos-ref', normalized.aosRef],
+    ['data-aos-surface', normalized.surface],
+    ['data-semantic-target-id', normalized.id],
+  ];
+  if (normalized.action) attrs.push(['data-aos-action', normalized.action]);
+  if (normalized.selected !== null) attrs.push(['aria-selected', boolAttr(normalized.selected)]);
+  if (normalized.value !== null) attrs.push(['aria-valuetext', normalized.value]);
+  if (!normalized.enabled) attrs.push(['aria-disabled', 'true']);
+  if (normalized.role && !(options.nativeRole && normalized.role === options.nativeRole)) {
+    attrs.push(['role', normalized.role]);
+  }
+  return attrs
+    .filter(([, value]) => value !== undefined && value !== null && value !== '')
+    .map(([name, value]) => `${name}="${escAttr(value)}"`)
+    .join(' ');
+}
+
+export function objectRowAttrs(entry, selected = false) {
+  return semanticAttrString({
+    id: `object-${entry.key}`,
+    role: 'AXButton',
+    name: `Select ${entry.name}`,
+    action: 'select_object',
+    aosRef: `${SURFACE}:object:${entry.canvas_id}:${entry.object_id}`,
+    selected,
+  }, { nativeRole: 'button' });
+}
+
+export function tripletInputAttrs(entry, group, axis, value) {
+  const label = `${group.replace('_degrees', '')} ${axis} for ${entry.name}`;
+  return semanticAttrString({
+    id: `${group}-${axis}-${entry.key}`,
+    role: 'AXTextField',
+    name: label,
+    action: 'edit_transform',
+    aosRef: `${SURFACE}:input:${entry.canvas_id}:${entry.object_id}:${group}:${axis}`,
+    value,
+  }, { nativeRole: 'textbox' });
+}

--- a/packages/toolkit/components/object-transform-panel/styles.css
+++ b/packages/toolkit/components/object-transform-panel/styles.css
@@ -1,0 +1,261 @@
+.object-transform-root {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  color: var(--text-primary);
+}
+
+.object-transform-body {
+  height: 100%;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(190px, 0.9fr) minmax(280px, 1.35fr);
+  gap: 0;
+}
+
+.object-transform-sidebar {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--border-subtle);
+  background: rgba(10, 10, 18, 0.18);
+}
+
+.object-transform-sidebar > header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  font-size: var(--font-size-header);
+}
+
+.object-transform-sidebar > header strong {
+  color: var(--text-primary);
+}
+
+.object-transform-list {
+  min-height: 0;
+  overflow: auto;
+  padding: 6px;
+}
+
+.object-transform-row {
+  width: 100%;
+  appearance: none;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 2px;
+  padding: 7px 8px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.object-transform-row:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.object-transform-row.selected {
+  border-color: rgba(138, 180, 255, 0.35);
+  background: rgba(138, 180, 255, 0.10);
+  color: var(--text-primary);
+}
+
+.object-transform-row strong,
+.object-transform-row small,
+.object-transform-row em {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.object-transform-row strong {
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.object-transform-row small,
+.object-transform-row em {
+  color: var(--text-muted);
+  font-size: var(--font-size-small);
+  font-style: normal;
+}
+
+.object-transform-row em {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.object-transform-editor {
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px;
+}
+
+.object-transform-editor.empty {
+  align-items: center;
+  justify-content: center;
+}
+
+.object-transform-empty {
+  padding: 14px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.object-transform-target {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.object-transform-target div {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
+.object-transform-target strong,
+.object-transform-target span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.object-transform-target span {
+  color: var(--text-muted);
+  font-size: var(--font-size-small);
+}
+
+.object-transform-target em {
+  flex: 0 0 auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  padding: 2px 7px;
+  color: var(--text-secondary);
+  font-size: var(--font-size-small);
+  font-style: normal;
+}
+
+.object-transform-target em.ok {
+  color: var(--accent-green);
+  border-color: rgba(102, 170, 153, 0.35);
+}
+
+.object-transform-target em.warn {
+  color: var(--accent-yellow);
+  border-color: rgba(221, 170, 102, 0.35);
+}
+
+.object-transform-triplets {
+  display: grid;
+  gap: 10px;
+}
+
+.object-transform-triplet {
+  display: grid;
+  gap: 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  padding: 8px;
+}
+
+.object-transform-triplet legend {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 3px;
+  color: var(--text-secondary);
+  font-size: var(--font-size-small);
+  text-transform: uppercase;
+}
+
+.object-transform-triplet legend em {
+  color: var(--text-muted);
+  font-style: normal;
+  text-transform: none;
+}
+
+.object-transform-triplet-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.object-transform-triplet label {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
+.object-transform-triplet label span {
+  color: var(--text-label);
+  font-size: var(--font-size-header);
+}
+
+.object-transform-input {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: 5px;
+  background: rgba(0, 0, 0, 0.22);
+  color: var(--text-primary);
+  font: 11px var(--font-mono);
+  padding: 6px 7px;
+}
+
+.object-transform-input:focus {
+  outline: 1px solid rgba(138, 180, 255, 0.6);
+  border-color: rgba(138, 180, 255, 0.45);
+}
+
+.object-transform-status {
+  margin-top: auto;
+  min-height: 26px;
+  border-top: 1px solid var(--border-subtle);
+  padding: 8px 0 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-small);
+}
+
+.object-transform-status.applied {
+  color: var(--accent-green);
+}
+
+.object-transform-status.rejected,
+.object-transform-status.stale {
+  color: var(--accent-yellow);
+}
+
+@media (max-width: 520px) {
+  .object-transform-body {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(120px, 0.8fr) minmax(220px, 1fr);
+  }
+
+  .object-transform-sidebar {
+    border-right: 0;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+}

--- a/tests/toolkit/object-transform-panel-model.test.mjs
+++ b/tests/toolkit/object-transform-panel-model.test.mjs
@@ -1,0 +1,169 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  applyRegistryMessage,
+  applyTransformResultMessage,
+  buildTripletPatchMessage,
+  createObjectTransformState,
+  objectAddressKey,
+  patchDeliveryForTarget,
+  selectObject,
+  selectedObject,
+  sortedObjectEntries,
+} from '../../packages/toolkit/components/object-transform-panel/model.js';
+
+function registry(canvasId = 'avatar-main') {
+  return {
+    type: 'canvas_object.registry',
+    schema_version: '2026-05-03',
+    canvas_id: canvasId,
+    objects: [
+      {
+        object_id: 'radial.wiki-brain.tree',
+        name: 'Wiki Brain Tree',
+        kind: 'three.object3d',
+        capabilities: ['transform.read', 'transform.patch'],
+        transform: {
+          position: { x: 0.018, y: -0.035, z: 0.018 },
+          scale: { x: 1.32, y: 1.42, z: 1.2 },
+          rotation_degrees: { x: -11.5, y: 0, z: 0 },
+        },
+        units: {
+          position: 'scene',
+          scale: 'multiplier',
+          rotation: 'degrees',
+        },
+      },
+      {
+        object_id: 'radial.wiki-brain.shell',
+        name: 'Wiki Brain Shell',
+        kind: 'three.object3d',
+        capabilities: ['transform.read'],
+        transform: {
+          position: { x: 0, y: 0, z: 0 },
+          scale: { x: 1, y: 1, z: 1 },
+          rotation_degrees: { x: 0, y: 0, z: 0 },
+        },
+        units: {
+          position: 'scene',
+          scale: 'multiplier',
+          rotation: 'degrees',
+        },
+      },
+    ],
+  };
+}
+
+test('registry ingest stores advertised objects and selects the first object', () => {
+  const state = createObjectTransformState();
+  const result = applyRegistryMessage(state, registry());
+
+  assert.equal(result.ok, true);
+  assert.equal(sortedObjectEntries(state).length, 2);
+  assert.equal(selectedObject(state).name, 'Wiki Brain Shell');
+  assert.deepEqual(selectedObject(state).transform.scale, { x: 1, y: 1, z: 1 });
+});
+
+test('selection targets one advertised object without assuming renderer internals', () => {
+  const state = createObjectTransformState();
+  applyRegistryMessage(state, registry());
+
+  const key = objectAddressKey('avatar-main', 'radial.wiki-brain.tree');
+  const selected = selectObject(state, key);
+
+  assert.equal(selected.object_id, 'radial.wiki-brain.tree');
+  assert.equal(selected.kind, 'three.object3d');
+  assert.equal(selected.canvas_id, 'avatar-main');
+});
+
+test('triplet edits build a schema-shaped transform patch payload', () => {
+  const state = createObjectTransformState();
+  applyRegistryMessage(state, registry());
+  selectObject(state, objectAddressKey('avatar-main', 'radial.wiki-brain.tree'));
+
+  const patch = buildTripletPatchMessage(selectedObject(state), 'scale', {
+    x: '1.4',
+    y: '1.5',
+    z: '1.25',
+  }, { requestId: 'req-test' });
+
+  assert.deepEqual(patch, {
+    type: 'canvas_object.transform.patch',
+    schema_version: '2026-05-03',
+    request_id: 'req-test',
+    target: {
+      canvas_id: 'avatar-main',
+      object_id: 'radial.wiki-brain.tree',
+    },
+    patch: {
+      scale: { x: 1.4, y: 1.5, z: 1.25 },
+    },
+  });
+});
+
+test('patch delivery uses existing canvas.send routing to the owning canvas', () => {
+  const state = createObjectTransformState();
+  applyRegistryMessage(state, registry());
+  selectObject(state, objectAddressKey('avatar-main', 'radial.wiki-brain.tree'));
+
+  const entry = selectedObject(state);
+  const patch = buildTripletPatchMessage(entry, 'rotation_degrees', { x: -9 }, { requestId: 'req-rotate' });
+  const delivery = patchDeliveryForTarget(entry, patch);
+
+  assert.equal(delivery.type, 'canvas.send');
+  assert.equal(delivery.payload.target, 'avatar-main');
+  assert.equal(delivery.payload.message.type, 'canvas_object.transform.patch');
+  assert.equal(delivery.payload.message.request_id, 'req-rotate');
+});
+
+test('non-patchable advertised objects reject transform patch construction', () => {
+  const state = createObjectTransformState();
+  applyRegistryMessage(state, registry());
+  selectObject(state, objectAddressKey('avatar-main', 'radial.wiki-brain.shell'));
+
+  assert.throws(
+    () => buildTripletPatchMessage(selectedObject(state), 'scale', { x: 1.1 }, { requestId: 'req-shell' }),
+    /does not advertise transform.patch/,
+  );
+});
+
+test('owner results update local transform state and clear pending requests', () => {
+  const state = createObjectTransformState();
+  applyRegistryMessage(state, registry());
+  selectObject(state, objectAddressKey('avatar-main', 'radial.wiki-brain.tree'));
+  state.pendingByRequest.set('req-test', { key: state.selectedKey });
+
+  const result = applyTransformResultMessage(state, {
+    type: 'canvas_object.transform.result',
+    schema_version: '2026-05-03',
+    request_id: 'req-test',
+    target: {
+      canvas_id: 'avatar-main',
+      object_id: 'radial.wiki-brain.tree',
+    },
+    status: 'applied',
+    transform: {
+      position: { x: 0.018, y: -0.04, z: 0.02 },
+      scale: { x: 1.4, y: 1.5, z: 1.25 },
+      rotation_degrees: { x: -9, y: 0, z: 0 },
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(state.pendingByRequest.has('req-test'), false);
+  assert.deepEqual(selectedObject(state).transform.scale, { x: 1.4, y: 1.5, z: 1.25 });
+});
+
+test('empty registry snapshots remove a canvas object list', () => {
+  const state = createObjectTransformState();
+  applyRegistryMessage(state, registry());
+  applyRegistryMessage(state, {
+    type: 'canvas_object.registry',
+    schema_version: '2026-05-03',
+    canvas_id: 'avatar-main',
+    objects: [],
+  });
+
+  assert.equal(sortedObjectEntries(state).length, 0);
+  assert.equal(selectedObject(state), null);
+});

--- a/tests/toolkit/passive-component-semantics.test.mjs
+++ b/tests/toolkit/passive-component-semantics.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 
 import InspectorPanel from '../../packages/toolkit/components/inspector-panel/index.js'
 import LogConsole from '../../packages/toolkit/components/log-console/index.js'
+import ObjectTransformPanel from '../../packages/toolkit/components/object-transform-panel/index.js'
 import RenderPerformance from '../../packages/toolkit/components/render-performance/index.js'
 import SpatialTelemetry from '../../packages/toolkit/components/spatial-telemetry/index.js'
 
@@ -187,4 +188,41 @@ test('SpatialTelemetry exposes root region, labeled tables, and log semantics', 
   assert.match(root.innerHTML, /<table class="telemetry-table" aria-label="Canvas geometry">/)
   assert.match(root.innerHTML, /<table class="telemetry-table" aria-label="Cursor position">/)
   assert.match(root.innerHTML, /class="event-log" role="log" aria-label="Telemetry events" aria-live="polite"/)
+})
+
+test('ObjectTransformPanel exposes root region, object list, and triplet fields', (t) => {
+  withFakeBrowser(t)
+
+  const panel = ObjectTransformPanel()
+  const root = panel.render(fakeHost())
+
+  assert.equal(root.getAttribute('role'), 'region')
+  assert.equal(root.getAttribute('aria-label'), 'Object Transform')
+
+  panel.onMessage({
+    type: 'canvas_object.registry',
+    schema_version: '2026-05-03',
+    canvas_id: 'avatar-main',
+    objects: [{
+      object_id: 'radial.wiki-brain.tree',
+      name: 'Wiki Brain Tree',
+      kind: 'three.object3d',
+      capabilities: ['transform.read', 'transform.patch'],
+      transform: {
+        position: { x: 0, y: 0, z: 0 },
+        scale: { x: 1.32, y: 1.42, z: 1.2 },
+        rotation_degrees: { x: -11.5, y: 0, z: 0 },
+      },
+      units: {
+        position: 'scene',
+        scale: 'multiplier',
+        rotation: 'degrees',
+      },
+    }],
+  })
+
+  assert.match(root.innerHTML, /role="listbox" aria-label="Addressable objects"/)
+  assert.match(root.innerHTML, /data-aos-action="select_object"/)
+  assert.match(root.innerHTML, /data-aos-action="edit_transform"/)
+  assert.match(root.innerHTML, /aria-label="scale x for Wiki Brain Tree"/)
 })


### PR DESCRIPTION
Closes #199.\n\n## Summary\n- add reusable object-transform-panel toolkit component\n- add pure registry/selection/patch model and tests\n- document launch and machine-readable debug state\n\n## Verification\n- node --test tests/toolkit/object-transform-panel-model.test.mjs tests/toolkit/passive-component-semantics.test.mjs\n- node --test tests/toolkit/*.test.mjs\n- git diff --check\n- node --check packages/toolkit/components/object-transform-panel/index.js\n- node --check packages/toolkit/components/object-transform-panel/model.js\n- node --check packages/toolkit/components/object-transform-panel/semantics.js\n- bash -n packages/toolkit/components/object-transform-panel/launch.sh