### PR TITLE
Define AOS work records model

### DIFF
--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -99,12 +99,20 @@ Wiki pages can be projected from `aos wiki list/show --json` shapes with:
 import { createWikiPageSubject } from '../workbench/wiki-subject.js'
 ```
 
+Design-stage work records can be projected from schema-shaped work-record
+objects with:
+
+```js
+import { createWorkRecordSubject } from '../workbench/work-record-subject.js'
+```
+
 The current schema version is `2026-05-03`. The first adopters are:
 
 - Sigil radial item editor subjects: `sigil.radial_menu.item_3d`
 - Markdown workbench subjects: `markdown.document`
 - Wiki page subjects: `wiki.concept`, `wiki.entity`, `wiki.workflow`,
   `wiki.reference`, and `sigil.agent`
+- Work-record subjects: `aos.do_step` and `aos.recipe_health_event`
 
 Subject descriptors are included in lock-in/save handoff payloads so agents,
 apps, and future workbench shells can reason about different editors using one
@@ -114,6 +122,12 @@ Wiki subject ids use `wiki:<path>`, for example
 `wiki:aos/concepts/runtime-modes.md`. Their source uses `{ kind: "wiki", path,
 namespace, plugin }`, and their persistence route is the wiki write/change-event
 handoff rather than direct canvas filesystem access.
+
+Work-record subject ids use `work-record:<id>`. They expose the natural-language
+intent, execution map, evidence artifacts, and health state as workbench views.
+The helper is a projection layer only; recording, replay, repair, and retirement
+remain owned by the work-record model in
+[`docs/design/aos-work-records-and-self-healing-recipes.md`](../design/aos-work-records-and-self-healing-recipes.md).
 
 ## Stock Components Snapshot
 

--- a/docs/design/aos-work-records-and-self-healing-recipes.md
+++ b/docs/design/aos-work-records-and-self-healing-recipes.md
@@ -132,6 +132,18 @@ natural-language intent and AOS-level step/evidence envelope.
 
 Tracked in #239.
 
+## Computer-Use Control-Plane Lessons
+
+`pi-computer-use` validates a similar semantic-first direction for macOS
+desktop control: ref-first actions, perception state ids, stale-coordinate
+rejection, strict AX/background-safe policies, execution metadata, and quality
+benchmarks. AOS should adopt those lessons natively in its `see`, `do`, and
+work-record contracts instead of routing through `pi-computer-use` as a live
+intermediary.
+
+See
+[`pi-computer-use-lessons-for-aos-see-do.md`](pi-computer-use-lessons-for-aos-see-do.md).
+
 ## BNF, Schemas, And Logit Masking
 
 BNF-like grammar is useful for compact target strings and CLI forms. JSON

--- a/docs/design/aos-work-records-and-self-healing-recipes.md
+++ b/docs/design/aos-work-records-and-self-healing-recipes.md
@@ -1,0 +1,268 @@
+# AOS Work Records And Self-Healing Recipes
+
+**Status:** design seed, not a public API contract
+**Parent epic:** #234
+**First contract sketch:** #235
+
+## Problem
+
+AOS has primitives for perception, action, projection, communication, and wiki
+workflows. It also has source-backed ops recipes, browser targets, workbench
+subjects, gateway jobs, and a few specialized traces. Those pieces are useful,
+but they do not yet describe one first-class thing: work that was done and can
+be understood, repaired, replayed, or retired later.
+
+Raw event replay is too brittle. A click coordinate, selector, or accessibility
+reference can decay quickly. The durable part of a work record is the human or
+agent intent, backed by evidence and a repairable execution map.
+
+AOS should record work as:
+
+```text
+intent + execution map + evidence + health
+```
+
+## Core Vocabulary
+
+**Trace:** immutable evidence of what happened. A trace may include `see`
+summaries, `do` envelopes, daemon events, screenshots, Playwright traces,
+timestamps, exit codes, and artifact paths. A trace is never edited to make
+future replay easier.
+
+**Recipe:** mutable execution knowledge for how work might happen again. A
+recipe can be repaired when target references drift, or retired when the intent
+can no longer be satisfied.
+
+**Workflow:** a chain or graph of recipes, steps, sub-workflows, inputs,
+approval gates, outputs, and artifacts.
+
+**Work record:** a durable record tying intent, execution map, evidence, and
+health together for one piece of work.
+
+**Execution map:** semi-durable structured data that helps execute or replay a
+step: target strings, Playwright-like locators, AX refs, canvas object ids,
+waits, assertions, retry hints, artifact routes, and generated script hints.
+
+**`do_step`:** the smallest portable unit. It is one intentional action plus the
+perception context that made the action reasonable and the postcondition that
+proves whether it worked.
+
+**Health:** the current validity state of a recipe or step. Health is distinct
+from historical success.
+
+## Layer Model
+
+A work record has four layers.
+
+1. The intent layer is the natural-language spine: purpose, constraints,
+   acceptance conditions, and human meaning.
+2. The execution-map layer is structured but allowed to drift. It stores the
+   best known target refs, locators, waits, assertions, and action details.
+3. The evidence layer is immutable. It stores receipts of observed behavior and
+   produced artifacts.
+4. The health layer reports whether the record is still usable and why.
+
+The natural-language layer is not commentary. It is the repair spine. When a
+browser locator, AX ref, or canvas id fails, the agent can use the intent plus
+evidence to re-resolve the target. If the intent itself is no longer possible,
+the recipe should say so.
+
+## Primitive Boundary
+
+`aos do` should remain the primitive actuator. It should not become a macro
+recorder and should not be reshaped into Playwright globally.
+
+The work-record layer sits above primitives:
+
+```text
+work record
+  -> do_step
+    -> see
+    -> target resolution
+    -> do
+    -> see
+    -> verify
+```
+
+Replay should re-perceive before each action:
+
+```text
+intent -> see -> resolve target -> do -> see -> verify
+```
+
+Coordinates can be recorded, but they are fallback material. When semantic
+targets exist, prefer them.
+
+## Target Dialects
+
+The persisted model should allow target dialects without making every surface
+look like a browser.
+
+Examples:
+
+```text
+browser:<session>/<ref>
+ax:<pid>/<ref>
+canvas:<canvas-id>/<object-ref>
+screen:<frame-id>/<x,y>
+```
+
+The exact grammar can harden later. The important point is that target strings
+are compact handles while the execution map can carry richer candidates,
+metadata, and stale-ref repair hints.
+
+## Playwright And Codegen
+
+Playwright contributes useful ideas:
+
+- semantic locators
+- actionability checks
+- re-resolving locators before action
+- traces with before/after state
+- screenshots and video receipts
+- codegen as a way to derive a reusable action recipe
+
+AOS should borrow those ideas without making generated Playwright code the
+canonical record.
+
+The canonical AOS record is the work record. Playwright traces, videos, and
+generated scripts are evidence or execution-map hints. A browser work record
+can export generated Playwright code, but it should still preserve the
+natural-language intent and AOS-level step/evidence envelope.
+
+Tracked in #239.
+
+## BNF, Schemas, And Logit Masking
+
+BNF-like grammar is useful for compact target strings and CLI forms. JSON
+Schema is better for persisted records. The command registry should remain the
+source of legal command forms.
+
+Provider logit masking, grammar-constrained sampling, and JSON-schema decoding
+are adapter optimizations. They can reduce invalid model output when a provider
+supports them, but they are not the safety contract. AOS must validate every
+record and action before execution.
+
+```text
+model proposes -> AOS validates -> AOS executes or rejects
+```
+
+## Bounded Flight Recorder
+
+AOS should eventually have a bounded flight recorder, not permanent raw
+recording. The buffer keeps recent structured context for debugging, repair,
+and trace promotion.
+
+Candidate buffer entries:
+
+- `see` summaries and artifact handles
+- `do` envelopes
+- focus, app, window, browser session, and canvas context
+- target refs and locator candidates
+- daemon event summaries
+- errors and recovery attempts
+- selected screenshot handles or image hashes
+
+Promotion to durable trace should happen only when explicit:
+
+- the user or agent starts recording
+- a workflow run requires evidence
+- a failure promotes the last N seconds
+- a human or agent asks to save recent context
+
+The recorder should redact or summarize sensitive data by default. Permanent
+recording of raw screen/video/text is out of scope until privacy boundaries are
+designed. Tracked in #238.
+
+## Health, Repair, And Retirement
+
+Recipe health should be explicit.
+
+Suggested states:
+
+- `valid`: last check passed or the recipe is known usable.
+- `stale`: deterministic data is old or unverified.
+- `repairable`: replay failed, but enough semantic context exists to attempt
+  repair.
+- `blocked`: an external condition prevents execution, such as login or a
+  missing permission.
+- `impossible`: the NL intent cannot currently be satisfied.
+- `superseded`: a newer recipe should be used instead.
+- `retired`: do not run automatically; keep only for history/search.
+
+Repair patches the execution map. It does not rewrite historical traces.
+Retirement keeps the intent and evidence searchable while preventing accidental
+replay.
+
+Examples:
+
+- The user uninstalls an app required by a desktop recipe:
+  `required_surface_missing`.
+- Indeed removes a page section the recipe was intended to collect:
+  `intent_no_longer_supported`.
+- A website redesign changes selectors but the section still exists:
+  `target_drift_repaired`.
+- A better recipe replaces a fragile one:
+  `superseded_by`.
+
+Tracked in #236.
+
+## Workbench Projection
+
+The workbench should be the human/agent editing and inspection surface for work
+records. It should not own the recorder.
+
+Useful views:
+
+- NL intent editor
+- execution-map JSON editor
+- generated form from execution-map fields
+- step timeline
+- workflow graph
+- evidence/artifact gallery
+- repair history
+- health and retirement status
+
+This matches the existing layered workbench pattern: one subject, multiple
+expressions. The NL layer is the editable spine; structured layers make the
+subject executable or inspectable. Tracked in #237.
+
+## Relationship To Existing Work
+
+- #141 is the browser-only steerable-collection V0 projection. It should stay
+  scoped and can adopt work-record vocabulary when stable.
+- #148 should keep replay codegen deferred until #239 defines how codegen
+  attaches to AOS work records.
+- #149 supervised runs already wants run control, timelines, evidence packs,
+  and human feedback sidecars. Those concepts should converge here.
+- #211 and #215 define wiki-backed workbench/workflow subjects. Work records
+  should attach to those subjects later as run/evidence layers.
+- #129 `aos ops` recipes are source-backed operator recipes. They can become
+  one execution backend or compiled projection, not the whole work-record model.
+- #161 and #163 can supply friction telemetry and semantic target-resolution
+  evidence.
+- #223 supplies the surface/workbench UI substrate, not the recording model.
+
+## Schema-Shaped Fixtures
+
+These fixtures are intentionally examples, not contracts:
+
+- `docs/design/fixtures/aos-work-records/browser-artifact-collection-step.json`
+- `docs/design/fixtures/aos-work-records/desktop-workflow-demo-step.json`
+- `docs/design/fixtures/aos-work-records/canvas-toolkit-control-step.json`
+- `docs/design/fixtures/aos-work-records/recipe-health-retirement.json`
+
+They are parser-tested so future edits do not drift into invalid JSON, but no
+`shared/schemas/` contract exists yet. Promote a schema only after browser,
+desktop, and canvas examples keep the same shape under implementation pressure.
+
+## First Implementation Path
+
+1. Land this design seed and schema-shaped fixtures (#235).
+2. Add a draft shared schema only after a concrete producer and consumer are
+   selected.
+3. Pick one narrow producer: likely browser collection, supervised run trace,
+   or a workbench-driven manual record.
+4. Pick one narrow consumer: likely a workbench projection that reads fixtures
+   before executing anything.
+5. Only then add runtime recording, replay, or repair logic.

--- a/docs/design/aos-workbench-pattern.md
+++ b/docs/design/aos-workbench-pattern.md
@@ -220,6 +220,19 @@ Examples:
 Artifacts need metadata: origin subject, producing workflow run, source files,
 validation status, and preview/export routes.
 
+### Work Record Projection
+
+Workbench surfaces can render work records, but they should not own the
+recording or replay model. The canonical design seed for recorded work is
+`docs/design/aos-work-records-and-self-healing-recipes.md`.
+
+A work-record projection should keep the natural-language intent visible as the
+primary spine, while structured execution maps, evidence, repair history, and
+health status appear as synchronized views or attached artifact sets. This lets
+one subject be edited as Markdown, JSON, generated controls, a step timeline, a
+workflow graph, or an artifact gallery without turning any one view into the
+source of truth.
+
 ## Workflow Subjects
 
 A workflow is a subject, but it is also an executable composition.

--- a/docs/design/fixtures/aos-work-records/browser-artifact-collection-step.json
+++ b/docs/design/fixtures/aos-work-records/browser-artifact-collection-step.json
@@ -1,0 +1,76 @@
+{
+  "type": "aos.do_step",
+  "schema_version": "draft-2026-05-04",
+  "id": "collect-company-careers-page",
+  "surface": "browser",
+  "intent": {
+    "nl": "Open the company's careers page and capture the initial employer-brand message.",
+    "purpose": "collect_source_artifact",
+    "acceptance": "A screenshot, page text, and page source are attached to the evidence registry."
+  },
+  "precondition": {
+    "see": "A browser session exists and can navigate.",
+    "target": "browser:employer-brand"
+  },
+  "action": {
+    "verb": "navigate",
+    "target": "browser:employer-brand",
+    "args": {
+      "url": "https://example.com/careers"
+    }
+  },
+  "postcondition": {
+    "see": "The page has loaded enough to extract a title, visible text, and screenshot.",
+    "assertions": [
+      {
+        "kind": "page_state",
+        "field": "url",
+        "contains": "/careers"
+      }
+    ]
+  },
+  "execution_map": {
+    "browser": {
+      "target_grammar": "browser:<session>[/<ref>]",
+      "locator_candidates": [
+        {
+          "kind": "role",
+          "role": "heading",
+          "name": "Careers"
+        }
+      ],
+      "wait_hints": [
+        {
+          "kind": "selector",
+          "value": "main"
+        }
+      ],
+      "playwright_hints": {
+        "codegen_export": null,
+        "trace_artifact": null
+      }
+    }
+  },
+  "evidence": {
+    "request_id": "example-careers-home",
+    "capture_job_id": "capture-job-0001",
+    "artifacts": [
+      {
+        "kind": "screenshot",
+        "path": "artifacts/example-careers-home/screenshot.png"
+      },
+      {
+        "kind": "page_text",
+        "path": "artifacts/example-careers-home/page.txt"
+      },
+      {
+        "kind": "page_source",
+        "path": "artifacts/example-careers-home/page.html"
+      }
+    ]
+  },
+  "health": {
+    "state": "stale",
+    "reason": "example_fixture_not_executed"
+  }
+}

--- a/docs/design/fixtures/aos-work-records/canvas-toolkit-control-step.json
+++ b/docs/design/fixtures/aos-work-records/canvas-toolkit-control-step.json
@@ -1,0 +1,67 @@
+{
+  "type": "aos.do_step",
+  "schema_version": "draft-2026-05-04",
+  "id": "toggle-workbench-axis-visibility",
+  "surface": "canvas",
+  "intent": {
+    "nl": "Toggle the workbench preview axes so the user can visually align 3D objects.",
+    "purpose": "toolkit_control",
+    "acceptance": "The axes visibility state changes and the workbench reports the accepted patch."
+  },
+  "precondition": {
+    "see": "The workbench canvas is open and publishes semantic controls.",
+    "target": "canvas:sigil-radial-item-workbench/control.axes-visible"
+  },
+  "action": {
+    "verb": "press",
+    "target": "canvas:sigil-radial-item-workbench/control.axes-visible",
+    "args": {
+      "expected_role": "checkbox"
+    }
+  },
+  "postcondition": {
+    "see": "The axes checkbox state and preview state agree.",
+    "assertions": [
+      {
+        "kind": "canvas_state",
+        "path": [
+          "controls",
+          "axesVisible"
+        ],
+        "changed": true
+      }
+    ]
+  },
+  "execution_map": {
+    "canvas": {
+      "target_grammar": "canvas:<canvas-id>/<semantic-ref>",
+      "semantic_candidates": [
+        {
+          "canvas_id": "sigil-radial-item-workbench",
+          "role": "checkbox",
+          "label": "Axes"
+        }
+      ],
+      "message_hints": [
+        "canvas_object.registry",
+        "canvas_object.patch.result"
+      ]
+    }
+  },
+  "evidence": {
+    "artifacts": [
+      {
+        "kind": "before_canvas_state",
+        "path": "artifacts/workbench-axis/before.json"
+      },
+      {
+        "kind": "after_canvas_state",
+        "path": "artifacts/workbench-axis/after.json"
+      }
+    ]
+  },
+  "health": {
+    "state": "valid",
+    "reason": "schema_shaped_example"
+  }
+}

--- a/docs/design/fixtures/aos-work-records/desktop-workflow-demo-step.json
+++ b/docs/design/fixtures/aos-work-records/desktop-workflow-demo-step.json
@@ -1,0 +1,69 @@
+{
+  "type": "aos.do_step",
+  "schema_version": "draft-2026-05-04",
+  "id": "open-workflow-launcher",
+  "surface": "desktop",
+  "intent": {
+    "nl": "Open the workflow launcher and show the employer-brand competitor audit entry.",
+    "purpose": "workflow_demo",
+    "acceptance": "The launcher is visible and the target workflow entry can be inspected."
+  },
+  "precondition": {
+    "see": "AOS can inspect the foreground app and accessibility tree.",
+    "target": "ax:com.agent-os.launcher"
+  },
+  "action": {
+    "verb": "press",
+    "target": "ax:com.agent-os.launcher/workflow-entry-employer-brand",
+    "args": {
+      "role": "AXButton",
+      "title": "Employer Brand Competitor Audit"
+    }
+  },
+  "postcondition": {
+    "see": "The workflow detail pane or queued job confirmation is visible.",
+    "assertions": [
+      {
+        "kind": "ax_tree",
+        "role": "AXStaticText",
+        "title_contains": "Employer Brand"
+      }
+    ]
+  },
+  "execution_map": {
+    "desktop": {
+      "target_grammar": "ax:<bundle-or-pid>/<ref>",
+      "ax_candidates": [
+        {
+          "bundle_id": "com.agent-os.launcher",
+          "role": "AXButton",
+          "title": "Employer Brand Competitor Audit"
+        }
+      ],
+      "coordinate_fallback": {
+        "frame": "display:main",
+        "point": {
+          "x": 480,
+          "y": 320
+        },
+        "source": "last_successful_capture"
+      }
+    }
+  },
+  "evidence": {
+    "artifacts": [
+      {
+        "kind": "before_see",
+        "path": "artifacts/workflow-demo/before.json"
+      },
+      {
+        "kind": "after_see",
+        "path": "artifacts/workflow-demo/after.json"
+      }
+    ]
+  },
+  "health": {
+    "state": "repairable",
+    "reason": "desktop_target_unverified"
+  }
+}

--- a/docs/design/fixtures/aos-work-records/recipe-health-retirement.json
+++ b/docs/design/fixtures/aos-work-records/recipe-health-retirement.json
@@ -1,0 +1,27 @@
+{
+  "type": "aos.recipe_health_event",
+  "schema_version": "draft-2026-05-04",
+  "id": "indeed-benefits-section-retired",
+  "recipe_id": "employer-brand/collect-indeed-benefits-section",
+  "previous_health": {
+    "state": "repairable",
+    "reason": "target_not_found"
+  },
+  "next_health": {
+    "state": "impossible",
+    "reason": "intent_no_longer_supported"
+  },
+  "intent": {
+    "nl": "Collect the benefits section from the company's Indeed profile.",
+    "acceptance": "A page section explicitly describing employee benefits is captured."
+  },
+  "evidence": {
+    "last_trace": "artifacts/indeed-benefits/trace-2026-05-04.jsonl",
+    "last_observation": "The current page no longer exposes a benefits section or equivalent heading."
+  },
+  "retirement": {
+    "automatic_replay_allowed": false,
+    "replacement_recipe_id": null,
+    "note": "Keep the intent searchable, but do not replay until a human or agent defines a new source."
+  }
+}

--- a/docs/design/pi-computer-use-lessons-for-aos-see-do.md
+++ b/docs/design/pi-computer-use-lessons-for-aos-see-do.md
@@ -1,0 +1,159 @@
+# Pi Computer-Use Lessons For AOS See/Do
+
+**Status:** design input, not an implementation plan
+**Related epic:** #234
+**Reviewed:** 2026-05-04
+
+## Purpose
+
+`pi-computer-use` is useful evidence that macOS computer-use agents benefit
+from a semantic-first control contract. AOS should borrow the proven contract
+ideas that match its primitive model, but it should not route through
+`pi-computer-use` or add a competing desktop-control plane.
+
+The design stance is:
+
+```text
+borrow the control-plane lessons
+do not bridge to the tool at runtime
+express the useful parts through AOS see/do/work-record contracts
+```
+
+## Fit
+
+The conceptual bridge is clean:
+
+| Pi concept | AOS-native expression |
+| --- | --- |
+| `screenshot`, `list_apps`, `list_windows` | `aos see`, `aos graph`, focus channels |
+| Window refs such as `@w1` | AOS window/focus target refs |
+| AX element refs such as `@e1` | AOS semantic targets, AX refs, browser refs |
+| `stateId` | AOS perception state id |
+| Ref-first actions | `aos do` target grammar |
+| Strict AX mode | AOS execution constraints |
+| Execution metadata | Work-record execution map and evidence |
+| Benchmark ratios | AOS see/do regression metrics |
+
+The runtime bridge is not clean. A live intermediary would create two owners for
+the same permission-bearing job: two helpers, two target namespaces, two stale
+state models, two fallback policies, and two telemetry streams. That would work
+against the AOS architecture of one binary, one daemon, one socket, and one
+source of truth.
+
+## Patterns To Adopt
+
+### Semantic Refs Before Coordinates
+
+Agents should prefer target refs emitted by `see` over screen coordinates. A
+coordinate action should carry the perception state that produced it and should
+be rejected or revalidated when that state is stale.
+
+This applies across target dialects:
+
+```text
+browser:<session>/<ref>
+ax:<pid>/<ref>
+canvas:<canvas-id>/<ref>
+screen:<state-id>/<x,y>
+```
+
+### Perception State Ids
+
+Each actionable `see` result should expose a compact state id. Follow-up `do`
+actions can then prove which observed state they came from. This is especially
+important for coordinate fallbacks and screenshots, where stale positions are
+otherwise easy to replay by accident.
+
+### Execution Constraints
+
+`do` should eventually accept policy constraints such as:
+
+- allow or reject raw pointer fallback
+- allow or reject raw keyboard fallback
+- allow or reject foreground focus takeover
+- require semantic AX execution when possible
+
+Those constraints should be recorded in the work record so a future replay can
+distinguish "the agent clicked" from "AOS used AX press without taking over the
+cursor."
+
+### Execution Metadata
+
+Every non-trivial action should report what actually happened:
+
+```json
+{
+  "strategy": "ax_press",
+  "fallback_used": false,
+  "state_id": "see_abc123",
+  "duration_ms": 82
+}
+```
+
+This metadata belongs in the work-record execution map and trace evidence. It
+is more useful than only recording the requested command because it tells future
+repair code which path succeeded.
+
+### Bounded Batching
+
+Batched actions are useful when no intermediate perception is needed. They are
+dangerous when the second action depends on the result of the first. AOS should
+only adopt batching with an explicit contract: bounded action count, one target
+state, per-action execution metadata, and one post-action `see` result.
+
+### Quality Metrics
+
+AOS should eventually measure desktop-control quality with metrics similar to:
+
+- semantic-ref resolution ratio
+- coordinate fallback ratio
+- AX execution ratio
+- strict-policy compatibility ratio
+- primitive pass ratio
+- batch pass ratio
+- average perception/action latency
+- stale-action rejection coverage
+
+Those metrics should become regression gates for see/do changes, not general
+claims in prose.
+
+## Non-Goals
+
+- Do not call `pi-computer-use` from AOS.
+- Do not add the Codex Computer Use plugin as a repo development path.
+- Do not make AOS depend on Pi's ref syntax or runtime process model.
+- Do not reshape `aos do` into a recorder. Recording stays above primitives in
+  the work-record layer.
+- Do not make browser work look like generic desktop control when a
+  Playwright-shaped target map is available.
+
+## Work-Record Implication
+
+The AOS work-record model should treat these ideas as execution-map and evidence
+requirements:
+
+```text
+intent
+  -> see state id
+  -> resolved semantic target candidates
+  -> do action with execution constraints
+  -> execution metadata
+  -> post-action see state
+  -> health update when the step fails or drifts
+```
+
+This keeps durable intent above brittle target details while preserving enough
+structured data for replay, repair, and retirement.
+
+## Source Pointers
+
+- `pi-computer-use` README:
+  https://github.com/injaneity/pi-computer-use
+- Usage guide:
+  https://github.com/injaneity/pi-computer-use/blob/main/docs/usage.md
+- Configuration and strict AX mode:
+  https://github.com/injaneity/pi-computer-use/blob/main/docs/configuration.md
+- Troubleshooting and stale refs:
+  https://github.com/injaneity/pi-computer-use/blob/main/docs/troubleshooting.md
+- Benchmark model:
+  https://github.com/injaneity/pi-computer-use/blob/main/benchmarks/README.md

--- a/packages/toolkit/workbench/index.js
+++ b/packages/toolkit/workbench/index.js
@@ -1,2 +1,3 @@
 export * from './subject.js';
 export * from './wiki-subject.js';
+export * from './work-record-subject.js';

--- a/packages/toolkit/workbench/work-record-subject.js
+++ b/packages/toolkit/workbench/work-record-subject.js
@@ -1,0 +1,150 @@
+import { createWorkbenchSubject } from './subject.js';
+
+const DEFAULT_OWNER = 'aos-work-record';
+
+function text(value, fallback = '') {
+  const normalized = String(value ?? '').replace(/\s+/g, ' ').trim();
+  return normalized || fallback;
+}
+
+function cloneJson(value) {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function objectValue(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function arrayValue(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function labelFromIntent(intent = {}, fallback = '') {
+  const nl = text(objectValue(intent).nl);
+  if (!nl) return fallback;
+  return nl.length > 96 ? `${nl.slice(0, 93)}...` : nl;
+}
+
+function workRecordKind(record = {}) {
+  const kind = text(record.type);
+  if (kind === 'aos.do_step') return 'aos.do_step';
+  if (kind === 'aos.recipe_health_event') return 'aos.recipe_health_event';
+  return 'aos.work_record';
+}
+
+function workRecordId(record = {}) {
+  const id = text(record.id);
+  if (!id) throw new TypeError('work record subject requires an id');
+  return id;
+}
+
+function workRecordHealth(record = {}) {
+  const next = objectValue(record.next_health);
+  const current = objectValue(record.health);
+  return {
+    state: text(next.state || current.state, 'unknown'),
+    reason: text(next.reason || current.reason),
+  };
+}
+
+function workRecordArtifacts(record = {}) {
+  const evidence = objectValue(record.evidence);
+  const artifacts = arrayValue(evidence.artifacts).map((artifact) => objectValue(artifact));
+  if (evidence.last_trace) {
+    artifacts.push({
+      kind: 'trace',
+      path: text(evidence.last_trace),
+    });
+  }
+  return artifacts.filter((artifact) => text(artifact.kind) || text(artifact.path));
+}
+
+function workRecordViews(kind) {
+  const base = [
+    'work_record.intent',
+    'work_record.execution_map.json',
+    'work_record.evidence',
+    'work_record.health',
+  ];
+  if (kind === 'aos.do_step') return [...base, 'work_record.step.timeline'];
+  if (kind === 'aos.recipe_health_event') return [
+    'work_record.intent',
+    'work_record.evidence',
+    'work_record.health',
+    'work_record.retirement',
+  ];
+  return base;
+}
+
+function workRecordControls(kind) {
+  const base = ['intent.editor', 'health.status'];
+  if (kind === 'aos.do_step') return [...base, 'execution_map.json.editor'];
+  if (kind === 'aos.recipe_health_event') return [...base, 'retirement.note'];
+  return base;
+}
+
+function workRecordCapabilities(kind) {
+  const base = [
+    'work_record.intent.edit',
+    'work_record.evidence.view',
+    'work_record.health.view',
+  ];
+  if (kind === 'aos.do_step') return [
+    ...base,
+    'work_record.execution_map.edit',
+    'work_record.do_step.inspect',
+  ];
+  if (kind === 'aos.recipe_health_event') return [
+    ...base,
+    'work_record.retirement.inspect',
+  ];
+  return base;
+}
+
+export function createWorkRecordSubject(record = {}) {
+  const kind = workRecordKind(record);
+  const id = workRecordId(record);
+  const intent = objectValue(record.intent);
+  const health = workRecordHealth(record);
+  const label = labelFromIntent(intent, id);
+  const sourceKind = kind === 'aos.recipe_health_event' ? 'recipe_health_event' : 'work_record';
+
+  return createWorkbenchSubject({
+    id: `work-record:${id}`,
+    type: kind,
+    label,
+    owner: DEFAULT_OWNER,
+    source: {
+      kind: sourceKind,
+      record_type: text(record.type, kind),
+      record_id: id,
+      recipe_id: text(record.recipe_id) || null,
+    },
+    capabilities: workRecordCapabilities(kind),
+    views: workRecordViews(kind),
+    controls: workRecordControls(kind),
+    persistence: {
+      kind: 'agent_handoff',
+      request: 'work_record.patch.requested',
+      result: 'work_record.patch.result',
+    },
+    artifacts: workRecordArtifacts(record),
+    state: {
+      health,
+      surface: text(record.surface) || null,
+      action: objectValue(record.action).verb ? cloneJson(record.action) : null,
+      automatic_replay_allowed: objectValue(record.retirement).automatic_replay_allowed ?? null,
+    },
+    metadata: {
+      schema_version: text(record.schema_version),
+      purpose: text(intent.purpose),
+      acceptance: text(intent.acceptance),
+      has_execution_map: Object.keys(objectValue(record.execution_map)).length > 0,
+    },
+  });
+}
+
+export function createWorkRecordSubjects(records = []) {
+  return arrayValue(records).map((record) => createWorkRecordSubject(record));
+}

--- a/tests/design/aos-work-record-fixtures.test.mjs
+++ b/tests/design/aos-work-record-fixtures.test.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+const fixtureRoot = path.join(repoRoot, 'docs/design/fixtures/aos-work-records');
+
+const requiredDoStepKeys = [
+  'type',
+  'schema_version',
+  'id',
+  'surface',
+  'intent',
+  'precondition',
+  'action',
+  'postcondition',
+  'execution_map',
+  'evidence',
+  'health'
+];
+
+function readJson(fileName) {
+  return JSON.parse(fs.readFileSync(path.join(fixtureRoot, fileName), 'utf8'));
+}
+
+test('design work-record fixtures are valid JSON', () => {
+  const files = fs.readdirSync(fixtureRoot).filter((file) => file.endsWith('.json'));
+  assert.deepEqual(files.sort(), [
+    'browser-artifact-collection-step.json',
+    'canvas-toolkit-control-step.json',
+    'desktop-workflow-demo-step.json',
+    'recipe-health-retirement.json'
+  ]);
+
+  for (const file of files) {
+    assert.doesNotThrow(() => readJson(file), file);
+  }
+});
+
+test('do_step examples preserve the four-layer work-record shape', () => {
+  for (const file of [
+    'browser-artifact-collection-step.json',
+    'canvas-toolkit-control-step.json',
+    'desktop-workflow-demo-step.json'
+  ]) {
+    const fixture = readJson(file);
+    for (const key of requiredDoStepKeys) {
+      assert.ok(Object.hasOwn(fixture, key), `${file} missing ${key}`);
+    }
+    assert.equal(fixture.type, 'aos.do_step');
+    assert.equal(typeof fixture.intent.nl, 'string');
+    assert.ok(fixture.intent.nl.length > 20);
+    assert.equal(typeof fixture.action.verb, 'string');
+    assert.equal(typeof fixture.action.target, 'string');
+    assert.equal(typeof fixture.health.state, 'string');
+  }
+});
+
+test('health fixture keeps retirement separate from historical evidence', () => {
+  const fixture = readJson('recipe-health-retirement.json');
+  assert.equal(fixture.type, 'aos.recipe_health_event');
+  assert.equal(fixture.next_health.state, 'impossible');
+  assert.equal(fixture.retirement.automatic_replay_allowed, false);
+  assert.ok(fixture.evidence.last_trace.includes('trace'));
+});

--- a/tests/schemas/aos-workbench-subject.test.mjs
+++ b/tests/schemas/aos-workbench-subject.test.mjs
@@ -6,12 +6,17 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createWorkbenchSubject } from '../../packages/toolkit/workbench/subject.js';
 import { createWikiPageSubject } from '../../packages/toolkit/workbench/wiki-subject.js';
+import { createWorkRecordSubject } from '../../packages/toolkit/workbench/work-record-subject.js';
 import { buildMarkdownWorkbenchSubject, createMarkdownWorkbenchState } from '../../packages/toolkit/components/markdown-workbench/model.js';
 import { buildRadialItemWorkbenchSubject, createRadialItemEditorState } from '../../apps/sigil/radial-item-editor/model.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '../..');
 const schemaPath = path.join(repoRoot, 'shared/schemas/aos-workbench-subject.schema.json');
+const workRecordFixturePath = path.join(
+  repoRoot,
+  'docs/design/fixtures/aos-work-records/browser-artifact-collection-step.json',
+);
 
 async function validate(instance) {
   const result = spawnSync(
@@ -66,4 +71,5 @@ test('current workbench adopters emit schema-valid subject descriptors', async (
     plugin: 'self-check',
     tags: ['diagnostics', 'runtime'],
   }));
+  await validate(createWorkRecordSubject(JSON.parse(await fs.readFile(workRecordFixturePath, 'utf8'))));
 });

--- a/tests/toolkit/work-record-subject.test.mjs
+++ b/tests/toolkit/work-record-subject.test.mjs
@@ -1,0 +1,57 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  createWorkRecordSubject,
+  createWorkRecordSubjects,
+} from '../../packages/toolkit/workbench/work-record-subject.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+const fixtureRoot = path.join(repoRoot, 'docs/design/fixtures/aos-work-records');
+
+function fixture(name) {
+  return JSON.parse(fs.readFileSync(path.join(fixtureRoot, name), 'utf8'));
+}
+
+test('createWorkRecordSubject projects a browser do_step as a workbench subject', () => {
+  const subject = createWorkRecordSubject(fixture('browser-artifact-collection-step.json'));
+
+  assert.equal(subject.type, 'aos.workbench.subject');
+  assert.equal(subject.id, 'work-record:collect-company-careers-page');
+  assert.equal(subject.subject_type, 'aos.do_step');
+  assert.equal(subject.owner, 'aos-work-record');
+  assert.equal(subject.source.kind, 'work_record');
+  assert.equal(subject.state.health.state, 'stale');
+  assert.equal(subject.state.surface, 'browser');
+  assert.equal(subject.state.action.verb, 'navigate');
+  assert.equal(subject.metadata.has_execution_map, true);
+  assert.ok(subject.capabilities.includes('work_record.execution_map.edit'));
+  assert.ok(subject.views.includes('work_record.step.timeline'));
+  assert.ok(subject.controls.includes('execution_map.json.editor'));
+  assert.equal(subject.artifacts.length, 3);
+});
+
+test('createWorkRecordSubject projects recipe retirement as evidence and health', () => {
+  const subject = createWorkRecordSubject(fixture('recipe-health-retirement.json'));
+
+  assert.equal(subject.id, 'work-record:indeed-benefits-section-retired');
+  assert.equal(subject.subject_type, 'aos.recipe_health_event');
+  assert.equal(subject.source.kind, 'recipe_health_event');
+  assert.equal(subject.source.recipe_id, 'employer-brand/collect-indeed-benefits-section');
+  assert.equal(subject.state.health.state, 'impossible');
+  assert.equal(subject.state.automatic_replay_allowed, false);
+  assert.equal(subject.artifacts[0].kind, 'trace');
+  assert.ok(subject.views.includes('work_record.retirement'));
+  assert.ok(subject.capabilities.includes('work_record.retirement.inspect'));
+});
+
+test('createWorkRecordSubjects maps arrays and rejects records without ids', () => {
+  assert.equal(createWorkRecordSubjects([
+    fixture('browser-artifact-collection-step.json'),
+    fixture('canvas-toolkit-control-step.json'),
+  ]).length, 2);
+  assert.throws(() => createWorkRecordSubject({ type: 'aos.do_step' }), /requires an id/);
+});


### PR DESCRIPTION
## Summary

- add the AOS work-records and self-healing recipes design seed
- define trace, recipe, workflow, work record, execution map, `do_step`, and health vocabulary
- add schema-shaped browser, desktop, canvas, and retirement fixtures without promoting a shared schema yet
- project work records into existing toolkit workbench subject descriptors for manual inspection/editing
- capture `pi-computer-use` lessons as AOS-native see/do design input without adding a runtime bridge or implementation pivot
- connect the workbench pattern to work-record projections while keeping recorder/replay ownership outside toolkit

## Tracking

- Epic: #234
- Starts: #235
- Starts: #237
- Related: #236, #238, #239
- Reconciles direction with #129, #141, #149, #211, #215, #223

## Verification

- `node --check packages/toolkit/workbench/work-record-subject.js`
- `node --test tests/design/aos-work-record-fixtures.test.mjs tests/toolkit/work-record-subject.test.mjs tests/schemas/aos-workbench-subject.test.mjs`
- `git diff --check`