### PR TITLE
Project wiki workflow chains as workbench subjects

### DIFF
--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -106,12 +106,20 @@ objects with:
 import { createWorkRecordSubject } from '../workbench/work-record-subject.js'
 ```
 
+Wiki workflow maps can be projected into a chain descriptor without creating a
+workflow engine:
+
+```js
+import { createWikiWorkflowSubject } from '../workbench/workflow-subject.js'
+```
+
 The current schema version is `2026-05-03`. The first adopters are:
 
 - Sigil radial item editor subjects: `sigil.radial_menu.item_3d`
 - Markdown workbench subjects: `markdown.document`
 - Wiki page subjects: `wiki.concept`, `wiki.entity`, `wiki.workflow`,
   `wiki.reference`, and `sigil.agent`
+- Workflow chain subjects: `wiki.workflow_chain`
 - Work-record subjects: `aos.do_step` and `aos.recipe_health_event`
 
 Subject descriptors are included in lock-in/save handoff payloads so agents,
@@ -122,6 +130,15 @@ Wiki subject ids use `wiki:<path>`, for example
 `wiki:aos/concepts/runtime-modes.md`. Their source uses `{ kind: "wiki", path,
 namespace, plugin }`, and their persistence route is the wiki write/change-event
 handoff rather than direct canvas filesystem access.
+
+Workflow chain subjects use `workflow:<root-wiki-path>`. They project a wiki
+workflow page or concept workflow map into ordered steps, child workflow refs,
+artifact refs, outputs, approval-gate placeholders, and validation state. The
+first projection reads the employer-brand workflow map's stage-contract table
+and resolves linked wiki pages into `wiki:<path>` child subjects. This is a
+view/model contract only: invocation stays with existing `aos wiki invoke` or
+agent-driven workflow instructions, and run/evidence/repair layers attach later
+through the work-record model.
 
 Work-record subject ids use `work-record:<id>`. They expose the natural-language
 intent, execution map, evidence artifacts, and health state as workbench views.

--- a/packages/toolkit/workbench/index.js
+++ b/packages/toolkit/workbench/index.js
@@ -1,3 +1,4 @@
 export * from './subject.js';
 export * from './wiki-subject.js';
 export * from './work-record-subject.js';
+export * from './workflow-subject.js';

--- a/packages/toolkit/workbench/workflow-subject.js
+++ b/packages/toolkit/workbench/workflow-subject.js
@@ -1,0 +1,290 @@
+import { createWorkbenchSubject } from './subject.js';
+
+function text(value, fallback = '') {
+  const normalized = String(value ?? '').replace(/\s+/g, ' ').trim();
+  return normalized || fallback;
+}
+
+function pathText(value) {
+  return String(value ?? '').replace(/^\/+/, '').trim();
+}
+
+function basename(path = '') {
+  return pathText(path).split('/').filter(Boolean).pop() || '';
+}
+
+function namespaceForPath(path = '') {
+  return pathText(path).split('/').filter(Boolean)[0] || 'wiki';
+}
+
+function textList(values = []) {
+  if (Array.isArray(values)) return values.map((value) => text(value)).filter(Boolean);
+  return String(values ?? '').split(',').map((value) => text(value)).filter(Boolean);
+}
+
+function normalizePage(page = {}) {
+  const path = pathText(page.path);
+  const fallbackName = basename(path).replace(/\.md$/i, '').replace(/-/g, ' ');
+  return {
+    path,
+    type: text(page.type || page.frontmatter?.type, 'page'),
+    name: text(page.name || page.frontmatter?.name, fallbackName),
+    description: text(page.description || page.frontmatter?.description),
+    tags: textList(page.tags || page.frontmatter?.tags),
+    plugin: text(page.plugin || page.frontmatter?.plugin) || null,
+    modified_at: Number(page.modified_at || 0) || null,
+  };
+}
+
+function normalizeLinkTarget(sourcePath = '', href = '') {
+  const cleanHref = String(href || '').split('#')[0].split('?')[0].trim();
+  if (!cleanHref || /^[a-z]+:/i.test(cleanHref)) return null;
+
+  const parts = cleanHref.startsWith('/')
+    ? []
+    : pathText(sourcePath).split('/').filter(Boolean).slice(0, -1);
+
+  for (const part of cleanHref.split('/')) {
+    if (!part || part === '.') continue;
+    if (part === '..') {
+      parts.pop();
+    } else {
+      parts.push(part);
+    }
+  }
+
+  return parts.join('/');
+}
+
+function markdownLinks(markdown = '', sourcePath = '') {
+  const links = [];
+  const pattern = /\[([^\]]+)\]\(([^)]+)\)/g;
+  let match;
+  while ((match = pattern.exec(String(markdown || '')))) {
+    const target = normalizeLinkTarget(sourcePath, match[2]);
+    if (!target) continue;
+    links.push({
+      label: text(match[1]),
+      target,
+    });
+  }
+  return links;
+}
+
+function splitMarkdownRow(line = '') {
+  return String(line)
+    .trim()
+    .replace(/^\|/, '')
+    .replace(/\|$/, '')
+    .split('|')
+    .map((cell) => text(cell));
+}
+
+function parseStageContractRows(markdown = '') {
+  const lines = String(markdown || '').split(/\r?\n/);
+  const rows = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index].trim();
+    if (!line.startsWith('|')) continue;
+
+    const headers = splitMarkdownRow(line).map((header) => header.toLowerCase());
+    if (!headers.includes('stage') || !headers.some((header) => header.includes('output'))) continue;
+
+    const divider = lines[index + 1]?.trim() || '';
+    if (!/^\|?\s*:?-{2,}/.test(divider)) continue;
+
+    const stageIndex = headers.indexOf('stage');
+    const outputIndex = headers.findIndex((header) => header.includes('output'));
+    const targetIndex = headers.findIndex((header) => header.includes('canonical') || header.includes('page'));
+
+    for (let rowIndex = index + 2; rowIndex < lines.length; rowIndex += 1) {
+      const rowLine = lines[rowIndex].trim();
+      if (!rowLine.startsWith('|')) break;
+      const cells = splitMarkdownRow(rowLine);
+      if (cells.length < headers.length) continue;
+      rows.push({
+        stage: cells[stageIndex] || '',
+        output: cells[outputIndex] || '',
+        targetCell: targetIndex >= 0 ? cells[targetIndex] : '',
+        cells,
+      });
+    }
+    break;
+  }
+
+  return rows;
+}
+
+function pageKind(page = {}) {
+  const normalizedPath = pathText(page.path);
+  if (page.type === 'workflow' || normalizedPath.includes('/plugins/')) return 'workflow';
+  if (page.type === 'entity' || normalizedPath.includes('/entities/')) return 'artifact';
+  if (page.type === 'concept' || normalizedPath.includes('/concepts/')) return 'reference';
+  return 'reference';
+}
+
+function createPageLookup(pages = []) {
+  const lookup = new Map();
+  for (const page of pages) {
+    const normalized = normalizePage(page);
+    if (normalized.path) lookup.set(normalized.path, normalized);
+  }
+  return lookup;
+}
+
+function uniqueBy(items = [], keyFn = (item) => item) {
+  const seen = new Set();
+  const out = [];
+  for (const item of items) {
+    const key = keyFn(item);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    out.push(item);
+  }
+  return out;
+}
+
+function stageStepFromRow(row, index, root, pageLookup) {
+  const allLinks = markdownLinks(row.cells.join(' '), root.path);
+  const targetLink = markdownLinks(row.targetCell, root.path)[0] || allLinks[0] || null;
+  const targetPage = targetLink ? pageLookup.get(targetLink.target) : null;
+
+  return {
+    id: `step-${String(index + 1).padStart(2, '0')}`,
+    order: index + 1,
+    label: text(row.stage, `Step ${index + 1}`),
+    output: text(row.output),
+    target: targetLink ? {
+      subject_id: `wiki:${targetLink.target}`,
+      path: targetLink.target,
+      label: targetLink.label,
+      kind: targetPage ? pageKind(targetPage) : 'missing',
+      resolved: Boolean(targetPage),
+    } : null,
+    references: allLinks.map((link) => {
+      const page = pageLookup.get(link.target);
+      return {
+        subject_id: `wiki:${link.target}`,
+        path: link.target,
+        label: link.label,
+        kind: page ? pageKind(page) : 'missing',
+        resolved: Boolean(page),
+      };
+    }),
+  };
+}
+
+function fallbackSteps(root, pages, links) {
+  const pageLookup = createPageLookup(pages);
+  return (Array.isArray(links) ? links : [])
+    .filter((link) => pathText(link.source_path || link.source) === root.path)
+    .map((link, index) => {
+      const targetPath = pathText(link.target_path || link.target);
+      const targetPage = pageLookup.get(targetPath);
+      return {
+        id: `step-${String(index + 1).padStart(2, '0')}`,
+        order: index + 1,
+        label: targetPage?.name || targetPath,
+        output: '',
+        target: {
+          subject_id: `wiki:${targetPath}`,
+          path: targetPath,
+          label: targetPage?.name || targetPath,
+          kind: targetPage ? pageKind(targetPage) : 'missing',
+          resolved: Boolean(targetPage),
+        },
+        references: [],
+      };
+    });
+}
+
+export function createWikiWorkflowDescriptor({ root, pages = [], links = [], markdown = null } = {}) {
+  const normalizedRoot = normalizePage(root);
+  if (!normalizedRoot.path) throw new TypeError('wiki workflow descriptor requires a root path');
+
+  const sourceMarkdown = String(markdown ?? root?.content ?? root?.rawContent ?? root?.markdown ?? '');
+  const allPages = uniqueBy([normalizedRoot, ...(Array.isArray(pages) ? pages : [])].map(normalizePage), (page) => page.path);
+  const pageLookup = createPageLookup(allPages);
+  const stageRows = parseStageContractRows(sourceMarkdown);
+  const steps = stageRows.length
+    ? stageRows.map((row, index) => stageStepFromRow(row, index, normalizedRoot, pageLookup))
+    : fallbackSteps(normalizedRoot, allPages, links);
+
+  const references = uniqueBy(
+    steps.flatMap((step) => step.references || []),
+    (ref) => ref.path,
+  );
+  const artifacts = references
+    .filter((ref) => ref.kind === 'artifact')
+    .map((ref) => ({ kind: 'wiki_artifact', ...ref }));
+  const childWorkflows = uniqueBy(
+    steps
+      .map((step) => step.target)
+      .filter((target) => target?.kind === 'workflow'),
+    (target) => target.path,
+  );
+  const missingTargets = references.filter((ref) => !ref.resolved);
+
+  return {
+    root: {
+      subject_id: `wiki:${normalizedRoot.path}`,
+      path: normalizedRoot.path,
+      label: normalizedRoot.name,
+      type: normalizedRoot.type,
+    },
+    steps,
+    child_workflows: childWorkflows,
+    artifacts,
+    inputs: [],
+    outputs: uniqueBy(steps.map((step) => step.output).filter(Boolean)),
+    approval_gates: [],
+    validation: {
+      state: missingTargets.length ? 'repairable' : 'valid',
+      missing_targets: missingTargets,
+      source: stageRows.length ? 'stage_contract_table' : 'outgoing_links',
+    },
+  };
+}
+
+export function createWikiWorkflowSubject(input = {}) {
+  const descriptor = createWikiWorkflowDescriptor(input);
+  const root = normalizePage(input.root);
+  const namespace = namespaceForPath(root.path);
+  const hasInvocableChildren = descriptor.child_workflows.length > 0;
+
+  return createWorkbenchSubject({
+    id: `workflow:${root.path}`,
+    type: 'wiki.workflow_chain',
+    label: root.name,
+    owner: namespace,
+    source: {
+      kind: 'wiki_workflow',
+      path: root.path,
+      namespace,
+      plugin: root.plugin,
+    },
+    capabilities: [
+      'wiki.read',
+      'workflow.project',
+      'workflow.chain.inspect',
+      ...(hasInvocableChildren ? ['wiki.invoke'] : []),
+    ],
+    views: ['workflow.chain', 'workflow.graph', 'workflow.source', 'workflow.artifacts'],
+    controls: ['open', 'inspect.step', ...(hasInvocableChildren ? ['invoke.child_workflow'] : [])],
+    artifacts: descriptor.artifacts,
+    state: {
+      workflow: descriptor,
+      modified_at: root.modified_at,
+    },
+    metadata: {
+      wiki_type: root.type,
+      description: root.description,
+      tags: root.tags,
+      step_count: descriptor.steps.length,
+      child_workflow_count: descriptor.child_workflows.length,
+      artifact_count: descriptor.artifacts.length,
+      validation_state: descriptor.validation.state,
+    },
+  });
+}

--- a/tests/schemas/aos-workbench-subject.test.mjs
+++ b/tests/schemas/aos-workbench-subject.test.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { createWorkbenchSubject } from '../../packages/toolkit/workbench/subject.js';
 import { createWikiPageSubject } from '../../packages/toolkit/workbench/wiki-subject.js';
 import { createWorkRecordSubject } from '../../packages/toolkit/workbench/work-record-subject.js';
+import { createWikiWorkflowSubject } from '../../packages/toolkit/workbench/workflow-subject.js';
 import { buildMarkdownWorkbenchSubject, createMarkdownWorkbenchState } from '../../packages/toolkit/components/markdown-workbench/model.js';
 import { buildWorkRecordWorkbenchSubject, createWorkRecordWorkbenchState } from '../../packages/toolkit/components/work-record-workbench/model.js';
 import { buildRadialItemWorkbenchSubject, createRadialItemEditorState } from '../../apps/sigil/radial-item-editor/model.js';
@@ -18,6 +19,7 @@ const workRecordFixturePath = path.join(
   repoRoot,
   'docs/design/fixtures/aos-work-records/browser-artifact-collection-step.json',
 );
+const workflowMapMarkdownPath = path.join(repoRoot, 'wiki-seed/concepts/employer-brand-workflow-map.md');
 
 async function validate(instance) {
   const result = spawnSync(
@@ -73,6 +75,47 @@ test('current workbench adopters emit schema-valid subject descriptors', async (
     tags: ['diagnostics', 'runtime'],
   }));
   await validate(createWorkRecordSubject(JSON.parse(await fs.readFile(workRecordFixturePath, 'utf8'))));
+  await validate(createWikiWorkflowSubject({
+    root: {
+      path: 'aos/concepts/employer-brand-workflow-map.md',
+      type: 'concept',
+      name: 'Employer Brand Workflow Map',
+      tags: ['employer-brand', 'workflow', 'process'],
+    },
+    pages: [
+      {
+        path: 'aos/plugins/employer-brand-profile-intake/SKILL.md',
+        type: 'workflow',
+        name: 'employer-brand-profile-intake',
+      },
+      {
+        path: 'aos/plugins/employer-brand-artifact-collection-planner/SKILL.md',
+        type: 'workflow',
+        name: 'employer-brand-artifact-collection-planner',
+      },
+      {
+        path: 'aos/concepts/normalize-employer-brand-evidence.md',
+        type: 'concept',
+        name: 'Normalize Employer Brand Evidence',
+      },
+      {
+        path: 'aos/plugins/employer-brand-profile-synthesis/SKILL.md',
+        type: 'workflow',
+        name: 'employer-brand-profile-synthesis',
+      },
+      {
+        path: 'aos/plugins/employer-brand-competitor-comparison/SKILL.md',
+        type: 'workflow',
+        name: 'employer-brand-competitor-comparison',
+      },
+      {
+        path: 'aos/plugins/employer-brand-report-generation/SKILL.md',
+        type: 'workflow',
+        name: 'employer-brand-report-generation',
+      },
+    ],
+    markdown: await fs.readFile(workflowMapMarkdownPath, 'utf8'),
+  }));
   await validate(buildWorkRecordWorkbenchSubject(createWorkRecordWorkbenchState({
     record: JSON.parse(await fs.readFile(workRecordFixturePath, 'utf8')),
   })));

--- a/tests/toolkit/workflow-subject.test.mjs
+++ b/tests/toolkit/workflow-subject.test.mjs
@@ -1,0 +1,137 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  createWikiWorkflowDescriptor,
+  createWikiWorkflowSubject,
+} from '../../packages/toolkit/workbench/workflow-subject.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+const workflowMapPath = path.join(repoRoot, 'wiki-seed/concepts/employer-brand-workflow-map.md');
+const workflowMapMarkdown = fs.readFileSync(workflowMapPath, 'utf8');
+
+const pages = [
+  {
+    path: 'aos/concepts/employer-brand-workflow-map.md',
+    type: 'concept',
+    name: 'Employer Brand Workflow Map',
+    description: 'End-to-end map for the canonical employer-brand workflow set.',
+    tags: ['employer-brand', 'workflow', 'process'],
+    modified_at: 1776393337,
+  },
+  {
+    path: 'aos/plugins/employer-brand-profile-intake/SKILL.md',
+    type: 'workflow',
+    name: 'employer-brand-profile-intake',
+    plugin: 'employer-brand-profile-intake',
+  },
+  {
+    path: 'aos/plugins/employer-brand-artifact-collection-planner/SKILL.md',
+    type: 'workflow',
+    name: 'employer-brand-artifact-collection-planner',
+    plugin: 'employer-brand-artifact-collection-planner',
+  },
+  {
+    path: 'aos/concepts/normalize-employer-brand-evidence.md',
+    type: 'concept',
+    name: 'Normalize Employer Brand Evidence',
+  },
+  {
+    path: 'aos/plugins/employer-brand-profile-synthesis/SKILL.md',
+    type: 'workflow',
+    name: 'employer-brand-profile-synthesis',
+    plugin: 'employer-brand-profile-synthesis',
+  },
+  {
+    path: 'aos/plugins/employer-brand-competitor-comparison/SKILL.md',
+    type: 'workflow',
+    name: 'employer-brand-competitor-comparison',
+    plugin: 'employer-brand-competitor-comparison',
+  },
+  {
+    path: 'aos/plugins/employer-brand-report-generation/SKILL.md',
+    type: 'workflow',
+    name: 'employer-brand-report-generation',
+    plugin: 'employer-brand-report-generation',
+  },
+  {
+    path: 'aos/entities/employer-brand-profile.md',
+    type: 'entity',
+    name: 'Employer Brand Profile',
+  },
+  {
+    path: 'aos/entities/employer-brand-comparison.md',
+    type: 'entity',
+    name: 'Employer Brand Comparison',
+  },
+  {
+    path: 'aos/plugins/kilos-brand-audit-report/references/report-data-schema.md',
+    type: 'concept',
+    name: 'Brand Audit Report Data Schema',
+    plugin: 'kilos-brand-audit-report',
+  },
+  {
+    path: 'aos/plugins/kilos-brand-audit-report/references/folder-structure.md',
+    type: 'concept',
+    name: 'Brand Audit Report Folder Structure',
+    plugin: 'kilos-brand-audit-report',
+  },
+];
+
+test('createWikiWorkflowDescriptor projects the employer-brand workflow map chain', () => {
+  const descriptor = createWikiWorkflowDescriptor({
+    root: pages[0],
+    pages,
+    markdown: workflowMapMarkdown,
+  });
+
+  assert.equal(descriptor.root.path, 'aos/concepts/employer-brand-workflow-map.md');
+  assert.equal(descriptor.validation.state, 'valid');
+  assert.equal(descriptor.validation.source, 'stage_contract_table');
+  assert.equal(descriptor.steps.length, 6);
+  assert.equal(descriptor.steps[0].label, 'Intake');
+  assert.equal(descriptor.steps[0].target.path, 'aos/plugins/employer-brand-profile-intake/SKILL.md');
+  assert.equal(descriptor.steps[1].target.path, 'aos/plugins/employer-brand-artifact-collection-planner/SKILL.md');
+  assert.equal(descriptor.steps[2].target.kind, 'reference');
+  assert.equal(descriptor.steps[3].target.kind, 'workflow');
+  assert.ok(descriptor.child_workflows.some((child) => child.path === 'aos/plugins/employer-brand-report-generation/SKILL.md'));
+  assert.ok(descriptor.artifacts.some((artifact) => artifact.path === 'aos/entities/employer-brand-profile.md'));
+  assert.ok(descriptor.outputs.includes('One [Employer Brand Comparison](../entities/employer-brand-comparison.md)'));
+});
+
+test('createWikiWorkflowSubject emits a workflow-chain workbench subject', () => {
+  const subject = createWikiWorkflowSubject({
+    root: pages[0],
+    pages,
+    markdown: workflowMapMarkdown,
+  });
+
+  assert.equal(subject.type, 'aos.workbench.subject');
+  assert.equal(subject.id, 'workflow:aos/concepts/employer-brand-workflow-map.md');
+  assert.equal(subject.subject_type, 'wiki.workflow_chain');
+  assert.equal(subject.owner, 'aos');
+  assert.equal(subject.source.kind, 'wiki_workflow');
+  assert.equal(subject.metadata.step_count, 6);
+  assert.equal(subject.metadata.child_workflow_count, 5);
+  assert.equal(subject.metadata.validation_state, 'valid');
+  assert.ok(subject.capabilities.includes('workflow.chain.inspect'));
+  assert.ok(subject.views.includes('workflow.chain'));
+  assert.ok(subject.controls.includes('invoke.child_workflow'));
+  assert.equal(subject.state.workflow.steps[0].target.subject_id, 'wiki:aos/plugins/employer-brand-profile-intake/SKILL.md');
+});
+
+test('workflow descriptor marks unresolved linked workflow targets repairable', () => {
+  const descriptor = createWikiWorkflowDescriptor({
+    root: pages[0],
+    pages: pages.slice(0, 1),
+    markdown: workflowMapMarkdown,
+  });
+
+  assert.equal(descriptor.validation.state, 'repairable');
+  assert.ok(descriptor.validation.missing_targets.length > 0);
+  assert.equal(descriptor.steps[0].target.resolved, false);
+  assert.equal(descriptor.steps[0].target.kind, 'missing');
+});


### PR DESCRIPTION
## Summary
- add a toolkit workflow subject helper that projects wiki workflow maps into ordered chain descriptors
- resolve linked child workflows and wiki artifacts from the employer-brand stage contracts table
- document the `wiki.workflow_chain` subject contract and cover it with focused toolkit/schema tests

## Verification
- `node --test tests/toolkit/workflow-subject.test.mjs`
- `node --test tests/schemas/aos-workbench-subject.test.mjs`
- `node --test tests/toolkit/wiki-subject.test.mjs`
- `node --test tests/toolkit/*.test.mjs`
- `git diff --check`

Closes #215