### PR TITLE
Add toolkit split-pane layout

### DIFF
--- a/apps/sigil/radial-item-workbench/index.html
+++ b/apps/sigil/radial-item-workbench/index.html
@@ -36,8 +36,8 @@
         <button type="button" id="reset-orbit" title="Reset preview orbit and zoom">Reset view</button>
       </div>
     </div>
-    <main class="aos-workbench-main">
-      <section class="aos-workbench-preview-pane" aria-label="Radial item preview">
+    <main class="aos-workbench-main" id="workbench-main">
+      <section class="aos-workbench-preview-pane" id="preview-pane" aria-label="Radial item preview">
         <div class="aos-workbench-stage" id="preview-stage"></div>
         <div class="aos-workbench-stage-actions" role="toolbar" aria-label="Preview history">
           <button type="button" class="aos-icon-button" id="undo-change" aria-label="Undo transform change" disabled>
@@ -55,7 +55,7 @@
         </div>
         <div class="aos-workbench-readout" id="zoom-readout">100%</div>
       </section>
-      <section class="aos-workbench-controls-pane" aria-label="Object transform controls">
+      <section class="aos-workbench-controls-pane" id="controls-pane" aria-label="Object transform controls">
         <div class="aos-workbench-pane-title" id="controls-title">Object Transform</div>
         <div id="transform-panel"></div>
       </section>

--- a/apps/sigil/radial-item-workbench/index.js
+++ b/apps/sigil/radial-item-workbench/index.js
@@ -33,9 +33,12 @@ addStylesheet(`/${toolkitRoot}/controls/defaults.css`, { before: appStylesheet }
 addStylesheet(`/${toolkitRoot}/components/object-transform-panel/styles.css`, { before: appStylesheet });
 
 const { default: ObjectTransformPanel } = await import(`/${toolkitRoot}/components/object-transform-panel/index.js`);
-const { createMaximizeController, syncMaximizeButton } = await import(`/${toolkitRoot}/panel/chrome.js`);
+const { createMaximizeController, createSplitPane, syncMaximizeButton } = await import(`/${toolkitRoot}/panel/index.js`);
 const { removeSelf, spawnChild, suspendCanvas } = await import(`/${toolkitRoot}/runtime/canvas.js`);
 
+const workbenchMain = document.getElementById('workbench-main');
+const previewPane = document.getElementById('preview-pane');
+const controlsPane = document.getElementById('controls-pane');
 const stage = document.getElementById('preview-stage');
 const workbenchTitle = document.getElementById('workbench-title');
 const dragHandle = document.getElementById('drag-handle');
@@ -52,6 +55,21 @@ const redoButton = document.getElementById('redo-change');
 const transformPanel = document.getElementById('transform-panel');
 const controlsTitle = document.getElementById('controls-title');
 const zoomReadout = document.getElementById('zoom-readout');
+
+const splitPane = createSplitPane({
+    root: workbenchMain,
+    startPane: previewPane,
+    endPane: controlsPane,
+    orientation: 'horizontal',
+    initialRatio: 0.58,
+    minStart: 360,
+    minEnd: 360,
+    storageKey: 'sigil.radial-item-workbench.split',
+    ariaLabel: 'Resize preview and controls panes',
+    onChange() {
+        syncPreviewSize();
+    },
+});
 
 const editorState = createRadialItemEditorState({
     items: DEFAULT_SIGIL_RADIAL_ITEMS,
@@ -613,6 +631,7 @@ window.__sigilRadialItemWorkbench = {
             lastLockIn,
             history: { undo: undoStack.length, redo: redoStack.length },
             orbit: { x: orbitState.x, y: orbitState.y, zoom: orbitState.zoom },
+            splitPane: splitPane.getState(),
             axesVisible: axesGuide.visible,
             visuals: visuals.snapshot(),
         };

--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -691,8 +691,8 @@ animation/effects. The animation/effects area has three views: natural-language
 description, editable JSON control definitions, and a rendered mini-form driven
 by that JSON. Single-object transform editing is the current behavior.
 Multi-select, grouped edits over arbitrary subsets, and dockable/collapsible
-object-list panes belong to the follow-on split-pane and docking work rather
-than the control contract itself.
+object-list panes belong to the split-pane/docking surface layer rather than
+the control contract itself.
 
 Default launcher:
 
@@ -949,10 +949,12 @@ Public entrypoint:
 
 ```js
 import {
+  createSplitPane,
   createMaximizeController,
   mountPanel,
   mountChrome,
   Single,
+  SplitPane,
   Tabs,
 } from 'aos://toolkit/panel/index.js'
 ```
@@ -1064,6 +1066,74 @@ The controller state is:
 ### `Single(factoryOrContent)`
 
 Wraps one content unit.
+
+### `createSplitPane(options?)`
+
+Builds or wires a two-pane DOM layout with a draggable accessible separator.
+This helper is for custom workbench shells that already own their HTML.
+
+```js
+const split = createSplitPane({
+  root: document.querySelector('.workbench-main'),
+  startPane: document.querySelector('.preview-pane'),
+  endPane: document.querySelector('.controls-pane'),
+  orientation: 'horizontal',
+  initialRatio: 0.58,
+  minStart: 360,
+  minEnd: 320,
+  storageKey: 'my-workbench.split',
+})
+```
+
+Options:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `root` | `HTMLElement` | existing root to wire; created when omitted |
+| `startPane` / `endPane` | `HTMLElement` | existing panes to wire; created when omitted |
+| `divider` | `HTMLElement` | existing separator; created when omitted |
+| `orientation` | `'horizontal' \| 'vertical'` | left-right or top-bottom split, default `horizontal` |
+| `initialRatio` | `number` | start pane ratio before restore, default `0.5` |
+| `restoreState` | `object \| number` | explicit restored state or ratio |
+| `storageKey` | `string` | optional localStorage-backed ratio persistence |
+| `minStart` / `minEnd` | `number` | minimum start/end pane size in pixels |
+| `maxStart` / `maxEnd` | `number` | optional maximum start/end pane size in pixels |
+| `keyboardStep` | `number` | arrow-key resize step in pixels |
+| `ariaLabel` | `string` | accessible separator label |
+| `onChange` | `function` | called with `{ orientation, ratio, startSize, endSize, availableSize }` |
+
+The returned controller exposes:
+
+| Field / method | Meaning |
+| --- | --- |
+| `root`, `startPane`, `endPane`, `divider` | wired DOM nodes |
+| `getState()` | current normalized split state |
+| `setRatio(ratio, options?)` | update by ratio |
+| `setStartSize(px, options?)` | update by start pane pixels |
+| `destroy()` | remove controller event listeners |
+
+The separator uses `role="separator"`, `aria-orientation`, `aria-valuenow`,
+and pointer/keyboard semantics. Apps should treat `.aos-split-pane*` classes as
+styling hooks and the controller state as the behavior contract.
+
+### `SplitPane(startFactoryOrContent, endFactoryOrContent, options?)`
+
+Wraps two content units in a toolkit split-pane layout for `mountPanel`.
+
+```js
+mountPanel({
+  title: 'Workbench',
+  layout: SplitPane(PreviewContent, ControlsContent, {
+    initialRatio: 0.6,
+    minStart: 320,
+    minEnd: 280,
+  }),
+})
+```
+
+`SplitPane` accepts the same geometry options as `createSplitPane`. It emits
+`split-pane/resized` and declares a panel manifest with the two pane contents.
+Individual content units are routed by their existing `manifest.channelPrefix`.
 
 ### `Tabs(factoriesOrContents, options?)`
 

--- a/docs/design/aos-surface-system.md
+++ b/docs/design/aos-surface-system.md
@@ -62,6 +62,12 @@ left, a right controls pane, and inside that controls pane an object/layer list
 beside transform triplets. The same primitive should later support Markdown
 preview/source, workflow graph/source, and report/slides workbenches.
 
+The first promoted slice is `createSplitPane` / `SplitPane` in
+`packages/toolkit/panel/`: a reusable draggable separator with min/max pane
+constraints, keyboard semantics, and optional ratio restore. Docking,
+collapsing, and breakout behavior build on top of this primitive instead of
+being separate editor-specific layout code.
+
 The object/layer list should treat grouped scene objects as a tree, not a flat
 bag. A whole-composition group can own child meshes, and later it can own
 bespoke effects, reveal thresholds, cursor-coupled animation, particles, and

--- a/packages/toolkit/CLAUDE.md
+++ b/packages/toolkit/CLAUDE.md
@@ -12,7 +12,7 @@ Consumer-facing reference: [docs/api/toolkit.md](../../docs/api/toolkit.md)
 aos daemon (Layer 0)           canvas.create/update/remove, subscribe streams, eval, content server
   └─ runtime/ (Layer 1a)       in-canvas helpers: bridge, subscribe, canvas mutation, manifest
        ├─ controls/            reusable app-control behavior for WKWebView surfaces
-       ├─ panel/ (Layer 1b)    panel-shaped scaffolding: chrome, router, layouts (Single, Tabs)
+       ├─ panel/ (Layer 1b)    panel-shaped scaffolding: chrome, router, layouts (Single, SplitPane, Tabs)
        ├─ workbench/           subject descriptors and reusable workbench contracts
        │    └─ components/     reusable Content units consumed by panel layouts
        └─ apps/ (Layer 3)      presence surfaces use 1a directly; panels use 1a + 1b + 2
@@ -45,6 +45,7 @@ panel/                  Layer 1b — panel primitives
   router.js               createRouter — manifest-prefix dispatch
   layouts/
     single.js             Single(Content)
+    split-pane.js         SplitPane(start, end) + createSplitPane DOM controller
     tabs.js               Tabs([Content...])
   mount.js                mountPanel orchestrator
   index.js                re-exports + Content typedef

--- a/packages/toolkit/panel/defaults.css
+++ b/packages/toolkit/panel/defaults.css
@@ -133,6 +133,66 @@
   background: var(--bg-panel-content, transparent);
 }
 
+.aos-split-pane {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  overflow: hidden;
+}
+
+.aos-split-pane[data-orientation="horizontal"] {
+  flex-direction: row;
+}
+
+.aos-split-pane[data-orientation="vertical"] {
+  flex-direction: column;
+}
+
+.aos-split-pane-pane {
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+}
+
+.aos-split-pane-divider {
+  flex: 0 0 var(--aos-split-divider-size, 8px);
+  position: relative;
+  background: rgba(122, 241, 255, 0.12);
+  outline: none;
+  user-select: none;
+  touch-action: none;
+}
+
+.aos-split-pane[data-orientation="horizontal"] > .aos-split-pane-divider {
+  cursor: col-resize;
+  border-inline: 1px solid rgba(122, 241, 255, 0.18);
+}
+
+.aos-split-pane[data-orientation="vertical"] > .aos-split-pane-divider {
+  cursor: row-resize;
+  border-block: 1px solid rgba(122, 241, 255, 0.18);
+}
+
+.aos-split-pane-divider::after {
+  content: "";
+  position: absolute;
+  inset: 40% 3px;
+  border-radius: 999px;
+  background: rgba(220, 255, 255, 0.34);
+}
+
+.aos-split-pane[data-orientation="vertical"] > .aos-split-pane-divider::after {
+  inset: 3px 40%;
+}
+
+.aos-split-pane-divider:hover,
+.aos-split-pane-divider:focus-visible,
+.aos-split-pane-divider[data-dragging="true"] {
+  background: rgba(122, 241, 255, 0.18);
+}
+
 .aos-tabs {
   display: flex;
   align-items: center;

--- a/packages/toolkit/panel/index.js
+++ b/packages/toolkit/panel/index.js
@@ -28,4 +28,9 @@ export {
   workAreaFromWindow,
 } from './chrome.js'
 export { Single } from './layouts/single.js'
+export {
+  clampSplitPaneState,
+  createSplitPane,
+  SplitPane,
+} from './layouts/split-pane.js'
 export { Tabs } from './layouts/tabs.js'

--- a/packages/toolkit/panel/layouts/split-pane.js
+++ b/packages/toolkit/panel/layouts/split-pane.js
@@ -1,0 +1,425 @@
+// split-pane.js — two-pane panel/workbench layout with a draggable separator.
+//
+// The controller is pure DOM: it owns geometry, constraints, keyboard/pointer
+// affordances, and optional ratio persistence. Consumers still own pane content.
+
+import { wireBridge, emit } from '../../runtime/bridge.js'
+import { subscribe } from '../../runtime/subscribe.js'
+import { evalCanvas, spawnChild } from '../../runtime/canvas.js'
+import { declareManifest, emitReady } from '../../runtime/manifest.js'
+import { createRouter } from '../router.js'
+
+const ORIENTATIONS = new Set(['horizontal', 'vertical'])
+
+function finiteNumber(value, fallback = 0) {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : fallback
+}
+
+function positiveNumber(value, fallback = 1) {
+  return Math.max(1, finiteNumber(value, fallback))
+}
+
+function normalizeRatio(value, fallback = 0.5) {
+  const number = finiteNumber(value, fallback)
+  return Math.max(0, Math.min(1, number))
+}
+
+function normalizeOrientation(value) {
+  return ORIENTATIONS.has(value) ? value : 'horizontal'
+}
+
+function axis(orientation) {
+  return orientation === 'vertical'
+    ? { size: 'height', client: 'clientY', origin: 'top', flexDirection: 'column', aria: 'horizontal', minStyle: 'minHeight', maxStyle: 'maxHeight' }
+    : { size: 'width', client: 'clientX', origin: 'left', flexDirection: 'row', aria: 'vertical', minStyle: 'minWidth', maxStyle: 'maxWidth' }
+}
+
+function addClass(element, ...names) {
+  if (!element) return
+  if (element.classList?.add) {
+    element.classList.add(...names)
+    return
+  }
+  const current = new Set(String(element.className || '').split(/\s+/).filter(Boolean))
+  for (const name of names) current.add(name)
+  element.className = Array.from(current).join(' ')
+}
+
+function setStyle(element, name, value) {
+  if (!element?.style) return
+  if (name.startsWith('--') && element.style.setProperty) element.style.setProperty(name, value)
+  else element.style[name] = value
+}
+
+function setData(element, name, value) {
+  if (element?.dataset) element.dataset[name] = String(value)
+}
+
+function cloneState(state) {
+  return {
+    orientation: state.orientation,
+    ratio: state.ratio,
+    startSize: state.startSize,
+    endSize: state.endSize,
+    availableSize: state.availableSize,
+  }
+}
+
+function stateFromSource(source = null) {
+  if (typeof source === 'number') return { ratio: source }
+  if (typeof source === 'string') {
+    const trimmed = source.trim()
+    if (!trimmed) return null
+    const parsedNumber = Number(trimmed)
+    if (Number.isFinite(parsedNumber)) return { ratio: parsedNumber }
+    try {
+      return stateFromSource(JSON.parse(trimmed))
+    } catch {
+      return null
+    }
+  }
+  if (source && typeof source === 'object') return { ratio: source.ratio }
+  return null
+}
+
+function readStoredState(storage, storageKey) {
+  if (!storage || !storageKey) return null
+  try {
+    return stateFromSource(storage.getItem(storageKey))
+  } catch {
+    return null
+  }
+}
+
+function writeStoredState(storage, storageKey, state) {
+  if (!storage || !storageKey) return
+  try {
+    storage.setItem(storageKey, JSON.stringify({ ratio: state.ratio }))
+  } catch {}
+}
+
+function defaultStorage() {
+  try {
+    return globalThis.window?.localStorage || null
+  } catch {
+    return null
+  }
+}
+
+export function clampSplitPaneState({
+  ratio = 0.5,
+  size = 1,
+  dividerSize = 8,
+  minStart = 160,
+  minEnd = 160,
+  maxStart = Infinity,
+  maxEnd = Infinity,
+} = {}) {
+  const availableSize = Math.max(1, positiveNumber(size) - Math.max(0, finiteNumber(dividerSize, 8)))
+  const startMin = Math.max(0, finiteNumber(minStart, 0))
+  const endMin = Math.max(0, finiteNumber(minEnd, 0))
+  const startMax = Math.max(startMin, finiteNumber(maxStart, Infinity))
+  const endMax = Math.max(endMin, finiteNumber(maxEnd, Infinity))
+  const minSizeFromEnd = Math.max(0, availableSize - endMax)
+  const maxSizeFromEnd = Math.max(0, availableSize - endMin)
+  const lower = Math.min(availableSize, Math.max(startMin, minSizeFromEnd))
+  const upper = Math.max(lower, Math.min(availableSize, startMax, maxSizeFromEnd))
+  const requested = normalizeRatio(ratio) * availableSize
+  const startSize = Math.round(Math.max(lower, Math.min(upper, requested)))
+  const endSize = Math.max(0, Math.round(availableSize - startSize))
+
+  return {
+    ratio: startSize / availableSize,
+    startSize,
+    endSize,
+    availableSize,
+  }
+}
+
+export function createSplitPane({
+  root = null,
+  startPane = null,
+  endPane = null,
+  divider = null,
+  document: documentRef = null,
+  orientation = 'horizontal',
+  initialRatio = 0.5,
+  restoreState = null,
+  storageKey = '',
+  storage = null,
+  dividerSize = 8,
+  minStart = 160,
+  minEnd = 160,
+  maxStart = Infinity,
+  maxEnd = Infinity,
+  keyboardStep = 24,
+  ariaLabel = 'Resize panes',
+  onChange = null,
+} = {}) {
+  const doc = documentRef || root?.ownerDocument || globalThis.document
+  if (!doc?.createElement) throw new Error('createSplitPane: document with createElement is required')
+
+  const rootEl = root || doc.createElement('div')
+  const startEl = startPane || doc.createElement('div')
+  const endEl = endPane || doc.createElement('div')
+  const dividerEl = divider || doc.createElement('div')
+  const resolvedStorage = storage || defaultStorage()
+  const stored = readStoredState(resolvedStorage, storageKey)
+  const restored = stateFromSource(restoreState) || stored || { ratio: initialRatio }
+  const splitOrientation = normalizeOrientation(orientation)
+  const splitAxis = axis(splitOrientation)
+
+  addClass(rootEl, 'aos-split-pane')
+  addClass(startEl, 'aos-split-pane-pane', 'aos-split-pane-start')
+  addClass(endEl, 'aos-split-pane-pane', 'aos-split-pane-end')
+  addClass(dividerEl, 'aos-split-pane-divider')
+
+  rootEl.dataset.orientation = splitOrientation
+  setStyle(rootEl, 'flexDirection', splitAxis.flexDirection)
+  setStyle(rootEl, '--aos-split-divider-size', `${positiveNumber(dividerSize, 8)}px`)
+  setStyle(rootEl, '--aos-split-min-start', `${Math.max(0, finiteNumber(minStart, 0))}px`)
+  setStyle(rootEl, '--aos-split-min-end', `${Math.max(0, finiteNumber(minEnd, 0))}px`)
+
+  dividerEl.setAttribute('role', 'separator')
+  dividerEl.setAttribute('tabindex', '0')
+  dividerEl.setAttribute('aria-orientation', splitAxis.aria)
+  dividerEl.setAttribute('aria-label', ariaLabel)
+
+  if (!rootEl.contains?.(startEl)) rootEl.appendChild(startEl)
+  if (!rootEl.contains?.(dividerEl)) {
+    if (rootEl.contains?.(endEl) && rootEl.insertBefore) rootEl.insertBefore(dividerEl, endEl)
+    else rootEl.appendChild(dividerEl)
+  }
+  if (!rootEl.contains?.(endEl)) rootEl.appendChild(endEl)
+
+  const state = {
+    orientation: splitOrientation,
+    ratio: normalizeRatio(restored.ratio, initialRatio),
+    startSize: 0,
+    endSize: 0,
+    availableSize: 0,
+  }
+
+  function bounds() {
+    return rootEl.getBoundingClientRect?.() || { left: 0, top: 0, width: 1, height: 1 }
+  }
+
+  function apply(nextRatio, { notify = true, persist = true } = {}) {
+    const rect = bounds()
+    const next = clampSplitPaneState({
+      ratio: nextRatio,
+      size: rect[splitAxis.size],
+      dividerSize,
+      minStart,
+      minEnd,
+      maxStart,
+      maxEnd,
+    })
+    state.ratio = next.ratio
+    state.startSize = next.startSize
+    state.endSize = next.endSize
+    state.availableSize = next.availableSize
+
+    setStyle(startEl, 'flex', `0 0 ${state.startSize}px`)
+    setStyle(endEl, 'flex', '1 1 0')
+    setStyle(dividerEl, 'flex', `0 0 ${positiveNumber(dividerSize, 8)}px`)
+    setStyle(startEl, splitAxis.minStyle, `${Math.max(0, finiteNumber(minStart, 0))}px`)
+    setStyle(endEl, splitAxis.minStyle, `${Math.max(0, finiteNumber(minEnd, 0))}px`)
+    if (Number.isFinite(maxStart)) setStyle(startEl, splitAxis.maxStyle, `${maxStart}px`)
+    if (Number.isFinite(maxEnd)) setStyle(endEl, splitAxis.maxStyle, `${maxEnd}px`)
+
+    setData(rootEl, 'ratio', state.ratio.toFixed(4))
+    setData(dividerEl, 'ratio', state.ratio.toFixed(4))
+    dividerEl.setAttribute('aria-valuemin', '0')
+    dividerEl.setAttribute('aria-valuemax', '100')
+    dividerEl.setAttribute('aria-valuenow', String(Math.round(state.ratio * 100)))
+
+    const snapshot = cloneState(state)
+    if (persist) writeStoredState(resolvedStorage, storageKey, snapshot)
+    if (notify) onChange?.(snapshot)
+    return snapshot
+  }
+
+  function setRatio(nextRatio, options = {}) {
+    return apply(nextRatio, options)
+  }
+
+  function setStartSize(nextSize, options = {}) {
+    const available = Math.max(1, state.availableSize || (bounds()[splitAxis.size] - positiveNumber(dividerSize, 8)))
+    return apply(finiteNumber(nextSize, state.startSize) / available, options)
+  }
+
+  let pointerId = null
+
+  function pointerDown(event) {
+    if (event.button !== undefined && event.button !== 0) return
+    pointerId = event.pointerId
+    dividerEl.dataset.dragging = 'true'
+    rootEl.dataset.dragging = 'true'
+    dividerEl.setPointerCapture?.(pointerId)
+    event.preventDefault?.()
+  }
+
+  function pointerMove(event) {
+    if (pointerId === null || event.pointerId !== pointerId) return
+    const rect = bounds()
+    const rawSize = finiteNumber(event[splitAxis.client], rect[splitAxis.origin]) - finiteNumber(rect[splitAxis.origin], 0) - (positiveNumber(dividerSize, 8) / 2)
+    setStartSize(rawSize)
+    event.preventDefault?.()
+  }
+
+  function stopDrag(event = {}) {
+    if (pointerId === null || (event.pointerId !== undefined && event.pointerId !== pointerId)) return
+    const activePointer = pointerId
+    pointerId = null
+    delete dividerEl.dataset.dragging
+    delete rootEl.dataset.dragging
+    try {
+      if (dividerEl.hasPointerCapture?.(activePointer)) dividerEl.releasePointerCapture(activePointer)
+    } catch {}
+  }
+
+  function keyDown(event) {
+    const available = Math.max(1, state.availableSize)
+    const step = positiveNumber(keyboardStep, 24)
+    let delta = 0
+    if (splitOrientation === 'horizontal') {
+      if (event.key === 'ArrowLeft') delta = -step
+      if (event.key === 'ArrowRight') delta = step
+    } else {
+      if (event.key === 'ArrowUp') delta = -step
+      if (event.key === 'ArrowDown') delta = step
+    }
+    if (event.key === 'Home') {
+      setStartSize(0)
+      event.preventDefault?.()
+      return
+    }
+    if (event.key === 'End') {
+      setStartSize(available)
+      event.preventDefault?.()
+      return
+    }
+    if (delta !== 0) {
+      setStartSize(state.startSize + delta)
+      event.preventDefault?.()
+    }
+  }
+
+  dividerEl.addEventListener('pointerdown', pointerDown)
+  dividerEl.addEventListener('pointermove', pointerMove)
+  dividerEl.addEventListener('pointerup', stopDrag)
+  dividerEl.addEventListener('pointercancel', stopDrag)
+  dividerEl.addEventListener('lostpointercapture', stopDrag)
+  dividerEl.addEventListener('keydown', keyDown)
+
+  let resizeObserver = null
+  if (typeof ResizeObserver !== 'undefined') {
+    resizeObserver = new ResizeObserver(() => apply(state.ratio, { notify: false, persist: false }))
+    resizeObserver.observe(rootEl)
+  }
+
+  apply(state.ratio, { notify: false, persist: false })
+
+  return {
+    root: rootEl,
+    startPane: startEl,
+    endPane: endEl,
+    divider: dividerEl,
+    getState() {
+      return cloneState(state)
+    },
+    setRatio,
+    setStartSize,
+    destroy() {
+      dividerEl.removeEventListener?.('pointerdown', pointerDown)
+      dividerEl.removeEventListener?.('pointermove', pointerMove)
+      dividerEl.removeEventListener?.('pointerup', stopDrag)
+      dividerEl.removeEventListener?.('pointercancel', stopDrag)
+      dividerEl.removeEventListener?.('lostpointercapture', stopDrag)
+      dividerEl.removeEventListener?.('keydown', keyDown)
+      resizeObserver?.disconnect?.()
+    },
+  }
+}
+
+export function SplitPane(startFactory, endFactory, options = {}) {
+  if (!startFactory || !endFactory) {
+    throw new Error('SplitPane: requires start and end content factories')
+  }
+
+  return {
+    kind: 'split-pane',
+    startFactory,
+    endFactory,
+    mount(chrome) {
+      const consumerOnChange = typeof options.onChange === 'function' ? options.onChange : null
+      const split = createSplitPane({
+        ...options,
+        onChange(state) {
+          consumerOnChange?.(state)
+          emit('split-pane/resized', state)
+        },
+      })
+      chrome.contentEl.innerHTML = ''
+      chrome.contentEl.appendChild(split.root)
+
+      const contents = [
+        typeof startFactory === 'function' ? startFactory() : startFactory,
+        typeof endFactory === 'function' ? endFactory() : endFactory,
+      ]
+      const panes = [split.startPane, split.endPane]
+      const hostByContent = new Map()
+
+      contents.forEach((content, index) => {
+        const host = makeHost(panes[index], content)
+        hostByContent.set(content, host)
+        const rendered = content.render(host)
+        if (rendered instanceof Node) panes[index].appendChild(rendered)
+        else if (typeof rendered === 'string') panes[index].innerHTML = rendered
+        const requires = content.manifest?.requires || []
+        if (requires.length > 0) subscribe(requires, { snapshot: true })
+      })
+
+      declareManifest({
+        name: chrome.titleEl.textContent || 'split-pane',
+        accepts: contents.flatMap(content => (content.manifest?.accepts || []).map(type => `${content.manifest?.channelPrefix}/${type}`)),
+        emits: [
+          'split-pane/resized',
+          ...contents.flatMap(content => (content.manifest?.emits || []).map(type => `${content.manifest?.channelPrefix}/${type}`)),
+        ],
+        layout: {
+          kind: 'split-pane',
+          orientation: split.getState().orientation,
+        },
+        contents: contents.map((content, index) => ({
+          pane: index === 0 ? 'start' : 'end',
+          name: content.manifest?.name,
+          prefix: content.manifest?.channelPrefix,
+        })),
+      })
+
+      const router = createRouter({ contents, hostByContent })
+      wireBridge(router)
+
+      emitReady()
+      return split
+    },
+  }
+}
+
+function makeHost(slotEl, content) {
+  return {
+    contentEl: slotEl,
+    setTitle() {},
+    emit(type, payload) {
+      const prefix = content.manifest?.channelPrefix
+      const fullType = prefix ? `${prefix}/${type}` : type
+      emit(fullType, payload)
+    },
+    subscribe(events, options) { subscribe(events, options) },
+    spawnChild(opts) { return spawnChild(opts) },
+    evalCanvas(id, js, options) { return evalCanvas(id, js, options) },
+  }
+}

--- a/packages/toolkit/panel/mount.js
+++ b/packages/toolkit/panel/mount.js
@@ -39,6 +39,8 @@ export function mountPanel({
     mountSingle(chrome, content)
   } else if (layout.kind === 'tabs') {
     layout.mount(chrome)
+  } else if (layout.kind === 'split-pane') {
+    layout.mount(chrome)
   } else {
     throw new Error(`mountPanel: unknown layout kind '${layout.kind}'`)
   }

--- a/packages/toolkit/workbench/defaults.css
+++ b/packages/toolkit/workbench/defaults.css
@@ -190,6 +190,20 @@ body {
   grid-template-columns: minmax(380px, 1.22fr) minmax(420px, 0.9fr);
 }
 
+.aos-workbench-main.aos-split-pane {
+  display: flex;
+  grid-template-columns: none;
+  grid-template-rows: none;
+}
+
+.aos-workbench-main.aos-split-pane > .aos-split-pane-divider {
+  background: rgba(122, 241, 255, 0.1);
+}
+
+.aos-workbench-main.aos-split-pane > .aos-split-pane-divider::after {
+  background: rgba(183, 252, 255, 0.42);
+}
+
 .aos-workbench-preview-pane {
   min-width: 0;
   min-height: 0;
@@ -255,6 +269,15 @@ body {
   background: rgba(12, 14, 22, 0.94);
 }
 
+.aos-workbench-main.aos-split-pane[data-orientation="horizontal"] > .aos-workbench-controls-pane {
+  border-left: 0;
+}
+
+.aos-workbench-main.aos-split-pane[data-orientation="vertical"] > .aos-workbench-controls-pane {
+  border-left: 0;
+  border-top: 0;
+}
+
 .aos-workbench-pane-title {
   flex: 0 0 auto;
   padding: 8px 10px;
@@ -287,12 +310,12 @@ body {
 }
 
 @media (max-width: 780px) {
-  .aos-workbench-main {
+  .aos-workbench-main:not(.aos-split-pane) {
     grid-template-columns: 1fr;
     grid-template-rows: minmax(260px, 1fr) minmax(240px, 0.9fr);
   }
 
-  .aos-workbench-controls-pane {
+  .aos-workbench-main:not(.aos-split-pane) .aos-workbench-controls-pane {
     border-left: 0;
     border-top: 1px solid rgba(122, 241, 255, 0.18);
   }

--- a/tests/toolkit/split-pane-layout.test.mjs
+++ b/tests/toolkit/split-pane-layout.test.mjs
@@ -1,0 +1,330 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  clampSplitPaneState,
+  createSplitPane,
+  SplitPane,
+} from '../../packages/toolkit/panel/layouts/split-pane.js';
+
+class FakeNode {}
+
+class FakeClassList {
+  constructor(owner) {
+    this.owner = owner;
+    this.names = new Set();
+  }
+
+  setFromString(value) {
+    this.names = new Set(String(value || '').split(/\s+/).filter(Boolean));
+  }
+
+  add(...names) {
+    for (const name of names) this.names.add(name);
+    this.owner._className = Array.from(this.names).join(' ');
+  }
+
+  contains(name) {
+    return this.names.has(name);
+  }
+}
+
+class FakeStyle {
+  setProperty(name, value) {
+    this[name] = String(value);
+  }
+}
+
+class FakeElement extends FakeNode {
+  constructor(tagName = 'div') {
+    super();
+    this.tagName = tagName.toUpperCase();
+    this.children = [];
+    this.parentNode = null;
+    this.listeners = new Map();
+    this.dataset = {};
+    this.attributes = {};
+    this.style = new FakeStyle();
+    this.classList = new FakeClassList(this);
+    this._className = '';
+    this.innerHTML = '';
+    this.textContent = '';
+    this.rect = { left: 0, top: 0, width: 1000, height: 600 };
+    this.capturedPointers = new Set();
+  }
+
+  get className() {
+    return this._className;
+  }
+
+  set className(value) {
+    this._className = String(value);
+    this.classList.setFromString(this._className);
+  }
+
+  appendChild(child) {
+    child.parentNode = this;
+    this.children.push(child);
+    return child;
+  }
+
+  insertBefore(child, reference) {
+    child.parentNode = this;
+    const index = this.children.indexOf(reference);
+    if (index < 0) this.children.push(child);
+    else this.children.splice(index, 0, child);
+    return child;
+  }
+
+  contains(target) {
+    if (target === this) return true;
+    return this.children.some((child) => child === target || child.contains?.(target));
+  }
+
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+    if (name === 'id') this.id = String(value);
+  }
+
+  getAttribute(name) {
+    return this.attributes[name] ?? null;
+  }
+
+  addEventListener(type, handler) {
+    const handlers = this.listeners.get(type) ?? [];
+    handlers.push(handler);
+    this.listeners.set(type, handlers);
+  }
+
+  removeEventListener(type, handler) {
+    const handlers = this.listeners.get(type) ?? [];
+    this.listeners.set(type, handlers.filter((entry) => entry !== handler));
+  }
+
+  dispatch(type, overrides = {}) {
+    const event = {
+      button: 0,
+      pointerId: 1,
+      clientX: 0,
+      clientY: 0,
+      key: '',
+      target: this,
+      defaultPrevented: false,
+      preventDefault() { this.defaultPrevented = true; },
+      ...overrides,
+    };
+    for (const handler of this.listeners.get(type) ?? []) handler(event);
+    return event;
+  }
+
+  getBoundingClientRect() {
+    return { ...this.rect };
+  }
+
+  setPointerCapture(pointerId) {
+    this.capturedPointers.add(pointerId);
+  }
+
+  hasPointerCapture(pointerId) {
+    return this.capturedPointers.has(pointerId);
+  }
+
+  releasePointerCapture(pointerId) {
+    this.capturedPointers.delete(pointerId);
+  }
+}
+
+class FakeDocument {
+  createElement(tagName) {
+    return new FakeElement(tagName);
+  }
+}
+
+class FakeStorage {
+  constructor(seed = {}) {
+    this.values = new Map(Object.entries(seed));
+  }
+
+  getItem(key) {
+    return this.values.has(key) ? this.values.get(key) : null;
+  }
+
+  setItem(key, value) {
+    this.values.set(key, String(value));
+  }
+}
+
+function makeContent(name) {
+  return () => ({
+    manifest: {
+      name,
+      channelPrefix: name,
+      accepts: ['ping'],
+      emits: ['pong'],
+    },
+    render() {
+      const element = new FakeElement('section');
+      element.textContent = name;
+      return element;
+    },
+  });
+}
+
+test('clampSplitPaneState enforces min and max pane constraints', () => {
+  assert.deepEqual(clampSplitPaneState({
+    ratio: 0.1,
+    size: 1000,
+    dividerSize: 8,
+    minStart: 240,
+    minEnd: 300,
+  }), {
+    ratio: 240 / 992,
+    startSize: 240,
+    endSize: 752,
+    availableSize: 992,
+  });
+
+  assert.deepEqual(clampSplitPaneState({
+    ratio: 0.95,
+    size: 1000,
+    dividerSize: 8,
+    minStart: 240,
+    minEnd: 300,
+    maxStart: 620,
+  }), {
+    ratio: 620 / 992,
+    startSize: 620,
+    endSize: 372,
+    availableSize: 992,
+  });
+});
+
+test('createSplitPane wires existing panes with separator semantics and restored state', () => {
+  const documentRef = new FakeDocument();
+  const root = documentRef.createElement('main');
+  const startPane = documentRef.createElement('section');
+  const endPane = documentRef.createElement('aside');
+  root.appendChild(startPane);
+  root.appendChild(endPane);
+  root.rect = { left: 0, top: 0, width: 1008, height: 600 };
+
+  const split = createSplitPane({
+    root,
+    startPane,
+    endPane,
+    document: documentRef,
+    restoreState: { ratio: 0.6 },
+    minStart: 200,
+    minEnd: 240,
+    dividerSize: 8,
+    ariaLabel: 'Resize preview and controls panes',
+  });
+
+  assert.equal(root.classList.contains('aos-split-pane'), true);
+  assert.equal(startPane.classList.contains('aos-split-pane-start'), true);
+  assert.equal(endPane.classList.contains('aos-split-pane-end'), true);
+  assert.equal(root.children[1], split.divider);
+  assert.equal(split.divider.getAttribute('role'), 'separator');
+  assert.equal(split.divider.getAttribute('aria-orientation'), 'vertical');
+  assert.equal(split.divider.getAttribute('aria-label'), 'Resize preview and controls panes');
+  assert.equal(split.divider.getAttribute('aria-valuenow'), '60');
+  assert.deepEqual(split.getState(), {
+    orientation: 'horizontal',
+    ratio: 0.6,
+    startSize: 600,
+    endSize: 400,
+    availableSize: 1000,
+  });
+});
+
+test('split pane pointer and keyboard updates emit constrained persisted ratios', () => {
+  const documentRef = new FakeDocument();
+  const storage = new FakeStorage({ split: JSON.stringify({ ratio: 0.5 }) });
+  const changes = [];
+  const split = createSplitPane({
+    document: documentRef,
+    storage,
+    storageKey: 'split',
+    minStart: 120,
+    minEnd: 160,
+    dividerSize: 8,
+    keyboardStep: 40,
+    onChange(state) {
+      changes.push(state);
+    },
+  });
+  split.root.rect = { left: 0, top: 0, width: 808, height: 500 };
+  split.setRatio(0.5, { notify: false, persist: false });
+
+  split.divider.dispatch('pointerdown', { pointerId: 9, clientX: 400 });
+  assert.equal(split.divider.dataset.dragging, 'true');
+  assert.equal(split.root.dataset.dragging, 'true');
+  split.divider.dispatch('pointermove', { pointerId: 9, clientX: 604 });
+  split.divider.dispatch('pointerup', { pointerId: 9 });
+
+  assert.equal(split.divider.dataset.dragging, undefined);
+  assert.equal(split.getState().startSize, 600);
+  assert.equal(changes.at(-1).startSize, 600);
+  assert.deepEqual(JSON.parse(storage.getItem('split')), { ratio: 0.75 });
+
+  split.divider.dispatch('keydown', { key: 'ArrowLeft' });
+  assert.equal(split.getState().startSize, 560);
+  split.divider.dispatch('keydown', { key: 'Home' });
+  assert.equal(split.getState().startSize, 120);
+  split.divider.dispatch('keydown', { key: 'End' });
+  assert.equal(split.getState().startSize, 640);
+});
+
+test('SplitPane layout mounts two content factories into start and end panes', async (t) => {
+  const previousNode = globalThis.Node;
+  const previousDocument = globalThis.document;
+  const previousWindow = globalThis.window;
+  const previousAtob = globalThis.atob;
+
+  globalThis.Node = FakeNode;
+  globalThis.document = new FakeDocument();
+  const outbound = [];
+  globalThis.window = {
+    headsup: {},
+    webkit: {
+      messageHandlers: {
+        headsup: {
+          postMessage(message) {
+            outbound.push(message);
+          },
+        },
+      },
+    },
+  };
+  globalThis.atob = (value) => Buffer.from(value, 'base64').toString('utf8');
+
+  t.after(() => {
+    globalThis.Node = previousNode;
+    globalThis.document = previousDocument;
+    globalThis.window = previousWindow;
+    globalThis.atob = previousAtob;
+  });
+
+  const layout = SplitPane(makeContent('preview'), makeContent('controls'), {
+    initialRatio: 0.58,
+    minStart: 200,
+    minEnd: 200,
+  });
+  const chrome = {
+    contentEl: new FakeElement('div'),
+    titleEl: { textContent: 'Split Smoke' },
+  };
+  const split = layout.mount(chrome);
+
+  assert.equal(chrome.contentEl.children[0], split.root);
+  assert.equal(split.startPane.children[0].textContent, 'preview');
+  assert.equal(split.endPane.children[0].textContent, 'controls');
+  assert.deepEqual(window.headsup.manifest.layout, {
+    kind: 'split-pane',
+    orientation: 'horizontal',
+  });
+  assert.deepEqual(window.headsup.manifest.contents, [
+    { pane: 'start', name: 'preview', prefix: 'preview' },
+    { pane: 'end', name: 'controls', prefix: 'controls' },
+  ]);
+  assert.equal(outbound.some((message) => message.type === 'ready'), true);
+});

--- a/tests/toolkit/workbench-shell.test.mjs
+++ b/tests/toolkit/workbench-shell.test.mjs
@@ -19,6 +19,7 @@ test('workbench defaults define shell, toolbar, and pane primitives', async () =
     '.aos-workbench-stage-actions',
     '.aos-workbench-preview-pane',
     '.aos-workbench-controls-pane',
+    '.aos-workbench-main.aos-split-pane',
   ]) {
     assert.match(css, new RegExp(`${selector.replace('.', '\\.')}\\s*\\{`));
   }
@@ -34,6 +35,9 @@ test('Sigil radial item workbench keeps editor controls out of titlebar chrome',
   assert.match(titlebar, /id="minimize-workbench"/);
   assert.match(titlebar, /id="maximize-workbench"/);
   assert.match(titlebar, /id="close-workbench"/);
+  assert.match(html, /id="workbench-main"/);
+  assert.match(html, /id="preview-pane"/);
+  assert.match(html, /id="controls-pane"/);
   assert.doesNotMatch(titlebar, /id="item-select"|id="axes-toggle"|id="lock-in"/);
 
   assert.match(toolbar, /id="item-select"/);


### PR DESCRIPTION
## Summary
- add a reusable toolkit SplitPane layout and createSplitPane DOM controller with pointer, keyboard, min/max, and ratio restore support
- wire the Sigil radial item workbench preview/control panes through the toolkit split-pane controller
- document the panel API and surface-system split-pane slice

## Verification
- node --check packages/toolkit/panel/layouts/split-pane.js apps/sigil/radial-item-workbench/index.js packages/toolkit/panel/index.js packages/toolkit/panel/mount.js
- node --test tests/toolkit/split-pane-layout.test.mjs tests/toolkit/workbench-shell.test.mjs
- node --test tests/toolkit/*.test.mjs tests/renderer/radial-item-editor.test.mjs tests/renderer/radial-object-control.test.mjs
- git diff --check

Closes #231