### PR TITLE
Persist work record workbench edits

### DIFF
--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -136,7 +136,11 @@ The stock work-record workbench lives at:
 It accepts `work_record.open` and `work_record.patch.result`, emits
 `work-record-workbench/patch.requested`, and intentionally stays manual-first:
 it edits the NL intent and execution-map JSON while displaying health and
-evidence. It does not record, replay, repair, or retire recipes by itself.
+evidence. `work_record.open` may include a file `source`, which is preserved in
+snapshots and patch requests. The companion
+`packages/toolkit/components/work-record-workbench/save-current.sh` helper can
+persist the current edited record JSON back to that file source or an explicit
+output path. It does not record, replay, repair, or retire recipes by itself.
 
 ## Stock Components Snapshot
 

--- a/packages/toolkit/components/work-record-workbench/index.js
+++ b/packages/toolkit/components/work-record-workbench/index.js
@@ -151,7 +151,7 @@ export default function WorkRecordWorkbench(options = {}) {
   }
 
   function revert() {
-    openWorkRecord(state, { type: 'work_record.open', record: state.savedRecord });
+    openWorkRecord(state, { type: 'work_record.open', record: state.savedRecord, source: state.source });
     sync({ replaceEditorValues: true });
   }
 

--- a/packages/toolkit/components/work-record-workbench/model.js
+++ b/packages/toolkit/components/work-record-workbench/model.js
@@ -87,11 +87,23 @@ function recordFromMessage(message = {}) {
   return payload.record && typeof payload.record === 'object' ? payload.record : payload;
 }
 
-export function createWorkRecordWorkbenchState({ record = null } = {}) {
+function normalizeSource(source = null) {
+  if (!source || typeof source !== 'object') return null;
+  const kind = text(source.kind);
+  if (!kind) return null;
+  return {
+    ...cloneJson(source),
+    kind,
+    path: text(source.path) || null,
+  };
+}
+
+export function createWorkRecordWorkbenchState({ record = null, source = null } = {}) {
   const initial = normalizeRecord(record || defaultRecord());
   return {
     record: initial,
     savedRecord: cloneJson(initial),
+    source: normalizeSource(source),
     dirty: false,
     selectedView: 'intent',
     lastResult: null,
@@ -100,15 +112,18 @@ export function createWorkRecordWorkbenchState({ record = null } = {}) {
 }
 
 export function openWorkRecord(state, message = {}) {
+  const payload = unwrapMessage(message);
   const record = normalizeRecord(recordFromMessage(message));
   state.record = record;
   state.savedRecord = cloneJson(record);
+  state.source = normalizeSource(payload.source) || state.source || null;
   state.dirty = false;
   state.lastResult = {
     type: 'work_record.open.result',
     schema_version: WORK_RECORD_WORKBENCH_SCHEMA_VERSION,
     status: 'opened',
     record_id: record.id,
+    source: state.source,
     subject: buildWorkRecordWorkbenchSubject(state),
   };
   return state.lastResult;
@@ -203,6 +218,7 @@ export function buildWorkRecordPatchRequest(state, {
     schema_version: WORK_RECORD_WORKBENCH_SCHEMA_VERSION,
     request_id: requestId,
     subject: buildWorkRecordWorkbenchSubject(state),
+    source: state.source,
     record_id: state.record.id,
     patch: {
       intent: cloneJson(objectValue(state.record.intent)),
@@ -238,6 +254,7 @@ export function workRecordWorkbenchSnapshot(state) {
     type: 'work_record.snapshot',
     schema_version: WORK_RECORD_WORKBENCH_SCHEMA_VERSION,
     subject: buildWorkRecordWorkbenchSubject(state),
+    source: state.source,
     record: cloneJson(state.record),
     dirty: !!state.dirty,
     diagnostics: workRecordDiagnostics(state.record),

--- a/packages/toolkit/components/work-record-workbench/save-current.sh
+++ b/packages/toolkit/components/work-record-workbench/save-current.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# save-current.sh - Persist the current work-record workbench canvas state.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null || pwd)"
+AOS="${AOS:-$ROOT/aos}"
+CANVAS_ID="${1:-${CANVAS_ID:-work-record-workbench}}"
+OUTPUT_PATH="${2:-${OUTPUT_PATH:-}}"
+
+if [[ ! -x "$AOS" ]]; then
+  echo "aos binary not found at $AOS" >&2
+  exit 1
+fi
+
+EVAL_JSON="$("$AOS" show eval --id "$CANVAS_ID" --js 'JSON.stringify(window.__workRecordWorkbenchState || null)')"
+
+SAVE_JSON="$(
+  EVAL_JSON="$EVAL_JSON" OUTPUT_PATH="$OUTPUT_PATH" python3 -c '
+import json, os, pathlib
+
+try:
+    outer = json.loads(os.environ["EVAL_JSON"])
+    snapshot = json.loads(outer.get("result") or "null")
+except Exception as error:
+    raise SystemExit(f"failed to read work-record workbench state: {error}")
+
+if not isinstance(snapshot, dict):
+    raise SystemExit("work-record workbench state is unavailable")
+
+record = snapshot.get("record")
+if not isinstance(record, dict):
+    raise SystemExit("work-record workbench state did not include a record")
+
+source = snapshot.get("source") or {}
+output = os.environ.get("OUTPUT_PATH") or ""
+if not output:
+    if source.get("kind") != "file" or not source.get("path"):
+        raise SystemExit("no output path supplied and work record is not file-backed")
+    output = str(source["path"])
+
+path = pathlib.Path(output).expanduser().resolve()
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+print(json.dumps({
+    "type": "work_record.patch.result",
+    "status": "saved",
+    "record_id": record.get("id") or "",
+    "source": {
+        "kind": "file",
+        "path": str(path),
+    },
+    "message": f"saved work record to {path}",
+}))
+'
+)"
+
+"$AOS" show post --id "$CANVAS_ID" --event "$SAVE_JSON" >/dev/null
+
+echo "$SAVE_JSON"

--- a/tests/toolkit/work-record-workbench-model.test.mjs
+++ b/tests/toolkit/work-record-workbench-model.test.mjs
@@ -28,6 +28,10 @@ test('work record workbench opens a do_step and exposes subject snapshot', () =>
   const state = createWorkRecordWorkbenchState();
   const result = openWorkRecord(state, {
     type: 'work_record.open',
+    source: {
+      kind: 'file',
+      path: '/tmp/work-record.json',
+    },
     record: fixture('browser-artifact-collection-step.json'),
   });
   const snapshot = workRecordWorkbenchSnapshot(state);
@@ -37,6 +41,7 @@ test('work record workbench opens a do_step and exposes subject snapshot', () =>
   assert.equal(snapshot.subject.type, 'aos.workbench.subject');
   assert.equal(snapshot.subject.id, 'work-record:collect-company-careers-page');
   assert.equal(snapshot.subject.subject_type, 'aos.do_step');
+  assert.deepEqual(snapshot.source, { kind: 'file', path: '/tmp/work-record.json' });
   assert.ok(snapshot.subject.capabilities.includes('work_record.patch.requested'));
   assert.equal(snapshot.diagnostics.health_state, 'stale');
   assert.equal(snapshot.diagnostics.artifact_count, 3);
@@ -62,8 +67,25 @@ test('work record workbench edits intent and execution-map JSON', () => {
   const request = buildWorkRecordPatchRequest(state, { requestId: 'patch-1' });
   assert.equal(request.request_id, 'patch-1');
   assert.equal(request.record_id, state.record.id);
+  assert.equal(request.source, null);
   assert.equal(request.patch.intent.nl, 'Tune the panel with the updated target.');
   assert.equal(request.patch.execution_map.target, 'canvas:object-transform-panel/wiki-brain');
+});
+
+test('work record patch requests preserve file source metadata', () => {
+  const state = createWorkRecordWorkbenchState({
+    record: fixture('browser-artifact-collection-step.json'),
+    source: {
+      kind: 'file',
+      path: '/tmp/source-record.json',
+    },
+  });
+
+  updateWorkRecordIntent(state, { purpose: 'source-preserving edit' });
+  const request = buildWorkRecordPatchRequest(state, { requestId: 'source-patch' });
+
+  assert.deepEqual(request.source, { kind: 'file', path: '/tmp/source-record.json' });
+  assert.deepEqual(workRecordWorkbenchSnapshot(state).source, { kind: 'file', path: '/tmp/source-record.json' });
 });
 
 test('invalid execution-map JSON is rejected without mutating current map', () => {


### PR DESCRIPTION
## Summary

- preserve file `source` metadata on `work_record.open`, snapshots, and patch requests
- keep source metadata when reverting a work record
- add `work-record-workbench/save-current.sh` to save the current canvas record JSON to its file source or an explicit output path
- extend focused model tests for source preservation

## Tracking

- Closes #242
- Parent: #234
- Builds on #241

## Verification

- `bash -n packages/toolkit/components/work-record-workbench/save-current.sh`
- `bash -n packages/toolkit/components/work-record-workbench/launch.sh`
- `node --check packages/toolkit/components/work-record-workbench/model.js`
- `node --check packages/toolkit/components/work-record-workbench/index.js`
- `node --test tests/toolkit/work-record-workbench-model.test.mjs tests/schemas/aos-workbench-subject.test.mjs`
- `git diff --check`
- AOS smoke: launched a temp file-backed record, edited intent purpose in the canvas, ran `save-current.sh`, confirmed the JSON file persisted `intent.purpose = "saved via smoke"`, then removed the canvas.
