### PR TITLE
Add toolkit Markdown workbench

### DIFF
--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -87,6 +87,7 @@ Current reusable toolkit components include:
 - `aos://toolkit/components/render-performance/index.html` - live framerate, frame-time, and coarse renderer telemetry panel
 - `aos://toolkit/components/wiki-kb/index.html` - wiki graph browser with force-graph and mind-map views
 - `aos://toolkit/components/object-transform-panel/index.html` - addressable canvas object transform editor for position/scale/rotation triplets
+- `aos://toolkit/components/markdown-workbench/index.html` - Markdown source editor, rendered preview, outline, diagnostics, and explicit save handoff
 
 ### Inline Canvas Stats
 
@@ -258,6 +259,61 @@ consumer-facing fields:
 - `defaults.searchQuery`
 - `defaults.tagMatchMode` (`any` or `all`)
 - `limits.minDepth` / `limits.maxDepth`
+
+### Markdown Workbench
+
+`markdown-workbench` is the first file-backed Markdown editing surface. It owns
+the in-canvas edit state and renders a source pane, rendered preview, outline,
+and diagnostics. The canvas does not write files directly. Pressing Save emits a
+structured handoff so an agent, app, or future persistence adapter can write the
+accepted content to the correct source of truth.
+
+Launch the sample or a repo file:
+
+```bash
+packages/toolkit/components/markdown-workbench/launch.sh
+packages/toolkit/components/markdown-workbench/launch.sh docs/design/aos-workbench-pattern.md
+```
+
+Persist the current canvas state from an agent shell:
+
+```bash
+packages/toolkit/components/markdown-workbench/save-current.sh markdown-workbench
+```
+
+Accepted messages:
+
+- `markdown_document.open` with `{ path, content }` replaces the current subject
+  and clears dirty state.
+- `markdown_document.text.patch` with `{ patch: { content } }` replaces the
+  editable source and recomputes preview/diagnostics.
+- `markdown_document.save.result` with `{ status: "saved" | "rejected",
+  message? }` acknowledges a previous save request. `saved` clears dirty state.
+
+Save requests are emitted as `markdown-workbench/save.requested` with payload:
+
+```json
+{
+  "type": "markdown_document.save.requested",
+  "schema_version": "2026-05-03",
+  "request_id": "markdown-save-example",
+  "path": "docs/example.md",
+  "content": "# Example\n\nUpdated body",
+  "diagnostics": {
+    "line_count": 3,
+    "word_count": 3,
+    "heading_count": 1,
+    "headings": [{ "depth": 1, "text": "Example", "line": 1 }],
+    "mermaid_blocks": [],
+    "unclosed_fence": false
+  }
+}
+```
+
+Current renderer support is intentionally small: frontmatter is skipped,
+headings up to depth 3 render, lists render, inline code/bold/emphasis render,
+and unsafe links are stripped. Mermaid fences are detected for diagnostics but
+not rendered yet.
 
 When enabled, the graph controls can also expose:
 

--- a/packages/toolkit/components/markdown-workbench/index.html
+++ b/packages/toolkit/components/markdown-workbench/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../_base/theme.css">
+<link rel="stylesheet" href="../../panel/defaults.css">
+<link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+<script type="module">
+import { mountPanel, Single } from '../../panel/index.js'
+import MarkdownWorkbench from './index.js'
+
+mountPanel({ title: 'Markdown Workbench', layout: Single(MarkdownWorkbench) })
+</script>
+</body>
+</html>

--- a/packages/toolkit/components/markdown-workbench/index.js
+++ b/packages/toolkit/components/markdown-workbench/index.js
@@ -1,0 +1,162 @@
+import { renderMarkdown } from '../../markdown/render.js';
+import {
+  applyMarkdownSaveResult,
+  applyMarkdownTextPatch,
+  buildMarkdownSaveRequest,
+  createMarkdownWorkbenchState,
+  markdownWorkbenchSnapshot,
+  openMarkdownDocument,
+} from './model.js';
+
+function el(tag, className, textContent) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (textContent !== undefined) node.textContent = textContent;
+  return node;
+}
+
+export default function MarkdownWorkbench(options = {}) {
+  let host = null;
+  const state = createMarkdownWorkbenchState(options.document || {});
+  const dom = {};
+
+  function emit(type, payload) {
+    if (host?.emit) host.emit(type, payload);
+  }
+
+  function syncTitle() {
+    host?.setTitle?.(`Markdown - ${state.path}${state.dirty ? ' *' : ''}`);
+  }
+
+  function syncDiagnostics() {
+    const diagnostics = markdownWorkbenchSnapshot(state).diagnostics;
+    dom.stats.textContent = `${diagnostics.line_count} lines · ${diagnostics.word_count} words · ${diagnostics.heading_count} headings`;
+    dom.outline.replaceChildren();
+    if (diagnostics.headings.length === 0) {
+      dom.outline.appendChild(el('li', 'markdown-workbench-empty', 'No headings'));
+    } else {
+      for (const heading of diagnostics.headings) {
+        const item = el('li');
+        item.style.setProperty('--depth', String(Math.min(4, heading.depth)));
+        item.textContent = `${heading.text} · ${heading.line}`;
+        dom.outline.appendChild(item);
+      }
+    }
+    dom.warning.hidden = !diagnostics.unclosed_fence;
+    dom.mermaid.textContent = diagnostics.mermaid_blocks.length > 0
+      ? `${diagnostics.mermaid_blocks.length} Mermaid fence${diagnostics.mermaid_blocks.length === 1 ? '' : 's'} detected`
+      : 'No Mermaid fences';
+  }
+
+  function syncPreview() {
+    dom.preview.innerHTML = renderMarkdown(state.content);
+  }
+
+  function sync() {
+    dom.path.textContent = state.path;
+    dom.editor.value = state.content;
+    dom.dirty.textContent = state.dirty ? 'Unsaved changes' : 'Saved';
+    dom.dirty.dataset.dirty = state.dirty ? 'true' : 'false';
+    syncTitle();
+    syncDiagnostics();
+    syncPreview();
+    window.__markdownWorkbenchState = markdownWorkbenchSnapshot(state);
+  }
+
+  function setContent(content) {
+    state.content = String(content ?? '');
+    state.dirty = state.content !== state.savedContent;
+    sync();
+  }
+
+  function requestSave() {
+    const request = buildMarkdownSaveRequest(state);
+    state.lastResult = request;
+    emit('save.requested', request);
+    sync();
+    return request;
+  }
+
+  function render() {
+    const root = el('div', 'markdown-workbench-root');
+    root.innerHTML = `
+      <header class="markdown-workbench-toolbar">
+        <div class="markdown-workbench-file">
+          <strong data-role="path"></strong>
+          <span data-role="dirty"></span>
+        </div>
+        <div class="markdown-workbench-actions">
+          <button type="button" data-action="revert">Revert</button>
+          <button type="button" data-action="save">Save</button>
+        </div>
+      </header>
+      <main class="markdown-workbench-main">
+        <section class="markdown-workbench-source" aria-label="Markdown source">
+          <textarea spellcheck="true" aria-label="Markdown source editor"></textarea>
+        </section>
+        <section class="markdown-workbench-preview-pane" aria-label="Rendered Markdown preview">
+          <div class="markdown-workbench-preview"></div>
+        </section>
+        <aside class="markdown-workbench-inspector" aria-label="Markdown diagnostics">
+          <strong>Diagnostics</strong>
+          <p data-role="stats"></p>
+          <p data-role="mermaid"></p>
+          <p class="markdown-workbench-warning" data-role="warning" hidden>Unclosed fenced code block</p>
+          <strong>Outline</strong>
+          <ol data-role="outline"></ol>
+        </aside>
+      </main>
+    `;
+    dom.path = root.querySelector('[data-role="path"]');
+    dom.dirty = root.querySelector('[data-role="dirty"]');
+    dom.editor = root.querySelector('textarea');
+    dom.preview = root.querySelector('.markdown-workbench-preview');
+    dom.stats = root.querySelector('[data-role="stats"]');
+    dom.mermaid = root.querySelector('[data-role="mermaid"]');
+    dom.warning = root.querySelector('[data-role="warning"]');
+    dom.outline = root.querySelector('[data-role="outline"]');
+
+    dom.editor.addEventListener('input', () => setContent(dom.editor.value));
+    root.querySelector('[data-action="save"]').addEventListener('click', requestSave);
+    root.querySelector('[data-action="revert"]').addEventListener('click', () => setContent(state.savedContent));
+    sync();
+    return root;
+  }
+
+  function onMessage(message = {}) {
+    const type = message.type || message.payload?.type;
+    if (type === 'markdown_document.open') {
+      openMarkdownDocument(state, message);
+      sync();
+    } else if (type === 'markdown_document.text.patch') {
+      applyMarkdownTextPatch(state, message);
+      sync();
+    } else if (type === 'markdown_document.save.result') {
+      applyMarkdownSaveResult(state, message);
+      sync();
+    }
+  }
+
+  return {
+    manifest: {
+      name: 'markdown-workbench',
+      title: 'Markdown Workbench',
+      accepts: ['markdown_document.open', 'markdown_document.text.patch', 'markdown_document.save.result'],
+      emits: ['markdown-workbench/save.requested'],
+      channelPrefix: 'markdown-workbench',
+      defaultSize: { w: 1120, h: 720 },
+    },
+
+    render(host_) {
+      host = host_;
+      host.contentEl.style.overflow = 'hidden';
+      return render();
+    },
+
+    onMessage,
+
+    serialize() {
+      return markdownWorkbenchSnapshot(state);
+    },
+  };
+}

--- a/packages/toolkit/components/markdown-workbench/launch.sh
+++ b/packages/toolkit/components/markdown-workbench/launch.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# launch.sh - Open a file-backed Markdown workbench.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null || pwd)"
+AOS="${AOS:-$ROOT/aos}"
+CANVAS_ID="${CANVAS_ID:-markdown-workbench}"
+TARGET_FILE="${1:-$DIR/sample.md}"
+PANEL_W="${AOS_MARKDOWN_WORKBENCH_W:-1120}"
+PANEL_H="${AOS_MARKDOWN_WORKBENCH_H:-720}"
+
+root_key_for() {
+  local prefix="$1"
+  local branch suffix
+  branch="$(git -C "$ROOT" branch --show-current 2>/dev/null || true)"
+  if [[ -z "$branch" || "$branch" == "main" ]]; then
+    printf '%s\n' "$prefix"
+    return
+  fi
+  suffix="$(
+    printf '%s' "$branch" \
+      | tr '[:upper:]' '[:lower:]' \
+      | sed -E 's/[^a-z0-9]+/_/g; s/^_+//; s/_+$//'
+  )"
+  printf '%s_%s\n' "$prefix" "${suffix:-worktree}"
+}
+
+TOOLKIT_CONTENT_ROOT="${AOS_TOOLKIT_CONTENT_ROOT:-$(root_key_for toolkit)}"
+CANONICAL_REPO_ROOT="${AOS_CANONICAL_REPO_ROOT:-/Users/Michael/Code/agent-os}"
+
+if [[ ! -x "$AOS" ]]; then
+  echo "aos binary not found at $AOS" >&2
+  exit 1
+fi
+
+if [[ ! -f "$TARGET_FILE" ]]; then
+  echo "Markdown file not found: $TARGET_FILE" >&2
+  exit 1
+fi
+
+if [[ "$TOOLKIT_CONTENT_ROOT" != "toolkit" && -d "$CANONICAL_REPO_ROOT/packages/toolkit" ]]; then
+  "$AOS" set content.roots.toolkit "$CANONICAL_REPO_ROOT/packages/toolkit" >/dev/null
+fi
+
+"$AOS" set "content.roots.$TOOLKIT_CONTENT_ROOT" "$ROOT/packages/toolkit" >/dev/null
+
+content_root_live() {
+  "$AOS" content status --json 2>/dev/null \
+    | TOOLKIT_CONTENT_ROOT="$TOOLKIT_CONTENT_ROOT" \
+      TOOLKIT_PATH="$ROOT/packages/toolkit" \
+      python3 -c '
+import json, os, sys
+try:
+    roots = json.load(sys.stdin).get("roots", {})
+except Exception:
+    sys.exit(1)
+sys.exit(0 if roots.get(os.environ["TOOLKIT_CONTENT_ROOT"]) == os.environ["TOOLKIT_PATH"] else 1)
+'
+}
+
+if ! content_root_live; then
+  echo "Refreshing repo daemon so new content root is live: $TOOLKIT_CONTENT_ROOT" >&2
+  "$AOS" service restart --mode repo >/dev/null
+fi
+
+"$AOS" content wait --root "$TOOLKIT_CONTENT_ROOT" --auto-start --timeout 15s >/dev/null
+
+DISPLAY_JSON="$("$AOS" graph displays --json 2>/dev/null || echo '{"data":{"displays":[]}}')"
+GEOMETRY="$(
+  echo "$DISPLAY_JSON" | PANEL_W="$PANEL_W" PANEL_H="$PANEL_H" python3 -c '
+import json, os, sys
+
+payload = json.load(sys.stdin)
+displays = payload.get("data", {}).get("displays", payload.get("displays", [])) if isinstance(payload, dict) else payload
+main = next((entry for entry in displays if entry.get("is_main")), displays[0] if displays else None)
+rect = (main or {}).get("visible_bounds") or (main or {}).get("bounds") or {}
+x = int(rect.get("x", 0))
+y = int(rect.get("y", 0))
+w = int(rect.get("w", 1728))
+h = int(rect.get("h", 1117))
+panel_w = min(int(os.environ["PANEL_W"]), max(760, w - 48))
+panel_h = min(int(os.environ["PANEL_H"]), max(520, h - 96))
+print(x + 24, y + 64, panel_w, panel_h)
+' 2>/dev/null || echo "24 64 $PANEL_W $PANEL_H"
+)"
+
+read -r X Y W H <<<"$GEOMETRY"
+
+"$AOS" show remove --id "$CANVAS_ID" 2>/dev/null || true
+"$AOS" show create \
+  --id "$CANVAS_ID" \
+  --at "$X,$Y,$W,$H" \
+  --interactive \
+  --focus \
+  --scope global \
+  --url "aos://$TOOLKIT_CONTENT_ROOT/components/markdown-workbench/index.html" >/dev/null
+
+"$AOS" show wait \
+  --id "$CANVAS_ID" \
+  --manifest markdown-workbench \
+  --js 'typeof window.__markdownWorkbenchState === "object"' \
+  --timeout 5s >/dev/null
+
+CONTENT_JSON="$(TARGET_FILE="$TARGET_FILE" python3 -c '
+import json, os, pathlib
+path = pathlib.Path(os.environ["TARGET_FILE"]).resolve()
+print(json.dumps({
+    "type": "markdown_document.open",
+    "path": str(path),
+    "content": path.read_text(encoding="utf-8"),
+}))
+')"
+
+"$AOS" show post --id "$CANVAS_ID" --event "$CONTENT_JSON" >/dev/null
+
+echo "Markdown workbench launched at ${X},${Y} (${W}x${H})"
+echo "Canvas: $CANVAS_ID"
+echo "File: $(cd "$(dirname "$TARGET_FILE")" && pwd)/$(basename "$TARGET_FILE")"
+echo "Save handoff: use window.__markdownWorkbenchState.content or the emitted markdown-workbench/save.requested event."
+echo "Agent save helper: packages/toolkit/components/markdown-workbench/save-current.sh $CANVAS_ID"

--- a/packages/toolkit/components/markdown-workbench/model.js
+++ b/packages/toolkit/components/markdown-workbench/model.js
@@ -1,0 +1,160 @@
+export const MARKDOWN_WORKBENCH_SCHEMA_VERSION = '2026-05-03';
+
+function text(value, fallback = '') {
+  const normalized = String(value ?? '').trim();
+  return normalized || fallback;
+}
+
+function normalizePath(value) {
+  return text(value, 'untitled.md');
+}
+
+export function createMarkdownWorkbenchState({
+  path = 'untitled.md',
+  content = '',
+  savedContent = content,
+  dirty = false,
+} = {}) {
+  const current = String(content ?? '');
+  return {
+    path: normalizePath(path),
+    content: current,
+    savedContent: String(savedContent ?? current),
+    dirty: !!dirty,
+    lastResult: null,
+  };
+}
+
+export function markdownDiagnostics(content = '') {
+  const source = String(content ?? '');
+  const lines = source.split('\n');
+  const words = source.trim() ? source.trim().split(/\s+/).length : 0;
+  const headings = [];
+  const mermaidBlocks = [];
+  let inFence = false;
+  let fenceLang = '';
+  let fenceStart = 0;
+
+  lines.forEach((line, index) => {
+    const fence = line.match(/^```\s*([a-zA-Z0-9_-]+)?\s*$/);
+    if (fence) {
+      if (!inFence) {
+        inFence = true;
+        fenceLang = (fence[1] || '').toLowerCase();
+        fenceStart = index + 1;
+      } else {
+        if (fenceLang === 'mermaid') {
+          mermaidBlocks.push({ start_line: fenceStart, end_line: index + 1 });
+        }
+        inFence = false;
+        fenceLang = '';
+      }
+      return;
+    }
+
+    if (inFence) return;
+    const heading = line.match(/^(#{1,6})\s+(.+)$/);
+    if (heading) {
+      headings.push({
+        depth: heading[1].length,
+        text: heading[2].trim(),
+        line: index + 1,
+      });
+    }
+  });
+
+  return {
+    line_count: source ? lines.length : 0,
+    word_count: words,
+    heading_count: headings.length,
+    headings,
+    mermaid_blocks: mermaidBlocks,
+    unclosed_fence: inFence,
+  };
+}
+
+export function openMarkdownDocument(state, message = {}) {
+  const payload = message.payload || message;
+  const content = String(payload.content ?? payload.markdown ?? '');
+  state.path = normalizePath(payload.path);
+  state.content = content;
+  state.savedContent = content;
+  state.dirty = false;
+  state.lastResult = {
+    type: 'markdown_document.open.result',
+    schema_version: MARKDOWN_WORKBENCH_SCHEMA_VERSION,
+    status: 'opened',
+    path: state.path,
+    diagnostics: markdownDiagnostics(content),
+  };
+  return state.lastResult;
+}
+
+export function applyMarkdownTextPatch(state, message = {}) {
+  const payload = message.payload || message;
+  const patch = payload.patch || payload;
+  if (typeof patch.content !== 'string') {
+    state.lastResult = {
+      type: 'markdown_document.patch.result',
+      schema_version: MARKDOWN_WORKBENCH_SCHEMA_VERSION,
+      status: 'rejected',
+      reason: 'missing_content',
+      path: state.path,
+    };
+    return state.lastResult;
+  }
+
+  state.content = patch.content;
+  state.dirty = state.content !== state.savedContent;
+  state.lastResult = {
+    type: 'markdown_document.patch.result',
+    schema_version: MARKDOWN_WORKBENCH_SCHEMA_VERSION,
+    status: 'applied',
+    path: state.path,
+    dirty: state.dirty,
+    diagnostics: markdownDiagnostics(state.content),
+  };
+  return state.lastResult;
+}
+
+export function buildMarkdownSaveRequest(state, {
+  requestId = `markdown-save-${Date.now().toString(36)}`,
+} = {}) {
+  return {
+    type: 'markdown_document.save.requested',
+    schema_version: MARKDOWN_WORKBENCH_SCHEMA_VERSION,
+    request_id: requestId,
+    path: state.path,
+    content: state.content,
+    diagnostics: markdownDiagnostics(state.content),
+  };
+}
+
+export function applyMarkdownSaveResult(state, message = {}) {
+  const payload = message.payload || message;
+  const status = payload.status === 'saved' ? 'saved' : 'rejected';
+  if (status === 'saved') {
+    state.savedContent = state.content;
+    state.dirty = false;
+  }
+  state.lastResult = {
+    type: 'markdown_document.save.result',
+    schema_version: MARKDOWN_WORKBENCH_SCHEMA_VERSION,
+    status,
+    path: state.path,
+    message: text(payload.message),
+  };
+  return state.lastResult;
+}
+
+export function markdownWorkbenchSnapshot(state) {
+  return {
+    type: 'markdown_document.snapshot',
+    schema_version: MARKDOWN_WORKBENCH_SCHEMA_VERSION,
+    path: state.path,
+    content: state.content,
+    dirty: state.dirty,
+    diagnostics: markdownDiagnostics(state.content),
+    last_result: state.lastResult,
+  };
+}

--- a/packages/toolkit/components/markdown-workbench/sample.md
+++ b/packages/toolkit/components/markdown-workbench/sample.md
@@ -1,0 +1,20 @@
+---
+title: Markdown Workbench Sample
+---
+
+# Markdown Workbench
+
+Edit the source on the left and inspect the rendered preview beside it.
+
+## First Slice
+
+- file-backed launch
+- source and preview panes
+- explicit save handoff
+- outline and diagnostics
+
+```mermaid
+flowchart LR
+  Source --> Preview
+  Source --> Save
+```

--- a/packages/toolkit/components/markdown-workbench/save-current.sh
+++ b/packages/toolkit/components/markdown-workbench/save-current.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# save-current.sh - Persist the current Markdown workbench canvas state.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null || pwd)"
+AOS="${AOS:-$ROOT/aos}"
+CANVAS_ID="${1:-${CANVAS_ID:-markdown-workbench}}"
+
+if [[ ! -x "$AOS" ]]; then
+  echo "aos binary not found at $AOS" >&2
+  exit 1
+fi
+
+EVAL_JSON="$("$AOS" show eval --id "$CANVAS_ID" --js 'JSON.stringify(window.__markdownWorkbenchState || null)')"
+
+SAVE_JSON="$(
+  EVAL_JSON="$EVAL_JSON" python3 -c '
+import json, os, pathlib, sys
+
+try:
+    outer = json.loads(os.environ["EVAL_JSON"])
+    snapshot = json.loads(outer.get("result") or "null")
+except Exception as error:
+    raise SystemExit(f"failed to read markdown workbench state: {error}")
+
+if not isinstance(snapshot, dict):
+    raise SystemExit("markdown workbench state is unavailable")
+
+path = pathlib.Path(snapshot.get("path") or "").expanduser().resolve()
+if not path:
+    raise SystemExit("markdown workbench state did not include a path")
+
+path.write_text(str(snapshot.get("content") or ""), encoding="utf-8")
+print(json.dumps({
+    "type": "markdown_document.save.result",
+    "status": "saved",
+    "path": str(path),
+    "message": "saved by markdown-workbench/save-current.sh",
+}))
+'
+)"
+
+"$AOS" show post --id "$CANVAS_ID" --event "$SAVE_JSON" >/dev/null
+
+echo "$SAVE_JSON"

--- a/packages/toolkit/components/markdown-workbench/styles.css
+++ b/packages/toolkit/components/markdown-workbench/styles.css
@@ -1,0 +1,177 @@
+.markdown-workbench-root {
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  color: var(--text-primary);
+  background: rgba(9, 11, 16, 0.96);
+}
+
+.markdown-workbench-toolbar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: rgba(18, 20, 30, 0.96);
+}
+
+.markdown-workbench-file {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.markdown-workbench-file strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font: 650 11px/1.3 var(--font-mono);
+}
+
+.markdown-workbench-file span,
+.markdown-workbench-inspector p,
+.markdown-workbench-inspector li {
+  color: var(--text-muted);
+  font: 10px/1.45 var(--font-mono);
+}
+
+.markdown-workbench-file span[data-dirty="true"] {
+  color: #ffd166;
+}
+
+.markdown-workbench-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.markdown-workbench-actions button {
+  min-height: 28px;
+  border: 1px solid rgba(138, 180, 255, 0.28);
+  border-radius: 6px;
+  background: rgba(26, 31, 44, 0.9);
+  color: var(--text-primary);
+  font: 650 10px/1.3 var(--font-mono);
+  cursor: pointer;
+}
+
+.markdown-workbench-main {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(320px, 1fr) minmax(320px, 1fr) minmax(220px, 0.42fr);
+}
+
+.markdown-workbench-source,
+.markdown-workbench-preview-pane,
+.markdown-workbench-inspector {
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.markdown-workbench-source textarea {
+  width: 100%;
+  height: 100%;
+  resize: none;
+  box-sizing: border-box;
+  border: 0;
+  border-right: 1px solid var(--border-subtle);
+  outline: none;
+  padding: 16px;
+  background: rgba(4, 6, 10, 0.92);
+  color: var(--text-primary);
+  font: 12px/1.55 var(--font-mono);
+}
+
+.markdown-workbench-preview-pane {
+  border-right: 1px solid var(--border-subtle);
+  overflow: auto;
+  background: rgba(12, 14, 20, 0.92);
+}
+
+.markdown-workbench-preview {
+  max-width: 760px;
+  padding: 20px 24px 48px;
+  color: #e7eef8;
+  font: 13px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.markdown-workbench-preview h1,
+.markdown-workbench-preview h2,
+.markdown-workbench-preview h3 {
+  margin: 1.1em 0 0.45em;
+  color: #ffffff;
+  letter-spacing: 0;
+}
+
+.markdown-workbench-preview p,
+.markdown-workbench-preview ul,
+.markdown-workbench-preview ol {
+  margin: 0.55em 0;
+}
+
+.markdown-workbench-preview code {
+  padding: 1px 4px;
+  border-radius: 4px;
+  background: rgba(138, 180, 255, 0.12);
+  color: #cbe2ff;
+}
+
+.markdown-workbench-preview a {
+  color: #8ab4ff;
+}
+
+.markdown-workbench-inspector {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px;
+  overflow: auto;
+  background: rgba(15, 17, 24, 0.94);
+}
+
+.markdown-workbench-inspector strong {
+  color: var(--text-secondary);
+  font: 650 10px/1.3 var(--font-mono);
+  text-transform: uppercase;
+}
+
+.markdown-workbench-inspector ol {
+  display: grid;
+  gap: 6px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.markdown-workbench-inspector li {
+  padding-left: calc((var(--depth, 1) - 1) * 10px);
+}
+
+.markdown-workbench-warning {
+  color: #ffd166 !important;
+}
+
+.markdown-workbench-empty {
+  color: var(--text-muted);
+}
+
+@media (max-width: 940px) {
+  .markdown-workbench-main {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(240px, 1fr) minmax(240px, 1fr) minmax(180px, 0.6fr);
+  }
+
+  .markdown-workbench-source textarea,
+  .markdown-workbench-preview-pane {
+    border-right: 0;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+}

--- a/packages/toolkit/components/wiki-kb/views/shared.js
+++ b/packages/toolkit/components/wiki-kb/views/shared.js
@@ -1,12 +1,16 @@
 // Shared helpers for the wiki-kb toolkit component.
 
+export {
+  escHtml,
+  renderMarkdown,
+  safeExternalHref,
+} from '../../../markdown/render.js'
+
 const NODE_COLORS = Object.freeze({
   entity: '#8ab4ff',
   concept: '#6a9966',
   plugin: '#ddaa66',
 })
-
-const SAFE_PROTOCOLS = new Set(['aos:', 'http:', 'https:', 'mailto:'])
 
 export const DEFAULT_GRAPH_VIEW_CONFIG = Object.freeze({
   controls: Object.freeze({
@@ -595,176 +599,6 @@ export function nodeRadius(node, { root = false } = {}) {
   if (root) return 10
   const tagCount = Array.isArray(node?.tags) ? node.tags.length : 0
   return 5 + Math.min(tagCount, 4) * 1.2
-}
-
-export function escHtml(value) {
-  return String(value ?? '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-}
-
-function escAttribute(value) {
-  return escHtml(value)
-}
-
-export function safeExternalHref(rawHref) {
-  const href = String(rawHref ?? '').trim()
-  if (!href) return ''
-  if (href.startsWith('#') || href.startsWith('/')) return href
-
-  try {
-    const parsed = new URL(href, 'https://example.invalid')
-    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(href)) {
-      return SAFE_PROTOCOLS.has(parsed.protocol) ? href : ''
-    }
-  } catch {
-    return ''
-  }
-
-  return ''
-}
-
-function replaceMarkdownLinks(content, token) {
-  let output = ''
-
-  for (let index = 0; index < content.length; index += 1) {
-    if (content[index] !== '[') {
-      output += content[index]
-      continue
-    }
-
-    const labelEnd = content.indexOf(']', index + 1)
-    if (labelEnd < 0 || content[labelEnd + 1] !== '(') {
-      output += content[index]
-      continue
-    }
-
-    let depth = 0
-    let hrefEnd = -1
-    for (let cursor = labelEnd + 2; cursor < content.length; cursor += 1) {
-      const char = content[cursor]
-      if (char === '(') depth += 1
-      else if (char === ')') {
-        if (depth === 0) {
-          hrefEnd = cursor
-          break
-        }
-        depth -= 1
-      }
-    }
-
-    if (hrefEnd < 0) {
-      output += content[index]
-      continue
-    }
-
-    const label = content.slice(index + 1, labelEnd)
-    const href = content.slice(labelEnd + 2, hrefEnd)
-    const safeHref = safeExternalHref(href)
-    if (!safeHref) output += token(escHtml(label))
-    else {
-      output += token(
-        `<a href="${escAttribute(safeHref)}" target="_blank" rel="noopener noreferrer">${escHtml(label)}</a>`
-      )
-    }
-    index = hrefEnd
-  }
-
-  return output
-}
-
-function renderInline(text) {
-  const tokens = []
-  const token = (html) => {
-    const marker = `@@TOKEN_${tokens.length}@@`
-    tokens.push(html)
-    return marker
-  }
-
-  let content = String(text ?? '')
-  content = content.replace(/`([^`]+)`/g, (_, code) => token(`<code>${escHtml(code)}</code>`))
-  content = replaceMarkdownLinks(content, token)
-
-  let html = escHtml(content)
-  html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
-  html = html.replace(/\*([^*]+)\*/g, '<em>$1</em>')
-
-  return html.replace(/@@TOKEN_(\d+)@@/g, (_, index) => tokens[Number(index)] || '')
-}
-
-export function renderMarkdown(source) {
-  if (!source) return ''
-
-  const lines = String(source).split('\n')
-  let html = ''
-  let listTag = null
-
-  function closeList() {
-    if (listTag) {
-      html += `</${listTag}>`
-      listTag = null
-    }
-  }
-
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index]
-
-    if (index === 0 && line.trim() === '---') {
-      index += 1
-      while (index < lines.length && lines[index].trim() !== '---') index += 1
-      continue
-    }
-
-    const heading = line.match(/^(#{1,3})\s+(.+)/)
-    if (heading) {
-      closeList()
-      const depth = heading[1].length
-      html += `<h${depth}>${renderInline(heading[2])}</h${depth}>`
-      continue
-    }
-
-    if (/^---+$/.test(line.trim())) {
-      closeList()
-      html += '<hr>'
-      continue
-    }
-
-    const unordered = line.match(/^[-*]\s+(.+)/)
-    if (unordered) {
-      if (listTag !== 'ul') {
-        closeList()
-        html += '<ul>'
-        listTag = 'ul'
-      }
-      html += `<li>${renderInline(unordered[1])}</li>`
-      continue
-    }
-
-    const ordered = line.match(/^\d+\.\s+(.+)/)
-    if (ordered) {
-      if (listTag !== 'ol') {
-        closeList()
-        html += '<ol>'
-        listTag = 'ol'
-      }
-      html += `<li>${renderInline(ordered[1])}</li>`
-      continue
-    }
-
-    if (line.trim() === '') {
-      closeList()
-      continue
-    }
-
-    closeList()
-    html += `<p>${renderInline(line)}</p>`
-  }
-
-  closeList()
-  return html
 }
 
 export function resizeCanvasToContainer(canvas, container) {

--- a/packages/toolkit/markdown/render.js
+++ b/packages/toolkit/markdown/render.js
@@ -1,0 +1,171 @@
+const SAFE_PROTOCOLS = new Set(['aos:', 'http:', 'https:', 'mailto:']);
+
+export function escHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escAttribute(value) {
+  return escHtml(value);
+}
+
+export function safeExternalHref(rawHref) {
+  const href = String(rawHref ?? '').trim();
+  if (!href) return '';
+  if (href.startsWith('#') || href.startsWith('/')) return href;
+
+  try {
+    const parsed = new URL(href, 'https://example.invalid');
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(href)) {
+      return SAFE_PROTOCOLS.has(parsed.protocol) ? href : '';
+    }
+  } catch {
+    return '';
+  }
+
+  return '';
+}
+
+function replaceMarkdownLinks(content, token) {
+  let output = '';
+
+  for (let index = 0; index < content.length; index += 1) {
+    if (content[index] !== '[') {
+      output += content[index];
+      continue;
+    }
+
+    const labelEnd = content.indexOf(']', index + 1);
+    if (labelEnd < 0 || content[labelEnd + 1] !== '(') {
+      output += content[index];
+      continue;
+    }
+
+    let depth = 0;
+    let hrefEnd = -1;
+    for (let cursor = labelEnd + 2; cursor < content.length; cursor += 1) {
+      const char = content[cursor];
+      if (char === '(') depth += 1;
+      else if (char === ')') {
+        if (depth === 0) {
+          hrefEnd = cursor;
+          break;
+        }
+        depth -= 1;
+      }
+    }
+
+    if (hrefEnd < 0) {
+      output += content[index];
+      continue;
+    }
+
+    const label = content.slice(index + 1, labelEnd);
+    const href = content.slice(labelEnd + 2, hrefEnd);
+    const safeHref = safeExternalHref(href);
+    if (!safeHref) output += token(escHtml(label));
+    else {
+      output += token(
+        `<a href="${escAttribute(safeHref)}" target="_blank" rel="noopener noreferrer">${escHtml(label)}</a>`
+      );
+    }
+    index = hrefEnd;
+  }
+
+  return output;
+}
+
+function renderInline(text) {
+  const tokens = [];
+  const token = (html) => {
+    const marker = `@@TOKEN_${tokens.length}@@`;
+    tokens.push(html);
+    return marker;
+  };
+
+  let content = String(text ?? '');
+  content = content.replace(/`([^`]+)`/g, (_, code) => token(`<code>${escHtml(code)}</code>`));
+  content = replaceMarkdownLinks(content, token);
+
+  let html = escHtml(content);
+  html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  html = html.replace(/\*([^*]+)\*/g, '<em>$1</em>');
+
+  return html.replace(/@@TOKEN_(\d+)@@/g, (_, index) => tokens[Number(index)] || '');
+}
+
+export function renderMarkdown(source) {
+  if (!source) return '';
+
+  const lines = String(source).split('\n');
+  let html = '';
+  let listTag = null;
+
+  function closeList() {
+    if (listTag) {
+      html += `</${listTag}>`;
+      listTag = null;
+    }
+  }
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+
+    if (index === 0 && line.trim() === '---') {
+      index += 1;
+      while (index < lines.length && lines[index].trim() !== '---') index += 1;
+      continue;
+    }
+
+    const heading = line.match(/^(#{1,3})\s+(.+)/);
+    if (heading) {
+      closeList();
+      const depth = heading[1].length;
+      html += `<h${depth}>${renderInline(heading[2])}</h${depth}>`;
+      continue;
+    }
+
+    if (/^---+$/.test(line.trim())) {
+      closeList();
+      html += '<hr>';
+      continue;
+    }
+
+    const unordered = line.match(/^[-*]\s+(.+)/);
+    if (unordered) {
+      if (listTag !== 'ul') {
+        closeList();
+        html += '<ul>';
+        listTag = 'ul';
+      }
+      html += `<li>${renderInline(unordered[1])}</li>`;
+      continue;
+    }
+
+    const ordered = line.match(/^\d+\.\s+(.+)/);
+    if (ordered) {
+      if (listTag !== 'ol') {
+        closeList();
+        html += '<ol>';
+        listTag = 'ol';
+      }
+      html += `<li>${renderInline(ordered[1])}</li>`;
+      continue;
+    }
+
+    if (line.trim() === '') {
+      closeList();
+      continue;
+    }
+
+    closeList();
+    html += `<p>${renderInline(line)}</p>`;
+  }
+
+  closeList();
+  return html;
+}

--- a/tests/toolkit/markdown-render.test.mjs
+++ b/tests/toolkit/markdown-render.test.mjs
@@ -1,0 +1,21 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  renderMarkdown,
+  safeExternalHref,
+} from '../../packages/toolkit/markdown/render.js';
+
+test('renderMarkdown escapes HTML and strips unsafe links', () => {
+  const html = renderMarkdown('Hello <script>alert(1)</script>\n[good](https://example.com)\n[bad](javascript:alert(1))');
+  assert.match(html, /Hello &lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  assert.match(html, /href="https:\/\/example\.com"/);
+  assert.doesNotMatch(html, /javascript:/);
+  assert.match(html, />bad</);
+});
+
+test('safeExternalHref allows explicit safe protocols only', () => {
+  assert.equal(safeExternalHref('https://example.com/test'), 'https://example.com/test');
+  assert.equal(safeExternalHref('aos://toolkit/components/wiki-kb/index.html'), 'aos://toolkit/components/wiki-kb/index.html');
+  assert.equal(safeExternalHref('/wiki/aos/page.md'), '/wiki/aos/page.md');
+  assert.equal(safeExternalHref('javascript:alert(1)'), '');
+});

--- a/tests/toolkit/markdown-workbench-model.test.mjs
+++ b/tests/toolkit/markdown-workbench-model.test.mjs
@@ -1,0 +1,52 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  applyMarkdownSaveResult,
+  applyMarkdownTextPatch,
+  buildMarkdownSaveRequest,
+  createMarkdownWorkbenchState,
+  markdownDiagnostics,
+  openMarkdownDocument,
+} from '../../packages/toolkit/components/markdown-workbench/model.js';
+
+test('markdownDiagnostics builds outline and mermaid counts', () => {
+  const diagnostics = markdownDiagnostics('# One\n\n## Two\n\n```mermaid\na-->b\n```\n');
+  assert.equal(diagnostics.line_count, 8);
+  assert.equal(diagnostics.word_count, 7);
+  assert.deepEqual(diagnostics.headings, [
+    { depth: 1, text: 'One', line: 1 },
+    { depth: 2, text: 'Two', line: 3 },
+  ]);
+  assert.deepEqual(diagnostics.mermaid_blocks, [{ start_line: 5, end_line: 7 }]);
+  assert.equal(diagnostics.unclosed_fence, false);
+});
+
+test('markdown workbench state opens, patches, and builds save requests', () => {
+  const state = createMarkdownWorkbenchState();
+  const opened = openMarkdownDocument(state, {
+    type: 'markdown_document.open',
+    path: 'docs/example.md',
+    content: '# Example',
+  });
+  assert.equal(opened.status, 'opened');
+  assert.equal(state.dirty, false);
+
+  const patched = applyMarkdownTextPatch(state, {
+    type: 'markdown_document.text.patch',
+    patch: { content: '# Example\n\nChanged.' },
+  });
+  assert.equal(patched.status, 'applied');
+  assert.equal(state.dirty, true);
+
+  const save = buildMarkdownSaveRequest(state, { requestId: 'req-1' });
+  assert.equal(save.request_id, 'req-1');
+  assert.equal(save.path, 'docs/example.md');
+  assert.equal(save.content, '# Example\n\nChanged.');
+
+  const saved = applyMarkdownSaveResult(state, {
+    type: 'markdown_document.save.result',
+    status: 'saved',
+  });
+  assert.equal(saved.status, 'saved');
+  assert.equal(state.dirty, false);
+});


### PR DESCRIPTION
## Summary

- Extract the existing safe Markdown renderer into `packages/toolkit/markdown/render.js` and keep `wiki-kb` re-exporting it.
- Add `markdown-workbench`, a toolkit panel with source editing, rendered preview, outline, diagnostics, explicit save requests, and a sample document.
- Add a repo-side `save-current.sh` helper that lets an agent persist the current canvas state back to its file and acknowledge the canvas without daemon changes.
- Document the workbench messages and launch/save commands in `docs/api/toolkit.md`.

## Verification

- `node --check packages/toolkit/markdown/render.js`
- `node --check packages/toolkit/components/wiki-kb/views/shared.js`
- `node --check packages/toolkit/components/markdown-workbench/model.js`
- `node --check packages/toolkit/components/markdown-workbench/index.js`
- `bash -n packages/toolkit/components/markdown-workbench/launch.sh`
- `bash -n packages/toolkit/components/markdown-workbench/save-current.sh`
- `node --test tests/toolkit/markdown-render.test.mjs tests/toolkit/markdown-workbench-model.test.mjs tests/toolkit/wiki-kb.test.mjs`
- Live AOS launch against `docs/design/aos-workbench-pattern.md`
- Live edit/preview check and save helper verification against `/tmp/aos-markdown-workbench-live-test.md`
