### PR TITLE
Add see/do state metadata

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -228,6 +228,11 @@ Useful capture modifiers include:
 - `--exclude-window <CGWindowID>` to omit specific windows from a display/region capture
 - `--perception` to attach spatial metadata alongside the image payload
 
+Capture responses include an opaque `state_id` such as `see_abc123def456`.
+Work-record and recipe layers can carry that id into the next action as the
+perception state the agent acted from. The id is a correlation handle, not a
+stable object reference or cache key.
+
 `--xray` returns AX-derived interactive elements in `elements`. For AOS-owned
 canvas captures, `aos see capture --canvas <id> --xray` also runs a fixed
 semantic target probe inside that canvas and returns `semantic_targets`. Those
@@ -348,6 +353,33 @@ Primary public verbs:
 | `press` | semantic AX press |
 | `set-value` | semantic AX set-value |
 | `focus` | semantic AX focus |
+| `raise` | raise an app/window |
+| `move` | move a window |
+| `resize` | resize a window |
+| `tell` | AppleScript verb |
+| `session` | interactive action session |
+| `profiles` | inspect behavior profiles |
+
+Coordinate and browser-target actions accept `--state-id <id>` when the action
+was chosen from a prior `aos see capture` response. Direct one-shot responses
+and session responses report an additive `execution` object:
+
+```json
+{
+  "execution": {
+    "strategy": "cgevent_click",
+    "backend": "cgevent",
+    "fallback_used": false,
+    "state_id": "see_abc123def456"
+  }
+}
+```
+
+`strategy` names the path that actually ran, `backend` identifies the actuator
+family (`cgevent`, `ax`, `applescript`, `playwright`, `canvas`, or `session`), and
+`fallback_used` is reserved for paths that intentionally degrade from a
+preferred semantic strategy. `duration_ms` remains the top-level timing field on
+session responses.
 
 ## `aos graph`
 
@@ -369,12 +401,6 @@ aos graph displays --json
 `displays[].visible_bounds` uses the same top-left-origin logical coordinate
 space as `bounds`, but reflects the usable display area after macOS menu bar /
 dock insets.
-| `raise` | raise an app/window |
-| `move` | move a window |
-| `resize` | resize a window |
-| `tell` | AppleScript verb |
-| `session` | interactive action session |
-| `profiles` | inspect behavior profiles |
 
 ## `aos say`
 

--- a/docs/design/aos-work-records-and-self-healing-recipes.md
+++ b/docs/design/aos-work-records-and-self-healing-recipes.md
@@ -90,6 +90,12 @@ Replay should re-perceive before each action:
 intent -> see -> resolve target -> do -> see -> verify
 ```
 
+Runtime `aos see capture` responses expose an opaque `state_id`, and `aos do`
+responses expose an `execution` object with the actuator backend, strategy,
+fallback flag, and originating `state_id` when supplied. Work records should
+carry those fields as correlation metadata between the natural-language spine,
+the structured execution map, and immutable evidence.
+
 Coordinates can be recorded, but they are fallback material. When semantic
 targets exist, prefer them.
 

--- a/docs/design/fixtures/aos-work-records/browser-artifact-collection-step.json
+++ b/docs/design/fixtures/aos-work-records/browser-artifact-collection-step.json
@@ -10,11 +10,13 @@
   },
   "precondition": {
     "see": "A browser session exists and can navigate.",
-    "target": "browser:employer-brand"
+    "target": "browser:employer-brand",
+    "state_id": "see_browser000001"
   },
   "action": {
     "verb": "navigate",
     "target": "browser:employer-brand",
+    "state_id": "see_browser000001",
     "args": {
       "url": "https://example.com/careers"
     }
@@ -54,6 +56,12 @@
   "evidence": {
     "request_id": "example-careers-home",
     "capture_job_id": "capture-job-0001",
+    "execution": {
+      "strategy": "playwright_goto",
+      "backend": "playwright",
+      "fallback_used": false,
+      "state_id": "see_browser000001"
+    },
     "artifacts": [
       {
         "kind": "screenshot",

--- a/docs/design/fixtures/aos-work-records/canvas-toolkit-control-step.json
+++ b/docs/design/fixtures/aos-work-records/canvas-toolkit-control-step.json
@@ -10,11 +10,13 @@
   },
   "precondition": {
     "see": "The workbench canvas is open and publishes semantic controls.",
-    "target": "canvas:sigil-radial-item-workbench/control.axes-visible"
+    "target": "canvas:sigil-radial-item-workbench/control.axes-visible",
+    "state_id": "see_canvas000001"
   },
   "action": {
     "verb": "press",
     "target": "canvas:sigil-radial-item-workbench/control.axes-visible",
+    "state_id": "see_canvas000001",
     "args": {
       "expected_role": "checkbox"
     }
@@ -49,6 +51,12 @@
     }
   },
   "evidence": {
+    "execution": {
+      "strategy": "canvas_semantic_press",
+      "backend": "canvas",
+      "fallback_used": false,
+      "state_id": "see_canvas000001"
+    },
     "artifacts": [
       {
         "kind": "before_canvas_state",

--- a/docs/design/fixtures/aos-work-records/desktop-workflow-demo-step.json
+++ b/docs/design/fixtures/aos-work-records/desktop-workflow-demo-step.json
@@ -10,11 +10,13 @@
   },
   "precondition": {
     "see": "AOS can inspect the foreground app and accessibility tree.",
-    "target": "ax:com.agent-os.launcher"
+    "target": "ax:com.agent-os.launcher",
+    "state_id": "see_desktop000001"
   },
   "action": {
     "verb": "press",
     "target": "ax:com.agent-os.launcher/workflow-entry-employer-brand",
+    "state_id": "see_desktop000001",
     "args": {
       "role": "AXButton",
       "title": "Employer Brand Competitor Audit"
@@ -51,6 +53,12 @@
     }
   },
   "evidence": {
+    "execution": {
+      "strategy": "ax_press",
+      "backend": "ax",
+      "fallback_used": false,
+      "state_id": "see_desktop000001"
+    },
     "artifacts": [
       {
         "kind": "before_see",

--- a/docs/design/pi-computer-use-lessons-for-aos-see-do.md
+++ b/docs/design/pi-computer-use-lessons-for-aos-see-do.md
@@ -84,9 +84,9 @@ Every non-trivial action should report what actually happened:
 ```json
 {
   "strategy": "ax_press",
+  "backend": "ax",
   "fallback_used": false,
-  "state_id": "see_abc123",
-  "duration_ms": 82
+  "state_id": "see_abc123"
 }
 ```
 

--- a/src/act/act-cli.swift
+++ b/src/act/act-cli.swift
@@ -19,9 +19,16 @@ func cliSessionState(args: [String]) -> SessionState {
 }
 
 /// Print a v1-compatible legacy response to stdout.
-func cliPrintLegacy(action: String, backend: String, target: LegacyTargetInfo, detail: String? = nil, dryRun: Bool) {
+func cliPrintLegacy(action: String, backend: String, target: LegacyTargetInfo, detail: String? = nil, dryRun: Bool, stateID: String? = nil) {
     var resp = LegacySuccessResponse(status: dryRun ? "dry_run" : "success", action: action, backend: backend, target: target)
     resp.detail = detail
+    let normalizedAction = action.replacingOccurrences(of: "-", with: "_")
+    resp.execution = ActionExecutionMetadata(
+        strategy: dryRun ? "dry_run_\(normalizedAction)" : "\(backend)_\(normalizedAction)",
+        backend: backend,
+        fallback_used: false,
+        state_id: stateID
+    )
     writeJSONLine(resp)
 }
 
@@ -64,7 +71,8 @@ private func positionalArgs(_ args: [String]) -> [String] {
             let valuedFlags = ["--pid", "--role", "--title", "--label", "--identifier",
                                "--index", "--near", "--match", "--depth", "--timeout",
                                "--profile", "--value", "--to", "--dy", "--dx", "--window",
-                               "--delay", "--variance", "--dwell", "--steps", "--speed"]
+                               "--delay", "--variance", "--dwell", "--steps", "--speed",
+                               "--state-id"]
             if valuedFlags.contains(arg) { skipNext = true }
             continue
         }
@@ -304,6 +312,7 @@ func cliClick(args: [String]) {
         return
     }
     let dryRun = hasFlag(args, "--dry-run")
+    let stateID = getArg(args, "--state-id")
     let state = cliSessionState(args: args)
 
     guard let first = positional.first, let coords = parseCoords(first) else {
@@ -326,7 +335,7 @@ func cliClick(args: [String]) {
         var detail: String? = nil
         if isRight { detail = "right-click" }
         if isDouble { detail = "double-click" }
-        cliPrintLegacy(action: "click", backend: "cgevent", target: target, detail: detail, dryRun: true)
+        cliPrintLegacy(action: "click", backend: "cgevent", target: target, detail: detail, dryRun: true, stateID: stateID)
         return
     }
 
@@ -334,13 +343,14 @@ func cliClick(args: [String]) {
         action: "click",
         x: coords.0, y: coords.1,
         button: isRight ? "right" : "left",
-        count: isDouble ? 2 : 1
+        count: isDouble ? 2 : 1,
+        state_id: stateID
     )
     let resp = handleClick(req, state: state)
     if resp.status == "error" {
         exitError(resp.error ?? "click failed", code: resp.code ?? "UNKNOWN")
     }
-    cliPrintLegacy(action: "click", backend: "cgevent", target: target, dryRun: false)
+    cliPrintLegacy(action: "click", backend: "cgevent", target: target, dryRun: false, stateID: stateID)
 }
 
 /// `aos do hover` — move cursor to coordinates.
@@ -352,6 +362,7 @@ func cliHover(args: [String]) {
         return
     }
     let dryRun = hasFlag(args, "--dry-run")
+    let stateID = getArg(args, "--state-id")
     let state = cliSessionState(args: args)
 
     guard let first = positional.first, let coords = parseCoords(first) else {
@@ -363,16 +374,16 @@ func cliHover(args: [String]) {
     target.y = coords.1
 
     if dryRun {
-        cliPrintLegacy(action: "hover", backend: "cgevent", target: target, dryRun: true)
+        cliPrintLegacy(action: "hover", backend: "cgevent", target: target, dryRun: true, stateID: stateID)
         return
     }
 
-    let req = ActionRequest(action: "move", x: coords.0, y: coords.1)
+    let req = ActionRequest(action: "move", x: coords.0, y: coords.1, state_id: stateID)
     let resp = handleMove(req, state: state)
     if resp.status == "error" {
         exitError(resp.error ?? "hover failed", code: resp.code ?? "UNKNOWN")
     }
-    cliPrintLegacy(action: "hover", backend: "cgevent", target: target, dryRun: false)
+    cliPrintLegacy(action: "hover", backend: "cgevent", target: target, dryRun: false, stateID: stateID)
 }
 
 /// `aos do drag` — drag from one point to another.
@@ -398,7 +409,7 @@ func cliDrag(args: [String]) {
                 withTempFilename: false
             ))
             try requireSuccess(r, action: "drag")
-            emitDoResult(r)
+            emitDoResult(r, backend: "playwright", strategy: "playwright_drag", stateID: getArg(args, "--state-id"))
             return
         } catch BrowserTargetError.invalid(let msg) {
             exitError("invalid browser target: \(msg)", code: "INVALID_TARGET")
@@ -411,6 +422,7 @@ func cliDrag(args: [String]) {
         }
     }
     let dryRun = hasFlag(args, "--dry-run")
+    let stateID = getArg(args, "--state-id")
     let state = cliSessionState(args: args)
 
     guard positional.count >= 2,
@@ -431,20 +443,21 @@ func cliDrag(args: [String]) {
     target.y2 = to.1
 
     if dryRun {
-        cliPrintLegacy(action: "drag", backend: "cgevent", target: target, dryRun: true)
+        cliPrintLegacy(action: "drag", backend: "cgevent", target: target, dryRun: true, stateID: stateID)
         return
     }
 
     let req = ActionRequest(
         action: "drag",
         x: to.0, y: to.1,
-        from: CursorPosition(x: from.0, y: from.1)
+        from: CursorPosition(x: from.0, y: from.1),
+        state_id: stateID
     )
     let resp = handleDrag(req, state: state)
     if resp.status == "error" {
         exitError(resp.error ?? "drag failed", code: resp.code ?? "UNKNOWN")
     }
-    cliPrintLegacy(action: "drag", backend: "cgevent", target: target, dryRun: false)
+    cliPrintLegacy(action: "drag", backend: "cgevent", target: target, dryRun: false, stateID: stateID)
 }
 
 /// `aos do scroll` — scroll at coordinates.
@@ -456,6 +469,7 @@ func cliScroll(args: [String]) {
         return
     }
     let dryRun = hasFlag(args, "--dry-run")
+    let stateID = getArg(args, "--state-id")
     let state = cliSessionState(args: args)
 
     guard let first = positional.first, let coords = parseCoords(first) else {
@@ -477,20 +491,21 @@ func cliScroll(args: [String]) {
         var detail = "scroll"
         if let dy = dy { detail += " dy=\(Int(dy))" }
         if let dx = dx { detail += " dx=\(Int(dx))" }
-        cliPrintLegacy(action: "scroll", backend: "cgevent", target: target, detail: detail, dryRun: true)
+        cliPrintLegacy(action: "scroll", backend: "cgevent", target: target, detail: detail, dryRun: true, stateID: stateID)
         return
     }
 
     let req = ActionRequest(
         action: "scroll",
         x: coords.0, y: coords.1,
-        dx: dx, dy: dy
+        dx: dx, dy: dy,
+        state_id: stateID
     )
     let resp = handleScroll(req, state: state)
     if resp.status == "error" {
         exitError(resp.error ?? "scroll failed", code: resp.code ?? "UNKNOWN")
     }
-    cliPrintLegacy(action: "scroll", backend: "cgevent", target: target, dryRun: false)
+    cliPrintLegacy(action: "scroll", backend: "cgevent", target: target, dryRun: false, stateID: stateID)
 }
 
 /// `aos do type` — type text string.
@@ -668,7 +683,7 @@ func dispatchBrowserVerb(_ aosVerb: String, targetString: String, remaining: [St
                 // playwright's dblclick verb.
                 let r = try doVerb("dblclick", target: t)
                 try requireSuccess(r, action: "dblclick")
-                emitDoResult(r)
+                emitDoResult(r, backend: "playwright", strategy: "playwright_dblclick", stateID: getArg(flags, "--state-id"))
                 return
             }
         case "type", "press":
@@ -696,7 +711,7 @@ func dispatchBrowserVerb(_ aosVerb: String, targetString: String, remaining: [St
         }
         let r = try doVerb(pwVerb, target: t, extraArgs: extra)
         try requireSuccess(r, action: pwVerb)
-        emitDoResult(r)
+        emitDoResult(r, backend: "playwright", strategy: "playwright_\(pwVerb)", stateID: getArg(flags, "--state-id"))
     } catch BrowserTargetError.invalid(let msg) {
         exitError("invalid browser target: \(msg)", code: "INVALID_TARGET")
     } catch BrowserTargetError.missingSession {
@@ -712,9 +727,22 @@ func dispatchBrowserVerb(_ aosVerb: String, targetString: String, remaining: [St
 
 /// Emit the `{status, result}` JSON payload for a PlaywrightResult from a
 /// browser-target `do` verb.
-func emitDoResult(_ r: PlaywrightResult) {
-    struct Payload: Encodable { let status: String; let result: PlaywrightResult }
-    let payload = Payload(status: r.exit_code == 0 ? "success" : "error", result: r)
+func emitDoResult(_ r: PlaywrightResult, backend: String = "playwright", strategy: String = "playwright_do", stateID: String? = nil) {
+    struct Payload: Encodable {
+        let status: String
+        let result: PlaywrightResult
+        let execution: ActionExecutionMetadata
+    }
+    let payload = Payload(
+        status: r.exit_code == 0 ? "success" : "error",
+        result: r,
+        execution: ActionExecutionMetadata(
+            strategy: strategy,
+            backend: backend,
+            fallback_used: false,
+            state_id: stateID
+        )
+    )
     let enc = JSONEncoder()
     enc.outputFormatting = [.sortedKeys]
     print(String(data: try! enc.encode(payload), encoding: .utf8)!)

--- a/src/act/act-models.swift
+++ b/src/act/act-models.swift
@@ -52,6 +52,9 @@ struct ActionRequest: Codable {
     // Phase 2 placeholder
     var channel: String?
 
+    // Optional perception state this action was chosen from.
+    var state_id: String?
+
     // Memberwise init with defaults for use in CLI bridge
     init(action: String, x: Double? = nil, y: Double? = nil, dx: Double? = nil, dy: Double? = nil,
          from: CursorPosition? = nil, button: String? = nil, count: Int? = nil,
@@ -60,7 +63,8 @@ struct ActionRequest: Codable {
          identifier: String? = nil, value: String? = nil, index: Int? = nil,
          near: [Double]? = nil, match: String? = nil, depth: Int? = nil, timeout: Int? = nil,
          set: ContextFields? = nil, clear: Bool? = nil,
-         app: String? = nil, script: String? = nil, window_id: Int? = nil, channel: String? = nil) {
+         app: String? = nil, script: String? = nil, window_id: Int? = nil, channel: String? = nil,
+         state_id: String? = nil) {
         self.action = action; self.x = x; self.y = y; self.dx = dx; self.dy = dy
         self.from = from; self.button = button; self.count = count
         self.text = text; self.key = key
@@ -69,6 +73,7 @@ struct ActionRequest: Codable {
         self.near = near; self.match = match; self.depth = depth; self.timeout = timeout
         self.set = set; self.clear = clear
         self.app = app; self.script = script; self.window_id = window_id; self.channel = channel
+        self.state_id = state_id
     }
 }
 
@@ -96,6 +101,7 @@ struct ActionResponse: Encodable {
     var modifiers: [String]?
     var context: ContextSnapshot?
     var duration_ms: Int?
+    var execution: ActionExecutionMetadata? = nil
 
     // Error fields
     var error: String?
@@ -111,6 +117,13 @@ struct ActionResponse: Encodable {
 
     // Action introspection (for list_actions)
     var available: [AvailableAction]?
+}
+
+struct ActionExecutionMetadata: Encodable {
+    let strategy: String
+    let backend: String
+    let fallback_used: Bool
+    let state_id: String?
 }
 
 struct AvailableAction: Encodable {
@@ -333,6 +346,7 @@ struct LegacySuccessResponse: Encodable {
     let backend: String
     let target: LegacyTargetInfo
     var detail: String?
+    var execution: ActionExecutionMetadata?
 }
 
 struct LegacyTargetInfo: Encodable {

--- a/src/act/actions.swift
+++ b/src/act/actions.swift
@@ -9,7 +9,16 @@ import Foundation
 // MARK: - Private Helpers
 
 /// Build a success response carrying current cursor, modifiers, context, and timing.
-private func okResponse(_ action: String, state: SessionState, start: Date, extra: ((inout ActionResponse) -> Void)? = nil) -> ActionResponse {
+private func okResponse(
+    _ action: String,
+    state: SessionState,
+    start: Date,
+    backend: String = "session",
+    strategy: String? = nil,
+    fallbackUsed: Bool = false,
+    stateID: String? = nil,
+    extra: ((inout ActionResponse) -> Void)? = nil
+) -> ActionResponse {
     let elapsed = Int(Date().timeIntervalSince(start) * 1000)
     var resp = ActionResponse(
         status: "ok",
@@ -18,6 +27,12 @@ private func okResponse(_ action: String, state: SessionState, start: Date, extr
         modifiers: state.modifiers.sorted(),
         context: state.contextSnapshot(),
         duration_ms: elapsed
+    )
+    resp.execution = ActionExecutionMetadata(
+        strategy: strategy ?? "\(backend)_\(action)",
+        backend: backend,
+        fallback_used: fallbackUsed,
+        state_id: stateID
     )
     extra?(&resp)
     return resp
@@ -104,7 +119,7 @@ func handleMove(_ req: ActionRequest, state: SessionState) -> ActionResponse {
     }
 
     state.updateCursor(target)
-    return okResponse("move", state: state, start: start)
+    return okResponse("move", state: state, start: start, backend: "cgevent", strategy: "cgevent_move", stateID: req.state_id)
 }
 
 /// Click at (req.x, req.y). Moves to target first if cursor is more than 2px away.
@@ -169,7 +184,7 @@ func handleClick(_ req: ActionRequest, state: SessionState) -> ActionResponse {
     }
 
     state.updateCursor(clickPoint)
-    return okResponse("click", state: state, start: start)
+    return okResponse("click", state: state, start: start, backend: "cgevent", strategy: "cgevent_click", stateID: req.state_id)
 }
 
 /// Drag from req.from (or current cursor) to req.x, req.y along a Bezier curve.
@@ -242,7 +257,7 @@ func handleDrag(_ req: ActionRequest, state: SessionState) -> ActionResponse {
     up.post(tap: .cghidEventTap)
 
     state.updateCursor(target)
-    return okResponse("drag", state: state, start: start)
+    return okResponse("drag", state: state, start: start, backend: "cgevent", strategy: "cgevent_drag", stateID: req.state_id)
 }
 
 /// Scroll at (req.x, req.y) or current cursor with req.dx/req.dy.
@@ -298,7 +313,7 @@ func handleScroll(_ req: ActionRequest, state: SessionState) -> ActionResponse {
         usleep(intervalUs)
     }
 
-    return okResponse("scroll", state: state, start: start)
+    return okResponse("scroll", state: state, start: start, backend: "cgevent", strategy: "cgevent_scroll", stateID: req.state_id)
 }
 
 /// Press and hold a key. If it is a modifier, add to state.modifiers.
@@ -319,7 +334,7 @@ func handleKeyDown(_ req: ActionRequest, state: SessionState) -> ActionResponse 
             event.flags = currentFlags(state)
             event.post(tap: .cghidEventTap)
         }
-        return okResponse("key_down", state: state, start: start)
+        return okResponse("key_down", state: state, start: start, backend: "cgevent", strategy: "cgevent_key_down", stateID: req.state_id)
     }
 
     // Regular key
@@ -333,7 +348,7 @@ func handleKeyDown(_ req: ActionRequest, state: SessionState) -> ActionResponse 
         event.post(tap: .cghidEventTap)
     }
 
-    return okResponse("key_down", state: state, start: start)
+    return okResponse("key_down", state: state, start: start, backend: "cgevent", strategy: "cgevent_key_down", stateID: req.state_id)
 }
 
 /// Release a key. If modifier, remove all aliases from state.modifiers.
@@ -358,7 +373,7 @@ func handleKeyUp(_ req: ActionRequest, state: SessionState) -> ActionResponse {
             event.flags = currentFlags(state)
             event.post(tap: .cghidEventTap)
         }
-        return okResponse("key_up", state: state, start: start)
+        return okResponse("key_up", state: state, start: start, backend: "cgevent", strategy: "cgevent_key_up", stateID: req.state_id)
     }
 
     // Regular key
@@ -372,7 +387,7 @@ func handleKeyUp(_ req: ActionRequest, state: SessionState) -> ActionResponse {
         event.post(tap: .cghidEventTap)
     }
 
-    return okResponse("key_up", state: state, start: start)
+    return okResponse("key_up", state: state, start: start, backend: "cgevent", strategy: "cgevent_key_up", stateID: req.state_id)
 }
 
 /// Press and release a key combo (e.g. "cmd+shift+tab"). Uses parseKeyCombo from helpers.
@@ -408,7 +423,7 @@ func handleKeyTap(_ req: ActionRequest, state: SessionState) -> ActionResponse {
         up.post(tap: .cghidEventTap)
     }
 
-    return okResponse("key_tap", state: state, start: start)
+    return okResponse("key_tap", state: state, start: start, backend: "cgevent", strategy: "cgevent_key_tap", stateID: req.state_id)
 }
 
 /// Type text character by character with profile-driven cadence.
@@ -453,7 +468,7 @@ func handleType(_ req: ActionRequest, state: SessionState) -> ActionResponse {
         }
     }
 
-    return okResponse("type", state: state, start: start)
+    return okResponse("type", state: state, start: start, backend: "cgevent", strategy: "cgevent_type", stateID: req.state_id)
 }
 
 // MARK: - AX Action Handlers
@@ -485,7 +500,7 @@ func handlePress(_ req: ActionRequest, state: SessionState) -> ActionResponse {
         if result != .success {
             return errorResponse("press", state: state, message: "AXPress failed with code \(result.rawValue)", code: "AX_ACTION_FAILED")
         }
-        return okResponse("press", state: state, start: start)
+        return okResponse("press", state: state, start: start, backend: "ax", strategy: "ax_press", stateID: req.state_id)
     case .notFound(let msg):
         return errorResponse("press", state: state, message: msg, code: "ELEMENT_NOT_FOUND")
     case .timeout:
@@ -541,7 +556,7 @@ func handleSetValue(_ req: ActionRequest, state: SessionState) -> ActionResponse
             return errorResponse("set_value", state: state,
                 message: "Failed to set value (AX error \(setResult.rawValue))", code: "AX_ACTION_FAILED")
         }
-        return okResponse("set_value", state: state, start: start)
+        return okResponse("set_value", state: state, start: start, backend: "ax", strategy: "ax_set_value", stateID: req.state_id)
 
     case .notFound(let msg):
         return errorResponse("set_value", state: state, message: msg, code: "ELEMENT_NOT_FOUND")
@@ -567,7 +582,7 @@ func handleFocus(_ req: ActionRequest, state: SessionState) -> ActionResponse {
             return errorResponse("focus", state: state,
                 message: "Failed to set focus (AX error \(result.rawValue))", code: "AX_ACTION_FAILED")
         }
-        return okResponse("focus", state: state, start: start)
+        return okResponse("focus", state: state, start: start, backend: "ax", strategy: "ax_focus", stateID: req.state_id)
     case .notFound(let msg):
         return errorResponse("focus", state: state, message: msg, code: "ELEMENT_NOT_FOUND")
     case .timeout:
@@ -603,7 +618,7 @@ func handleRaise(_ req: ActionRequest, state: SessionState) -> ActionResponse {
         AXUIElementPerformAction(win, kAXRaiseAction as CFString)
     }
 
-    return okResponse("raise", state: state, start: start)
+    return okResponse("raise", state: state, start: start, backend: "ax", strategy: "ax_raise", stateID: req.state_id)
 }
 
 // MARK: - AppleScript Handler
@@ -629,7 +644,7 @@ func handleTell(_ req: ActionRequest, state: SessionState) -> ActionResponse {
         return errorResponse("tell", state: state, message: msg, code: "APPLESCRIPT_FAILED")
     }
 
-    return okResponse("tell", state: state, start: start)
+    return okResponse("tell", state: state, start: start, backend: "applescript", strategy: "applescript_tell", stateID: req.state_id)
 }
 
 // MARK: - Meta Handlers
@@ -637,7 +652,7 @@ func handleTell(_ req: ActionRequest, state: SessionState) -> ActionResponse {
 /// Return session status: cursor, modifiers, context, profile, uptime, bound_channel.
 func handleStatus(_ req: ActionRequest, state: SessionState) -> ActionResponse {
     let start = Date()
-    return okResponse("status", state: state, start: start) { resp in
+    return okResponse("status", state: state, start: start, stateID: req.state_id) { resp in
         resp.profile = state.profileName
         resp.session_uptime_s = Date().timeIntervalSince(state.startTime)
         resp.bound_channel = state.boundChannel
@@ -691,7 +706,7 @@ func handleListActions(_ req: ActionRequest, state: SessionState) -> ActionRespo
         actions: ["key_down", "key_tap", "key_up", "move", "scroll", "type"]
     ))
 
-    return okResponse("list_actions", state: state, start: start) { resp in
+    return okResponse("list_actions", state: state, start: start, stateID: req.state_id) { resp in
         resp.available = available
         resp.bound_channel = state.boundChannel
     }

--- a/src/perceive/capture-pipeline.swift
+++ b/src/perceive/capture-pipeline.swift
@@ -1843,6 +1843,7 @@ func captureBrowserTarget(opts: CaptureOptions) async {
         if opts.xray {
             let elements = try seeCaptureXray(target: bt, withBounds: opts.label)
             var resp = SuccessResponse()
+            resp.state_id = makeAOSStateID()
             resp.elements = elements
             if opts.label {
                 let anns = buildAnnotations(from: elements)
@@ -1869,6 +1870,7 @@ func captureBrowserTarget(opts: CaptureOptions) async {
         let dst = opts.resolvedOutputPath
         _ = try seeCaptureScreenshot(target: bt, outPath: dst)
         var resp = SuccessResponse()
+        resp.state_id = makeAOSStateID()
         resp.files = [dst]
         print(jsonString(resp))
         return
@@ -2446,6 +2448,7 @@ func captureCommand(args: [String]) async {
     // ── Output ──
     func buildResponse() -> SuccessResponse {
         var resp = SuccessResponse()
+        resp.state_id = makeAOSStateID()
         resp.cursor = responseCursor
         resp.bounds = interactiveBounds
         resp.click_x = responseClickX

--- a/src/perceive/models.swift
+++ b/src/perceive/models.swift
@@ -315,6 +315,7 @@ struct CaptureSurfaceJSON: Encodable {
 
 struct SuccessResponse: Encodable {
     let status = "success"
+    var state_id: String?
     var files: [String]?
     var base64: [String]?
     var cursor: CursorJSON?
@@ -330,12 +331,13 @@ struct SuccessResponse: Encodable {
     var perceptions: [CapturePerceptionJSON]?
 
     enum CodingKeys: String, CodingKey {
-        case status, files, base64, cursor, bounds, click_x, click_y, warning, elements, semantic_targets, annotations, window, surfaces, perceptions
+        case status, state_id, files, base64, cursor, bounds, click_x, click_y, warning, elements, semantic_targets, annotations, window, surfaces, perceptions
     }
 
     func encode(to encoder: Encoder) throws {
         var c = encoder.container(keyedBy: CodingKeys.self)
         try c.encode(status, forKey: .status)
+        if let id = state_id { try c.encode(id, forKey: .state_id) }
         if let f = files { try c.encode(f, forKey: .files) }
         if let b = base64 { try c.encode(b, forKey: .base64) }
         if let cur = cursor { try c.encode(cur, forKey: .cursor) }

--- a/src/shared/command-registry-data.swift
+++ b/src/shared/command-registry-data.swift
@@ -406,44 +406,53 @@ func buildCommandRegistry() -> [CommandDescriptor] {
 
     // ── do ────────────────────────────────────────────────
     let permAction = execMutating(permissions: true)
+    let permActionDryRun = execMutating(permissions: true, dryRun: true)
+    let doStateIDArg = flag("state-id", "--state-id", "Perception state id this action was chosen from")
+    let doDryRunArg = flag("dry-run", "--dry-run", "Validate and describe the action without executing it", type: .bool)
 
     reg.append(CommandDescriptor(path: ["do"], summary: "Action — execute mouse, keyboard, AX actions", forms: [
-        InvocationForm(id: "do-click", usage: "aos do click <x,y> [--right] [--double] [--dwell N]",
+        InvocationForm(id: "do-click", usage: "aos do click <x,y> [--right] [--double] [--dwell N] [--state-id id]",
             args: [
                 pos("coords", "Click coordinates as x,y"),
                 flag("right", "--right", "Right-click", type: .bool),
                 flag("double", "--double", "Double-click", type: .bool),
-                flag("dwell", "--dwell", "Dwell time in ms", type: .int)
+                flag("dwell", "--dwell", "Dwell time in ms", type: .int),
+                doStateIDArg,
+                doDryRunArg
             ],
             stdin: nil, constraints: nil,
-            execution: permAction,
+            execution: permActionDryRun,
             output: outJSON,
             examples: ["aos do click 500,300", "aos do click 500,300 --right"]),
-        InvocationForm(id: "do-hover", usage: "aos do hover <x,y>",
-            args: [pos("coords", "Target coordinates as x,y")],
+        InvocationForm(id: "do-hover", usage: "aos do hover <x,y> [--state-id id]",
+            args: [pos("coords", "Target coordinates as x,y"), doStateIDArg, doDryRunArg],
             stdin: nil, constraints: nil,
-            execution: permAction,
+            execution: permActionDryRun,
             output: outJSON,
             examples: ["aos do hover 500,300"]),
-        InvocationForm(id: "do-drag", usage: "aos do drag <x1,y1> <x2,y2> [--speed N]",
+        InvocationForm(id: "do-drag", usage: "aos do drag <x1,y1> <x2,y2> [--speed N] [--state-id id]",
             args: [
                 pos("from", "Start coordinates as x,y"),
                 pos("to", "End coordinates as x,y"),
-                flag("speed", "--speed", "Drag speed in pixels/sec", type: .int)
+                flag("speed", "--speed", "Drag speed in pixels/sec", type: .int),
+                doStateIDArg,
+                doDryRunArg
             ],
             stdin: nil, constraints: nil,
-            execution: permAction,
+            execution: permActionDryRun,
             output: outJSON,
             examples: ["aos do drag 100,100 500,500"]),
-        InvocationForm(id: "do-scroll", usage: "aos do scroll <x,y> [--dx N] [--dy N]",
+        InvocationForm(id: "do-scroll", usage: "aos do scroll <x,y> [--dx N] [--dy N] [--state-id id]",
             args: [
                 pos("coords", "Scroll position as x,y"),
                 flag("dx", "--dx", "Horizontal scroll amount", type: .int),
-                flag("dy", "--dy", "Vertical scroll amount", type: .int)
+                flag("dy", "--dy", "Vertical scroll amount", type: .int),
+                doStateIDArg,
+                doDryRunArg
             ],
             stdin: nil,
             constraints: ConstraintSet(requires: nil, conflicts: nil, oneOf: [["dx", "dy"]], implies: nil),
-            execution: permAction,
+            execution: permActionDryRun,
             output: outJSON,
             examples: ["aos do scroll 500,300 --dy -3"]),
         InvocationForm(id: "do-type", usage: "aos do type <text> [--delay ms] [--variance N]",

--- a/src/shared/helpers.swift
+++ b/src/shared/helpers.swift
@@ -92,6 +92,16 @@ func iso8601Now() -> String {
     return fmt.string(from: Date())
 }
 
+// MARK: - Opaque Runtime IDs
+
+func makeAOSStateID(prefix: String = "see") -> String {
+    let token = UUID().uuidString
+        .lowercased()
+        .replacingOccurrences(of: "-", with: "")
+        .prefix(12)
+    return "\(prefix)_\(token)"
+}
+
 // MARK: - Response Helpers
 
 func sendResponse(to fd: Int32, _ data: Data) {

--- a/tests/design/aos-work-record-fixtures.test.mjs
+++ b/tests/design/aos-work-record-fixtures.test.mjs
@@ -55,6 +55,12 @@ test('do_step examples preserve the four-layer work-record shape', () => {
     assert.ok(fixture.intent.nl.length > 20);
     assert.equal(typeof fixture.action.verb, 'string');
     assert.equal(typeof fixture.action.target, 'string');
+    assert.match(fixture.precondition.state_id, /^see_[a-z0-9]+$/);
+    assert.equal(fixture.action.state_id, fixture.precondition.state_id);
+    assert.equal(fixture.evidence.execution.state_id, fixture.precondition.state_id);
+    assert.equal(typeof fixture.evidence.execution.strategy, 'string');
+    assert.equal(typeof fixture.evidence.execution.backend, 'string');
+    assert.equal(typeof fixture.evidence.execution.fallback_used, 'boolean');
     assert.equal(typeof fixture.health.state, 'string');
   }
 });

--- a/tests/see-do-state-metadata.sh
+++ b/tests/see-do-state-metadata.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STATE_ID="see_test000001"
+
+OUT="$(AOS_BYPASS_PREFLIGHT=1 ./aos do click 10,10 --dry-run --state-id "$STATE_ID")"
+OUT="$OUT" STATE_ID="$STATE_ID" python3 - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["OUT"])
+execution = payload.get("execution") or {}
+assert payload["status"] == "dry_run", payload
+assert payload["backend"] == "cgevent", payload
+assert execution["backend"] == "cgevent", payload
+assert execution["strategy"] == "dry_run_click", payload
+assert execution["fallback_used"] is False, payload
+assert execution["state_id"] == os.environ["STATE_ID"], payload
+PY
+
+if ! python3 - <<'PY'
+import json
+import subprocess
+
+perms = json.loads(subprocess.check_output(["./aos", "permissions", "check", "--json"], text=True)).get("permissions", {})
+raise SystemExit(0 if perms.get("screen_recording") else 1)
+PY
+then
+  echo "SKIP: see capture state_id requires screen recording"
+  exit 0
+fi
+
+ARTIFACT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/aos-see-do-state.XXXXXX")"
+trap 'rm -rf "$ARTIFACT_DIR"' EXIT
+PNG_PATH="$ARTIFACT_DIR/capture.png"
+JSON_PATH="$ARTIFACT_DIR/capture.json"
+
+AOS_BYPASS_PREFLIGHT=1 ./aos see capture --region 0,0,8,8 --out "$PNG_PATH" > "$JSON_PATH"
+
+python3 - "$JSON_PATH" <<'PY'
+import json
+import re
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+state_id = payload.get("state_id")
+assert re.fullmatch(r"see_[a-z0-9]{12}", state_id or ""), payload
+assert payload.get("files"), payload
+PY
+
+echo "PASS"


### PR DESCRIPTION
## Summary
- add opaque `state_id` values to `aos see capture` success responses
- add `execution` metadata to `aos do` session, legacy, and browser-target success responses
- document the runtime contract and carry state/execution metadata through work-record fixtures

## Verification
- `./aos dev build --no-restart`
- `bash tests/see-do-state-metadata.sh`
- `node --test tests/design/aos-work-record-fixtures.test.mjs`
- `./aos help do click --json | python3 -c 'import json,sys; p=json.load(sys.stdin); ids=[a["id"] for a in p["forms"][0]["args"]]; assert "state-id" in ids and "dry-run" in ids, ids; assert p["forms"][0]["execution"]["supports_dry_run"] is True; print("PASS help do click state-id")'`
- `git diff --check`

Closes #244
