### PR TITLE
Clamp toolkit panel drag placement

### DIFF
--- a/apps/sigil/radial-item-workbench/index.js
+++ b/apps/sigil/radial-item-workbench/index.js
@@ -33,7 +33,7 @@ addStylesheet(`/${toolkitRoot}/controls/defaults.css`, { before: appStylesheet }
 addStylesheet(`/${toolkitRoot}/components/object-transform-panel/styles.css`, { before: appStylesheet });
 
 const { default: ObjectTransformPanel } = await import(`/${toolkitRoot}/components/object-transform-panel/index.js`);
-const { createMaximizeController, createSplitPane, syncMaximizeButton, wireResize } = await import(`/${toolkitRoot}/panel/index.js`);
+const { createMaximizeController, createSplitPane, syncMaximizeButton, wireDrag, wireResize } = await import(`/${toolkitRoot}/panel/index.js`);
 const { removeSelf, spawnChild, suspendCanvas } = await import(`/${toolkitRoot}/runtime/canvas.js`);
 
 const workbenchShell = document.querySelector('.aos-workbench-shell');
@@ -108,10 +108,6 @@ const MAX_SCENE_ZOOM = 2.2;
 function post(type, payload) {
     const body = payload === undefined ? { type } : { type, payload };
     window.webkit?.messageHandlers?.headsup?.postMessage(body);
-}
-
-function postRaw(message) {
-    window.webkit?.messageHandlers?.headsup?.postMessage(message);
 }
 
 const scene = new THREE.Scene();
@@ -232,13 +228,6 @@ const orbitState = {
     pointerId: null,
     lastX: 0,
     lastY: 0,
-};
-
-const windowDragState = {
-    active: false,
-    pointerId: null,
-    offsetX: 0,
-    offsetY: 0,
 };
 
 function syncOrbit() {
@@ -451,50 +440,14 @@ window.headsup.receive = function receive(b64) {
     }
 };
 
-dragHandle.addEventListener('pointerdown', (event) => {
-    if (event.button !== 0) return;
-    if (event.target?.closest?.('button, select, input, label')) return;
-    windowDragState.active = true;
-    windowDragState.pointerId = event.pointerId;
-    windowDragState.offsetX = event.clientX;
-    windowDragState.offsetY = event.clientY;
-    dragHandle.dataset.dragging = 'true';
-    postRaw({
-        type: 'drag_start',
-        offsetX: windowDragState.offsetX,
-        offsetY: windowDragState.offsetY,
-    });
-    dragHandle.setPointerCapture?.(event.pointerId);
-    event.preventDefault();
-});
-
-dragHandle.addEventListener('pointermove', (event) => {
-    if (!windowDragState.active || event.pointerId !== windowDragState.pointerId) return;
-    postRaw({
-        type: 'move_abs',
-        screenX: event.screenX,
-        screenY: event.screenY,
-        offsetX: windowDragState.offsetX,
-        offsetY: windowDragState.offsetY,
-    });
-    event.preventDefault();
-});
-
-function endWindowDrag(event) {
-    if (event.pointerId !== windowDragState.pointerId) return;
-    windowDragState.active = false;
-    windowDragState.pointerId = null;
-    delete dragHandle.dataset.dragging;
-    dragHandle.releasePointerCapture?.(event.pointerId);
-    postRaw({ type: 'drag_end' });
-}
-
-dragHandle.addEventListener('pointerup', endWindowDrag);
-dragHandle.addEventListener('pointercancel', endWindowDrag);
-dragHandle.addEventListener('lostpointercapture', (event) => {
-    if (!windowDragState.active || event.pointerId !== windowDragState.pointerId) return;
-    endWindowDrag(event);
-});
+const dragController = dragHandle
+    ? wireDrag(dragHandle, workbenchShell?.querySelector('.aos-window-controls'), {
+        clampOnEnd: true,
+        onStart() {
+            if (maximizeController.getState().maximized) maximizeController.restore();
+        },
+    })
+    : null;
 
 renderer.domElement.addEventListener('pointerdown', (event) => {
     orbitState.dragging = true;
@@ -628,6 +581,7 @@ window.__sigilRadialItemWorkbench = {
     orbit,
     orbitState,
     maximizeController,
+    dragController,
     resizeController,
     registry,
     syncPanelRegistry,

--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -949,15 +949,18 @@ Public entrypoint:
 
 ```js
 import {
+  createDragController,
   createResizeController,
   createSplitPane,
   createMaximizeController,
+  dragFrameFromPointer,
   mountPanel,
   mountChrome,
   resizeFrame,
   Single,
   SplitPane,
   Tabs,
+  wireDrag,
   wireResize,
 } from 'aos://toolkit/panel/index.js'
 ```
@@ -979,6 +982,7 @@ Options:
 | --- | --- | --- |
 | `title` | `string` | header title |
 | `draggable` | `boolean` | whether header drag emits absolute move updates plus `drag_start` / `drag_end` lifecycle messages |
+| `drag` | `object` | optional drag controller settings; stock chrome clamps final placement by default |
 | `close` | `boolean` | whether to show the stock close control, default `true` |
 | `minimize` | `boolean` | whether to show the stock minimize control, default `true` |
 | `maximize` | `boolean` | whether to show the stock maximize/restore control, default `false` |
@@ -1000,6 +1004,7 @@ Returns an object with:
 | `windowControlsEl` | stock lifecycle controls slot element |
 | `contentEl` | content mount element |
 | `maximizeController` | controller when `maximize: true`, otherwise `null` |
+| `dragController` | controller when `draggable: true`, otherwise `null` |
 | `resizeController` | controller wrapper when `resizable: true`, otherwise `null` |
 | `setTitle(text)` | update the title slot |
 | `setControls(html)` | replace controls slot contents with HTML |
@@ -1011,6 +1016,9 @@ Notes:
 - when draggable, the stock header emits `drag_start` once on primary-button
   pointerdown, drives window movement through absolute drag updates, then emits
   `drag_end` on pointerup / cancel / lost capture
+- stock chrome clamps final drag placement to the current display work area so
+  titlebars and window controls remain reachable; custom surfaces can call
+  `wireDrag(..., { clampOnEnd: true })` to opt into the same behavior
 - when maximize is enabled, the stock controller stores the current canvas frame,
   updates the canvas to the current display work area, and restores the stored
   frame on the next toggle
@@ -1038,12 +1046,48 @@ Options:
 | `title` | `string` | header title |
 | `layout` | layout object | required |
 | `draggable` | `boolean` | whether the mounted stock header emits absolute drag updates plus `drag_start` / `drag_end` lifecycle messages |
+| `drag` | `object` | optional drag controller settings |
 | `close` | `boolean` | whether to show the stock close control, default `true` |
 | `minimize` | `boolean` | whether to show the stock minimize control, default `true` |
 | `maximize` | `boolean` | whether to show the stock maximize/restore control, default `false` |
 | `resizable` | `boolean` | whether to add stock edge/corner resize handles, default `false` |
 | `resize` | `object` | optional resize controller settings |
 | `container` | `HTMLElement` | mount target, default `document.body` |
+
+### `createDragController(options?)`
+
+Creates the toolkit-owned panel drag state used by stock panel chrome and custom
+workbench titlebars.
+
+```js
+const controller = createDragController({ clampOnEnd: true })
+```
+
+By default the controller sends absolute drag updates through `move_abs`. When
+`clampOnEnd` is true, it reads the current window frame at drag completion,
+clamps it to the current display work area, and writes the corrected frame
+through `canvas.update` only when the panel would otherwise be stranded.
+
+Options:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `move` | `function` | absolute drag writer, default `move_abs` |
+| `getFrame` | `function` | current `[x, y, width, height]`, default current window frame |
+| `getWorkArea` | `function` | current display work area, default `window.screen.avail*` |
+| `updateFrame` | `function` | frame writer for final clamp, default `canvas.update` |
+| `clampOnEnd` | `boolean` | whether to clamp final drag placement, default `false` |
+| `minVisibleWidth` / `minVisibleHeight` | `number` | visible affordance retained when clamping oversized frames |
+| `onStateChange` | `function` | receives drag state snapshots |
+
+`dragFrameFromPointer(pointer, offsetX, offsetY, frame?)` is the pure geometry
+helper for tests and custom hosts.
+
+`wireDrag(headerEl, controlsEl, options?)` wires primary-button titlebar dragging
+to a DOM element. It ignores events originating inside `controlsEl`, emits
+`drag_start` / `drag_end`, returns the drag controller, and accepts
+`onStart` / `onEnd` hooks for custom surfaces such as workbenches that need to
+restore from maximized state before moving.
 
 ### `createMaximizeController(options?)`
 

--- a/docs/design/aos-surface-system.md
+++ b/docs/design/aos-surface-system.md
@@ -140,6 +140,11 @@ During drag, AOS should preserve macOS-like transfer behavior:
 The temporary outline can initially be a short-lived canvas. Later it can become
 a layer on the desktop-world stage.
 
+Current implementation status: toolkit panel chrome and the Sigil radial item
+workbench use `wireDrag(..., { clampOnEnd: true })` for final single-display
+placement recovery. Cross-display destination outlines remain the next transfer
+affordance slice.
+
 ## Surface Capabilities
 
 AOS should not recreate macOS window management. It should expose the small set

--- a/packages/toolkit/CLAUDE.md
+++ b/packages/toolkit/CLAUDE.md
@@ -40,7 +40,7 @@ controls/               Layer 1a — reusable app-control behavior for WKWebView
   index.js                re-exports
 
 panel/                  Layer 1b — panel primitives
-  chrome.js               mountChrome — pure DOM scaffold + drag/resize lifecycle + absolute drag/resize frame updates + optional maximize/restore state
+  chrome.js               mountChrome — pure DOM scaffold + drag/resize lifecycle + absolute drag updates, final drag clamp, resize frame updates, and optional maximize/restore state
   defaults.css            optional stock panel visuals (opt-in)
   router.js               createRouter — manifest-prefix dispatch
   layouts/

--- a/packages/toolkit/panel/chrome.js
+++ b/packages/toolkit/panel/chrome.js
@@ -9,6 +9,7 @@ import { moveAbsolute, mutateSelf, removeSelf, spawnChild, suspendCanvas } from 
 export function mountChrome(container, {
   title = 'AOS',
   draggable = true,
+  drag = {},
   close = true,
   minimize = true,
   maximize = false,
@@ -109,7 +110,9 @@ export function mountChrome(container, {
   panel.appendChild(content)
   container.appendChild(panel)
 
-  if (draggable) wireDrag(header, controlsEl)
+  const dragController = draggable
+    ? wireDrag(header, controlsEl, { clampOnEnd: true, ...drag })
+    : null
   const resizeController = resizable
     ? wireResize(panel, {
       ...resize,
@@ -129,6 +132,7 @@ export function mountChrome(container, {
     windowControlsEl,
     contentEl: content,
     maximizeController,
+    dragController,
     resizeController,
     setTitle(text) { titleEl.textContent = text },
     setControls(html) { customControlsEl.innerHTML = html },
@@ -201,6 +205,94 @@ export function clampFrameToWorkArea(frame, {
   if (next[3] <= area[3]) next[1] = clamp(next[1], area[1], maxY)
   else next[1] = clamp(next[1], area[1] - next[3] + minVisibleHeight, areaBottom - minVisibleHeight)
   return cloneFrame(next)
+}
+
+function framesEqual(lhs, rhs) {
+  const a = cloneFrame(lhs)
+  const b = cloneFrame(rhs)
+  return a.every((value, index) => value === b[index])
+}
+
+export function dragFrameFromPointer(pointer = {}, offsetX = 0, offsetY = 0, frame = frameFromWindow()) {
+  const source = cloneFrame(frame)
+  return cloneFrame([
+    finiteNumber(pointer.screenX, source[0] + finiteNumber(offsetX, 0)) - finiteNumber(offsetX, 0),
+    finiteNumber(pointer.screenY, source[1] + finiteNumber(offsetY, 0)) - finiteNumber(offsetY, 0),
+    source[2],
+    source[3],
+  ])
+}
+
+export function createDragController({
+  move = moveAbsolute,
+  getFrame = () => frameFromWindow(),
+  getWorkArea = () => workAreaFromWindow(),
+  updateFrame = (frame) => mutateSelf({ frame }),
+  clampOnEnd = false,
+  minVisibleWidth = 160,
+  minVisibleHeight = 44,
+  onStateChange = null,
+} = {}) {
+  let active = null
+  let frame = cloneFrame(getFrame())
+
+  function state(extra = {}) {
+    return {
+      active: Boolean(active),
+      frame: cloneFrame(frame),
+      ...extra,
+    }
+  }
+
+  function notify(extra = {}) {
+    const snapshot = state(extra)
+    onStateChange?.(snapshot)
+    return snapshot
+  }
+
+  return {
+    start(pointer = {}) {
+      active = {
+        pointerId: pointer.pointerId ?? null,
+        offsetX: finiteNumber(pointer.clientX, 0),
+        offsetY: finiteNumber(pointer.clientY, 0),
+        frame: cloneFrame(getFrame()),
+      }
+      frame = cloneFrame(active.frame)
+      return notify({ phase: 'start' })
+    },
+    move(pointer = {}) {
+      if (!active) return state({ phase: 'idle' })
+      move(
+        finiteNumber(pointer.screenX, active.frame[0] + active.offsetX),
+        finiteNumber(pointer.screenY, active.frame[1] + active.offsetY),
+        active.offsetX,
+        active.offsetY
+      )
+      frame = dragFrameFromPointer(pointer, active.offsetX, active.offsetY, active.frame)
+      return notify({ phase: 'move' })
+    },
+    end() {
+      if (!active) return state({ phase: 'idle' })
+      active = null
+      frame = cloneFrame(getFrame())
+      if (clampOnEnd) {
+        const clamped = clampFrameToWorkArea(frame, {
+          workArea: getWorkArea(),
+          minVisibleWidth,
+          minVisibleHeight,
+        })
+        if (!framesEqual(frame, clamped)) {
+          frame = clamped
+          updateFrame(clamped)
+        }
+      }
+      return notify({ phase: 'end' })
+    },
+    getState() {
+      return state()
+    },
+  }
 }
 
 export function normalizeResizeEdge(edge = '') {
@@ -460,25 +552,33 @@ function defaultMinimize({ title = 'AOS' } = {}) {
     })
 }
 
-export function wireDrag(header, controlsEl, { move = moveAbsolute } = {}) {
+export function wireDrag(header, controlsEl, {
+  controller = null,
+  move = moveAbsolute,
+  onStart = null,
+  onEnd = null,
+  ...controllerOptions
+} = {}) {
+  const dragController = controller || createDragController({ move, ...controllerOptions })
   header.addEventListener('pointerdown', (e) => {
     if (e.button !== 0) return
-    if (e.target instanceof Node && controlsEl.contains(e.target)) return
+    const NodeCtor = globalThis.Node
+    if ((!NodeCtor || e.target instanceof NodeCtor) && controlsEl?.contains?.(e.target)) return
     const pointerId = e.pointerId
-    const offsetX = e.clientX
-    const offsetY = e.clientY
     header.dataset.dragging = 'true'
     e.preventDefault()
     // Drag lifecycle matters to the daemon: mixed-DPI seam placement keeps a
     // direct path during active drags and only falls back to re-home behavior
     // for non-drag placements.
     emit('drag_start')
+    onStart?.(e, dragController)
+    dragController.start(e)
 
     try { header.setPointerCapture(pointerId) } catch {}
 
     const onMove = (ev) => {
       if (ev.pointerId !== pointerId) return
-      move(ev.screenX, ev.screenY, offsetX, offsetY)
+      dragController.move(ev)
     }
 
     const onUp = (ev) => {
@@ -491,7 +591,9 @@ export function wireDrag(header, controlsEl, { move = moveAbsolute } = {}) {
       try {
         if (header.hasPointerCapture(pointerId)) header.releasePointerCapture(pointerId)
       } catch {}
+      dragController.end(ev)
       emit('drag_end')
+      onEnd?.(ev, dragController)
     }
 
     header.addEventListener('pointermove', onMove)
@@ -499,6 +601,7 @@ export function wireDrag(header, controlsEl, { move = moveAbsolute } = {}) {
     header.addEventListener('pointercancel', onUp)
     header.addEventListener('lostpointercapture', onUp)
   })
+  return dragController
 }
 
 export function wireResize(panel, {

--- a/packages/toolkit/panel/index.js
+++ b/packages/toolkit/panel/index.js
@@ -22,8 +22,10 @@
 export { mountPanel } from './mount.js'
 export {
   clampFrameToWorkArea,
+  createDragController,
   createMaximizeController,
   createResizeController,
+  dragFrameFromPointer,
   frameFromWindow,
   mountChrome,
   normalizeResizeEdge,

--- a/packages/toolkit/panel/mount.js
+++ b/packages/toolkit/panel/mount.js
@@ -13,6 +13,7 @@ export function mountPanel({
   title = 'AOS',
   layout,
   draggable = true,
+  drag = {},
   close = true,
   minimize = true,
   maximize = false,
@@ -28,6 +29,7 @@ export function mountPanel({
   const chrome = mountChrome(container, {
     title,
     draggable,
+    drag,
     close,
     minimize,
     maximize,

--- a/tests/toolkit/panel-chrome.test.mjs
+++ b/tests/toolkit/panel-chrome.test.mjs
@@ -2,8 +2,10 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   clampFrameToWorkArea,
+  createDragController,
   createMaximizeController,
   createResizeController,
+  dragFrameFromPointer,
   frameFromWindow,
   normalizeResizeEdge,
   resizeFrame,
@@ -183,6 +185,45 @@ test('resize geometry handles edges, corners, constraints, and work-area clamp',
   }), [600, 480, 200, 120]);
 });
 
+test('drag geometry derives pointer frames and clamps final placement', () => {
+  assert.deepEqual(dragFrameFromPointer(
+    { screenX: 640, screenY: 420 },
+    40,
+    20,
+    [100, 100, 360, 240],
+  ), [600, 400, 360, 240]);
+
+  let frame = [700, 560, 240, 160];
+  const updates = [];
+  const moves = [];
+  const states = [];
+  const controller = createDragController({
+    move(screenX, screenY, offsetX, offsetY) {
+      moves.push({ screenX, screenY, offsetX, offsetY });
+      frame = [screenX - offsetX, screenY - offsetY, frame[2], frame[3]];
+    },
+    getFrame: () => frame,
+    getWorkArea: () => [0, 0, 800, 600],
+    updateFrame(nextFrame) {
+      frame = nextFrame;
+      updates.push(nextFrame);
+    },
+    clampOnEnd: true,
+    onStateChange(state) {
+      states.push(state);
+    },
+  });
+
+  controller.start({ pointerId: 1, clientX: 40, clientY: 20 });
+  controller.move({ pointerId: 1, screenX: 770, screenY: 620 });
+  assert.deepEqual(moves, [{ screenX: 770, screenY: 620, offsetX: 40, offsetY: 20 }]);
+  controller.end();
+
+  assert.deepEqual(updates.at(-1), [560, 440, 240, 160]);
+  assert.deepEqual(frame, [560, 440, 240, 160]);
+  assert.deepEqual(states.map((state) => state.phase), ['start', 'move', 'end']);
+});
+
 test('createResizeController updates frames from pointer deltas', () => {
   let frame = [100, 100, 400, 300];
   const updates = [];
@@ -251,11 +292,12 @@ test('wireDrag emits absolute drag updates with the original pointer offset', as
   const header = new FakeElement();
   const controls = new FakeElement();
   const moves = [];
-  wireDrag(header, controls, {
+  const controller = wireDrag(header, controls, {
     move(screenX, screenY, offsetX, offsetY) {
       moves.push({ screenX, screenY, offsetX, offsetY });
     },
   });
+  assert.equal(controller.getState().active, false);
 
   const down = header.dispatch('pointerdown', {
     button: 0,
@@ -279,6 +321,7 @@ test('wireDrag emits absolute drag updates with the original pointer offset', as
 
   header.dispatch('pointerup', { pointerId: 7 });
   assert.equal('dragging' in header.dataset, false);
+  assert.equal(controller.getState().active, false);
   assert.equal(header.hasPointerCapture(7), false);
   assert.deepEqual(emitted, [{ type: 'drag_start' }, { type: 'drag_end' }]);
 });

--- a/tests/toolkit/workbench-shell.test.mjs
+++ b/tests/toolkit/workbench-shell.test.mjs
@@ -56,8 +56,11 @@ test('Sigil radial item workbench is focused on object transforms only', async (
   assert.match(html, /id="undo-change"/);
   assert.match(html, /id="redo-change"/);
   const js = await repoText('apps/sigil/radial-item-workbench/index.js');
+  assert.match(js, /wireDrag/);
   assert.match(js, /wireResize/);
+  assert.match(js, /clampOnEnd: true/);
   assert.match(js, /minWidth: 760/);
+  assert.doesNotMatch(js, /postRaw\(\{ type: 'move_abs'/);
 });
 
 test('workbench shell smoke does not masquerade as the Sigil editor', async () => {


### PR DESCRIPTION
Refs #226

## Summary
- add a reusable toolkit drag controller and pointer-frame geometry helper
- make stock panel chrome clamp final drag placement to the current display work area
- move the Sigil radial item workbench titlebar onto the shared drag helper with clamp-on-end
- document this as the single-display recovery slice, leaving destination outline transfer behavior open under #226

## Verification
- node --check packages/toolkit/panel/chrome.js packages/toolkit/panel/mount.js packages/toolkit/panel/index.js apps/sigil/radial-item-workbench/index.js
- node --test tests/toolkit/panel-chrome.test.mjs tests/toolkit/workbench-shell.test.mjs && git diff --check
- node --test tests/toolkit/*.test.mjs tests/renderer/radial-item-editor.test.mjs tests/renderer/radial-object-control.test.mjs