### PR TITLE
Add toolkit split-pane docking state

### DIFF
--- a/apps/sigil/radial-item-workbench/index.html
+++ b/apps/sigil/radial-item-workbench/index.html
@@ -32,6 +32,7 @@
           <input type="checkbox" id="axes-toggle" checked>
           <span>Axes</span>
         </label>
+        <button type="button" id="toggle-controls-pane" aria-pressed="true" title="Hide transform controls">Controls</button>
         <button type="button" id="lock-in" title="Export the current item definition">Lock in</button>
         <button type="button" id="reset-orbit" title="Reset preview orbit and zoom">Reset view</button>
       </div>

--- a/apps/sigil/radial-item-workbench/index.js
+++ b/apps/sigil/radial-item-workbench/index.js
@@ -48,6 +48,7 @@ const maximizeWorkbenchButton = document.getElementById('maximize-workbench');
 const itemSelect = document.getElementById('item-select');
 const spinToggle = document.getElementById('spin-toggle');
 const axesToggle = document.getElementById('axes-toggle');
+const toggleControlsPaneButton = document.getElementById('toggle-controls-pane');
 const lockInButton = document.getElementById('lock-in');
 const resetOrbitButton = document.getElementById('reset-orbit');
 const undoButton = document.getElementById('undo-change');
@@ -68,6 +69,7 @@ const splitPane = createSplitPane({
     ariaLabel: 'Resize preview and controls panes',
     onChange() {
         syncPreviewSize();
+        syncControlsPaneToggle();
     },
 });
 
@@ -325,6 +327,14 @@ function clearHistory() {
     updateHistoryButtons();
 }
 
+function syncControlsPaneToggle() {
+    if (!toggleControlsPaneButton) return;
+    const isOpen = splitPane.isPaneOpen('end');
+    toggleControlsPaneButton.setAttribute('aria-pressed', String(isOpen));
+    toggleControlsPaneButton.dataset.open = String(isOpen);
+    toggleControlsPaneButton.title = isOpen ? 'Hide transform controls' : 'Show transform controls';
+}
+
 function applyPatch(message, { recordHistory = true } = {}) {
     const before = recordHistory ? objectSnapshot(message.target) : null;
     const result = applyEditorObjectPatch(editorState, message);
@@ -527,6 +537,10 @@ spinToggle.addEventListener('change', () => {
 });
 
 axesToggle.addEventListener('change', syncOrbit);
+toggleControlsPaneButton?.addEventListener('click', () => {
+    splitPane.togglePane('end');
+    syncControlsPaneToggle();
+});
 lockInButton.addEventListener('click', lockIn);
 resetOrbitButton.addEventListener('click', resetOrbit);
 undoButton.addEventListener('click', undoChange);
@@ -588,6 +602,7 @@ maximizeWorkbenchButton?.addEventListener('click', (event) => {
 });
 
 syncControls();
+syncControlsPaneToggle();
 syncOrbit();
 syncPanelRegistry();
 post('ready', {
@@ -632,6 +647,7 @@ window.__sigilRadialItemWorkbench = {
             history: { undo: undoStack.length, redo: redoStack.length },
             orbit: { x: orbitState.x, y: orbitState.y, zoom: orbitState.zoom },
             splitPane: splitPane.getState(),
+            controlsPaneOpen: splitPane.isPaneOpen('end'),
             axesVisible: axesGuide.visible,
             visuals: visuals.snapshot(),
         };

--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -1094,13 +1094,13 @@ Options:
 | `divider` | `HTMLElement` | existing separator; created when omitted |
 | `orientation` | `'horizontal' \| 'vertical'` | left-right or top-bottom split, default `horizontal` |
 | `initialRatio` | `number` | start pane ratio before restore, default `0.5` |
-| `restoreState` | `object \| number` | explicit restored state or ratio |
-| `storageKey` | `string` | optional localStorage-backed ratio persistence |
+| `restoreState` | `object \| number` | explicit restored state or ratio; objects may include `closedPane` |
+| `storageKey` | `string` | optional localStorage-backed ratio and closed-pane persistence |
 | `minStart` / `minEnd` | `number` | minimum start/end pane size in pixels |
 | `maxStart` / `maxEnd` | `number` | optional maximum start/end pane size in pixels |
 | `keyboardStep` | `number` | arrow-key resize step in pixels |
 | `ariaLabel` | `string` | accessible separator label |
-| `onChange` | `function` | called with `{ orientation, ratio, startSize, endSize, availableSize }` |
+| `onChange` | `function` | called with `{ orientation, ratio, startSize, endSize, availableSize, closedPane }` |
 
 The returned controller exposes:
 
@@ -1110,6 +1110,10 @@ The returned controller exposes:
 | `getState()` | current normalized split state |
 | `setRatio(ratio, options?)` | update by ratio |
 | `setStartSize(px, options?)` | update by start pane pixels |
+| `closePane('start' \| 'end')` | close one pane and let the other fill the split root |
+| `openPane('start' \| 'end')` | reopen a closed pane and restore the last ratio |
+| `togglePane('start' \| 'end')` | close/open one pane |
+| `isPaneOpen('start' \| 'end')` | return whether a pane is currently open |
 | `destroy()` | remove controller event listeners |
 
 The separator uses `role="separator"`, `aria-orientation`, `aria-valuenow`,

--- a/docs/design/aos-surface-system.md
+++ b/docs/design/aos-surface-system.md
@@ -64,9 +64,9 @@ preview/source, workflow graph/source, and report/slides workbenches.
 
 The first promoted slice is `createSplitPane` / `SplitPane` in
 `packages/toolkit/panel/`: a reusable draggable separator with min/max pane
-constraints, keyboard semantics, and optional ratio restore. Docking,
-collapsing, and breakout behavior build on top of this primitive instead of
-being separate editor-specific layout code.
+constraints, keyboard semantics, optional ratio restore, and open/closed pane
+state. Collapsing to minimized bars and breakout behavior build on top of this
+primitive instead of being separate editor-specific layout code.
 
 The object/layer list should treat grouped scene objects as a tree, not a flat
 bag. A whole-composition group can own child meshes, and later it can own

--- a/packages/toolkit/panel/defaults.css
+++ b/packages/toolkit/panel/defaults.css
@@ -156,6 +156,11 @@
   overflow: auto;
 }
 
+.aos-split-pane-pane[hidden],
+.aos-split-pane-divider[hidden] {
+  display: none !important;
+}
+
 .aos-split-pane-divider {
   flex: 0 0 var(--aos-split-divider-size, 8px);
   position: relative;

--- a/packages/toolkit/panel/layouts/split-pane.js
+++ b/packages/toolkit/panel/layouts/split-pane.js
@@ -56,6 +56,14 @@ function setData(element, name, value) {
   if (element?.dataset) element.dataset[name] = String(value)
 }
 
+function removeData(element, name) {
+  if (element?.dataset) delete element.dataset[name]
+}
+
+function normalizePane(value) {
+  return value === 'start' || value === 'end' ? value : null
+}
+
 function cloneState(state) {
   return {
     orientation: state.orientation,
@@ -63,6 +71,7 @@ function cloneState(state) {
     startSize: state.startSize,
     endSize: state.endSize,
     availableSize: state.availableSize,
+    closedPane: state.closedPane,
   }
 }
 
@@ -79,7 +88,13 @@ function stateFromSource(source = null) {
       return null
     }
   }
-  if (source && typeof source === 'object') return { ratio: source.ratio }
+  if (source && typeof source === 'object') {
+    return {
+      ratio: source.ratio,
+      restoreRatio: source.restoreRatio,
+      closedPane: normalizePane(source.closedPane),
+    }
+  }
   return null
 }
 
@@ -95,7 +110,10 @@ function readStoredState(storage, storageKey) {
 function writeStoredState(storage, storageKey, state) {
   if (!storage || !storageKey) return
   try {
-    storage.setItem(storageKey, JSON.stringify({ ratio: state.ratio }))
+    storage.setItem(storageKey, JSON.stringify({
+      ratio: state.ratio,
+      closedPane: state.closedPane,
+    }))
   } catch {}
 }
 
@@ -196,6 +214,8 @@ export function createSplitPane({
   const state = {
     orientation: splitOrientation,
     ratio: normalizeRatio(restored.ratio, initialRatio),
+    restoreRatio: normalizeRatio(restored.restoreRatio ?? restored.ratio, initialRatio),
+    closedPane: normalizePane(restored.closedPane),
     startSize: 0,
     endSize: 0,
     availableSize: 0,
@@ -207,8 +227,41 @@ export function createSplitPane({
 
   function apply(nextRatio, { notify = true, persist = true } = {}) {
     const rect = bounds()
+    state.ratio = normalizeRatio(nextRatio, state.ratio)
+
+    if (state.closedPane) {
+      state.restoreRatio = state.ratio
+      const fullSize = positiveNumber(rect[splitAxis.size], 1)
+      const startOpen = state.closedPane !== 'start'
+      const endOpen = state.closedPane !== 'end'
+      state.startSize = startOpen ? fullSize : 0
+      state.endSize = endOpen ? fullSize : 0
+      state.availableSize = fullSize
+
+      startEl.hidden = !startOpen
+      endEl.hidden = !endOpen
+      dividerEl.hidden = true
+      setStyle(startEl, 'flex', startOpen ? '1 1 0' : '0 0 0px')
+      setStyle(endEl, 'flex', endOpen ? '1 1 0' : '0 0 0px')
+      setStyle(dividerEl, 'flex', '0 0 0px')
+      setData(rootEl, 'closedPane', state.closedPane)
+      setData(rootEl, 'ratio', state.ratio.toFixed(4))
+      dividerEl.setAttribute('aria-valuemin', '0')
+      dividerEl.setAttribute('aria-valuemax', '100')
+      dividerEl.setAttribute('aria-valuenow', String(Math.round(state.ratio * 100)))
+
+      const closedSnapshot = cloneState(state)
+      if (persist) writeStoredState(resolvedStorage, storageKey, closedSnapshot)
+      if (notify) onChange?.(closedSnapshot)
+      return closedSnapshot
+    }
+
+    startEl.hidden = false
+    endEl.hidden = false
+    dividerEl.hidden = false
+    removeData(rootEl, 'closedPane')
     const next = clampSplitPaneState({
-      ratio: nextRatio,
+      ratio: state.ratio,
       size: rect[splitAxis.size],
       dividerSize,
       minStart,
@@ -217,6 +270,7 @@ export function createSplitPane({
       maxEnd,
     })
     state.ratio = next.ratio
+    state.restoreRatio = next.ratio
     state.startSize = next.startSize
     state.endSize = next.endSize
     state.availableSize = next.availableSize
@@ -248,6 +302,31 @@ export function createSplitPane({
   function setStartSize(nextSize, options = {}) {
     const available = Math.max(1, state.availableSize || (bounds()[splitAxis.size] - positiveNumber(dividerSize, 8)))
     return apply(finiteNumber(nextSize, state.startSize) / available, options)
+  }
+
+  function closePane(pane = 'end', options = {}) {
+    const targetPane = normalizePane(pane) || 'end'
+    if (state.closedPane === targetPane) return cloneState(state)
+    if (!state.closedPane) state.restoreRatio = state.ratio
+    state.closedPane = targetPane
+    return apply(state.ratio, options)
+  }
+
+  function openPane(pane = state.closedPane, options = {}) {
+    const targetPane = normalizePane(pane) || state.closedPane
+    if (!state.closedPane || (targetPane && state.closedPane !== targetPane)) return cloneState(state)
+    state.closedPane = null
+    return apply(state.restoreRatio ?? state.ratio, options)
+  }
+
+  function togglePane(pane = 'end', options = {}) {
+    const targetPane = normalizePane(pane) || 'end'
+    return state.closedPane === targetPane ? openPane(targetPane, options) : closePane(targetPane, options)
+  }
+
+  function isPaneOpen(pane = 'end') {
+    const targetPane = normalizePane(pane) || 'end'
+    return state.closedPane !== targetPane
   }
 
   let pointerId = null
@@ -332,6 +411,10 @@ export function createSplitPane({
     },
     setRatio,
     setStartSize,
+    closePane,
+    openPane,
+    togglePane,
+    isPaneOpen,
     destroy() {
       dividerEl.removeEventListener?.('pointerdown', pointerDown)
       dividerEl.removeEventListener?.('pointermove', pointerMove)

--- a/tests/toolkit/split-pane-layout.test.mjs
+++ b/tests/toolkit/split-pane-layout.test.mjs
@@ -233,6 +233,7 @@ test('createSplitPane wires existing panes with separator semantics and restored
     startSize: 600,
     endSize: 400,
     availableSize: 1000,
+    closedPane: null,
   });
 });
 
@@ -264,7 +265,7 @@ test('split pane pointer and keyboard updates emit constrained persisted ratios'
   assert.equal(split.divider.dataset.dragging, undefined);
   assert.equal(split.getState().startSize, 600);
   assert.equal(changes.at(-1).startSize, 600);
-  assert.deepEqual(JSON.parse(storage.getItem('split')), { ratio: 0.75 });
+  assert.deepEqual(JSON.parse(storage.getItem('split')), { ratio: 0.75, closedPane: null });
 
   split.divider.dispatch('keydown', { key: 'ArrowLeft' });
   assert.equal(split.getState().startSize, 560);
@@ -272,6 +273,46 @@ test('split pane pointer and keyboard updates emit constrained persisted ratios'
   assert.equal(split.getState().startSize, 120);
   split.divider.dispatch('keydown', { key: 'End' });
   assert.equal(split.getState().startSize, 640);
+});
+
+test('split pane can close and reopen a sidebar while preserving prior ratio', () => {
+  const documentRef = new FakeDocument();
+  const storage = new FakeStorage();
+  const changes = [];
+  const split = createSplitPane({
+    document: documentRef,
+    storage,
+    storageKey: 'dock',
+    initialRatio: 0.55,
+    minStart: 120,
+    minEnd: 160,
+    dividerSize: 8,
+    onChange(state) {
+      changes.push(state);
+    },
+  });
+  split.root.rect = { left: 0, top: 0, width: 808, height: 500 };
+  split.setRatio(0.55, { notify: false, persist: false });
+
+  const closed = split.closePane('end');
+  assert.equal(closed.closedPane, 'end');
+  assert.equal(closed.startSize, 808);
+  assert.equal(closed.endSize, 0);
+  assert.equal(split.endPane.hidden, true);
+  assert.equal(split.divider.hidden, true);
+  assert.equal(split.isPaneOpen('end'), false);
+  assert.equal(split.root.dataset.closedPane, 'end');
+  assert.deepEqual(JSON.parse(storage.getItem('dock')), { ratio: 0.55, closedPane: 'end' });
+
+  const reopened = split.openPane('end');
+  assert.equal(reopened.closedPane, null);
+  assert.equal(reopened.startSize, 440);
+  assert.equal(reopened.endSize, 360);
+  assert.equal(split.endPane.hidden, false);
+  assert.equal(split.divider.hidden, false);
+  assert.equal(split.isPaneOpen('end'), true);
+  assert.equal(split.root.dataset.closedPane, undefined);
+  assert.deepEqual(changes.map((state) => state.closedPane), ['end', null]);
 });
 
 test('SplitPane layout mounts two content factories into start and end panes', async (t) => {

--- a/tests/toolkit/workbench-shell.test.mjs
+++ b/tests/toolkit/workbench-shell.test.mjs
@@ -42,6 +42,7 @@ test('Sigil radial item workbench keeps editor controls out of titlebar chrome',
 
   assert.match(toolbar, /id="item-select"/);
   assert.match(toolbar, /id="axes-toggle"/);
+  assert.match(toolbar, /id="toggle-controls-pane"/);
   assert.match(toolbar, /id="lock-in"/);
   assert.doesNotMatch(toolbar, /id="pulse-control"/);
 });


### PR DESCRIPTION
## Summary
- extend the toolkit split-pane controller with open/closed pane state and close/open/toggle/isPaneOpen methods
- persist closed-pane state alongside the split ratio and expose closedPane in controller snapshots
- add a Controls sidebar toggle to the Sigil radial item workbench as the first adopter

## Verification
- node --check packages/toolkit/panel/layouts/split-pane.js apps/sigil/radial-item-workbench/index.js
- node --test tests/toolkit/split-pane-layout.test.mjs tests/toolkit/workbench-shell.test.mjs
- node --test tests/toolkit/*.test.mjs tests/renderer/radial-item-editor.test.mjs tests/renderer/radial-object-control.test.mjs
- git diff --check

Closes #232