### PR TITLE
Add toolkit panel maximize and restore

### DIFF
--- a/apps/sigil/radial-item-workbench/index.html
+++ b/apps/sigil/radial-item-workbench/index.html
@@ -14,6 +14,7 @@
       <strong class="aos-workbench-title" id="workbench-title">Sigil / Radial Menu / Item Editor</strong>
       <div class="aos-window-controls" aria-label="Window controls">
         <button type="button" class="aos-window-button aos-window-minimize" id="minimize-workbench" aria-label="Minimize workbench" title="Minimize">-</button>
+        <button type="button" class="aos-window-button aos-window-maximize" id="maximize-workbench" aria-label="Maximize workbench" aria-pressed="false" title="Maximize">+</button>
         <button type="button" class="aos-window-button aos-window-close" id="close-workbench" aria-label="Close workbench" title="Close">x</button>
       </div>
     </header>

--- a/apps/sigil/radial-item-workbench/index.js
+++ b/apps/sigil/radial-item-workbench/index.js
@@ -33,6 +33,7 @@ addStylesheet(`/${toolkitRoot}/controls/defaults.css`, { before: appStylesheet }
 addStylesheet(`/${toolkitRoot}/components/object-transform-panel/styles.css`, { before: appStylesheet });
 
 const { default: ObjectTransformPanel } = await import(`/${toolkitRoot}/components/object-transform-panel/index.js`);
+const { createMaximizeController, syncMaximizeButton } = await import(`/${toolkitRoot}/panel/chrome.js`);
 const { removeSelf, spawnChild, suspendCanvas } = await import(`/${toolkitRoot}/runtime/canvas.js`);
 
 const stage = document.getElementById('preview-stage');
@@ -40,6 +41,7 @@ const workbenchTitle = document.getElementById('workbench-title');
 const dragHandle = document.getElementById('drag-handle');
 const closeWorkbenchButton = document.getElementById('close-workbench');
 const minimizeWorkbenchButton = document.getElementById('minimize-workbench');
+const maximizeWorkbenchButton = document.getElementById('maximize-workbench');
 const itemSelect = document.getElementById('item-select');
 const spinToggle = document.getElementById('spin-toggle');
 const axesToggle = document.getElementById('axes-toggle');
@@ -59,6 +61,15 @@ const editorState = createRadialItemEditorState({
 let lastLockIn = null;
 const undoStack = [];
 const redoStack = [];
+
+const maximizeController = createMaximizeController({
+    onStateChange(state) {
+        if (maximizeWorkbenchButton) syncMaximizeButton(maximizeWorkbenchButton, state);
+    },
+});
+if (maximizeWorkbenchButton) {
+    syncMaximizeButton(maximizeWorkbenchButton, maximizeController.getState());
+}
 
 const MIN_SCENE_ZOOM = 0.55;
 const MAX_SCENE_ZOOM = 2.2;
@@ -552,6 +563,12 @@ minimizeWorkbenchButton?.addEventListener('click', (event) => {
     minimizeWorkbench();
 });
 
+maximizeWorkbenchButton?.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    maximizeController.toggle();
+});
+
 syncControls();
 syncOrbit();
 syncPanelRegistry();
@@ -566,6 +583,7 @@ window.__sigilRadialItemWorkbench = {
     visuals,
     orbit,
     orbitState,
+    maximizeController,
     registry,
     syncPanelRegistry,
     resetOrbit,

--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -948,7 +948,13 @@ Convenience hook for inbound `ready` events.
 Public entrypoint:
 
 ```js
-import { mountPanel, mountChrome, Single, Tabs } from 'aos://toolkit/panel/index.js'
+import {
+  createMaximizeController,
+  mountPanel,
+  mountChrome,
+  Single,
+  Tabs,
+} from 'aos://toolkit/panel/index.js'
 ```
 
 ### `mountChrome(container, options?)`
@@ -968,6 +974,12 @@ Options:
 | --- | --- | --- |
 | `title` | `string` | header title |
 | `draggable` | `boolean` | whether header drag emits absolute move updates plus `drag_start` / `drag_end` lifecycle messages |
+| `close` | `boolean` | whether to show the stock close control, default `true` |
+| `minimize` | `boolean` | whether to show the stock minimize control, default `true` |
+| `maximize` | `boolean` | whether to show the stock maximize/restore control, default `false` |
+| `onClose` | `function` | optional close override |
+| `onMinimize` | `function` | optional minimize override |
+| `onMaximize` | `function` | optional maximize/restore override; receives the maximize controller |
 
 Returns an object with:
 
@@ -977,7 +989,10 @@ Returns an object with:
 | `headerEl` | header element |
 | `titleEl` | title slot element |
 | `controlsEl` | controls slot element |
+| `customControlsEl` | app controls slot element |
+| `windowControlsEl` | stock lifecycle controls slot element |
 | `contentEl` | content mount element |
+| `maximizeController` | controller when `maximize: true`, otherwise `null` |
 | `setTitle(text)` | update the title slot |
 | `setControls(html)` | replace controls slot contents with HTML |
 
@@ -988,6 +1003,9 @@ Notes:
 - when draggable, the stock header emits `drag_start` once on primary-button
   pointerdown, drives window movement through absolute drag updates, then emits
   `drag_end` on pointerup / cancel / lost capture
+- when maximize is enabled, the stock controller stores the current canvas frame,
+  updates the canvas to the current display work area, and restores the stored
+  frame on the next toggle
 
 ### `mountPanel(options)`
 
@@ -1009,7 +1027,39 @@ Options:
 | `title` | `string` | header title |
 | `layout` | layout object | required |
 | `draggable` | `boolean` | whether the mounted stock header emits absolute drag updates plus `drag_start` / `drag_end` lifecycle messages |
+| `close` | `boolean` | whether to show the stock close control, default `true` |
+| `minimize` | `boolean` | whether to show the stock minimize control, default `true` |
+| `maximize` | `boolean` | whether to show the stock maximize/restore control, default `false` |
 | `container` | `HTMLElement` | mount target, default `document.body` |
+
+### `createMaximizeController(options?)`
+
+Creates the toolkit-owned maximize/restore state used by stock panel chrome and
+by custom workbench titlebars that need the same behavior.
+
+```js
+const controller = createMaximizeController()
+controller.maximize()
+controller.restore()
+controller.toggle()
+```
+
+By default the controller reads `window.screenX/screenY` and
+`window.innerWidth/innerHeight` for the restore frame, reads
+`window.screen.avail*` for the current display work area, and updates the
+calling canvas through `canvas.update`. If the browser does not expose a display
+origin, the helper keeps the current window origin as the safest fallback. Tests
+and custom hosts can override `getFrame`, `getWorkArea`, `updateFrame`, and
+`onStateChange`.
+
+The controller state is:
+
+```js
+{
+  maximized: true,
+  restoreFrame: [x, y, width, height]
+}
+```
 
 ### `Single(factoryOrContent)`
 

--- a/docs/design/aos-surface-system.md
+++ b/docs/design/aos-surface-system.md
@@ -23,6 +23,7 @@ The toolkit owns reusable panel chrome for normal interactive surfaces:
 - title truncation
 - close action
 - minimize action and restore chip
+- optional maximize and restore within the current display work area
 - focus and dirty-state affordances
 - window-action slots for app-specific lifecycle controls
 - theme tokens with app override support

--- a/packages/toolkit/CLAUDE.md
+++ b/packages/toolkit/CLAUDE.md
@@ -40,7 +40,7 @@ controls/               Layer 1a — reusable app-control behavior for WKWebView
   index.js                re-exports
 
 panel/                  Layer 1b — panel primitives
-  chrome.js               mountChrome — pure DOM scaffold + drag_start/drag_end lifecycle + absolute drag updates
+  chrome.js               mountChrome — pure DOM scaffold + drag_start/drag_end lifecycle + absolute drag updates + optional maximize/restore state
   defaults.css            optional stock panel visuals (opt-in)
   router.js               createRouter — manifest-prefix dispatch
   layouts/

--- a/packages/toolkit/panel/_smoke/index.html
+++ b/packages/toolkit/panel/_smoke/index.html
@@ -58,7 +58,7 @@ function HelloContent() {
   }
 }
 
-mountPanel({ title: 'panel/_smoke', layout: Single(HelloContent) })
+mountPanel({ title: 'panel/_smoke', layout: Single(HelloContent), maximize: true })
 </script>
 </body>
 </html>

--- a/packages/toolkit/panel/chrome.js
+++ b/packages/toolkit/panel/chrome.js
@@ -4,15 +4,17 @@
 // and reports absolute drag updates through the runtime canvas helper.
 
 import { emit } from '../runtime/bridge.js'
-import { moveAbsolute, removeSelf, spawnChild, suspendCanvas } from '../runtime/canvas.js'
+import { moveAbsolute, mutateSelf, removeSelf, spawnChild, suspendCanvas } from '../runtime/canvas.js'
 
 export function mountChrome(container, {
   title = 'AOS',
   draggable = true,
   close = true,
   minimize = true,
+  maximize = false,
   onClose = defaultClose,
   onMinimize = null,
+  onMaximize = null,
 } = {}) {
   container.innerHTML = ''
   container.classList.add('aos-panel-root')
@@ -36,6 +38,30 @@ export function mountChrome(container, {
 
   const windowControlsEl = document.createElement('span')
   windowControlsEl.className = 'aos-window-controls'
+
+  let maximizeController = null
+  if (maximize) {
+    const maximizeButton = document.createElement('button')
+    maximizeButton.type = 'button'
+    maximizeButton.className = 'aos-window-button aos-window-maximize'
+    maximizeButton.setAttribute('aria-label', 'Maximize panel')
+    maximizeButton.setAttribute('aria-pressed', 'false')
+    maximizeButton.title = 'Maximize'
+    maximizeButton.textContent = '+'
+    maximizeController = createMaximizeController({
+      onStateChange(state) {
+        syncMaximizeButton(maximizeButton, state)
+      },
+    })
+    syncMaximizeButton(maximizeButton, maximizeController.getState())
+    maximizeButton.addEventListener('click', (event) => {
+      event.preventDefault()
+      event.stopPropagation()
+      if (onMaximize) onMaximize(maximizeController, event)
+      else maximizeController.toggle()
+    })
+    windowControlsEl.appendChild(maximizeButton)
+  }
 
   if (minimize) {
     const minimizeButton = document.createElement('button')
@@ -91,9 +117,106 @@ export function mountChrome(container, {
     customControlsEl,
     windowControlsEl,
     contentEl: content,
+    maximizeController,
     setTitle(text) { titleEl.textContent = text },
     setControls(html) { customControlsEl.innerHTML = html },
   }
+}
+
+function finiteNumber(value, fallback = null) {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : fallback
+}
+
+function positiveNumber(value, fallback = 1) {
+  const number = finiteNumber(value, fallback)
+  return Math.max(1, number)
+}
+
+function cloneFrame(frame) {
+  return [
+    Math.round(finiteNumber(frame?.[0], 0)),
+    Math.round(finiteNumber(frame?.[1], 0)),
+    Math.round(positiveNumber(frame?.[2], 1)),
+    Math.round(positiveNumber(frame?.[3], 1)),
+  ]
+}
+
+export function frameFromWindow(view = window) {
+  return cloneFrame([
+    finiteNumber(view.screenX ?? view.screenLeft, 0),
+    finiteNumber(view.screenY ?? view.screenTop, 0),
+    positiveNumber(view.outerWidth || view.innerWidth || view.document?.documentElement?.clientWidth, 1),
+    positiveNumber(view.outerHeight || view.innerHeight || view.document?.documentElement?.clientHeight, 1),
+  ])
+}
+
+export function workAreaFromWindow(view = window) {
+  const screen = view.screen || {}
+  const fallbackFrame = frameFromWindow(view)
+  const x = finiteNumber(screen.availLeft ?? screen.left, fallbackFrame[0])
+  const y = finiteNumber(screen.availTop ?? screen.top, fallbackFrame[1])
+  const width = positiveNumber(screen.availWidth || screen.width, fallbackFrame[2])
+  const height = positiveNumber(screen.availHeight || screen.height, fallbackFrame[3])
+  return cloneFrame([x, y, width, height])
+}
+
+export function createMaximizeController({
+  getFrame = () => frameFromWindow(),
+  getWorkArea = () => workAreaFromWindow(),
+  updateFrame = (frame) => mutateSelf({ frame }),
+  onStateChange = null,
+} = {}) {
+  let maximized = false
+  let restoreFrame = null
+
+  function state() {
+    return {
+      maximized,
+      restoreFrame: restoreFrame ? cloneFrame(restoreFrame) : null,
+    }
+  }
+
+  function notify() {
+    onStateChange?.(state())
+  }
+
+  function maximizePanel() {
+    if (maximized) return state()
+    restoreFrame = cloneFrame(getFrame())
+    maximized = true
+    updateFrame(cloneFrame(getWorkArea()))
+    notify()
+    return state()
+  }
+
+  function restorePanel() {
+    if (!maximized || !restoreFrame) return state()
+    const frame = cloneFrame(restoreFrame)
+    maximized = false
+    restoreFrame = null
+    updateFrame(frame)
+    notify()
+    return state()
+  }
+
+  return {
+    maximize: maximizePanel,
+    restore: restorePanel,
+    toggle() {
+      return maximized ? restorePanel() : maximizePanel()
+    },
+    getState: state,
+  }
+}
+
+export function syncMaximizeButton(button, state = {}) {
+  const maximized = Boolean(state.maximized)
+  button.setAttribute('aria-label', maximized ? 'Restore panel' : 'Maximize panel')
+  button.setAttribute('aria-pressed', String(maximized))
+  button.title = maximized ? 'Restore' : 'Maximize'
+  button.textContent = maximized ? '[]' : '+'
+  button.dataset.maximized = String(maximized)
 }
 
 function currentCanvasId() {

--- a/packages/toolkit/panel/defaults.css
+++ b/packages/toolkit/panel/defaults.css
@@ -120,6 +120,12 @@
   background: rgba(72, 50, 13, 0.76);
 }
 
+.aos-window-maximize:hover,
+.aos-window-maximize[data-maximized="true"] {
+  border-color: rgba(111, 232, 196, 0.58);
+  background: rgba(12, 62, 52, 0.76);
+}
+
 .aos-content {
   flex: 1;
   min-height: 0;

--- a/packages/toolkit/panel/index.js
+++ b/packages/toolkit/panel/index.js
@@ -20,6 +20,12 @@
 // @property {(state: unknown, host: ContentHost) => void} [restore]
 
 export { mountPanel } from './mount.js'
-export { mountChrome } from './chrome.js'
+export {
+  createMaximizeController,
+  frameFromWindow,
+  mountChrome,
+  syncMaximizeButton,
+  workAreaFromWindow,
+} from './chrome.js'
 export { Single } from './layouts/single.js'
 export { Tabs } from './layouts/tabs.js'

--- a/packages/toolkit/panel/mount.js
+++ b/packages/toolkit/panel/mount.js
@@ -15,13 +15,24 @@ export function mountPanel({
   draggable = true,
   close = true,
   minimize = true,
+  maximize = false,
   onClose,
   onMinimize,
+  onMaximize,
   container = document.body,
 } = {}) {
   if (!layout) throw new Error('mountPanel: layout is required')
 
-  const chrome = mountChrome(container, { title, draggable, close, minimize, onClose, onMinimize })
+  const chrome = mountChrome(container, {
+    title,
+    draggable,
+    close,
+    minimize,
+    maximize,
+    onClose,
+    onMinimize,
+    onMaximize,
+  })
 
   if (layout.kind === 'single') {
     const content = layout.instantiate()

--- a/tests/toolkit/panel-chrome.test.mjs
+++ b/tests/toolkit/panel-chrome.test.mjs
@@ -1,6 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { wireDrag } from '../../packages/toolkit/panel/chrome.js';
+import {
+  createMaximizeController,
+  frameFromWindow,
+  syncMaximizeButton,
+  wireDrag,
+  workAreaFromWindow,
+} from '../../packages/toolkit/panel/chrome.js';
 
 class FakeNode {}
 
@@ -58,6 +64,100 @@ class FakeElement extends FakeNode {
     return event;
   }
 }
+
+class FakeButton {
+  constructor() {
+    this.attributes = new Map();
+    this.dataset = {};
+    this.title = '';
+    this.textContent = '';
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+  }
+
+  getAttribute(name) {
+    return this.attributes.get(name);
+  }
+}
+
+test('frame and work area helpers normalize current window geometry', () => {
+  const view = {
+    screenX: 22.3,
+    screenY: 44.8,
+    innerWidth: 640.2,
+    innerHeight: 420.6,
+    screen: {
+      availLeft: -1440,
+      availTop: 25,
+      availWidth: 1440,
+      availHeight: 875,
+    },
+  };
+
+  assert.deepEqual(frameFromWindow(view), [22, 45, 640, 421]);
+  assert.deepEqual(workAreaFromWindow(view), [-1440, 25, 1440, 875]);
+  assert.deepEqual(workAreaFromWindow({
+    screenX: 300,
+    screenY: 140,
+    innerWidth: 500,
+    innerHeight: 320,
+    screen: { availWidth: 1200, availHeight: 800 },
+  }), [300, 140, 1200, 800]);
+});
+
+test('createMaximizeController toggles work-area frame and restores previous frame', () => {
+  const updates = [];
+  const states = [];
+  const controller = createMaximizeController({
+    getFrame: () => [40, 70, 500, 360],
+    getWorkArea: () => [0, 24, 1280, 776],
+    updateFrame(frame) {
+      updates.push(frame);
+    },
+    onStateChange(state) {
+      states.push(state);
+    },
+  });
+
+  assert.deepEqual(controller.getState(), { maximized: false, restoreFrame: null });
+
+  assert.deepEqual(controller.maximize(), {
+    maximized: true,
+    restoreFrame: [40, 70, 500, 360],
+  });
+  assert.deepEqual(updates, [[0, 24, 1280, 776]]);
+  assert.deepEqual(states, [{
+    maximized: true,
+    restoreFrame: [40, 70, 500, 360],
+  }]);
+
+  assert.deepEqual(controller.restore(), { maximized: false, restoreFrame: null });
+  assert.deepEqual(updates, [
+    [0, 24, 1280, 776],
+    [40, 70, 500, 360],
+  ]);
+  assert.deepEqual(states.at(-1), { maximized: false, restoreFrame: null });
+});
+
+test('syncMaximizeButton reports maximize and restore state accessibly', () => {
+  const button = new FakeButton();
+
+  syncMaximizeButton(button, { maximized: false });
+  assert.equal(button.getAttribute('aria-label'), 'Maximize panel');
+  assert.equal(button.getAttribute('aria-pressed'), 'false');
+  assert.equal(button.title, 'Maximize');
+  assert.equal(button.textContent, '+');
+  assert.equal(button.dataset.maximized, 'false');
+
+  syncMaximizeButton(button, { maximized: true });
+  assert.equal(button.getAttribute('aria-label'), 'Restore panel');
+  assert.equal(button.getAttribute('aria-pressed'), 'true');
+  assert.equal(button.title, 'Restore');
+  assert.equal(button.textContent, '[]');
+  assert.equal(button.dataset.maximized, 'true');
+});
 
 test('wireDrag emits absolute drag updates with the original pointer offset', async (t) => {
   const previousNode = globalThis.Node;

--- a/tests/toolkit/workbench-shell.test.mjs
+++ b/tests/toolkit/workbench-shell.test.mjs
@@ -32,6 +32,7 @@ test('Sigil radial item workbench keeps editor controls out of titlebar chrome',
   assert.match(titlebar, /aos-workbench-title/);
   assert.match(titlebar, /Sigil \/ Radial Menu \/ Item Editor/);
   assert.match(titlebar, /id="minimize-workbench"/);
+  assert.match(titlebar, /id="maximize-workbench"/);
   assert.match(titlebar, /id="close-workbench"/);
   assert.doesNotMatch(titlebar, /id="item-select"|id="axes-toggle"|id="lock-in"/);
 


### PR DESCRIPTION
## Summary
- add an opt-in toolkit panel maximize/restore controller that stores the current frame and toggles to the current display work area
- expose maximize helpers from the panel package and document the panel API
- add a stock maximize window button style and enable it in the panel smoke surface
- wire the Sigil radial item workbench titlebar to the shared maximize controller

## Verification
- `node --check packages/toolkit/panel/chrome.js packages/toolkit/panel/mount.js packages/toolkit/panel/index.js apps/sigil/radial-item-workbench/index.js`
- `node --test tests/toolkit/panel-chrome.test.mjs tests/toolkit/workbench-shell.test.mjs`
- `node --test tests/renderer/radial-item-editor.test.mjs tests/renderer/radial-object-control.test.mjs`
- `node --test tests/toolkit/*.test.mjs`
- `git diff --check`
- root daemon status check: `status=ok`, input tap active, stale resources clean

Closes #230