### PR TITLE
Add Markdown editor shortcuts

### DIFF
--- a/packages/toolkit/components/markdown-workbench/editor-commands.js
+++ b/packages/toolkit/components/markdown-workbench/editor-commands.js
@@ -1,0 +1,56 @@
+export function indentMarkdownSelection({
+  value = '',
+  selectionStart = 0,
+  selectionEnd = selectionStart,
+  indent = '  ',
+} = {}) {
+  const source = String(value ?? '');
+  const start = Math.max(0, Math.min(source.length, Number(selectionStart) || 0));
+  const end = Math.max(start, Math.min(source.length, Number(selectionEnd) || start));
+  const lineStart = source.lastIndexOf('\n', Math.max(0, start - 1)) + 1;
+  const selection = source.slice(lineStart, end);
+  const lines = selection.split('\n');
+  const nextSelection = lines.map((line) => `${indent}${line}`).join('\n');
+  const nextValue = `${source.slice(0, lineStart)}${nextSelection}${source.slice(end)}`;
+  return {
+    value: nextValue,
+    selectionStart: start + indent.length,
+    selectionEnd: end + (indent.length * lines.length),
+  };
+}
+
+export function outdentMarkdownSelection({
+  value = '',
+  selectionStart = 0,
+  selectionEnd = selectionStart,
+  indent = '  ',
+} = {}) {
+  const source = String(value ?? '');
+  const start = Math.max(0, Math.min(source.length, Number(selectionStart) || 0));
+  const end = Math.max(start, Math.min(source.length, Number(selectionEnd) || start));
+  const lineStart = source.lastIndexOf('\n', Math.max(0, start - 1)) + 1;
+  const selection = source.slice(lineStart, end);
+  const lines = selection.split('\n');
+  let removedBeforeStart = 0;
+  let removedTotal = 0;
+  let cursor = lineStart;
+  const nextLines = lines.map((line) => {
+    let removeCount = 0;
+    if (line.startsWith(indent)) removeCount = indent.length;
+    else if (line.startsWith('\t')) removeCount = 1;
+    else if (line.startsWith(' ')) removeCount = 1;
+
+    if (cursor < start) removedBeforeStart += Math.min(removeCount, start - cursor);
+    removedTotal += removeCount;
+    cursor += line.length + 1;
+    return line.slice(removeCount);
+  });
+
+  const nextSelection = nextLines.join('\n');
+  const nextValue = `${source.slice(0, lineStart)}${nextSelection}${source.slice(end)}`;
+  return {
+    value: nextValue,
+    selectionStart: Math.max(lineStart, start - removedBeforeStart),
+    selectionEnd: Math.max(lineStart, end - removedTotal),
+  };
+}

--- a/packages/toolkit/components/markdown-workbench/index.js
+++ b/packages/toolkit/components/markdown-workbench/index.js
@@ -1,5 +1,9 @@
 import { renderMarkdown } from '../../markdown/render.js';
 import {
+  indentMarkdownSelection,
+  outdentMarkdownSelection,
+} from './editor-commands.js';
+import {
   applyMarkdownSaveResult,
   applyMarkdownTextPatch,
   buildMarkdownSaveRequest,
@@ -82,6 +86,30 @@ export default function MarkdownWorkbench(options = {}) {
     return request;
   }
 
+  function applyEditorCommand(result) {
+    dom.editor.value = result.value;
+    state.content = result.value;
+    state.dirty = state.content !== state.savedContent;
+    sync();
+    dom.editor.setSelectionRange(result.selectionStart, result.selectionEnd);
+  }
+
+  function handleEditorKeydown(event) {
+    const key = String(event.key || '').toLowerCase();
+    if ((event.metaKey || event.ctrlKey) && key === 's') {
+      event.preventDefault();
+      requestSave();
+      return;
+    }
+    if (event.key !== 'Tab') return;
+    event.preventDefault();
+    applyEditorCommand((event.shiftKey ? outdentMarkdownSelection : indentMarkdownSelection)({
+      value: dom.editor.value,
+      selectionStart: dom.editor.selectionStart,
+      selectionEnd: dom.editor.selectionEnd,
+    }));
+  }
+
   function render() {
     const root = el('div', 'markdown-workbench-root');
     root.innerHTML = `
@@ -122,6 +150,7 @@ export default function MarkdownWorkbench(options = {}) {
     dom.outline = root.querySelector('[data-role="outline"]');
 
     dom.editor.addEventListener('input', () => setContent(dom.editor.value));
+    dom.editor.addEventListener('keydown', handleEditorKeydown);
     root.querySelector('[data-action="save"]').addEventListener('click', requestSave);
     root.querySelector('[data-action="revert"]').addEventListener('click', () => {
       state.content = state.savedContent;

--- a/tests/toolkit/markdown-editor-commands.test.mjs
+++ b/tests/toolkit/markdown-editor-commands.test.mjs
@@ -1,0 +1,54 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  indentMarkdownSelection,
+  outdentMarkdownSelection,
+} from '../../packages/toolkit/components/markdown-workbench/editor-commands.js';
+
+test('indentMarkdownSelection indents the current line and preserves cursor intent', () => {
+  const result = indentMarkdownSelection({
+    value: 'alpha\nbeta',
+    selectionStart: 8,
+    selectionEnd: 8,
+  });
+
+  assert.equal(result.value, 'alpha\n  beta');
+  assert.equal(result.selectionStart, 10);
+  assert.equal(result.selectionEnd, 10);
+});
+
+test('indentMarkdownSelection indents all selected lines', () => {
+  const result = indentMarkdownSelection({
+    value: 'alpha\nbeta\ngamma',
+    selectionStart: 1,
+    selectionEnd: 12,
+  });
+
+  assert.equal(result.value, '  alpha\n  beta\n  gamma');
+  assert.equal(result.selectionStart, 3);
+  assert.equal(result.selectionEnd, 18);
+});
+
+test('outdentMarkdownSelection removes spaces from selected lines', () => {
+  const result = outdentMarkdownSelection({
+    value: '  alpha\n  beta\nplain',
+    selectionStart: 4,
+    selectionEnd: 14,
+  });
+
+  assert.equal(result.value, 'alpha\nbeta\nplain');
+  assert.equal(result.selectionStart, 2);
+  assert.equal(result.selectionEnd, 10);
+});
+
+test('outdentMarkdownSelection handles tabs and single spaces', () => {
+  const result = outdentMarkdownSelection({
+    value: '\tone\n two\nthree',
+    selectionStart: 0,
+    selectionEnd: 10,
+  });
+
+  assert.equal(result.value, 'one\ntwo\nthree');
+  assert.equal(result.selectionStart, 0);
+  assert.equal(result.selectionEnd, 8);
+});


### PR DESCRIPTION
## Summary

- Add Markdown editor command helpers for Tab indentation and Shift-Tab outdentation with selection preservation.
- Wire the Markdown workbench textarea to handle `Cmd-S`/`Ctrl-S` through the existing save-request path.
- Keep normal typing and undo behavior intact by only touching editor value for explicit editor commands.

## Verification

- `node --check packages/toolkit/components/markdown-workbench/editor-commands.js`
- `node --check packages/toolkit/components/markdown-workbench/index.js`
- `node --test tests/toolkit/markdown-editor-commands.test.mjs tests/toolkit/markdown-render.test.mjs tests/toolkit/markdown-workbench-model.test.mjs tests/toolkit/wiki-kb.test.mjs`
- `git diff --check`
- Live AOS WKWebView check: launched temp Markdown file, verified Tab indents, Shift-Tab outdents, and Cmd-S emits `markdown-workbench/save.requested` with `markdown_document.save.requested` payload.
