### PR TITLE
Capture AOS workbench pattern

### DIFF
--- a/docs/design/aos-workbench-pattern.md
+++ b/docs/design/aos-workbench-pattern.md
@@ -344,6 +344,21 @@ Minimum slice:
 
 This proves the pattern is not only for 3D.
 
+Near-term order:
+
+1. Build a file-backed Markdown workbench before adding wiki persistence. File
+   editing is easier to verify, avoids daemon/runtime changes, and matches the
+   repo docs use case.
+2. Keep the first surface app-owned or demo-scoped if needed, but structure the
+   source editor, preview, diagnostics, and persistence seams so they can move
+   into `packages/toolkit/` after one real consumer.
+3. Start with source plus rendered preview. Add Mermaid fences, outline,
+   metadata controls, and richer patch/history only after the basic edit,
+   render, validate, and save loop is reliable.
+4. Treat the editor as the subject owner. Agent operations should be explicit
+   text or metadata patches with accepted/rejected results, not hidden DOM
+   mutation.
+
 ### Workflow Workbench
 
 Use a small workflow definition as the third proof.
@@ -395,7 +410,9 @@ Promote a concept from this note when all are true:
 
 ## Next Planning Move
 
-Do not start with a grand workbench implementation. Start by extracting the
-current 3D radial item tuning loop into the first formal subject/view/control
-adapter. Then add a Markdown/Mermaid subject. If those two fit the same contract
-without contortion, promote the shared pieces into toolkit workbench components.
+Do not start with a grand workbench implementation. The 3D radial item tuning
+loop is already the first proof. The next practical move is a file-backed
+Markdown workbench with source and preview panes, explicit save, and a narrow
+text patch/result contract. If that and the 3D workbench fit the same pattern
+without contortion, promote the shared shell and subject descriptors into
+toolkit workbench components.

--- a/docs/design/aos-workbench-pattern.md
+++ b/docs/design/aos-workbench-pattern.md
@@ -1,0 +1,401 @@
+# AOS Workbench Pattern
+
+Status: Concept and planning note, not scheduled.
+
+This note captures a platform direction before it leaks out of session memory.
+It is not an implementation mandate. Promote slices from this note only when a
+concrete consumer needs them and the slice can be specified with explicit
+contracts.
+
+## Problem
+
+agent-os is accumulating several related needs:
+
+- tune addressable 3D objects in a live or preview canvas
+- edit Markdown and render it beside the source
+- render Mermaid diagrams from text
+- model workflows from Markdown, JSON, and recorded browser actions
+- generate and review reports, slide decks, screenshots, and SPA artifacts
+- let a human and agent discuss, inspect, edit, validate, and lock in visible
+  work
+
+Treating each surface as a one-off app will duplicate the same mechanics:
+preview, controls, patching, validation, persistence, artifacts, history, and
+agent handoff. Treating everything as a generic "item editor" is also too vague:
+a radial menu item, workflow, Markdown document, Playwright recording, report,
+and slide deck do not have the same domain model.
+
+The useful abstraction is the workbench loop itself.
+
+## Principle
+
+AOS should provide a reusable workbench pattern:
+
+```text
+subject + views + controls + patch channel + persistence adapter + artifact set
+```
+
+The subject is what is being edited. Views and controls attach to the subject
+through explicit contracts. The subject owner remains responsible for validation
+and persistence. The workbench shell coordinates the loop but does not become
+the owner of every domain model.
+
+This keeps the platform flexible enough to support design, documents, slides,
+3D scenes, workflows, reports, and app-specific editors without forcing them
+into one inheritance hierarchy.
+
+## Relationship To Open Design
+
+Open Design is relevant as a working peer pattern, not as code to import
+wholesale. Its README describes a local-first design workbench where a local
+daemon delegates to existing agent CLIs, skills live as folders with `SKILL.md`,
+artifacts render in sandboxed previews, project state persists locally, and
+outputs can export as HTML, PDF, PPTX, ZIP, Markdown, images, and video:
+
+https://github.com/nexu-io/open-design
+
+The AOS version should reuse the underlying ideas while preserving AOS layering:
+
+- the AOS daemon already owns primitives such as canvases, content serving,
+  IPC, pub/sub, capture, and input
+- `packages/toolkit/` should own reusable workbench components
+- apps such as Sigil should be consumers, not owners, of the generic pattern
+- workflows, reports, slide decks, and visual editors should be first-class
+  subjects above the primitive layer
+
+Do not clone Open Design's product shape into Sigil. Learn from its daemon,
+skill, preview, artifact, and project-loop architecture.
+
+## Existing AOS Footholds
+
+This is not a greenfield idea. Several AOS threads already point toward the
+same platform shape:
+
+- `canvas_object.registry` plus transform and visibility patches already prove
+  the owner-publishes, controller-patches, owner-acknowledges loop for 3D
+  objects.
+- `packages/toolkit/components/object-transform-panel/` is already a reusable
+  control surface that listens to a provider-neutral object contract.
+- `docs/api/integration-broker.md` describes a provider-neutral workflow
+  catalog where Slack is only one transport over reusable workflow and job
+  state.
+- `docs/sdk-first-scripts.md` treats saved scripts as workflows and frames the
+  SDK as primitive wrappers plus higher-level operations.
+- `docs/superpowers/specs/2026-04-24-playwright-browser-adapter-design.md`
+  explicitly calls out workflow recording, replay, and codegen as future work
+  that should store replayable workflows with canvas provenance.
+
+The workbench pattern should connect these footholds instead of creating a
+parallel philosophy.
+
+## Core Concepts
+
+### Subject
+
+A subject is the thing being edited, reviewed, generated, or executed.
+
+Examples:
+
+- 3D radial menu item
+- 3D scene
+- Markdown document
+- Mermaid diagram
+- slide deck
+- report
+- Playwright recording
+- workflow graph
+- provider session catalog
+- generated artifact bundle
+
+A subject needs stable identity, type, capabilities, state, and ownership.
+
+### View
+
+A view renders a subject or part of a subject.
+
+Examples:
+
+- source text editor
+- rendered Markdown
+- Mermaid canvas
+- 3D preview stage
+- production radial-menu preview
+- slide preview
+- workflow graph
+- execution timeline
+- browser replay
+- artifact gallery
+
+Multiple views can attach to the same subject. A workflow may be viewed as
+Markdown, JSON, a DAG, and an execution timeline. A radial menu item may be
+viewed as production radial preview, isolated 3D preview, object graph, and
+source config.
+
+### Controls
+
+Controls edit subject state through structured operations.
+
+Examples:
+
+- transform triplets
+- visibility toggles
+- material controls
+- text editor operations
+- property inspector fields
+- outline/tree controls
+- step editor
+- dependency editor
+- run/pause/resume controls
+- validation controls
+
+Controls should not mutate private renderer internals directly. They send
+patches or commands to the subject owner and render owner results.
+
+### Patch Channel
+
+The patch channel carries structured edits and results between controls, views,
+agents, and subject owners.
+
+Existing `canvas_object.registry`, transform patch, visibility patch, and result
+messages are the first narrow example. Future patch classes may include:
+
+- text edit
+- property patch
+- add/remove/reorder child
+- duplicate object
+- replace asset
+- select/focus
+- annotate
+- approve/reject
+- run/cancel workflow step
+- attach artifact
+
+Patches should be reversible where feasible and must produce explicit accepted,
+rejected, stale, or validation-result messages.
+
+### Persistence Adapter
+
+The persistence adapter writes accepted subject state back to the correct
+source of truth.
+
+Examples:
+
+- source file
+- wiki document
+- JSON config
+- app component module
+- generated artifact folder
+- workflow run record
+- provider session metadata
+
+The workbench should not assume one persistence model. A Markdown subject and a
+3D radial menu item can use the same workbench mechanics while saving to very
+different places.
+
+### Artifact Set
+
+Artifacts are durable outputs produced or collected by a subject or workflow.
+
+Examples:
+
+- HTML preview
+- PDF
+- PPTX
+- Markdown report
+- screenshots
+- Playwright trace
+- JSON result data
+- rendered image
+- video
+
+Artifacts need metadata: origin subject, producing workflow run, source files,
+validation status, and preview/export routes.
+
+## Workflow Subjects
+
+A workflow is a subject, but it is also an executable composition.
+
+It should be able to contain:
+
+- atomic steps
+- reusable sub-workflows
+- external tool calls
+- human approval gates
+- artifact-producing stages
+- validation stages
+- branches and conditionals
+- retries and fallbacks
+
+This makes a workflow a graph or DAG, not only a checklist.
+
+Example: SPA report workflow
+
+```text
+intake source data
+  -> capture app state with Playwright
+  -> run screenshot QA
+  -> generate Markdown report
+  -> generate charts
+  -> generate slide deck
+  -> export PDF/PPTX
+  -> review and approval
+```
+
+Each child workflow can have its own subject, views, controls, artifacts, and
+persistence. The parent workflow composes them and tracks state.
+
+Do not build a full Airflow-style orchestrator from this note. The first model
+should be small: workflow id, nodes, edges, inputs, outputs, status, artifact
+references, and subworkflow references.
+
+## Candidate Layering
+
+### Level 0: Primitives
+
+The daemon owns OS-facing and host-level primitives:
+
+- canvas lifecycle
+- content serving
+- IPC and pub/sub
+- screen/canvas capture
+- input and accessibility actions
+- readiness and permission diagnostics
+
+Workbench work should avoid changing the permission-bearing runtime unless a
+missing primitive is clearly identified.
+
+### Level 1: Shared Contracts
+
+Shared contracts belong in `shared/schemas/` and `docs/api/` when they become
+cross-tool interfaces:
+
+- subject descriptor
+- view descriptor
+- control descriptor
+- patch/result envelopes
+- artifact metadata
+- workflow descriptor
+- workflow run state
+
+Do not add schemas before a concrete adopter needs them.
+
+### Level 2: Toolkit Workbench Components
+
+Reusable workbench components belong in `packages/toolkit/`:
+
+- workbench shell
+- subject registry viewer
+- object transform panel
+- property inspector
+- source editor
+- Markdown renderer
+- Mermaid renderer
+- 3D preview stage
+- artifact gallery
+- workflow graph view
+- execution timeline
+- validation panel
+
+These components should be generic over subject contracts, not hardcoded to
+Sigil.
+
+### Level 3: App Consumers
+
+Apps compose toolkit pieces into product experiences:
+
+- Sigil 3D radial menu item editor
+- Sigil avatar composition editor
+- agent terminal/session workbench
+- report builder
+- slide deck builder
+- workflow modeler
+- Open-Design-style artifact studio
+
+Apps own product decisions, naming, layout, and domain-specific persistence.
+
+## First Concrete Adopters
+
+### 3D Radial Menu Item Editor
+
+Use current Sigil radial item work as the first proof.
+
+Minimum slice:
+
+- one subject: a 3D radial menu item
+- views: isolated 3D preview and production radial preview
+- controls: object list, transform triplets, visibility toggles, scene orbit
+- patch channel: current canvas object transform/visibility contract
+- persistence adapter: write accepted transforms back to item definition/config
+
+This should prove whether the `subject + views + controls + patch` pattern can
+replace one-off tuner pages.
+
+### Markdown/Mermaid Workbench
+
+Use a Markdown document as the second proof.
+
+Minimum slice:
+
+- one subject: Markdown file or wiki page
+- views: source editor, rendered Markdown, Mermaid previews for fenced diagrams
+- controls: outline, frontmatter/properties, validation diagnostics
+- patch channel: text edits and metadata patches
+- persistence adapter: file or wiki write-back
+
+This proves the pattern is not only for 3D.
+
+### Workflow Workbench
+
+Use a small workflow definition as the third proof.
+
+Minimum slice:
+
+- one subject: workflow graph persisted as Markdown or JSON
+- views: source, graph, run timeline
+- controls: edit nodes, edit dependencies, run/pause/cancel
+- patch channel: node/edge/property patches and run commands
+- artifact set: links to outputs from each node
+
+This proves composability and sub-workflow references.
+
+## Non-Goals
+
+- Do not create a universal `ItemEditor` class hierarchy.
+- Do not make Sigil the owner of generic workbench primitives.
+- Do not invent a broad AOS data bus before specific contracts demand it.
+- Do not build a full workflow orchestrator from this note alone.
+- Do not copy Open Design wholesale into agent-os.
+- Do not require Swift daemon changes for workbench behavior that can live in
+  content, toolkit, schemas, and app code.
+
+## Promotion Criteria
+
+Promote a concept from this note when all are true:
+
+1. A concrete consumer needs it now.
+2. The subject, view, control, or patch boundary can be described in one page.
+3. Existing AOS primitives are sufficient, or the missing primitive is narrow.
+4. The first adopter can be tested without building a broad platform first.
+5. The change creates reusable leverage for at least one plausible second
+   adopter.
+
+## Open Questions
+
+- What is the minimal subject descriptor that works for both 3D objects and
+  text documents?
+- Should workflow definitions live primarily in wiki documents, repo files, or
+  a runtime state store?
+- How much history/undo belongs in the toolkit versus each subject owner?
+- Should artifacts be addressed through wiki, content roots, or a dedicated
+  artifact registry?
+- How should human approval gates be represented without turning every
+  workflow into a bespoke UI?
+- Which provider-session concepts should become workbench participants versus
+  artifacts?
+
+## Next Planning Move
+
+Do not start with a grand workbench implementation. Start by extracting the
+current 3D radial item tuning loop into the first formal subject/view/control
+adapter. Then add a Markdown/Mermaid subject. If those two fit the same contract
+without contortion, promote the shared pieces into toolkit workbench components.

--- a/memory/scratchpad/agent-human-collab-stage.md
+++ b/memory/scratchpad/agent-human-collab-stage.md
@@ -1,11 +1,16 @@
 ---
 name: agent-human-collab-stage
-status: raw-musings
+status: promoted-to-design-note
 updated: 2026-05-03
 connects_to: AOS primitives, toolkit panels, Sigil, canvas object control, provider sessions, EVOI
+promoted_to: docs/design/aos-workbench-pattern.md
 ---
 
 # Agent-Human Collab Stage
+
+Update: the reusable platform direction from this scratchpad has been promoted
+to `docs/design/aos-workbench-pattern.md`. Keep this file as session provenance
+and raw idea history; use the design note for future planning.
 
 ## Raw Thought
 

--- a/memory/scratchpad/agent-human-collab-stage.md
+++ b/memory/scratchpad/agent-human-collab-stage.md
@@ -1,0 +1,217 @@
+---
+name: agent-human-collab-stage
+status: raw-musings
+updated: 2026-05-03
+connects_to: AOS primitives, toolkit panels, Sigil, canvas object control, provider sessions, EVOI
+---
+
+# Agent-Human Collab Stage
+
+## Raw Thought
+
+Build an agent-human visual collaboration space, something in the neighborhood
+of Gemini canvas mode, but not limited to coding. A coding-specific surface
+should exist, but it should sit on top of a more general lower layer: a collab
+stage, workbench, or sandbox where humans and agents can share visible state,
+point at things, modify artifacts, and carry context across turns.
+
+The deeper question is which lower abstractions give enough leverage to build
+many later app-layer experiences without locking agent-os into one product
+shape too early. Sigil could be one consumer, but the primitive should not be
+Sigil-specific.
+
+## Deeper Connection
+
+The 3D object remote-control protocol was probably a concrete symptom of this
+larger need. The immediate ask was to tune position, scale, and rotation of
+Sigil wiki-brain objects. The underlying need was broader:
+
+```text
+make visual things addressable
+make their state observable
+make changes explicit and reversible
+let humans and agents share control of the same visible workspace
+```
+
+That is a collab-stage problem, not only a 3D-transform problem.
+
+## Existing AOS Pieces That Already Point This Way
+
+- `show` creates visible canvases and overlays.
+- `see` captures screens, canvases, xray semantics, cursor, and topology.
+- `do` acts against native apps and AOS-visible affordances.
+- `tell` and `listen` are the communication verbs that can eventually route
+  between human, agent, canvas, voice, and other sinks.
+- DesktopWorld coordinates provide a shared spatial frame across displays.
+- Toolkit panels provide reusable interaction surfaces above the daemon.
+- Semantic targets make canvas controls discoverable to agents.
+- `canvas_object.registry`, transform patches, and transform results make
+  canvas-owned objects addressable and remotely controllable.
+- Provider session catalog and telemetry give agent sessions an identity that a
+  workspace can show, resume, or annotate.
+- Canvas owner metadata and worktree/session-scope notes point toward scoped
+  visible work owned by a particular agent run, worktree, or harness.
+
+These are enough to suggest a lower abstraction without inventing a whole
+generic "AOS bus" yet.
+
+## Candidate Abstraction Stack
+
+### Level 0: AOS Primitives
+
+The daemon owns OS-facing primitives: display canvases, capture, input,
+accessibility actions, event delivery, content serving, readiness, and
+permissions. This layer should stay small and stable.
+
+### Level 1: Shared Stage Substrate
+
+The toolkit could grow a provider-neutral stage substrate over primitives:
+
+- stage identity and lifecycle
+- participant identity: human, agent session, harness, worktree, app
+- spatial frame: DesktopWorld, local canvas coordinates, object-local frames
+- addressable object registry
+- object selection and focus
+- annotations, cursors, pointers, labels, and highlights
+- command/result events for transforms and object edits
+- timeline or transcript of visible decisions
+- snapshot/export/import of declarative stage state
+
+This substrate should not know whether the stage is for coding, design review,
+3D tuning, research, or Sigil avatar work.
+
+### Level 2: Reusable Workbench Components
+
+Reusable components can compose the stage substrate:
+
+- object transform panel
+- inspector panel
+- annotation layer
+- comments or chat side rail
+- file/code/artifact preview
+- visual diff viewer
+- session list and resume affordances
+- action log and reversible command history
+- semantic-target explorer for agents
+
+These should be ordinary toolkit components, not daemon features.
+
+### Level 3: App-Specific Experiences
+
+Apps such as Sigil can build opinionated products on top:
+
+- Sigil avatar composition editor
+- Sigil agent terminal plus session side rail
+- coding canvas/workbench
+- research intake board
+- visual diagnostic lab
+- 3D object tuning bench
+
+The app decides the product shape; the lower layers provide shared mechanics.
+
+## Important Design Distinction
+
+A collab stage is not only a chat panel next to content. It is shared,
+addressable state. The human and the agent should be able to refer to the same
+thing by stable identity:
+
+```text
+"move this branch"
+"compare these two render states"
+"resume that session"
+"pin this evidence"
+"turn the shell opacity down"
+"show me what changed"
+```
+
+The useful primitive is not the visible panel itself. The useful primitive is
+the contract that lets visible things publish identity, state, capabilities,
+and accepted mutations.
+
+## Relationship To Canvas Object Control
+
+Canvas object control is the first narrow slice:
+
+- owner canvas publishes addressable objects
+- controller sees object identity and transform
+- controller sends a patch
+- owner applies, rejects, or reports result
+
+Future collab-stage work could generalize from "3D transform of an object" to
+"workspace entity with observable state and accepted operations." A transform
+is one operation class. Other operation classes might be annotate, select,
+focus, compare, approve, reject, edit text, run command, or attach evidence.
+
+Do not jump straight to that generality. Let the specific object-control and
+workbench cases teach the right contract.
+
+## Relationship To EVOI
+
+EVOI is adjacent because a collab stage gives the agent a place to externalize
+its sense-plan-act loop:
+
+- sense: perceive stage state, semantic targets, annotations, object registry
+- plan: propose visible operations or ask projected clarification questions
+- act: mutate stage objects or external apps through explicit commands
+- review: compare result state, show evidence, record decisions
+
+The stage could become the visual medium where agent reasoning becomes
+inspectable without requiring the user to read every internal step.
+
+## Relationship To Provider Sessions
+
+The agent terminal/session catalog work also belongs here. A general collab
+stage should be able to show active and historical provider sessions as
+participants or artifacts:
+
+- current session
+- resumable session
+- session telemetry
+- session-owned canvases
+- open terminals
+- worktree or project scope
+
+This is how a coding-specific canvas can be built later without hardcoding
+Codex or Claude Code behavior into Sigil's visual layer.
+
+## Guardrails
+
+- Do not turn this scratchpad into a roadmap item by default.
+- Do not invent a broad generic AOS event bus yet.
+- Do not put product-specific Gemini-canvas behavior into the daemon.
+- Do not make Sigil the owner of the general abstraction.
+- Start with small toolkit components and explicit schemas where specific
+  consumers already exist.
+- Keep the permission-bearing runtime boundary stable: the collab stage should
+  mostly be content, toolkit code, schemas, and app composition.
+
+## Plausible First Slices
+
+The most practical first slices are already near current work:
+
+1. Strengthen canvas object control from 3D transforms into a reusable
+   addressable-object pattern, still narrow and schema-backed.
+2. Make the object transform panel a real toolkit component that can target any
+   object registry producer.
+3. Build a small "stage inspector" that shows participants, canvases,
+   addressable objects, semantic targets, and recent commands for one stage.
+4. Use Sigil wiki-brain tuning as the first adopter, not as the owner of the
+   abstraction.
+5. Later, build a coding-specific workbench on top of the same substrate:
+   files, diffs, terminal sessions, annotations, review comments, and agent
+   proposals.
+
+## Open Naming
+
+Possible names:
+
+- collab stage
+- collaboration stage
+- shared stage
+- workbench substrate
+- visual workbench
+- agent-human stage
+- workspace canvas
+
+Working preference: "collab stage" for scratchpad discussion, but do not
+standardize the term until a first concrete component exists.


### PR DESCRIPTION
## Summary

Captures the AOS workbench pattern as a design note before the session context is lost, with Markdown editing called out as the next concrete proof.

- promotes the raw agent-human collab stage scratchpad into `docs/design/aos-workbench-pattern.md`
- frames the reusable abstraction as subject + views + controls + patch channel + persistence adapter + artifact set
- positions Open Design as a peer pattern to learn from, not a product shape to copy into Sigil
- calls out workflow composition, concrete first adopters, non-goals, and promotion criteria
- prioritizes a file-backed Markdown workbench as the next proof after the 3D radial item workbench

## Verification

- `git diff --check`

## Notes

Concept/planning note only. This is not a broad workbench implementation.