### PR TITLE
Define AOS workbench subject descriptor

### DIFF
--- a/apps/sigil/radial-item-editor/model.js
+++ b/apps/sigil/radial-item-editor/model.js
@@ -10,6 +10,7 @@ export const DEFAULT_EDITOR_CANVAS_ID = 'sigil-radial-item-editor';
 export const DEFAULT_EDITOR_ITEM_ID = 'wiki-graph';
 export const RADIAL_ITEM_EDITOR_LOCK_IN_TYPE = 'sigil.radial_item_editor.lock_in';
 export const RADIAL_ITEM_EDITOR_LOCK_IN_SCHEMA_VERSION = '2026-05-03';
+export const WORKBENCH_SUBJECT_SCHEMA_VERSION = '2026-05-03';
 export const RADIAL_ITEM_SOURCE = Object.freeze({
     kind: 'sigil.radial_menu.default_items',
     path: 'apps/sigil/renderer/radial-menu-defaults.js',
@@ -150,10 +151,49 @@ export function exportSelectedRadialItemDefinition(state = {}, {
         type: RADIAL_ITEM_EDITOR_LOCK_IN_TYPE,
         schema_version: RADIAL_ITEM_EDITOR_LOCK_IN_SCHEMA_VERSION,
         generated_at: text(generatedAt, new Date().toISOString()),
+        subject: buildRadialItemWorkbenchSubject(state),
         source: cloneConfig(RADIAL_ITEM_SOURCE),
         item_id: item?.id || null,
         item: item ? cloneConfig(item) : null,
         registry: buildEditorObjectRegistry(state),
+    };
+}
+
+export function buildRadialItemWorkbenchSubject(state = {}) {
+    const item = selectedRadialItem(state);
+    const registry = buildEditorObjectRegistry(state);
+    return {
+        type: 'aos.workbench.subject',
+        schema_version: WORKBENCH_SUBJECT_SCHEMA_VERSION,
+        id: item ? `sigil.radial_menu.item:${item.id}` : 'sigil.radial_menu.item:none',
+        subject_type: 'sigil.radial_menu.item_3d',
+        label: item ? text(item.label, item.id) : 'No radial item',
+        owner: 'sigil.radial-item-editor',
+        source: cloneConfig(RADIAL_ITEM_SOURCE),
+        capabilities: [
+            'canvas_object.registry',
+            'canvas_object.transform.patch',
+            'canvas_object.visibility.patch',
+            'sigil.radial_item_editor.lock_in',
+            'sigil.radial_item.preview',
+        ],
+        views: ['3d.preview', 'object.registry', 'production.radial.preview'],
+        controls: ['object.transform', 'object.visibility', 'scene.orbit', 'lock_in'],
+        persistence: {
+            kind: 'agent_handoff',
+            request: RADIAL_ITEM_EDITOR_LOCK_IN_TYPE,
+            result: 'source.patch.result',
+        },
+        state: {
+            item_id: item?.id || null,
+            canvas_id: text(state.canvasId, DEFAULT_EDITOR_CANVAS_ID),
+            object_count: registry.objects.length,
+            dirty: true,
+        },
+        metadata: {
+            action: text(item?.action),
+            geometry_kind: geometryKind(item || {}),
+        },
     };
 }
 

--- a/apps/sigil/renderer/live-modules/main.js
+++ b/apps/sigil/renderer/live-modules/main.js
@@ -39,6 +39,10 @@ import { createSigilRadialGestureMenu } from './radial-gesture-menu.js';
 import { createRadialMenuTargetSurface } from './radial-menu-target-surface.js';
 import { createSigilRadialGestureVisuals } from './radial-gesture-visuals.js';
 import {
+    advanceMenuActivation,
+    createMenuActivationRequest,
+} from './menu-activation-runtime.js';
+import {
     SIGIL_OBJECT_CONTROL_CANVAS_ID,
     applyRadialMenuObjectTransformPatch,
     buildRadialMenuObjectRegistry,
@@ -102,6 +106,7 @@ const liveJs = {
     utilityCanvases: new Map(),
     defaultAvatarSave: { dirty: false, saving: false, lastSavedAt: null, lastError: null },
     sessionVitality: null,
+    lastRadialActivation: null,
     appearanceVersion: 0,
     appliedAppearanceVersion: null,
     lastPublishedAppearanceVersion: null,
@@ -114,6 +119,10 @@ const AGENT_TERMINAL_CANVAS_ID = 'sigil-agent-terminal';
 const LEGACY_CODEX_TERMINAL_CANVAS_ID = 'sigil-codex-terminal';
 const AGENT_TERMINAL_URL = 'aos://sigil/agent-terminal/index.html?port=17761&session=sigil-agent-terminal-agent-os';
 const AGENT_TERMINAL_PARK_SCALE = 0.24;
+const WIKI_WORKBENCH_CANVAS_ID = 'sigil-wiki-workbench';
+const WIKI_WORKBENCH_DEFAULT_PATH = 'aos/concepts/employer-brand-workflow-map.md';
+const WIKI_WORKBENCH_URL = 'aos://toolkit/components/markdown-workbench/index.html';
+const WIKI_WORKBENCH_DEFAULT_URL = `${WIKI_WORKBENCH_URL}?wiki=${encodeURIComponent(WIKI_WORKBENCH_DEFAULT_PATH)}`;
 const RENDER_PERFORMANCE_CANVAS_ID = 'sigil-render-performance';
 const STATUS_PARK_SCALE = 0.2;
 
@@ -588,6 +597,7 @@ const UTILITY_CANVAS_IDS = new Set([
     'canvas-inspector',
     'sigil-interaction-trace',
     RENDER_PERFORMANCE_CANVAS_ID,
+    WIKI_WORKBENCH_CANVAS_ID,
     AGENT_TERMINAL_CANVAS_ID,
     LEGACY_CODEX_TERMINAL_CANVAS_ID,
 ]);
@@ -642,6 +652,16 @@ function utilityFrame(kind) {
             Math.round(height),
         ];
     }
+    if (kind === 'wiki-workbench') {
+        const width = Math.min(1180, Math.max(840, visible.w * 0.72));
+        const height = Math.min(760, Math.max(560, visible.h * 0.74));
+        return [
+            Math.round(visible.x + (visible.w - width) / 2),
+            Math.round(visible.y + 48),
+            Math.round(width),
+            Math.round(height),
+        ];
+    }
 
     const width = Math.min(360, Math.max(320, visible.w * 0.26));
     const height = Math.min(520, Math.max(420, visible.h * 0.55));
@@ -672,6 +692,13 @@ function utilityConfig(kind) {
         return {
             id: RENDER_PERFORMANCE_CANVAS_ID,
             url: 'aos://toolkit/components/render-performance/index.html',
+            frame: utilityFrame(kind),
+        };
+    }
+    if (kind === 'wiki-workbench') {
+        return {
+            id: WIKI_WORKBENCH_CANVAS_ID,
+            url: WIKI_WORKBENCH_DEFAULT_URL,
             frame: utilityFrame(kind),
         };
     }
@@ -979,6 +1006,92 @@ async function toggleUtilityCanvas(kind) {
     }
 }
 
+async function ensureUtilityCanvasVisible(kind, { focus = true } = {}) {
+    const config = utilityConfig(kind);
+    const current = liveJs.utilityCanvases.get(config.id);
+    const frame = Array.isArray(current?.at) ? current.at : config.frame;
+    try {
+        if (current) {
+            host.canvasUpdate({ id: config.id, frame });
+            if (current.suspended === true) await host.canvasResume(config.id);
+            liveJs.utilityCanvases.set(config.id, { ...current, suspended: false, at: frame });
+            return { id: config.id, frame, created: false };
+        }
+        await host.canvasCreate({
+            id: config.id,
+            url: config.url,
+            frame,
+            interactive: true,
+            focus,
+        });
+        liveJs.utilityCanvases.set(config.id, {
+            id: config.id,
+            suspended: false,
+            at: frame,
+        });
+        return { id: config.id, frame, created: true };
+    } catch (error) {
+        if (!current) {
+            await host.canvasResume(config.id);
+            liveJs.utilityCanvases.set(config.id, {
+                id: config.id,
+                suspended: false,
+                at: frame,
+            });
+            return { id: config.id, frame, created: false, recovered: true };
+        }
+        throw error;
+    }
+}
+
+async function fetchWikiMarkdownDocument(path = WIKI_WORKBENCH_DEFAULT_PATH) {
+    const wikiPath = String(path || WIKI_WORKBENCH_DEFAULT_PATH).replace(/^\/+/, '');
+    const response = await fetch(`/wiki/${wikiPath}`, { cache: 'no-store' });
+    if (!response.ok) throw new Error(`wiki fetch failed for ${wikiPath}: ${response.status}`);
+    const content = await response.text();
+    return {
+        type: 'markdown_document.open',
+        path: wikiPath,
+        source: {
+            kind: 'wiki',
+            path: wikiPath,
+            page: {
+                path: wikiPath,
+                frontmatter: {},
+            },
+        },
+        content,
+    };
+}
+
+function sendCanvasMessage(target, message) {
+    host.post('canvas.send', { target, message });
+}
+
+function sendActivationUpdate(activation, phase, extra = {}) {
+    const update = advanceMenuActivation(activation, phase, extra);
+    liveJs.lastRadialActivation = update;
+    host.post('sigil.radial_menu.activation', update);
+    return update;
+}
+
+async function openWikiWorkbench(path = WIKI_WORKBENCH_DEFAULT_PATH, activation = null) {
+    const canvas = await ensureUtilityCanvasVisible('wiki-workbench', { focus: true });
+    const message = await fetchWikiMarkdownDocument(path);
+    if (!canvas.created) {
+        sendCanvasMessage(WIKI_WORKBENCH_CANVAS_ID, message);
+    }
+    if (activation) {
+        sendActivationUpdate(activation, 'completed', {
+            result: {
+                canvas_id: WIKI_WORKBENCH_CANVAS_ID,
+                subject: message.source,
+            },
+        });
+    }
+    return { canvas, message };
+}
+
 function projectAvatarToScene(screenX, screenY, yOffset = 0) {
     const local = desktopWorldToSegmentLocalPoint({ x: screenX, y: screenY }) ?? { x: screenX, y: screenY };
     const vec = new THREE.Vector3();
@@ -1118,25 +1231,62 @@ const fastTravel = createFastTravelController({
 });
 const radialGestureMenu = createSigilRadialGestureMenu({
     state,
-    onCommitItem(item) {
+    onCommitItem(item, snapshot) {
+        const activation = createMenuActivationRequest({
+            menuId: 'sigil.radial',
+            item,
+            input: snapshot?.phase === 'committed' ? 'gesture' : 'radial',
+            source: 'sigil.avatar',
+            surface: item?.action === 'wikiGraph' ? {
+                kind: 'markdown-workbench',
+                canvas_id: WIKI_WORKBENCH_CANVAS_ID,
+                subject: {
+                    id: `wiki:${WIKI_WORKBENCH_DEFAULT_PATH}`,
+                    source: {
+                        kind: 'wiki',
+                        path: WIKI_WORKBENCH_DEFAULT_PATH,
+                    },
+                },
+            } : null,
+            transition: item?.action === 'wikiGraph' ? {
+                preset: 'wiki-brain-zoom-dissolve',
+                item: {
+                    zoom: 'fill-camera',
+                    dissolve: true,
+                },
+                menu: {
+                    dissolve: true,
+                },
+                surface: {
+                    fade: 'in',
+                },
+            } : null,
+        });
+        liveJs.lastRadialActivation = activation;
+        host.post('sigil.radial_menu.activation', activation);
         if (item?.action === 'contextMenu') {
             openContextMenuAt(liveJs.avatarPos.x, liveJs.avatarPos.y, { force: true });
+            sendActivationUpdate(activation, 'completed', { result: { opened: 'context-menu' } });
             return;
         }
         if (item?.action === 'agentTerminal' || item?.action === 'codexTerminal') {
             toggleUtilityCanvas('agent-terminal');
+            sendActivationUpdate(activation, 'completed', { result: { canvas_id: AGENT_TERMINAL_CANVAS_ID } });
             return;
         }
         if (item?.action === 'wikiGraph') {
-            host.post('sigil.radial_menu.action', {
-                action: 'wikiGraph',
-                status: 'stub',
+            void openWikiWorkbench(WIKI_WORKBENCH_DEFAULT_PATH, activation).catch((error) => {
+                console.warn('[sigil] wiki workbench activation failed:', error);
+                sendActivationUpdate(activation, 'failed', {
+                    error: String(error?.message || error),
+                });
             });
             return;
         }
         host.post('sigil.radial_menu.action', {
             action: item?.action || item?.id || 'unknown',
         });
+        sendActivationUpdate(activation, 'completed', { result: { action: item?.action || item?.id || 'unknown' } });
     },
 });
 let omegaTrailTravelKey = null;

--- a/apps/sigil/renderer/live-modules/menu-activation-runtime.js
+++ b/apps/sigil/renderer/live-modules/menu-activation-runtime.js
@@ -1,0 +1,18 @@
+const TOOLKIT_MENU_ACTIVATION_SPECIFIER = (
+    typeof window !== 'undefined'
+    && typeof location !== 'undefined'
+    && /^https?:$/.test(location.protocol)
+)
+    ? '/toolkit/runtime/menu-activation.js'
+    : (
+        typeof location !== 'undefined'
+        && location.protocol === 'aos:'
+    )
+        ? 'aos://toolkit/runtime/menu-activation.js'
+        : '../../../../packages/toolkit/runtime/menu-activation.js';
+
+export const {
+    MENU_ACTIVATION_SCHEMA_VERSION,
+    advanceMenuActivation,
+    createMenuActivationRequest,
+} = await import(TOOLKIT_MENU_ACTIVATION_SPECIFIER);

--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -313,6 +313,7 @@ Launch the sample or a repo file:
 ```bash
 packages/toolkit/components/markdown-workbench/launch.sh
 packages/toolkit/components/markdown-workbench/launch.sh docs/design/aos-workbench-pattern.md
+packages/toolkit/components/markdown-workbench/launch.sh wiki:aos/concepts/runtime-modes.md
 ```
 
 Persist the current canvas state from an agent shell:
@@ -324,7 +325,8 @@ packages/toolkit/components/markdown-workbench/save-current.sh markdown-workbenc
 Accepted messages:
 
 - `markdown_document.open` with `{ path, content }` replaces the current subject
-  and clears dirty state.
+  and clears dirty state. Wiki-backed opens may include
+  `{ source: { kind: "wiki", path, page? } }`.
 - `markdown_document.text.patch` with `{ patch: { content } }` replaces the
   editable source and recomputes preview/diagnostics.
 - `markdown_document.save.result` with `{ status: "saved" | "rejected",
@@ -362,6 +364,11 @@ Current renderer support is intentionally small: frontmatter is skipped,
 headings up to depth 3 render, lists render, inline code/bold/emphasis render,
 and unsafe links are stripped. Mermaid fences are detected for diagnostics but
 not rendered yet.
+
+`save-current.sh` persists file-backed documents by writing the source file and
+wiki-backed documents by PUT-ing to the local wiki content server. The canvas
+still only emits save requests; the helper performs the privileged write and
+posts `markdown_document.save.result` back to the canvas.
 
 When enabled, the graph controls can also expose:
 

--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -93,14 +93,27 @@ Create descriptors with:
 import { createWorkbenchSubject } from '../workbench/subject.js'
 ```
 
+Wiki pages can be projected from `aos wiki list/show --json` shapes with:
+
+```js
+import { createWikiPageSubject } from '../workbench/wiki-subject.js'
+```
+
 The current schema version is `2026-05-03`. The first adopters are:
 
 - Sigil radial item editor subjects: `sigil.radial_menu.item_3d`
 - Markdown workbench subjects: `markdown.document`
+- Wiki page subjects: `wiki.concept`, `wiki.entity`, `wiki.workflow`,
+  `wiki.reference`, and `sigil.agent`
 
 Subject descriptors are included in lock-in/save handoff payloads so agents,
 apps, and future workbench shells can reason about different editors using one
 vocabulary.
+
+Wiki subject ids use `wiki:<path>`, for example
+`wiki:aos/concepts/runtime-modes.md`. Their source uses `{ kind: "wiki", path,
+namespace, plugin }`, and their persistence route is the wiki write/change-event
+handoff rather than direct canvas filesystem access.
 
 ## Stock Components Snapshot
 

--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -21,6 +21,7 @@ It is split into three layers:
 | Runtime | `packages/toolkit/runtime/` | bridge, subscriptions, canvas mutation helpers, manifest handshake |
 | Controls | `packages/toolkit/controls/` | reusable app-control behavior for WKWebView surfaces |
 | Panel | `packages/toolkit/panel/` | structure and composition primitives (`mountPanel`, `Single`, `Tabs`) |
+| Workbench | `packages/toolkit/workbench/` | shared subject descriptors and workbench contracts |
 | Components | `packages/toolkit/components/` | reusable content units and optional stock styles |
 
 ### DesktopWorld Surface Runtime
@@ -74,6 +75,32 @@ fields marked with `data-aos-control="number-field"`. It uses the field's
 native `step`, `min`, and `max` attributes, dispatches bubbling `input` and
 `change` events after a step, uses `Shift` for coarse stepping, and uses
 `Option` for fine stepping.
+
+## Workbench Contracts
+
+Workbench surfaces should describe the thing being edited with
+`aos.workbench.subject`. The descriptor is intentionally small: it names stable
+identity, subject type, owner, source, capabilities, views, controls,
+persistence, artifacts, and current state. It does not move domain ownership
+into the toolkit.
+
+Canonical schema:
+[`shared/schemas/aos-workbench-subject.schema.json`](../../shared/schemas/aos-workbench-subject.schema.json)
+
+Create descriptors with:
+
+```js
+import { createWorkbenchSubject } from '../workbench/subject.js'
+```
+
+The current schema version is `2026-05-03`. The first adopters are:
+
+- Sigil radial item editor subjects: `sigil.radial_menu.item_3d`
+- Markdown workbench subjects: `markdown.document`
+
+Subject descriptors are included in lock-in/save handoff payloads so agents,
+apps, and future workbench shells can reason about different editors using one
+vocabulary.
 
 ## Stock Components Snapshot
 
@@ -297,6 +324,14 @@ Save requests are emitted as `markdown-workbench/save.requested` with payload:
   "type": "markdown_document.save.requested",
   "schema_version": "2026-05-03",
   "request_id": "markdown-save-example",
+  "subject": {
+    "type": "aos.workbench.subject",
+    "schema_version": "2026-05-03",
+    "id": "file:docs/example.md",
+    "subject_type": "markdown.document",
+    "label": "example.md",
+    "owner": "markdown-workbench"
+  },
   "path": "docs/example.md",
   "content": "# Example\n\nUpdated body",
   "diagnostics": {

--- a/docs/design/aos-workbench-pattern.md
+++ b/docs/design/aos-workbench-pattern.md
@@ -113,6 +113,11 @@ Current adopters publish this as `aos.workbench.subject` so a workbench shell,
 agent, or persistence adapter can inspect different subject kinds without
 knowing their private renderer internals.
 
+Wiki pages are the next natural subject catalog. A wiki page can project as
+`wiki.concept`, `wiki.entity`, `wiki.workflow`, `wiki.reference`, or an
+app-specialized type such as `sigil.agent` while retaining its canonical wiki
+path as source identity.
+
 ### View
 
 A view renders a subject or part of a subject.

--- a/docs/design/aos-workbench-pattern.md
+++ b/docs/design/aos-workbench-pattern.md
@@ -1,11 +1,12 @@
 # AOS Workbench Pattern
 
-Status: Concept and planning note, not scheduled.
+Status: Planning note with narrow contract extraction in progress.
 
 This note captures a platform direction before it leaks out of session memory.
 It is not an implementation mandate. Promote slices from this note only when a
 concrete consumer needs them and the slice can be specified with explicit
-contracts.
+contracts. The first promoted slice is the shared workbench subject descriptor
+in `packages/toolkit/workbench/subject.js`.
 
 ## Problem
 
@@ -108,6 +109,9 @@ Examples:
 - generated artifact bundle
 
 A subject needs stable identity, type, capabilities, state, and ownership.
+Current adopters publish this as `aos.workbench.subject` so a workbench shell,
+agent, or persistence adapter can inspect different subject kinds without
+knowing their private renderer internals.
 
 ### View
 
@@ -228,6 +232,13 @@ It should be able to contain:
 
 This makes a workflow a graph or DAG, not only a checklist.
 
+Workflows should also be chainable: one workflow node may reference a reusable
+sub-workflow with its own inputs, outputs, approval gates, artifacts, and
+validation state. Chaining should be modeled as subject composition, not as a
+new special-case editor. A workflow workbench can render the same subject as
+source text, JSON, a DAG, a run timeline, or an artifact gallery while patching
+the underlying graph through structured node and edge operations.
+
 Example: SPA report workflow
 
 ```text
@@ -283,6 +294,7 @@ Do not add schemas before a concrete adopter needs them.
 
 Reusable workbench components belong in `packages/toolkit/`:
 
+- subject descriptor helpers
 - workbench shell
 - subject registry viewer
 - object transform panel

--- a/packages/toolkit/CLAUDE.md
+++ b/packages/toolkit/CLAUDE.md
@@ -13,6 +13,7 @@ aos daemon (Layer 0)           canvas.create/update/remove, subscribe streams, e
   └─ runtime/ (Layer 1a)       in-canvas helpers: bridge, subscribe, canvas mutation, manifest
        ├─ controls/            reusable app-control behavior for WKWebView surfaces
        ├─ panel/ (Layer 1b)    panel-shaped scaffolding: chrome, router, layouts (Single, Tabs)
+       ├─ workbench/           subject descriptors and reusable workbench contracts
        │    └─ components/     reusable Content units consumed by panel layouts
        └─ apps/ (Layer 3)      presence surfaces use 1a directly; panels use 1a + 1b + 2
 ```
@@ -48,6 +49,9 @@ panel/                  Layer 1b — panel primitives
   mount.js                mountPanel orchestrator
   index.js                re-exports + Content typedef
   _smoke/                 smoke harness
+
+workbench/              Layer 1c — workbench contracts
+  subject.js              shared aos.workbench.subject descriptor helpers
 
 components/             Layer 2 — reusable Content units
   _base/                  shared theme.css tokens/reset (legacy AosComponent retired)

--- a/packages/toolkit/CLAUDE.md
+++ b/packages/toolkit/CLAUDE.md
@@ -52,6 +52,8 @@ panel/                  Layer 1b — panel primitives
 
 workbench/              Layer 1c — workbench contracts
   subject.js              shared aos.workbench.subject descriptor helpers
+  wiki-subject.js         wiki page → workbench subject projection helpers
+  index.js                re-exports
 
 components/             Layer 2 — reusable Content units
   _base/                  shared theme.css tokens/reset (legacy AosComponent retired)

--- a/packages/toolkit/components/markdown-workbench/index.js
+++ b/packages/toolkit/components/markdown-workbench/index.js
@@ -21,6 +21,7 @@ function el(tag, className, textContent) {
 
 export default function MarkdownWorkbench(options = {}) {
   let host = null;
+  let initialUrlOpenStarted = false;
   const state = createMarkdownWorkbenchState(options.document || {});
   const dom = {};
 
@@ -72,16 +73,111 @@ export default function MarkdownWorkbench(options = {}) {
     window.__markdownWorkbenchState = markdownWorkbenchSnapshot(state);
   }
 
+  function parseWikiFrontmatter(raw = '') {
+    const text = String(raw ?? '');
+    if (!text.startsWith('---\n')) return {};
+    const end = text.indexOf('\n---', 4);
+    if (end < 0) return {};
+    const frontmatter = {};
+    for (const line of text.slice(4, end).split('\n')) {
+      const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+      if (!match) continue;
+      let value = match[2].trim();
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1);
+      }
+      frontmatter[match[1]] = value;
+    }
+    return frontmatter;
+  }
+
+  async function openInitialWikiFromUrl() {
+    if (initialUrlOpenStarted || typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search || '');
+    const wikiPath = String(params.get('wiki') || '').replace(/^\/+/, '').trim();
+    if (!wikiPath) return;
+    initialUrlOpenStarted = true;
+    try {
+      const response = await fetch(`/wiki/${wikiPath}`, { cache: 'no-store' });
+      if (!response.ok) throw new Error(`wiki fetch failed for ${wikiPath}: ${response.status}`);
+      const content = await response.text();
+      openMarkdownDocument(state, {
+        type: 'markdown_document.open',
+        path: wikiPath,
+        source: {
+          kind: 'wiki',
+          path: wikiPath,
+          page: {
+            path: wikiPath,
+            frontmatter: parseWikiFrontmatter(content),
+          },
+        },
+        content,
+      });
+      sync({ replaceEditorValue: true });
+    } catch (error) {
+      state.lastResult = {
+        type: 'markdown_document.open.result',
+        status: 'rejected',
+        path: wikiPath,
+        message: String(error?.message || error),
+      };
+      sync();
+      console.warn('[markdown-workbench] initial wiki open failed:', error);
+    }
+  }
+
   function setContent(content) {
     state.content = String(content ?? '');
     state.dirty = state.content !== state.savedContent;
     sync();
   }
 
+  async function saveWikiDocument(request) {
+    const source = request.source || request.subject?.source;
+    if (source?.kind !== 'wiki' || !source.path) {
+      throw new Error('markdown document is not wiki-backed');
+    }
+    const response = await fetch(`/wiki/${String(source.path).replace(/^\/+/, '')}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+      body: String(request.content ?? ''),
+    });
+    if (!response.ok) throw new Error(`wiki save failed for ${source.path}: ${response.status}`);
+    return {
+      type: 'markdown_document.save.result',
+      request_id: request.request_id,
+      status: 'saved',
+      path: source.path,
+      message: 'Saved to wiki',
+    };
+  }
+
   function requestSave() {
     const request = buildMarkdownSaveRequest(state);
     state.lastResult = request;
-    emit('save.requested', request);
+    if (state.source?.kind === 'wiki') {
+      void saveWikiDocument(request)
+        .then((result) => {
+          applyMarkdownSaveResult(state, result);
+          emit('save.result', result);
+          sync();
+        })
+        .catch((error) => {
+          const result = {
+            type: 'markdown_document.save.result',
+            request_id: request.request_id,
+            status: 'rejected',
+            path: request.path,
+            message: String(error?.message || error),
+          };
+          applyMarkdownSaveResult(state, result);
+          emit('save.result', result);
+          sync();
+        });
+    } else {
+      emit('save.requested', request);
+    }
     sync();
     return request;
   }
@@ -180,7 +276,7 @@ export default function MarkdownWorkbench(options = {}) {
       name: 'markdown-workbench',
       title: 'Markdown Workbench',
       accepts: ['markdown_document.open', 'markdown_document.text.patch', 'markdown_document.save.result'],
-      emits: ['markdown-workbench/save.requested'],
+      emits: ['markdown-workbench/save.requested', 'markdown-workbench/save.result'],
       channelPrefix: 'markdown-workbench',
       defaultSize: { w: 1120, h: 720 },
     },
@@ -188,7 +284,9 @@ export default function MarkdownWorkbench(options = {}) {
     render(host_) {
       host = host_;
       host.contentEl.style.overflow = 'hidden';
-      return render();
+      const root = render();
+      void openInitialWikiFromUrl();
+      return root;
     },
 
     onMessage,

--- a/packages/toolkit/components/markdown-workbench/launch.sh
+++ b/packages/toolkit/components/markdown-workbench/launch.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# launch.sh - Open a file-backed Markdown workbench.
+# launch.sh - Open a file-backed or wiki-backed Markdown workbench.
 
 set -euo pipefail
 
@@ -7,7 +7,7 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null || pwd)"
 AOS="${AOS:-$ROOT/aos}"
 CANVAS_ID="${CANVAS_ID:-markdown-workbench}"
-TARGET_FILE="${1:-$DIR/sample.md}"
+TARGET="${1:-$DIR/sample.md}"
 PANEL_W="${AOS_MARKDOWN_WORKBENCH_W:-1120}"
 PANEL_H="${AOS_MARKDOWN_WORKBENCH_H:-720}"
 
@@ -35,9 +35,20 @@ if [[ ! -x "$AOS" ]]; then
   exit 1
 fi
 
-if [[ ! -f "$TARGET_FILE" ]]; then
-  echo "Markdown file not found: $TARGET_FILE" >&2
-  exit 1
+WIKI_PATH=""
+TARGET_FILE=""
+if [[ "$TARGET" == wiki:* ]]; then
+  WIKI_PATH="${TARGET#wiki:}"
+  if [[ -z "$WIKI_PATH" ]]; then
+    echo "Wiki target must be wiki:<path>" >&2
+    exit 1
+  fi
+else
+  TARGET_FILE="$TARGET"
+  if [[ ! -f "$TARGET_FILE" ]]; then
+    echo "Markdown file not found: $TARGET_FILE" >&2
+    exit 1
+  fi
 fi
 
 if [[ "$TOOLKIT_CONTENT_ROOT" != "toolkit" && -d "$CANONICAL_REPO_ROOT/packages/toolkit" ]]; then
@@ -103,7 +114,27 @@ read -r X Y W H <<<"$GEOMETRY"
   --js 'typeof window.__markdownWorkbenchState === "object"' \
   --timeout 5s >/dev/null
 
-CONTENT_JSON="$(TARGET_FILE="$TARGET_FILE" python3 -c '
+if [[ -n "$WIKI_PATH" ]]; then
+  PAGE_JSON="$("$AOS" wiki show "$WIKI_PATH" --json)"
+  CONTENT_JSON="$(PAGE_JSON="$PAGE_JSON" python3 -c '
+import json, os
+page = json.loads(os.environ["PAGE_JSON"])
+print(json.dumps({
+    "type": "markdown_document.open",
+    "path": page["path"],
+    "source": {
+        "kind": "wiki",
+        "path": page["path"],
+        "page": {
+            "path": page["path"],
+            "frontmatter": page.get("frontmatter") or {},
+        },
+    },
+    "content": page.get("raw") or "",
+}))
+')"
+else
+  CONTENT_JSON="$(TARGET_FILE="$TARGET_FILE" python3 -c '
 import json, os, pathlib
 path = pathlib.Path(os.environ["TARGET_FILE"]).resolve()
 print(json.dumps({
@@ -112,11 +143,16 @@ print(json.dumps({
     "content": path.read_text(encoding="utf-8"),
 }))
 ')"
+fi
 
 "$AOS" show post --id "$CANVAS_ID" --event "$CONTENT_JSON" >/dev/null
 
 echo "Markdown workbench launched at ${X},${Y} (${W}x${H})"
 echo "Canvas: $CANVAS_ID"
-echo "File: $(cd "$(dirname "$TARGET_FILE")" && pwd)/$(basename "$TARGET_FILE")"
+if [[ -n "$WIKI_PATH" ]]; then
+  echo "Wiki: $WIKI_PATH"
+else
+  echo "File: $(cd "$(dirname "$TARGET_FILE")" && pwd)/$(basename "$TARGET_FILE")"
+fi
 echo "Save handoff: use window.__markdownWorkbenchState.content or the emitted markdown-workbench/save.requested event."
 echo "Agent save helper: packages/toolkit/components/markdown-workbench/save-current.sh $CANVAS_ID"

--- a/packages/toolkit/components/markdown-workbench/model.js
+++ b/packages/toolkit/components/markdown-workbench/model.js
@@ -1,4 +1,5 @@
 import { createWorkbenchSubject } from '../../workbench/subject.js';
+import { createWikiPageSubject } from '../../workbench/wiki-subject.js';
 
 export const MARKDOWN_WORKBENCH_SCHEMA_VERSION = '2026-05-03';
 
@@ -16,14 +17,30 @@ export function createMarkdownWorkbenchState({
   content = '',
   savedContent = content,
   dirty = false,
+  source = null,
 } = {}) {
   const current = String(content ?? '');
   return {
     path: normalizePath(path),
+    source: normalizeSource(source, normalizePath(path)),
     content: current,
     savedContent: String(savedContent ?? current),
     dirty: !!dirty,
     lastResult: null,
+  };
+}
+
+function normalizeSource(source = null, path = 'untitled.md') {
+  if (source && typeof source === 'object' && source.kind === 'wiki') {
+    return {
+      kind: 'wiki',
+      path: normalizePath(source.path || path),
+      page: source.page && typeof source.page === 'object' ? source.page : null,
+    };
+  }
+  return {
+    kind: 'file',
+    path: normalizePath(path),
   };
 }
 
@@ -79,6 +96,7 @@ export function openMarkdownDocument(state, message = {}) {
   const payload = message.payload || message;
   const content = String(payload.content ?? payload.markdown ?? '');
   state.path = normalizePath(payload.path);
+  state.source = normalizeSource(payload.source, state.path);
   state.content = content;
   state.savedContent = content;
   state.dirty = false;
@@ -127,6 +145,7 @@ export function buildMarkdownSaveRequest(state, {
     schema_version: MARKDOWN_WORKBENCH_SCHEMA_VERSION,
     request_id: requestId,
     subject: buildMarkdownWorkbenchSubject(state),
+    source: state.source,
     path: state.path,
     content: state.content,
     diagnostics: markdownDiagnostics(state.content),
@@ -155,6 +174,7 @@ export function markdownWorkbenchSnapshot(state) {
     type: 'markdown_document.snapshot',
     schema_version: MARKDOWN_WORKBENCH_SCHEMA_VERSION,
     subject: buildMarkdownWorkbenchSubject(state),
+    source: state.source,
     path: state.path,
     content: state.content,
     dirty: state.dirty,
@@ -165,6 +185,32 @@ export function markdownWorkbenchSnapshot(state) {
 
 export function buildMarkdownWorkbenchSubject(state = {}) {
   const diagnostics = markdownDiagnostics(state.content);
+  if (state.source?.kind === 'wiki') {
+    const subject = createWikiPageSubject({
+      ...(state.source.page || {}),
+      path: state.source.path || state.path,
+    });
+    subject.capabilities = [...new Set([
+      ...subject.capabilities,
+      'markdown.render',
+      'markdown.diagnostics',
+      'markdown.outline',
+      'markdown_document.text.patch',
+      'markdown_document.save.requested',
+    ])];
+    subject.views = [...new Set([...subject.views, 'source', 'markdown.preview', 'outline', 'diagnostics'])];
+    subject.controls = [...new Set([...subject.controls, 'text.editor', 'save', 'revert'])];
+    subject.state = {
+      ...subject.state,
+      dirty: !!state.dirty,
+      line_count: diagnostics.line_count,
+      word_count: diagnostics.word_count,
+      heading_count: diagnostics.heading_count,
+      mermaid_block_count: diagnostics.mermaid_blocks.length,
+      unclosed_fence: diagnostics.unclosed_fence,
+    };
+    return subject;
+  }
   return createWorkbenchSubject({
     id: `file:${normalizePath(state.path)}`,
     type: 'markdown.document',

--- a/packages/toolkit/components/markdown-workbench/model.js
+++ b/packages/toolkit/components/markdown-workbench/model.js
@@ -1,3 +1,5 @@
+import { createWorkbenchSubject } from '../../workbench/subject.js';
+
 export const MARKDOWN_WORKBENCH_SCHEMA_VERSION = '2026-05-03';
 
 function text(value, fallback = '') {
@@ -124,6 +126,7 @@ export function buildMarkdownSaveRequest(state, {
     type: 'markdown_document.save.requested',
     schema_version: MARKDOWN_WORKBENCH_SCHEMA_VERSION,
     request_id: requestId,
+    subject: buildMarkdownWorkbenchSubject(state),
     path: state.path,
     content: state.content,
     diagnostics: markdownDiagnostics(state.content),
@@ -151,10 +154,48 @@ export function markdownWorkbenchSnapshot(state) {
   return {
     type: 'markdown_document.snapshot',
     schema_version: MARKDOWN_WORKBENCH_SCHEMA_VERSION,
+    subject: buildMarkdownWorkbenchSubject(state),
     path: state.path,
     content: state.content,
     dirty: state.dirty,
     diagnostics: markdownDiagnostics(state.content),
     last_result: state.lastResult,
   };
+}
+
+export function buildMarkdownWorkbenchSubject(state = {}) {
+  const diagnostics = markdownDiagnostics(state.content);
+  return createWorkbenchSubject({
+    id: `file:${normalizePath(state.path)}`,
+    type: 'markdown.document',
+    label: normalizePath(state.path).split('/').pop(),
+    owner: 'markdown-workbench',
+    source: {
+      kind: 'file',
+      path: normalizePath(state.path),
+    },
+    capabilities: [
+      'markdown.render',
+      'markdown.diagnostics',
+      'markdown.outline',
+      'markdown.mermaid.detect',
+      'markdown_document.text.patch',
+      'markdown_document.save.requested',
+    ],
+    views: ['source', 'markdown.preview', 'outline', 'diagnostics'],
+    controls: ['text.editor', 'save', 'revert'],
+    persistence: {
+      kind: 'agent_handoff',
+      request: 'markdown_document.save.requested',
+      result: 'markdown_document.save.result',
+    },
+    state: {
+      dirty: !!state.dirty,
+      line_count: diagnostics.line_count,
+      word_count: diagnostics.word_count,
+      heading_count: diagnostics.heading_count,
+      mermaid_block_count: diagnostics.mermaid_blocks.length,
+      unclosed_fence: diagnostics.unclosed_fence,
+    },
+  });
 }

--- a/packages/toolkit/components/markdown-workbench/save-current.sh
+++ b/packages/toolkit/components/markdown-workbench/save-current.sh
@@ -16,7 +16,7 @@ fi
 EVAL_JSON="$("$AOS" show eval --id "$CANVAS_ID" --js 'JSON.stringify(window.__markdownWorkbenchState || null)')"
 
 SAVE_JSON="$(
-  EVAL_JSON="$EVAL_JSON" python3 -c '
+  EVAL_JSON="$EVAL_JSON" AOS="$AOS" python3 -c '
 import json, os, pathlib, sys
 
 try:
@@ -29,10 +29,43 @@ if not isinstance(snapshot, dict):
     raise SystemExit("markdown workbench state is unavailable")
 
 path = pathlib.Path(snapshot.get("path") or "").expanduser().resolve()
+source = ((snapshot.get("subject") or {}).get("source") or snapshot.get("source") or {})
+content = str(snapshot.get("content") or "")
+
+if source.get("kind") == "wiki":
+    wiki_path = str(source.get("path") or snapshot.get("path") or "").lstrip("/")
+    if not wiki_path:
+        raise SystemExit("markdown workbench wiki source did not include a path")
+    try:
+        status_outer = json.loads(__import__("subprocess").check_output([os.environ.get("AOS", "aos"), "content", "status", "--json"], text=True))
+        port = int(status_outer["port"])
+    except Exception as error:
+        raise SystemExit(f"failed to resolve aos content server for wiki save: {error}")
+    import urllib.request
+    from urllib.parse import quote
+    url = f"http://127.0.0.1:{port}/wiki/{quote(wiki_path)}"
+    request = urllib.request.Request(url, data=content.encode("utf-8"), method="PUT")
+    request.add_header("Content-Type", "text/markdown; charset=utf-8")
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            if response.status < 200 or response.status >= 300:
+                raise RuntimeError(f"HTTP {response.status}")
+    except Exception as error:
+        raise SystemExit(f"failed to save wiki page {wiki_path}: {error}")
+    print(json.dumps({
+        "type": "markdown_document.save.result",
+        "status": "saved",
+        "path": wiki_path,
+        "source": source,
+        "message": "saved wiki page by markdown-workbench/save-current.sh",
+    }))
+    raise SystemExit(0)
+
+path = pathlib.Path(snapshot.get("path") or "").expanduser().resolve()
 if not path:
     raise SystemExit("markdown workbench state did not include a path")
 
-path.write_text(str(snapshot.get("content") or ""), encoding="utf-8")
+path.write_text(content, encoding="utf-8")
 print(json.dumps({
     "type": "markdown_document.save.result",
     "status": "saved",

--- a/packages/toolkit/runtime/index.js
+++ b/packages/toolkit/runtime/index.js
@@ -46,6 +46,11 @@ export {
   shortestAngleDelta,
 } from './radial-gesture.js'
 export {
+  MENU_ACTIVATION_SCHEMA_VERSION,
+  advanceMenuActivation,
+  createMenuActivationRequest,
+} from './menu-activation.js'
+export {
   createStackMenu,
   createStackMenuModel,
   applyStackMenuState,

--- a/packages/toolkit/runtime/menu-activation.js
+++ b/packages/toolkit/runtime/menu-activation.js
@@ -1,0 +1,62 @@
+export const MENU_ACTIVATION_SCHEMA_VERSION = '2026-05-04';
+
+function text(value, fallback = '') {
+  const normalized = String(value ?? '').replace(/\s+/g, ' ').trim();
+  return normalized || fallback;
+}
+
+function cloneJson(value) {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function stableId(prefix = 'activation') {
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function createMenuActivationRequest({
+  id,
+  menuId,
+  item,
+  input = 'unknown',
+  source = 'menu',
+  phase = 'requested',
+  surface = null,
+  transition = null,
+  metadata = {},
+} = {}) {
+  const itemId = text(item?.id || item?.action);
+  if (!itemId) throw new TypeError('menu activation requires an item id or action');
+
+  return {
+    type: 'aos.menu.activation',
+    schema_version: MENU_ACTIVATION_SCHEMA_VERSION,
+    id: text(id, stableId('menu-activation')),
+    menu_id: text(menuId, 'menu'),
+    phase: text(phase, 'requested'),
+    input: text(input, 'unknown'),
+    source: text(source, 'menu'),
+    action: text(item?.action || itemId),
+    item: {
+      id: itemId,
+      label: text(item?.label, itemId),
+      action: text(item?.action || itemId),
+    },
+    surface: surface ? cloneJson(surface) : null,
+    transition: transition ? cloneJson(transition) : null,
+    metadata: cloneJson(metadata) || {},
+    created_at: Date.now(),
+  };
+}
+
+export function advanceMenuActivation(request = {}, phase = 'completed', extra = {}) {
+  if (request.type !== 'aos.menu.activation') {
+    throw new TypeError('advanceMenuActivation requires an aos.menu.activation request');
+  }
+  return {
+    ...cloneJson(request),
+    ...cloneJson(extra),
+    phase: text(phase, 'completed'),
+    updated_at: Date.now(),
+  };
+}

--- a/packages/toolkit/workbench/index.js
+++ b/packages/toolkit/workbench/index.js
@@ -1,0 +1,2 @@
+export * from './subject.js';
+export * from './wiki-subject.js';

--- a/packages/toolkit/workbench/subject.js
+++ b/packages/toolkit/workbench/subject.js
@@ -1,0 +1,63 @@
+export const WORKBENCH_SUBJECT_SCHEMA_VERSION = '2026-05-03';
+
+function text(value, fallback = '') {
+  const normalized = String(value ?? '').replace(/\s+/g, ' ').trim();
+  return normalized || fallback;
+}
+
+function cloneJson(value) {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function textList(values = []) {
+  if (!Array.isArray(values)) return [];
+  return values
+    .map((value) => text(value))
+    .filter(Boolean);
+}
+
+export function createWorkbenchSubject({
+  id,
+  type,
+  label,
+  owner,
+  source = null,
+  capabilities = [],
+  views = [],
+  controls = [],
+  persistence = null,
+  artifacts = [],
+  state = {},
+  metadata = {},
+} = {}) {
+  const subjectId = text(id);
+  const subjectType = text(type);
+  if (!subjectId) throw new TypeError('workbench subject requires an id');
+  if (!subjectType) throw new TypeError('workbench subject requires a type');
+
+  return {
+    type: 'aos.workbench.subject',
+    schema_version: WORKBENCH_SUBJECT_SCHEMA_VERSION,
+    id: subjectId,
+    subject_type: subjectType,
+    label: text(label, subjectId),
+    owner: text(owner, 'unknown'),
+    source: source ? cloneJson(source) : null,
+    capabilities: textList(capabilities),
+    views: textList(views),
+    controls: textList(controls),
+    persistence: persistence ? cloneJson(persistence) : null,
+    artifacts: Array.isArray(artifacts) ? cloneJson(artifacts) : [],
+    state: cloneJson(state) || {},
+    metadata: cloneJson(metadata) || {},
+  };
+}
+
+export function subjectCapabilitySet(subject = {}) {
+  return new Set(textList(subject.capabilities));
+}
+
+export function subjectSupports(subject = {}, capability = '') {
+  return subjectCapabilitySet(subject).has(text(capability));
+}

--- a/packages/toolkit/workbench/wiki-subject.js
+++ b/packages/toolkit/workbench/wiki-subject.js
@@ -1,0 +1,110 @@
+import { createWorkbenchSubject } from './subject.js';
+
+function text(value, fallback = '') {
+  const normalized = String(value ?? '').replace(/\s+/g, ' ').trim();
+  return normalized || fallback;
+}
+
+function pathText(value) {
+  return String(value ?? '').replace(/^\/+/, '').trim();
+}
+
+function basename(path = '') {
+  return pathText(path).split('/').filter(Boolean).pop() || '';
+}
+
+function namespaceForPath(path = '') {
+  return pathText(path).split('/').filter(Boolean)[0] || 'wiki';
+}
+
+function normalizeTags(value = []) {
+  if (Array.isArray(value)) return value.map((tag) => text(tag)).filter(Boolean);
+  const raw = String(value ?? '').trim();
+  if (!raw) return [];
+  if (raw.startsWith('[') && raw.endsWith(']')) {
+    return raw.slice(1, -1).split(',').map((tag) => text(tag)).filter(Boolean);
+  }
+  return raw.split(/\s*,\s*/).map((tag) => text(tag)).filter(Boolean);
+}
+
+function frontmatterValue(page = {}, key = '') {
+  const frontmatter = page.frontmatter && typeof page.frontmatter === 'object' ? page.frontmatter : {};
+  return page[key] ?? frontmatter[key];
+}
+
+export function wikiSubjectType(page = {}) {
+  const path = pathText(page.path);
+  const pageType = text(frontmatterValue(page, 'type')).toLowerCase();
+  if (path.startsWith('sigil/agents/') || pageType === 'agent') return 'sigil.agent';
+  if (pageType === 'workflow' || path.includes('/plugins/') && basename(path) === 'SKILL.md') {
+    return 'wiki.workflow';
+  }
+  if (pageType === 'entity') return 'wiki.entity';
+  if (pageType === 'concept') return page.plugin ? 'wiki.reference' : 'wiki.concept';
+  return 'wiki.page';
+}
+
+export function createWikiPageSubject(page = {}) {
+  const path = pathText(page.path);
+  if (!path) throw new TypeError('wiki page subject requires a path');
+
+  const subjectType = wikiSubjectType(page);
+  const name = text(frontmatterValue(page, 'name'), basename(path).replace(/\.md$/i, ''));
+  const tags = normalizeTags(frontmatterValue(page, 'tags'));
+  const plugin = text(frontmatterValue(page, 'plugin') || page.plugin);
+  const namespace = namespaceForPath(path);
+  const capabilities = [
+    'wiki.read',
+    'wiki.markdown.render',
+    'markdown_document.text.patch',
+    'markdown_document.save.requested',
+  ];
+  const views = ['markdown.source', 'markdown.preview', 'wiki.graph'];
+  const controls = ['open', 'edit', 'save'];
+
+  if (subjectType === 'wiki.workflow') {
+    capabilities.push('wiki.invoke', 'workflow.project');
+    views.push('workflow.graph', 'workflow.source');
+    controls.push('invoke');
+  }
+
+  if (subjectType === 'sigil.agent') {
+    capabilities.push('sigil.agent.preview', 'sigil.agent.appearance');
+    views.push('sigil.avatar.preview');
+    controls.push('appearance.controls');
+  }
+
+  return createWorkbenchSubject({
+    id: `wiki:${path}`,
+    type: subjectType,
+    label: name,
+    owner: namespace,
+    source: {
+      kind: 'wiki',
+      path,
+      namespace,
+      plugin: plugin || null,
+    },
+    capabilities,
+    views,
+    controls,
+    persistence: {
+      kind: 'wiki_write',
+      request: 'markdown_document.save.requested',
+      result: 'wiki_page_changed',
+    },
+    state: {
+      modified_at: Number(page.modified_at || 0) || null,
+    },
+    metadata: {
+      wiki_type: text(frontmatterValue(page, 'type'), 'page'),
+      description: text(frontmatterValue(page, 'description')),
+      tags,
+      plugin: plugin || null,
+    },
+  });
+}
+
+export function createWikiPageSubjects(pages = []) {
+  return (Array.isArray(pages) ? pages : []).map((page) => createWikiPageSubject(page));
+}

--- a/shared/schemas/aos-workbench-subject.schema.json
+++ b/shared/schemas/aos-workbench-subject.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/michaelblum/agent-os/shared/schemas/aos-workbench-subject.schema.json",
+  "title": "AOS Workbench Subject",
+  "type": "object",
+  "required": ["type", "schema_version", "id", "subject_type", "label", "owner"],
+  "properties": {
+    "type": {
+      "const": "aos.workbench.subject"
+    },
+    "schema_version": {
+      "type": "string",
+      "pattern": "^2026-05-03$"
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "subject_type": {
+      "type": "string",
+      "minLength": 1
+    },
+    "label": {
+      "type": "string",
+      "minLength": 1
+    },
+    "owner": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source": {
+      "type": ["object", "null"]
+    },
+    "capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": []
+    },
+    "views": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": []
+    },
+    "controls": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "default": []
+    },
+    "persistence": {
+      "type": ["object", "null"]
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "default": []
+    },
+    "state": {
+      "type": "object",
+      "default": {}
+    },
+    "metadata": {
+      "type": "object",
+      "default": {}
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/renderer/radial-item-editor.test.mjs
+++ b/tests/renderer/radial-item-editor.test.mjs
@@ -11,6 +11,7 @@ import {
 } from '../../apps/sigil/renderer/live-modules/radial-object-control.js'
 import {
   applyEditorObjectPatch,
+  buildRadialItemWorkbenchSubject,
   buildEditorObjectRegistry,
   buildEditorRadialSnapshot,
   createRadialItemEditorState,
@@ -177,6 +178,8 @@ test('radial item editor exports a source-ready lock-in payload for the selected
   assert.equal(payload.type, 'sigil.radial_item_editor.lock_in')
   assert.equal(payload.schema_version, '2026-05-03')
   assert.equal(payload.generated_at, '2026-05-03T12:00:00.000Z')
+  assert.equal(payload.subject.id, 'sigil.radial_menu.item:agent-terminal')
+  assert.equal(payload.subject.subject_type, 'sigil.radial_menu.item_3d')
   assert.deepEqual(payload.source, {
     kind: 'sigil.radial_menu.default_items',
     path: 'apps/sigil/renderer/radial-menu-defaults.js',
@@ -193,6 +196,23 @@ test('radial item editor exports a source-ready lock-in payload for the selected
     AGENT_TERMINAL_MODEL_OBJECT_ID,
     AGENT_TERMINAL_SCREEN_OBJECT_ID,
   ])
+})
+
+test('radial item editor exposes an AOS workbench subject descriptor', () => {
+  const state = createRadialItemEditorState({
+    itemId: 'wiki-graph',
+    canvasId: 'preview',
+  })
+  const subject = buildRadialItemWorkbenchSubject(state)
+
+  assert.equal(subject.type, 'aos.workbench.subject')
+  assert.equal(subject.id, 'sigil.radial_menu.item:wiki-graph')
+  assert.equal(subject.subject_type, 'sigil.radial_menu.item_3d')
+  assert.equal(subject.owner, 'sigil.radial-item-editor')
+  assert.equal(subject.state.canvas_id, 'preview')
+  assert.equal(subject.state.object_count, 4)
+  assert.ok(subject.capabilities.includes('canvas_object.registry'))
+  assert.ok(subject.capabilities.includes('sigil.radial_item_editor.lock_in'))
 })
 
 test('radial item editor lock-in payload is detached from later state mutation', () => {

--- a/tests/schemas/aos-workbench-subject.test.mjs
+++ b/tests/schemas/aos-workbench-subject.test.mjs
@@ -5,6 +5,7 @@ import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createWorkbenchSubject } from '../../packages/toolkit/workbench/subject.js';
+import { createWikiPageSubject } from '../../packages/toolkit/workbench/wiki-subject.js';
 import { buildMarkdownWorkbenchSubject, createMarkdownWorkbenchState } from '../../packages/toolkit/components/markdown-workbench/model.js';
 import { buildRadialItemWorkbenchSubject, createRadialItemEditorState } from '../../apps/sigil/radial-item-editor/model.js';
 
@@ -58,4 +59,11 @@ test('current workbench adopters emit schema-valid subject descriptors', async (
     itemId: 'wiki-graph',
     canvasId: 'preview',
   })));
+  await validate(createWikiPageSubject({
+    path: 'aos/plugins/self-check/SKILL.md',
+    type: 'workflow',
+    name: 'self-check',
+    plugin: 'self-check',
+    tags: ['diagnostics', 'runtime'],
+  }));
 });

--- a/tests/schemas/aos-workbench-subject.test.mjs
+++ b/tests/schemas/aos-workbench-subject.test.mjs
@@ -1,0 +1,61 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createWorkbenchSubject } from '../../packages/toolkit/workbench/subject.js';
+import { buildMarkdownWorkbenchSubject, createMarkdownWorkbenchState } from '../../packages/toolkit/components/markdown-workbench/model.js';
+import { buildRadialItemWorkbenchSubject, createRadialItemEditorState } from '../../apps/sigil/radial-item-editor/model.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+const schemaPath = path.join(repoRoot, 'shared/schemas/aos-workbench-subject.schema.json');
+
+async function validate(instance) {
+  const result = spawnSync(
+    'python3',
+    [
+      '-c',
+      `
+import json, sys
+from pathlib import Path
+from jsonschema import Draft202012Validator
+
+schema = json.loads(Path(sys.argv[1]).read_text())
+instance = json.loads(sys.argv[2])
+Draft202012Validator.check_schema(schema)
+errors = sorted(Draft202012Validator(schema).iter_errors(instance), key=lambda e: list(e.path))
+if errors:
+    for error in errors[:8]:
+        print(error.message)
+    sys.exit(1)
+`,
+      schemaPath,
+      JSON.stringify(instance),
+    ],
+    { encoding: 'utf8' },
+  );
+  assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+}
+
+test('toolkit workbench subject helper emits schema-valid descriptors', async () => {
+  await fs.access(schemaPath);
+  await validate(createWorkbenchSubject({
+    id: 'file:docs/example.md',
+    type: 'markdown.document',
+    label: 'example.md',
+    owner: 'markdown-workbench',
+  }));
+});
+
+test('current workbench adopters emit schema-valid subject descriptors', async () => {
+  await validate(buildMarkdownWorkbenchSubject(createMarkdownWorkbenchState({
+    path: 'docs/example.md',
+    content: '# Example',
+  })));
+  await validate(buildRadialItemWorkbenchSubject(createRadialItemEditorState({
+    itemId: 'wiki-graph',
+    canvasId: 'preview',
+  })));
+});

--- a/tests/toolkit/markdown-workbench-model.test.mjs
+++ b/tests/toolkit/markdown-workbench-model.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   applyMarkdownSaveResult,
   applyMarkdownTextPatch,
+  buildMarkdownWorkbenchSubject,
   buildMarkdownSaveRequest,
   createMarkdownWorkbenchState,
   markdownDiagnostics,
@@ -40,6 +41,8 @@ test('markdown workbench state opens, patches, and builds save requests', () => 
 
   const save = buildMarkdownSaveRequest(state, { requestId: 'req-1' });
   assert.equal(save.request_id, 'req-1');
+  assert.equal(save.subject.id, 'file:docs/example.md');
+  assert.equal(save.subject.subject_type, 'markdown.document');
   assert.equal(save.path, 'docs/example.md');
   assert.equal(save.content, '# Example\n\nChanged.');
 
@@ -49,4 +52,23 @@ test('markdown workbench state opens, patches, and builds save requests', () => 
   });
   assert.equal(saved.status, 'saved');
   assert.equal(state.dirty, false);
+});
+
+test('markdown workbench exposes an AOS workbench subject descriptor', () => {
+  const state = createMarkdownWorkbenchState({
+    path: 'docs/example.md',
+    content: '# Example\n\n```mermaid\na-->b\n```\n',
+    dirty: true,
+  });
+  const subject = buildMarkdownWorkbenchSubject(state);
+
+  assert.equal(subject.type, 'aos.workbench.subject');
+  assert.equal(subject.id, 'file:docs/example.md');
+  assert.equal(subject.subject_type, 'markdown.document');
+  assert.equal(subject.owner, 'markdown-workbench');
+  assert.deepEqual(subject.source, { kind: 'file', path: 'docs/example.md' });
+  assert.equal(subject.state.dirty, true);
+  assert.equal(subject.state.mermaid_block_count, 1);
+  assert.ok(subject.capabilities.includes('markdown_document.text.patch'));
+  assert.ok(subject.capabilities.includes('markdown.mermaid.detect'));
 });

--- a/tests/toolkit/markdown-workbench-model.test.mjs
+++ b/tests/toolkit/markdown-workbench-model.test.mjs
@@ -72,3 +72,38 @@ test('markdown workbench exposes an AOS workbench subject descriptor', () => {
   assert.ok(subject.capabilities.includes('markdown_document.text.patch'));
   assert.ok(subject.capabilities.includes('markdown.mermaid.detect'));
 });
+
+test('markdown workbench exposes wiki-backed subjects when opened from wiki', () => {
+  const state = createMarkdownWorkbenchState();
+  openMarkdownDocument(state, {
+    type: 'markdown_document.open',
+    path: 'aos/concepts/runtime-modes.md',
+    source: {
+      kind: 'wiki',
+      path: 'aos/concepts/runtime-modes.md',
+      page: {
+        path: 'aos/concepts/runtime-modes.md',
+        frontmatter: {
+          type: 'concept',
+          name: 'Runtime Modes',
+          tags: '[infrastructure, runtime]',
+        },
+      },
+    },
+    content: '# Runtime Modes',
+  });
+
+  const save = buildMarkdownSaveRequest(state, { requestId: 'wiki-save-1' });
+  assert.equal(save.subject.id, 'wiki:aos/concepts/runtime-modes.md');
+  assert.equal(save.subject.subject_type, 'wiki.concept');
+  assert.equal(save.subject.source.kind, 'wiki');
+  assert.equal(save.source.kind, 'wiki');
+  assert.equal(save.path, 'aos/concepts/runtime-modes.md');
+  assert.equal(save.subject.state.dirty, false);
+
+  applyMarkdownTextPatch(state, {
+    type: 'markdown_document.text.patch',
+    patch: { content: '# Runtime Modes\n\nChanged.' },
+  });
+  assert.equal(buildMarkdownWorkbenchSubject(state).state.dirty, true);
+});

--- a/tests/toolkit/runtime-menu-activation.test.mjs
+++ b/tests/toolkit/runtime-menu-activation.test.mjs
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  MENU_ACTIVATION_SCHEMA_VERSION,
+  advanceMenuActivation,
+  createMenuActivationRequest,
+} from '../../packages/toolkit/runtime/menu-activation.js';
+
+test('createMenuActivationRequest normalizes menu item activation', () => {
+  const request = createMenuActivationRequest({
+    id: 'activation-1',
+    menuId: 'sigil.radial',
+    input: 'gesture',
+    source: 'sigil.avatar',
+    item: {
+      id: 'wiki-graph',
+      label: 'Wiki Graph',
+      action: 'wikiGraph',
+    },
+    surface: {
+      kind: 'markdown-workbench',
+      subject: { id: 'wiki:aos/concepts/example.md' },
+    },
+    transition: { preset: 'wiki-brain-zoom-dissolve' },
+  });
+
+  assert.equal(request.type, 'aos.menu.activation');
+  assert.equal(request.schema_version, MENU_ACTIVATION_SCHEMA_VERSION);
+  assert.equal(request.id, 'activation-1');
+  assert.equal(request.menu_id, 'sigil.radial');
+  assert.equal(request.phase, 'requested');
+  assert.equal(request.action, 'wikiGraph');
+  assert.deepEqual(request.item, {
+    id: 'wiki-graph',
+    label: 'Wiki Graph',
+    action: 'wikiGraph',
+  });
+  assert.equal(request.surface.kind, 'markdown-workbench');
+  assert.equal(request.transition.preset, 'wiki-brain-zoom-dissolve');
+});
+
+test('advanceMenuActivation preserves request identity while updating phase', () => {
+  const request = createMenuActivationRequest({
+    id: 'activation-2',
+    menuId: 'sigil.radial',
+    item: { id: 'agent-terminal' },
+  });
+  const completed = advanceMenuActivation(request, 'completed', {
+    result: { canvas_id: 'sigil-agent-terminal' },
+  });
+
+  assert.equal(completed.id, request.id);
+  assert.equal(completed.phase, 'completed');
+  assert.equal(completed.result.canvas_id, 'sigil-agent-terminal');
+  assert.equal(request.phase, 'requested');
+});
+
+test('createMenuActivationRequest rejects anonymous items', () => {
+  assert.throws(() => createMenuActivationRequest({ item: {} }), /requires an item id or action/);
+});

--- a/tests/toolkit/wiki-subject.test.mjs
+++ b/tests/toolkit/wiki-subject.test.mjs
@@ -1,0 +1,80 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createWikiPageSubject,
+  createWikiPageSubjects,
+  wikiSubjectType,
+} from '../../packages/toolkit/workbench/wiki-subject.js';
+
+test('wikiSubjectType maps canonical wiki page types', () => {
+  assert.equal(wikiSubjectType({ path: 'aos/concepts/runtime-modes.md', type: 'concept' }), 'wiki.concept');
+  assert.equal(wikiSubjectType({ path: 'aos/entities/daemon.md', type: 'entity' }), 'wiki.entity');
+  assert.equal(wikiSubjectType({ path: 'aos/plugins/self-check/SKILL.md', type: 'workflow' }), 'wiki.workflow');
+  assert.equal(wikiSubjectType({ path: 'aos/plugins/foo/references/bar.md', type: 'concept', plugin: 'foo' }), 'wiki.reference');
+  assert.equal(wikiSubjectType({ path: 'sigil/agents/default.md', type: 'agent' }), 'sigil.agent');
+});
+
+test('createWikiPageSubject builds a concept subject from wiki list shape', () => {
+  const subject = createWikiPageSubject({
+    path: 'aos/concepts/employer-brand-workflow-map.md',
+    type: 'concept',
+    name: 'Employer Brand Workflow Map',
+    description: 'End-to-end map for a workflow set.',
+    tags: ['employer-brand', 'workflow', 'process'],
+    modified_at: 1776393337,
+  });
+
+  assert.equal(subject.type, 'aos.workbench.subject');
+  assert.equal(subject.id, 'wiki:aos/concepts/employer-brand-workflow-map.md');
+  assert.equal(subject.subject_type, 'wiki.concept');
+  assert.equal(subject.label, 'Employer Brand Workflow Map');
+  assert.equal(subject.owner, 'aos');
+  assert.deepEqual(subject.source, {
+    kind: 'wiki',
+    path: 'aos/concepts/employer-brand-workflow-map.md',
+    namespace: 'aos',
+    plugin: null,
+  });
+  assert.equal(subject.state.modified_at, 1776393337);
+  assert.deepEqual(subject.metadata.tags, ['employer-brand', 'workflow', 'process']);
+  assert.ok(subject.capabilities.includes('wiki.read'));
+  assert.ok(subject.capabilities.includes('markdown_document.save.requested'));
+});
+
+test('createWikiPageSubject preserves plugin workflow capabilities', () => {
+  const subject = createWikiPageSubject({
+    path: 'aos/plugins/customize-with-agent/SKILL.md',
+    frontmatter: {
+      type: 'workflow',
+      name: 'customize-with-agent',
+      tags: '[meta, authoring, plugin-creation]',
+    },
+    plugin: 'customize-with-agent',
+  });
+
+  assert.equal(subject.subject_type, 'wiki.workflow');
+  assert.equal(subject.source.plugin, 'customize-with-agent');
+  assert.deepEqual(subject.metadata.tags, ['meta', 'authoring', 'plugin-creation']);
+  assert.ok(subject.capabilities.includes('wiki.invoke'));
+  assert.ok(subject.views.includes('workflow.graph'));
+  assert.ok(subject.controls.includes('invoke'));
+});
+
+test('createWikiPageSubject preserves Sigil agent specialization', () => {
+  const subject = createWikiPageSubject({
+    path: 'sigil/agents/default.md',
+    type: 'agent',
+    name: 'Default',
+    tags: ['sigil', 'orchestrator'],
+  });
+
+  assert.equal(subject.subject_type, 'sigil.agent');
+  assert.equal(subject.owner, 'sigil');
+  assert.ok(subject.capabilities.includes('sigil.agent.preview'));
+  assert.ok(subject.views.includes('sigil.avatar.preview'));
+});
+
+test('createWikiPageSubjects maps arrays and rejects missing path', () => {
+  assert.equal(createWikiPageSubjects([{ path: 'aos/entities/daemon.md', type: 'entity' }]).length, 1);
+  assert.throws(() => createWikiPageSubject({ type: 'concept' }), /requires a path/);
+});

--- a/tests/toolkit/workbench-subject.test.mjs
+++ b/tests/toolkit/workbench-subject.test.mjs
@@ -1,0 +1,33 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createWorkbenchSubject,
+  subjectSupports,
+  WORKBENCH_SUBJECT_SCHEMA_VERSION,
+} from '../../packages/toolkit/workbench/subject.js';
+
+test('createWorkbenchSubject normalizes the common subject descriptor', () => {
+  const subject = createWorkbenchSubject({
+    id: ' file:docs/example.md ',
+    type: ' markdown.document ',
+    label: ' Example ',
+    owner: 'markdown-workbench',
+    source: { kind: 'file', path: 'docs/example.md' },
+    capabilities: ['markdown.render', '', null, 'markdown_document.save.requested'],
+    state: { dirty: true },
+  });
+
+  assert.equal(subject.type, 'aos.workbench.subject');
+  assert.equal(subject.schema_version, WORKBENCH_SUBJECT_SCHEMA_VERSION);
+  assert.equal(subject.id, 'file:docs/example.md');
+  assert.equal(subject.subject_type, 'markdown.document');
+  assert.equal(subject.label, 'Example');
+  assert.deepEqual(subject.capabilities, ['markdown.render', 'markdown_document.save.requested']);
+  assert.equal(subjectSupports(subject, 'markdown.render'), true);
+  assert.equal(subjectSupports(subject, 'canvas_object.registry'), false);
+});
+
+test('createWorkbenchSubject rejects subjects without stable identity or type', () => {
+  assert.throws(() => createWorkbenchSubject({ type: 'markdown.document' }), /requires an id/);
+  assert.throws(() => createWorkbenchSubject({ id: 'file:docs/example.md' }), /requires a type/);
+});


### PR DESCRIPTION
## Summary

- add canonical `aos.workbench.subject` schema plus toolkit helper
- include subject descriptors in Markdown save/snapshot and Sigil radial-item lock-in payloads
- add wiki page -> workbench subject projection for concepts, entities, workflows/plugins, plugin references, and Sigil agent docs
- add wiki-backed Markdown Workbench open/save behavior through `wiki:<path>` launch targets, URL bootstrap, direct wiki persistence, and `save-current.sh`
- route Sigil wiki radial activation through a reusable `aos.menu.activation` payload and open the wiki-backed Markdown Workbench
- document workflow chaining as subject composition, not a new orchestrator

## Tracking

- Epic: #211
- First implementation slice: #212
- Wiki-backed Markdown slice: #213
- Wiki radial activation slice: #221
- Remaining transition animation: #222

## Verification

- `node --check packages/toolkit/workbench/subject.js`
- `node --check packages/toolkit/workbench/wiki-subject.js`
- `node --check packages/toolkit/workbench/index.js`
- `node --check packages/toolkit/components/markdown-workbench/model.js`
- `node --check packages/toolkit/components/markdown-workbench/index.js`
- `node --check packages/toolkit/runtime/menu-activation.js`
- `node --check apps/sigil/renderer/live-modules/main.js`
- `node --check apps/sigil/renderer/live-modules/menu-activation-runtime.js`
- `node --check apps/sigil/radial-item-editor/model.js`
- `bash -n packages/toolkit/components/markdown-workbench/launch.sh && bash -n packages/toolkit/components/markdown-workbench/save-current.sh`
- `node --test tests/toolkit/workbench-subject.test.mjs tests/toolkit/wiki-subject.test.mjs tests/schemas/aos-workbench-subject.test.mjs tests/toolkit/markdown-workbench-model.test.mjs tests/renderer/radial-item-editor.test.mjs`
- `node --test tests/toolkit/runtime-menu-activation.test.mjs tests/toolkit/runtime-radial-gesture.test.mjs tests/renderer/radial-gesture-menu.test.mjs tests/toolkit/markdown-workbench-model.test.mjs tests/toolkit/workbench-subject.test.mjs tests/toolkit/wiki-subject.test.mjs`
- `git diff --check`
- `./aos ready`
- live AOS import check for `aos://sigil/radial-item-editor/index.html`
- live wiki-backed Markdown Workbench smoke using temporary `test/workbench-adapter-smoke.md`
- live Sigil synthetic radial commit probe opened `sigil-wiki-workbench` on `aos/concepts/employer-brand-workflow-map.md`
- live Markdown Workbench Save button wrote the wiki-backed document and produced `markdown_document.save.result` with `status=saved`