### PR TITLE
Normalize stale Sigil radial menu configs

### DIFF
--- a/apps/sigil/renderer/appearance.js
+++ b/apps/sigil/renderer/appearance.js
@@ -17,7 +17,10 @@ import { updateAllColors } from './colors.js';
 import { updatePulsars, updateGammaRays, updateAccretion, updateNeutrinos } from './phenomena.js';
 import { updateGeometry, updateOmegaGeometry } from './geometry.js';
 import { applySkin } from './skins.js';
-import { DEFAULT_SIGIL_RADIAL_ITEMS } from './radial-menu-defaults.js';
+import {
+    DEFAULT_SIGIL_RADIAL_ITEMS,
+    normalizeSigilRadialGestureMenu,
+} from './radial-menu-defaults.js';
 import {
     DEFAULT_FAST_TRAVEL_EFFECT,
     DEFAULT_TRANSITION_EFFECT,
@@ -383,7 +386,9 @@ export function applyAppearance(blob) {
     state.dragCancelRadius = interaction.dragCancelRadius ?? D.interaction.dragCancelRadius;
     state.gotoRingRadius = interaction.gotoRingRadius ?? D.interaction.gotoRingRadius;
     state.menuRingRadius = interaction.menuRingRadius ?? D.interaction.menuRingRadius;
-    state.radialGestureMenu = interaction.radialGestureMenu ?? D.interaction.radialGestureMenu;
+    state.radialGestureMenu = normalizeSigilRadialGestureMenu(
+        interaction.radialGestureMenu ?? D.interaction.radialGestureMenu
+    );
 
     const windowing = blob.windowing ?? D.windowing;
     state.avatarWindowLevel = windowing.avatarLevel === 'screen_saver'

--- a/apps/sigil/renderer/live-modules/radial-gesture-menu.js
+++ b/apps/sigil/renderer/live-modules/radial-gesture-menu.js
@@ -1,5 +1,8 @@
 import { createRadialGestureModel } from './radial-gesture-runtime.js';
-import { DEFAULT_SIGIL_RADIAL_ITEMS } from '../radial-menu-defaults.js';
+import {
+    DEFAULT_SIGIL_RADIAL_ITEMS,
+    normalizeSigilRadialGestureMenu,
+} from '../radial-menu-defaults.js';
 
 export { DEFAULT_SIGIL_RADIAL_ITEMS };
 
@@ -24,17 +27,14 @@ function numberOr(value, fallback) {
 }
 
 function configFromState(state) {
-    const radial = state.radialGestureMenu && typeof state.radialGestureMenu === 'object'
+    const source = state.radialGestureMenu && typeof state.radialGestureMenu === 'object'
         ? state.radialGestureMenu
         : {};
-    const items = Array.isArray(radial.items) && radial.items.length > 0
-        ? radial.items
-        : DEFAULT_SIGIL_RADIAL_ITEMS;
+    const radial = normalizeSigilRadialGestureMenu(source);
     return {
         ...DEFAULT_CONFIG,
         ...radial,
         radiusBasis: numberOr(radial.radiusBasis, numberOr(state.avatarHitRadius, DEFAULT_CONFIG.radiusBasis)),
-        items,
     };
 }
 

--- a/apps/sigil/renderer/radial-menu-defaults.js
+++ b/apps/sigil/renderer/radial-menu-defaults.js
@@ -84,3 +84,72 @@ export const DEFAULT_SIGIL_RADIAL_ITEMS = [
         geometry: WIKI_BRAIN_HOLOGRAM_MODEL,
     },
 ];
+
+function isPlainObject(value) {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cloneConfig(value) {
+    if (Array.isArray(value)) return value.map((item) => cloneConfig(item));
+    if (!isPlainObject(value)) return value;
+    const next = {};
+    for (const [key, entry] of Object.entries(value)) {
+        next[key] = cloneConfig(entry);
+    }
+    return next;
+}
+
+function mergeConfig(base, override) {
+    if (!isPlainObject(base) || !isPlainObject(override)) {
+        return cloneConfig(override === undefined ? base : override);
+    }
+    const next = cloneConfig(base);
+    for (const [key, value] of Object.entries(override)) {
+        next[key] = isPlainObject(next[key]) && isPlainObject(value)
+            ? mergeConfig(next[key], value)
+            : cloneConfig(value);
+    }
+    return next;
+}
+
+function normalizeRadialItemOverride(item) {
+    const next = cloneConfig(item);
+    if (!isPlainObject(next)) return next;
+
+    if (next.id === 'codex-terminal') {
+        next.id = 'agent-terminal';
+        if (next.action === 'codexTerminal') next.action = 'agentTerminal';
+        if (next.label === 'Codex Terminal') next.label = 'Agent Terminal';
+    }
+
+    if (next.id === 'wiki-graph' && isPlainObject(next.geometry)) {
+        if (next.geometry.material === 'translucent-brain') {
+            next.geometry.material = WIKI_BRAIN_HOLOGRAM_MODEL.material;
+        }
+    }
+
+    return next;
+}
+
+const DEFAULT_SIGIL_RADIAL_ITEMS_BY_ID = new Map(
+    DEFAULT_SIGIL_RADIAL_ITEMS.map((item) => [item.id, item])
+);
+
+export function normalizeSigilRadialItems(items) {
+    if (!Array.isArray(items) || items.length === 0) {
+        return cloneConfig(DEFAULT_SIGIL_RADIAL_ITEMS);
+    }
+    return items.map((item) => {
+        const normalized = normalizeRadialItemOverride(item);
+        const defaults = DEFAULT_SIGIL_RADIAL_ITEMS_BY_ID.get(normalized?.id);
+        return defaults ? mergeConfig(defaults, normalized) : normalized;
+    });
+}
+
+export function normalizeSigilRadialGestureMenu(menu = {}) {
+    const source = isPlainObject(menu) ? menu : {};
+    return {
+        ...cloneConfig(source),
+        items: normalizeSigilRadialItems(source.items),
+    };
+}

--- a/docs/design/permission-bearing-runtime-boundary.md
+++ b/docs/design/permission-bearing-runtime-boundary.md
@@ -1,0 +1,88 @@
+# Permission-Bearing Runtime Boundary
+
+Status: Concept, not scheduled.
+
+This note captures an architectural guardrail. It is not a roadmap item and
+must not be promoted into implementation work unless the user explicitly asks
+for that promotion or a concrete issue exposes repeated runtime-boundary pain.
+
+## Problem
+
+macOS Accessibility, Input Monitoring, and related privacy grants attach to the
+process identity that requests protected access. In agent-os repo mode, that
+identity is the `aos` daemon binary. Rebuilding the active daemon binary, changing
+its signing identity, or pointing launchd at a different `aos` path can make
+macOS treat the runtime as a new or stale permission subject.
+
+That makes daemon churn expensive. Work that can be expressed above the daemon
+should not require changing the permission-bearing binary.
+
+## Principle
+
+Keep the permission-bearing core small, stable, primitive-oriented, and
+slow-changing. The daemon should expose durable primitives and contracts; apps,
+toolkit components, provider integrations, visuals, policies, and workflows
+should compose those primitives outside the privileged binary whenever possible.
+
+The stable core owns protected or host-level capabilities such as:
+
+- screen, cursor, window, and accessibility perception
+- accessibility actions and input-event injection
+- canvas window lifecycle
+- content serving
+- IPC, routing, and pub/sub
+- readiness, service, and permission diagnostics
+
+Consumers above that layer should own interpretation and product behavior.
+Sigil visuals, toolkit panels, provider session logic, and visual harnesses
+should remain content, JavaScript, schemas, or package code unless they require a
+new primitive.
+
+## Current Fit
+
+agent-os already partly follows this boundary. Sigil and toolkit surfaces are
+served as content by the stable daemon, shared contracts live in schemas and
+docs, and recent addressable-object work followed the right layering:
+
+- primitive contract first
+- reusable toolkit surface second
+- Sigil adopter third
+
+The remaining risk is operational. Visual or app debugging can still drift into
+runtime work when a local branch contains both app changes and Swift daemon
+changes, or when a worktree smoke test tempts an agent to build or run a second
+`aos` binary.
+
+## Operational Rule
+
+Before rebuilding `aos`, classify the task:
+
+- Content-only: JavaScript, HTML, CSS, assets, docs, schemas, package tests, and
+  app/toolkit behavior. Do not rebuild the daemon.
+- Runtime-core: Swift sources under `src/` or shared Swift IPC code that affect
+  daemon behavior. Rebuild only when the verification path actually executes the
+  changed binary.
+
+If a content-only task appears to require a daemon rebuild, pause and identify
+which missing primitive is forcing the boundary crossing.
+
+## Guardrail
+
+Do not design native daemon plugins, dynamically loaded privileged modules, or a
+broader runtime modularity system from this note alone. Those designs carry
+signing, stability, crash-isolation, and trust-boundary costs. They should be
+considered only after a specific primitive-boundary issue demonstrates that the
+current stable-core plus content/toolkit model is insufficient.
+
+## Promotion Criteria
+
+Create implementation issues only when there is concrete evidence, such as:
+
+- repeated app work requiring Swift daemon changes for the same missing
+  primitive
+- repeated macOS permission churn caused by active-runtime rebuilds
+- a narrow extension point that can be specified as a stable primitive contract
+  without turning the daemon into a plugin host
+
+Until then, this note should be used as design context and a review heuristic,
+not as next work.

--- a/tests/renderer/radial-gesture-menu.test.mjs
+++ b/tests/renderer/radial-gesture-menu.test.mjs
@@ -4,6 +4,7 @@ import {
   createSigilRadialGestureMenu,
   DEFAULT_SIGIL_RADIAL_ITEMS,
 } from '../../apps/sigil/renderer/live-modules/radial-gesture-menu.js'
+import { normalizeSigilRadialGestureMenu } from '../../apps/sigil/renderer/radial-menu-defaults.js'
 
 function createMenu(options = {}) {
   const commits = []
@@ -83,6 +84,70 @@ test('Sigil radial menu config carries native wiki model geometry', () => {
   })
   assert.equal(wikiItem.geometry.attribution.author, 'Versal')
   assert.equal(wikiItem.geometry.attribution.license, 'CC-BY-4.0')
+})
+
+test('Sigil radial menu normalizes stale wiki brain item geometry from saved config', () => {
+  const staleMenu = {
+    items: [
+      {
+        id: 'wiki-graph',
+        label: 'Wiki Graph',
+        action: 'wikiGraph',
+        geometry: {
+          type: 'gltf',
+          src: '../assets/models/human-brain/scene.gltf',
+          modelUid: '49bcdf19c1904c76a456b31838b0d7ac',
+          title: 'Human Brain',
+          radiusScale: 1.42,
+          normalizedRadius: 0.28,
+          material: 'translucent-brain',
+        },
+      },
+    ],
+  }
+
+  const normalized = normalizeSigilRadialGestureMenu(staleMenu)
+  const wikiItem = normalized.items.find((item) => item.id === 'wiki-graph')
+
+  assert.equal(wikiItem.geometry.material, 'translucent-brain-shell')
+  assert.deepEqual(wikiItem.geometry.radialEffect, {
+    kind: 'nested-neural-tree',
+    holdExitDirection: 'outward',
+    shellOpacity: {
+      rest: 0.75,
+      active: 0.26,
+      held: 0.75,
+    },
+  })
+  assert.equal(staleMenu.items[0].geometry.material, 'translucent-brain')
+  assert.equal(staleMenu.items[0].geometry.radialEffect, undefined)
+})
+
+test('Sigil radial menu start applies normalized stale item geometry', () => {
+  const { menu } = createMenu({
+    state: {
+      radialGestureMenu: {
+        items: [
+          {
+            id: 'wiki-graph',
+            label: 'Wiki Graph',
+            action: 'wikiGraph',
+            geometry: {
+              type: 'gltf',
+              src: '../assets/models/human-brain/scene.gltf',
+              material: 'translucent-brain',
+            },
+          },
+        ],
+      },
+    },
+  })
+
+  const started = menu.start({ x: 200, y: 200, valid: true })
+  const wikiItem = started.items.find((item) => item.id === 'wiki-graph')
+
+  assert.equal(wikiItem.geometry.material, 'translucent-brain-shell')
+  assert.equal(wikiItem.geometry.radialEffect.kind, 'nested-neural-tree')
 })
 
 test('Sigil radial menu reports fast-travel handoff and reentry', () => {


### PR DESCRIPTION
## Summary

- Adds a non-scheduled design note for the permission-bearing runtime boundary.
- Normalizes stale Sigil radial menu item configs by item id before applying or starting the radial menu.
- Fills missing current wiki-brain geometry defaults, including nested `radialEffect`, and migrates the old `translucent-brain` material name to `translucent-brain-shell`.

## Verification

- `node --check apps/sigil/renderer/radial-menu-defaults.js`
- `node --check apps/sigil/renderer/live-modules/radial-gesture-menu.js`
- `node --check apps/sigil/renderer/appearance.js`
- `node --test tests/renderer/radial-gesture-menu.test.mjs tests/renderer/radial-object-control.test.mjs tests/renderer/radial-gesture-visuals.test.mjs tests/toolkit/runtime-radial-gesture.test.mjs`
- `node --test tests/renderer/*.test.mjs`
- `git diff --check HEAD~2..HEAD`
- `./aos ready`