### PR TITLE
Add work record workbench

### DIFF
--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -129,6 +129,15 @@ The helper is a projection layer only; recording, replay, repair, and retirement
 remain owned by the work-record model in
 [`docs/design/aos-work-records-and-self-healing-recipes.md`](../design/aos-work-records-and-self-healing-recipes.md).
 
+The stock work-record workbench lives at:
+
+- `aos://toolkit/components/work-record-workbench/index.html`
+
+It accepts `work_record.open` and `work_record.patch.result`, emits
+`work-record-workbench/patch.requested`, and intentionally stays manual-first:
+it edits the NL intent and execution-map JSON while displaying health and
+evidence. It does not record, replay, repair, or retire recipes by itself.
+
 ## Stock Components Snapshot
 
 Current reusable toolkit components include:

--- a/packages/toolkit/components/work-record-workbench/index.html
+++ b/packages/toolkit/components/work-record-workbench/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../_base/theme.css">
+<link rel="stylesheet" href="../../panel/defaults.css">
+<link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+<script type="module">
+import { mountPanel, Single } from '../../panel/index.js'
+import WorkRecordWorkbench from './index.js'
+
+mountPanel({ title: 'Work Record Workbench', layout: Single(WorkRecordWorkbench) })
+</script>
+</body>
+</html>

--- a/packages/toolkit/components/work-record-workbench/index.js
+++ b/packages/toolkit/components/work-record-workbench/index.js
@@ -1,0 +1,272 @@
+import { esc } from '../../runtime/bridge.js';
+import {
+  applyWorkRecordPatchResult,
+  buildWorkRecordPatchRequest,
+  createWorkRecordWorkbenchState,
+  evidenceArtifacts,
+  executionMapJson,
+  openWorkRecord,
+  updateWorkRecordExecutionMapJson,
+  updateWorkRecordIntent,
+  workRecordDiagnostics,
+  workRecordWorkbenchSnapshot,
+} from './model.js';
+
+function el(tag, className, textContent) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (textContent !== undefined) node.textContent = textContent;
+  return node;
+}
+
+function text(value, fallback = '') {
+  const normalized = String(value ?? '').replace(/\s+/g, ' ').trim();
+  return normalized || fallback;
+}
+
+function artifactLabel(artifact = {}) {
+  return text(artifact.label || artifact.title || artifact.kind || artifact.path, 'artifact');
+}
+
+function renderEvidenceList(record = {}) {
+  const artifacts = evidenceArtifacts(record);
+  if (artifacts.length === 0) {
+    return '<p class="work-record-muted">No evidence artifacts attached.</p>';
+  }
+  return (
+    '<ol class="work-record-artifacts">'
+      + artifacts.map((artifact) => (
+        '<li>'
+          + `<strong>${esc(artifactLabel(artifact))}</strong>`
+          + `<span>${esc(text(artifact.path || artifact.url || artifact.id, 'no path'))}</span>`
+          + `<em>${esc(text(artifact.kind, 'artifact'))}</em>`
+        + '</li>'
+      )).join('')
+    + '</ol>'
+  );
+}
+
+function renderHealth(record = {}) {
+  const health = record.next_health || record.health || {};
+  const state = text(health.state, 'unknown');
+  const reason = text(health.reason);
+  return (
+    `<div class="work-record-health-state" data-health="${esc(state)}">`
+      + `<strong>${esc(state)}</strong>`
+      + `<span>${esc(reason || 'No health reason recorded')}</span>`
+    + '</div>'
+  );
+}
+
+function renderSummary(record = {}) {
+  const diagnostics = workRecordDiagnostics(record);
+  const rows = [
+    ['Record', diagnostics.record_id],
+    ['Type', diagnostics.record_type],
+    ['Surface', diagnostics.surface || 'none'],
+    ['Action', diagnostics.action_verb || 'none'],
+    ['Artifacts', String(diagnostics.artifact_count)],
+    ['Execution keys', diagnostics.execution_map_keys.join(', ') || 'none'],
+  ];
+  return rows.map(([label, value]) => (
+    `<div class="work-record-summary-row"><span>${esc(label)}</span><strong>${esc(value)}</strong></div>`
+  )).join('');
+}
+
+export default function WorkRecordWorkbench(options = {}) {
+  let host = null;
+  const state = createWorkRecordWorkbenchState({ record: options.record || null });
+  const dom = {};
+
+  function emit(type, payload) {
+    if (host?.emit) host.emit(type, payload);
+  }
+
+  function syncTitle() {
+    const record = state.record || {};
+    host?.setTitle?.(`Work Record - ${record.id}${state.dirty ? ' *' : ''}`);
+  }
+
+  function syncDebugState() {
+    window.__workRecordWorkbenchState = workRecordWorkbenchSnapshot(state);
+  }
+
+  function sync({ replaceEditorValues = false } = {}) {
+    const record = state.record || {};
+    const intent = record.intent || {};
+    dom.recordId.textContent = record.id;
+    dom.recordType.textContent = record.type;
+    dom.dirty.textContent = state.dirty ? 'Unsaved changes' : 'Saved';
+    dom.dirty.dataset.dirty = state.dirty ? 'true' : 'false';
+    dom.summary.innerHTML = renderSummary(record);
+    dom.health.innerHTML = renderHealth(record);
+    dom.evidence.innerHTML = renderEvidenceList(record);
+    dom.status.textContent = state.lastResult
+      ? `${state.lastResult.status}: ${state.lastResult.message || state.lastResult.reason || state.lastResult.type}`
+      : 'No edits yet';
+
+    if (replaceEditorValues) {
+      dom.intentNl.value = String(intent.nl || '');
+      dom.intentPurpose.value = String(intent.purpose || '');
+      dom.intentAcceptance.value = String(intent.acceptance || '');
+      dom.executionMap.value = executionMapJson(record);
+    }
+
+    syncTitle();
+    syncDebugState();
+  }
+
+  function handleIntentInput() {
+    updateWorkRecordIntent(state, {
+      nl: dom.intentNl.value,
+      purpose: dom.intentPurpose.value,
+      acceptance: dom.intentAcceptance.value,
+    });
+    sync();
+  }
+
+  function applyExecutionMapEditor() {
+    const result = updateWorkRecordExecutionMapJson(state, dom.executionMap.value);
+    if (result.status === 'applied') {
+      dom.executionMap.value = executionMapJson(state.record);
+    }
+    sync();
+    return result;
+  }
+
+  function requestSave() {
+    const result = applyExecutionMapEditor();
+    if (result.status !== 'applied') return null;
+    const request = buildWorkRecordPatchRequest(state);
+    state.lastResult = {
+      type: 'work_record.patch.requested',
+      schema_version: request.schema_version,
+      status: 'pending',
+      record_id: state.record.id,
+      message: 'waiting for owner',
+    };
+    emit('patch.requested', request);
+    sync();
+    return request;
+  }
+
+  function revert() {
+    openWorkRecord(state, { type: 'work_record.open', record: state.savedRecord });
+    sync({ replaceEditorValues: true });
+  }
+
+  function render() {
+    const root = el('div', 'work-record-root');
+    root.innerHTML = `
+      <header class="work-record-toolbar">
+        <div class="work-record-file">
+          <strong data-role="record-id"></strong>
+          <span data-role="record-type"></span>
+          <em data-role="dirty"></em>
+        </div>
+        <div class="work-record-actions">
+          <button type="button" data-action="apply-json">Apply JSON</button>
+          <button type="button" data-action="revert">Revert</button>
+          <button type="button" data-action="save">Save</button>
+        </div>
+      </header>
+      <main class="work-record-main">
+        <section class="work-record-intent" aria-label="Work record intent">
+          <label>
+            <span>Intent</span>
+            <textarea data-role="intent-nl" spellcheck="true" aria-label="Natural language intent"></textarea>
+          </label>
+          <div class="work-record-intent-grid">
+            <label>
+              <span>Purpose</span>
+              <textarea data-role="intent-purpose" spellcheck="true" aria-label="Intent purpose"></textarea>
+            </label>
+            <label>
+              <span>Acceptance</span>
+              <textarea data-role="intent-acceptance" spellcheck="true" aria-label="Acceptance condition"></textarea>
+            </label>
+          </div>
+        </section>
+        <section class="work-record-json" aria-label="Execution map JSON">
+          <div class="work-record-section-title">Execution Map JSON</div>
+          <textarea data-role="execution-map" spellcheck="false" aria-label="Execution map JSON editor"></textarea>
+        </section>
+        <aside class="work-record-inspector" aria-label="Work record health and evidence">
+          <section>
+            <strong>Summary</strong>
+            <div data-role="summary"></div>
+          </section>
+          <section>
+            <strong>Health</strong>
+            <div data-role="health"></div>
+          </section>
+          <section>
+            <strong>Evidence</strong>
+            <div data-role="evidence"></div>
+          </section>
+          <section>
+            <strong>Status</strong>
+            <p data-role="status"></p>
+          </section>
+        </aside>
+      </main>
+    `;
+
+    dom.recordId = root.querySelector('[data-role="record-id"]');
+    dom.recordType = root.querySelector('[data-role="record-type"]');
+    dom.dirty = root.querySelector('[data-role="dirty"]');
+    dom.summary = root.querySelector('[data-role="summary"]');
+    dom.health = root.querySelector('[data-role="health"]');
+    dom.evidence = root.querySelector('[data-role="evidence"]');
+    dom.status = root.querySelector('[data-role="status"]');
+    dom.intentNl = root.querySelector('[data-role="intent-nl"]');
+    dom.intentPurpose = root.querySelector('[data-role="intent-purpose"]');
+    dom.intentAcceptance = root.querySelector('[data-role="intent-acceptance"]');
+    dom.executionMap = root.querySelector('[data-role="execution-map"]');
+
+    for (const input of [dom.intentNl, dom.intentPurpose, dom.intentAcceptance]) {
+      input.addEventListener('input', handleIntentInput);
+    }
+    dom.executionMap.addEventListener('blur', applyExecutionMapEditor);
+    root.querySelector('[data-action="apply-json"]').addEventListener('click', applyExecutionMapEditor);
+    root.querySelector('[data-action="revert"]').addEventListener('click', revert);
+    root.querySelector('[data-action="save"]').addEventListener('click', requestSave);
+
+    sync({ replaceEditorValues: true });
+    return root;
+  }
+
+  function onMessage(message = {}) {
+    const type = message.type || message.payload?.type;
+    if (type === 'work_record.open') {
+      openWorkRecord(state, message);
+      sync({ replaceEditorValues: true });
+    } else if (type === 'work_record.patch.result') {
+      applyWorkRecordPatchResult(state, message);
+      sync();
+    }
+  }
+
+  return {
+    manifest: {
+      name: 'work-record-workbench',
+      title: 'Work Record Workbench',
+      accepts: ['work_record.open', 'work_record.patch.result'],
+      emits: ['work-record-workbench/patch.requested'],
+      channelPrefix: 'work-record-workbench',
+      defaultSize: { w: 1180, h: 720 },
+    },
+
+    render(host_) {
+      host = host_;
+      host.contentEl.style.overflow = 'hidden';
+      return render();
+    },
+
+    onMessage,
+
+    serialize() {
+      return workRecordWorkbenchSnapshot(state);
+    },
+  };
+}

--- a/packages/toolkit/components/work-record-workbench/launch.sh
+++ b/packages/toolkit/components/work-record-workbench/launch.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# launch.sh - Open a fixture-backed work-record workbench.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null || pwd)"
+AOS="${AOS:-$ROOT/aos}"
+CANVAS_ID="${CANVAS_ID:-work-record-workbench}"
+TARGET="${1:-$ROOT/docs/design/fixtures/aos-work-records/browser-artifact-collection-step.json}"
+PANEL_W="${AOS_WORK_RECORD_WORKBENCH_W:-1180}"
+PANEL_H="${AOS_WORK_RECORD_WORKBENCH_H:-720}"
+
+root_key_for() {
+  local prefix="$1"
+  local branch suffix
+  branch="$(git -C "$ROOT" branch --show-current 2>/dev/null || true)"
+  if [[ -z "$branch" || "$branch" == "main" ]]; then
+    printf '%s\n' "$prefix"
+    return
+  fi
+  suffix="$(
+    printf '%s' "$branch" \
+      | tr '[:upper:]' '[:lower:]' \
+      | sed -E 's/[^a-z0-9]+/_/g; s/^_+//; s/_+$//'
+  )"
+  printf '%s_%s\n' "$prefix" "${suffix:-worktree}"
+}
+
+TOOLKIT_CONTENT_ROOT="${AOS_TOOLKIT_CONTENT_ROOT:-$(root_key_for toolkit)}"
+CANONICAL_REPO_ROOT="${AOS_CANONICAL_REPO_ROOT:-/Users/Michael/Code/agent-os}"
+
+if [[ ! -x "$AOS" ]]; then
+  echo "aos binary not found at $AOS" >&2
+  exit 1
+fi
+
+if [[ ! -f "$TARGET" ]]; then
+  echo "Work record JSON not found: $TARGET" >&2
+  exit 1
+fi
+
+if [[ "$TOOLKIT_CONTENT_ROOT" != "toolkit" && -d "$CANONICAL_REPO_ROOT/packages/toolkit" ]]; then
+  "$AOS" set content.roots.toolkit "$CANONICAL_REPO_ROOT/packages/toolkit" >/dev/null
+fi
+
+"$AOS" set "content.roots.$TOOLKIT_CONTENT_ROOT" "$ROOT/packages/toolkit" >/dev/null
+
+content_root_live() {
+  "$AOS" content status --json 2>/dev/null \
+    | TOOLKIT_CONTENT_ROOT="$TOOLKIT_CONTENT_ROOT" \
+      TOOLKIT_PATH="$ROOT/packages/toolkit" \
+      python3 -c '
+import json, os, sys
+try:
+    roots = json.load(sys.stdin).get("roots", {})
+except Exception:
+    sys.exit(1)
+sys.exit(0 if roots.get(os.environ["TOOLKIT_CONTENT_ROOT"]) == os.environ["TOOLKIT_PATH"] else 1)
+'
+}
+
+if ! content_root_live; then
+  echo "Refreshing repo daemon so new content root is live: $TOOLKIT_CONTENT_ROOT" >&2
+  "$AOS" service restart --mode repo >/dev/null
+fi
+
+"$AOS" content wait --root "$TOOLKIT_CONTENT_ROOT" --auto-start --timeout 15s >/dev/null
+
+DISPLAY_JSON="$("$AOS" graph displays --json 2>/dev/null || echo '{"data":{"displays":[]}}')"
+GEOMETRY="$(
+  echo "$DISPLAY_JSON" | PANEL_W="$PANEL_W" PANEL_H="$PANEL_H" python3 -c '
+import json, os, sys
+
+payload = json.load(sys.stdin)
+displays = payload.get("data", {}).get("displays", payload.get("displays", [])) if isinstance(payload, dict) else payload
+main = next((entry for entry in displays if entry.get("is_main")), displays[0] if displays else None)
+rect = (main or {}).get("visible_bounds") or (main or {}).get("bounds") or {}
+x = int(rect.get("x", 0))
+y = int(rect.get("y", 0))
+w = int(rect.get("w", 1728))
+h = int(rect.get("h", 1117))
+panel_w = min(int(os.environ["PANEL_W"]), max(760, w - 48))
+panel_h = min(int(os.environ["PANEL_H"]), max(520, h - 96))
+print(x + 24, y + 64, panel_w, panel_h)
+' 2>/dev/null || echo "24 64 $PANEL_W $PANEL_H"
+)"
+
+read -r X Y W H <<<"$GEOMETRY"
+
+"$AOS" show remove --id "$CANVAS_ID" 2>/dev/null || true
+"$AOS" show create \
+  --id "$CANVAS_ID" \
+  --at "$X,$Y,$W,$H" \
+  --interactive \
+  --focus \
+  --scope global \
+  --url "aos://$TOOLKIT_CONTENT_ROOT/components/work-record-workbench/index.html" >/dev/null
+
+"$AOS" show wait \
+  --id "$CANVAS_ID" \
+  --manifest work-record-workbench \
+  --js 'typeof window.__workRecordWorkbenchState === "object"' \
+  --timeout 5s >/dev/null
+
+CONTENT_JSON="$(TARGET="$TARGET" python3 -c '
+import json, os, pathlib
+path = pathlib.Path(os.environ["TARGET"]).resolve()
+record = json.loads(path.read_text(encoding="utf-8"))
+print(json.dumps({
+    "type": "work_record.open",
+    "record": record,
+    "source": {
+        "kind": "file",
+        "path": str(path),
+    },
+}))
+')"
+
+"$AOS" show post --id "$CANVAS_ID" --event "$CONTENT_JSON" >/dev/null
+
+echo "Work record workbench launched at ${X},${Y} (${W}x${H})"

--- a/packages/toolkit/components/work-record-workbench/model.js
+++ b/packages/toolkit/components/work-record-workbench/model.js
@@ -1,0 +1,284 @@
+import { createWorkRecordSubject } from '../../workbench/work-record-subject.js';
+
+export const WORK_RECORD_WORKBENCH_SCHEMA_VERSION = '2026-05-04';
+
+function text(value, fallback = '') {
+  const normalized = String(value ?? '').replace(/\s+/g, ' ').trim();
+  return normalized || fallback;
+}
+
+function objectValue(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function arrayValue(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function cloneJson(value) {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function stableJson(value) {
+  return JSON.stringify(value ?? {}, null, 2);
+}
+
+function recordsEqual(a, b) {
+  return stableJson(a) === stableJson(b);
+}
+
+function defaultRecord() {
+  return {
+    type: 'aos.do_step',
+    schema_version: WORK_RECORD_WORKBENCH_SCHEMA_VERSION,
+    id: 'untitled-work-record',
+    intent: {
+      nl: '',
+      purpose: '',
+      acceptance: '',
+    },
+    execution_map: {},
+    evidence: {
+      artifacts: [],
+    },
+    health: {
+      state: 'stale',
+      reason: 'manual draft',
+    },
+  };
+}
+
+function normalizeRecord(record = {}) {
+  const next = objectValue(record);
+  const base = defaultRecord();
+  return {
+    ...base,
+    ...cloneJson(next),
+    type: text(next.type, base.type),
+    schema_version: text(next.schema_version, base.schema_version),
+    id: text(next.id, base.id),
+    intent: {
+      ...base.intent,
+      ...objectValue(next.intent),
+    },
+    execution_map: objectValue(next.execution_map),
+    evidence: {
+      ...base.evidence,
+      ...objectValue(next.evidence),
+      artifacts: arrayValue(objectValue(next.evidence).artifacts),
+    },
+    health: {
+      ...base.health,
+      ...objectValue(next.health),
+    },
+  };
+}
+
+function unwrapMessage(message = {}) {
+  if (message?.payload && typeof message.payload === 'object') {
+    return { ...message.payload, type: message.payload.type || message.type };
+  }
+  return message || {};
+}
+
+function recordFromMessage(message = {}) {
+  const payload = unwrapMessage(message);
+  return payload.record && typeof payload.record === 'object' ? payload.record : payload;
+}
+
+export function createWorkRecordWorkbenchState({ record = null } = {}) {
+  const initial = normalizeRecord(record || defaultRecord());
+  return {
+    record: initial,
+    savedRecord: cloneJson(initial),
+    dirty: false,
+    selectedView: 'intent',
+    lastResult: null,
+    errors: [],
+  };
+}
+
+export function openWorkRecord(state, message = {}) {
+  const record = normalizeRecord(recordFromMessage(message));
+  state.record = record;
+  state.savedRecord = cloneJson(record);
+  state.dirty = false;
+  state.lastResult = {
+    type: 'work_record.open.result',
+    schema_version: WORK_RECORD_WORKBENCH_SCHEMA_VERSION,
+    status: 'opened',
+    record_id: record.id,
+    subject: buildWorkRecordWorkbenchSubject(state),
+  };
+  return state.lastResult;
+}
+
+function markDirty(state) {
+  state.dirty = !recordsEqual(state.record, state.savedRecord);
+}
+
+export function updateWorkRecordIntent(state, intentPatch = {}) {
+  state.record.intent = {
+    ...objectValue(state.record.intent),
+    ...objectValue(intentPatch),
+  };
+  markDirty(state);
+  state.lastResult = {
+    type: 'work_record.intent.patch.result',
+    schema_version: WORK_RECORD_WORKBENCH_SCHEMA_VERSION,
+    status: 'applied',
+    record_id: state.record.id,
+    dirty: state.dirty,
+  };
+  return state.lastResult;
+}
+
+export function updateWorkRecordExecutionMapJson(state, jsonText = '') {
+  let executionMap;
+  try {
+    executionMap = JSON.parse(String(jsonText || '{}'));
+  } catch (error) {
+    state.lastResult = {
+      type: 'work_record.execution_map.patch.result',
+      schema_version: WORK_RECORD_WORKBENCH_SCHEMA_VERSION,
+      status: 'rejected',
+      record_id: state.record.id,
+      reason: 'invalid_json',
+      message: String(error?.message || error),
+    };
+    state.errors.push(state.lastResult.message);
+    while (state.errors.length > 12) state.errors.shift();
+    return state.lastResult;
+  }
+
+  if (!executionMap || typeof executionMap !== 'object' || Array.isArray(executionMap)) {
+    state.lastResult = {
+      type: 'work_record.execution_map.patch.result',
+      schema_version: WORK_RECORD_WORKBENCH_SCHEMA_VERSION,
+      status: 'rejected',
+      record_id: state.record.id,
+      reason: 'not_object',
+      message: 'execution_map must be a JSON object',
+    };
+    state.errors.push(state.lastResult.message);
+    while (state.errors.length > 12) state.errors.shift();
+    return state.lastResult;
+  }
+
+  state.record.execution_map = executionMap;
+  markDirty(state);
+  state.lastResult = {
+    type: 'work_record.execution_map.patch.result',
+    schema_version: WORK_RECORD_WORKBENCH_SCHEMA_VERSION,
+    status: 'applied',
+    record_id: state.record.id,
+    dirty: state.dirty,
+  };
+  return state.lastResult;
+}
+
+export function applyWorkRecordPatchResult(state, message = {}) {
+  const payload = unwrapMessage(message);
+  const status = ['saved', 'applied'].includes(payload.status) ? 'saved' : 'rejected';
+  if (status === 'saved') {
+    state.savedRecord = cloneJson(state.record);
+    state.dirty = false;
+  }
+  state.lastResult = {
+    type: 'work_record.patch.result',
+    schema_version: WORK_RECORD_WORKBENCH_SCHEMA_VERSION,
+    status,
+    record_id: state.record.id,
+    message: text(payload.message),
+  };
+  return state.lastResult;
+}
+
+export function buildWorkRecordPatchRequest(state, {
+  requestId = `work-record-patch-${Date.now().toString(36)}`,
+} = {}) {
+  return {
+    type: 'work_record.patch.requested',
+    schema_version: WORK_RECORD_WORKBENCH_SCHEMA_VERSION,
+    request_id: requestId,
+    subject: buildWorkRecordWorkbenchSubject(state),
+    record_id: state.record.id,
+    patch: {
+      intent: cloneJson(objectValue(state.record.intent)),
+      execution_map: cloneJson(objectValue(state.record.execution_map)),
+    },
+    record: cloneJson(state.record),
+  };
+}
+
+export function workRecordDiagnostics(record = {}) {
+  const normalized = normalizeRecord(record);
+  const evidence = objectValue(normalized.evidence);
+  const artifacts = [
+    ...arrayValue(evidence.artifacts),
+    ...(evidence.last_trace ? [{ kind: 'trace', path: evidence.last_trace }] : []),
+  ];
+  const executionMap = objectValue(normalized.execution_map);
+  return {
+    record_id: normalized.id,
+    record_type: normalized.type,
+    health_state: text(objectValue(normalized.next_health).state || normalized.health.state, 'unknown'),
+    health_reason: text(objectValue(normalized.next_health).reason || normalized.health.reason),
+    surface: text(normalized.surface),
+    action_verb: text(objectValue(normalized.action).verb),
+    artifact_count: artifacts.length,
+    execution_map_keys: Object.keys(executionMap).sort(),
+    has_intent: !!text(objectValue(normalized.intent).nl),
+  };
+}
+
+export function workRecordWorkbenchSnapshot(state) {
+  return {
+    type: 'work_record.snapshot',
+    schema_version: WORK_RECORD_WORKBENCH_SCHEMA_VERSION,
+    subject: buildWorkRecordWorkbenchSubject(state),
+    record: cloneJson(state.record),
+    dirty: !!state.dirty,
+    diagnostics: workRecordDiagnostics(state.record),
+    last_result: state.lastResult,
+    errors: [...state.errors],
+  };
+}
+
+export function buildWorkRecordWorkbenchSubject(state = {}) {
+  const subject = createWorkRecordSubject(normalizeRecord(state.record));
+  subject.capabilities = [...new Set([
+    ...subject.capabilities,
+    'work_record.patch.requested',
+    'work_record.snapshot',
+  ])];
+  subject.views = [...new Set([
+    ...subject.views,
+    'work_record.summary',
+  ])];
+  subject.controls = [...new Set([
+    ...subject.controls,
+    'patch.request',
+  ])];
+  subject.state = {
+    ...subject.state,
+    dirty: !!state.dirty,
+    diagnostics: workRecordDiagnostics(state.record),
+  };
+  return subject;
+}
+
+export function executionMapJson(record = {}) {
+  return stableJson(objectValue(normalizeRecord(record).execution_map));
+}
+
+export function evidenceArtifacts(record = {}) {
+  const normalized = normalizeRecord(record);
+  const evidence = objectValue(normalized.evidence);
+  const artifacts = arrayValue(evidence.artifacts).map((artifact) => objectValue(artifact));
+  if (evidence.last_trace) {
+    artifacts.push({ kind: 'trace', path: evidence.last_trace });
+  }
+  return artifacts.filter((artifact) => text(artifact.kind) || text(artifact.path));
+}

--- a/packages/toolkit/components/work-record-workbench/styles.css
+++ b/packages/toolkit/components/work-record-workbench/styles.css
@@ -1,0 +1,262 @@
+.work-record-root {
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  color: var(--text-primary);
+  background: rgba(9, 11, 16, 0.96);
+}
+
+.work-record-toolbar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: rgba(18, 20, 30, 0.96);
+}
+
+.work-record-file {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.work-record-file strong,
+.work-record-section-title,
+.work-record-inspector strong,
+.work-record-intent label > span {
+  color: var(--text-secondary);
+  font: 650 10px/1.3 var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+
+.work-record-file strong {
+  min-width: 0;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.work-record-file span,
+.work-record-file em,
+.work-record-inspector p,
+.work-record-muted,
+.work-record-summary-row,
+.work-record-artifacts li {
+  color: var(--text-muted);
+  font: 10px/1.45 var(--font-mono);
+}
+
+.work-record-file em {
+  font-style: normal;
+}
+
+.work-record-file em[data-dirty="true"] {
+  color: #ffd166;
+}
+
+.work-record-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.work-record-actions button {
+  min-height: 28px;
+  border: 1px solid rgba(138, 180, 255, 0.28);
+  border-radius: 6px;
+  background: rgba(26, 31, 44, 0.9);
+  color: var(--text-primary);
+  font: 650 10px/1.3 var(--font-mono);
+  cursor: pointer;
+}
+
+.work-record-actions button:hover {
+  border-color: rgba(138, 180, 255, 0.5);
+  background: rgba(42, 48, 66, 0.95);
+}
+
+.work-record-main {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(320px, 0.95fr) minmax(360px, 1.1fr) minmax(240px, 0.55fr);
+}
+
+.work-record-intent,
+.work-record-json,
+.work-record-inspector {
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.work-record-intent {
+  display: grid;
+  grid-template-rows: minmax(220px, 1fr) minmax(180px, 0.85fr);
+  gap: 10px;
+  padding: 14px;
+  border-right: 1px solid var(--border-subtle);
+  background: rgba(4, 6, 10, 0.92);
+}
+
+.work-record-intent-grid {
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+
+.work-record-intent label {
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 6px;
+}
+
+.work-record-intent textarea,
+.work-record-json textarea {
+  width: 100%;
+  height: 100%;
+  resize: none;
+  border: 1px solid rgba(80, 80, 120, 0.26);
+  border-radius: 6px;
+  outline: none;
+  padding: 10px;
+  background: rgba(8, 10, 16, 0.94);
+  color: var(--text-primary);
+  font: 12px/1.55 var(--font-mono);
+}
+
+.work-record-intent textarea:focus,
+.work-record-json textarea:focus {
+  border-color: rgba(138, 180, 255, 0.55);
+  box-shadow: 0 0 0 1px rgba(138, 180, 255, 0.12);
+}
+
+.work-record-json {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 8px;
+  padding: 14px;
+  border-right: 1px solid var(--border-subtle);
+  background: rgba(12, 14, 20, 0.92);
+}
+
+.work-record-inspector {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 14px;
+  overflow: auto;
+  background: rgba(15, 17, 24, 0.94);
+}
+
+.work-record-inspector section {
+  display: grid;
+  gap: 8px;
+}
+
+.work-record-summary-row {
+  display: grid;
+  grid-template-columns: 82px minmax(0, 1fr);
+  gap: 8px;
+  padding: 4px 0;
+  border-bottom: 1px solid rgba(80, 80, 120, 0.12);
+}
+
+.work-record-summary-row span {
+  color: var(--text-label);
+}
+
+.work-record-summary-row strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+  font: 10px/1.45 var(--font-mono);
+  text-transform: none;
+}
+
+.work-record-health-state {
+  display: grid;
+  gap: 4px;
+  padding: 10px;
+  border: 1px solid rgba(80, 80, 120, 0.26);
+  border-radius: 6px;
+  background: rgba(8, 10, 16, 0.58);
+}
+
+.work-record-health-state strong {
+  color: var(--accent-yellow);
+}
+
+.work-record-health-state[data-health="valid"] strong {
+  color: var(--accent-green);
+}
+
+.work-record-health-state[data-health="impossible"] strong,
+.work-record-health-state[data-health="blocked"] strong {
+  color: var(--accent-red);
+}
+
+.work-record-health-state span {
+  color: var(--text-muted);
+  font: 10px/1.45 var(--font-mono);
+}
+
+.work-record-artifacts {
+  display: grid;
+  gap: 8px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.work-record-artifacts li {
+  display: grid;
+  gap: 3px;
+  padding: 8px;
+  border: 1px solid rgba(80, 80, 120, 0.22);
+  border-radius: 6px;
+  background: rgba(8, 10, 16, 0.48);
+}
+
+.work-record-artifacts strong,
+.work-record-artifacts span,
+.work-record-artifacts em {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.work-record-artifacts strong {
+  color: var(--text-primary);
+}
+
+.work-record-artifacts em {
+  color: var(--text-label);
+  font-style: normal;
+}
+
+@media (max-width: 980px) {
+  .work-record-main {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(320px, 1fr) minmax(320px, 1fr) minmax(220px, 0.65fr);
+  }
+
+  .work-record-intent,
+  .work-record-json {
+    border-right: 0;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+}

--- a/tests/schemas/aos-workbench-subject.test.mjs
+++ b/tests/schemas/aos-workbench-subject.test.mjs
@@ -8,6 +8,7 @@ import { createWorkbenchSubject } from '../../packages/toolkit/workbench/subject
 import { createWikiPageSubject } from '../../packages/toolkit/workbench/wiki-subject.js';
 import { createWorkRecordSubject } from '../../packages/toolkit/workbench/work-record-subject.js';
 import { buildMarkdownWorkbenchSubject, createMarkdownWorkbenchState } from '../../packages/toolkit/components/markdown-workbench/model.js';
+import { buildWorkRecordWorkbenchSubject, createWorkRecordWorkbenchState } from '../../packages/toolkit/components/work-record-workbench/model.js';
 import { buildRadialItemWorkbenchSubject, createRadialItemEditorState } from '../../apps/sigil/radial-item-editor/model.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -72,4 +73,7 @@ test('current workbench adopters emit schema-valid subject descriptors', async (
     tags: ['diagnostics', 'runtime'],
   }));
   await validate(createWorkRecordSubject(JSON.parse(await fs.readFile(workRecordFixturePath, 'utf8'))));
+  await validate(buildWorkRecordWorkbenchSubject(createWorkRecordWorkbenchState({
+    record: JSON.parse(await fs.readFile(workRecordFixturePath, 'utf8')),
+  })));
 });

--- a/tests/toolkit/work-record-workbench-model.test.mjs
+++ b/tests/toolkit/work-record-workbench-model.test.mjs
@@ -1,0 +1,97 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  applyWorkRecordPatchResult,
+  buildWorkRecordPatchRequest,
+  createWorkRecordWorkbenchState,
+  evidenceArtifacts,
+  executionMapJson,
+  openWorkRecord,
+  updateWorkRecordExecutionMapJson,
+  updateWorkRecordIntent,
+  workRecordDiagnostics,
+  workRecordWorkbenchSnapshot,
+} from '../../packages/toolkit/components/work-record-workbench/model.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+const fixtureRoot = path.join(repoRoot, 'docs/design/fixtures/aos-work-records');
+
+function fixture(name) {
+  return JSON.parse(fs.readFileSync(path.join(fixtureRoot, name), 'utf8'));
+}
+
+test('work record workbench opens a do_step and exposes subject snapshot', () => {
+  const state = createWorkRecordWorkbenchState();
+  const result = openWorkRecord(state, {
+    type: 'work_record.open',
+    record: fixture('browser-artifact-collection-step.json'),
+  });
+  const snapshot = workRecordWorkbenchSnapshot(state);
+
+  assert.equal(result.status, 'opened');
+  assert.equal(state.dirty, false);
+  assert.equal(snapshot.subject.type, 'aos.workbench.subject');
+  assert.equal(snapshot.subject.id, 'work-record:collect-company-careers-page');
+  assert.equal(snapshot.subject.subject_type, 'aos.do_step');
+  assert.ok(snapshot.subject.capabilities.includes('work_record.patch.requested'));
+  assert.equal(snapshot.diagnostics.health_state, 'stale');
+  assert.equal(snapshot.diagnostics.artifact_count, 3);
+});
+
+test('work record workbench edits intent and execution-map JSON', () => {
+  const state = createWorkRecordWorkbenchState({ record: fixture('canvas-toolkit-control-step.json') });
+
+  updateWorkRecordIntent(state, {
+    nl: 'Tune the panel with the updated target.',
+    purpose: 'Manual repair',
+  });
+  assert.equal(state.dirty, true);
+  assert.equal(state.record.intent.nl, 'Tune the panel with the updated target.');
+
+  const applied = updateWorkRecordExecutionMapJson(state, JSON.stringify({
+    target: 'canvas:object-transform-panel/wiki-brain',
+    assertions: [{ kind: 'visible' }],
+  }));
+  assert.equal(applied.status, 'applied');
+  assert.deepEqual(state.record.execution_map.assertions, [{ kind: 'visible' }]);
+
+  const request = buildWorkRecordPatchRequest(state, { requestId: 'patch-1' });
+  assert.equal(request.request_id, 'patch-1');
+  assert.equal(request.record_id, state.record.id);
+  assert.equal(request.patch.intent.nl, 'Tune the panel with the updated target.');
+  assert.equal(request.patch.execution_map.target, 'canvas:object-transform-panel/wiki-brain');
+});
+
+test('invalid execution-map JSON is rejected without mutating current map', () => {
+  const state = createWorkRecordWorkbenchState({ record: fixture('browser-artifact-collection-step.json') });
+  const before = executionMapJson(state.record);
+  const result = updateWorkRecordExecutionMapJson(state, '{bad');
+
+  assert.equal(result.status, 'rejected');
+  assert.equal(result.reason, 'invalid_json');
+  assert.equal(executionMapJson(state.record), before);
+});
+
+test('recipe health records expose evidence and saved patch results', () => {
+  const state = createWorkRecordWorkbenchState({ record: fixture('recipe-health-retirement.json') });
+  const diagnostics = workRecordDiagnostics(state.record);
+  const artifacts = evidenceArtifacts(state.record);
+
+  assert.equal(diagnostics.health_state, 'impossible');
+  assert.equal(artifacts.length, 1);
+  assert.equal(artifacts[0].kind, 'trace');
+
+  updateWorkRecordIntent(state, { nl: 'Keep the retired record searchable.' });
+  assert.equal(state.dirty, true);
+  const saved = applyWorkRecordPatchResult(state, {
+    type: 'work_record.patch.result',
+    status: 'saved',
+    message: 'saved fixture',
+  });
+  assert.equal(saved.status, 'saved');
+  assert.equal(state.dirty, false);
+});


### PR DESCRIPTION
## Summary

- add a stock toolkit work-record workbench component
- support manual editing of NL intent and execution-map JSON
- display work-record summary, health, evidence, and status panels
- expose `work_record.open`, `work_record.patch.result`, and `work-record-workbench/patch.requested` handoff messages
- add model tests and schema validation for the new workbench subject projection

## Tracking

- Continues #237
- Builds on #240
- Related to #234, #235, #236, #238, #239

## Verification

- `node --check packages/toolkit/components/work-record-workbench/model.js`
- `node --check packages/toolkit/components/work-record-workbench/index.js`
- `node --test tests/design/aos-work-record-fixtures.test.mjs tests/toolkit/work-record-workbench-model.test.mjs tests/toolkit/work-record-subject.test.mjs tests/schemas/aos-workbench-subject.test.mjs`
- `git diff --check`
- `AOS=/Users/Michael/Code/agent-os/aos packages/toolkit/components/work-record-workbench/launch.sh`
- `/Users/Michael/Code/agent-os/aos show eval --id work-record-workbench --js 'JSON.stringify({manifest: window.__aosManifest, state: window.__workRecordWorkbenchState && {id: window.__workRecordWorkbenchState.record.id, subject: window.__workRecordWorkbenchState.subject.id, dirty: window.__workRecordWorkbenchState.dirty, health: window.__workRecordWorkbenchState.diagnostics.health_state, artifacts: window.__workRecordWorkbenchState.diagnostics.artifact_count}})'`
- `/Users/Michael/Code/agent-os/aos see capture --canvas work-record-workbench --xray --out /tmp/work-record-workbench.png`
