### PR TITLE
Add desktop-world visual stage

### DIFF
--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -43,6 +43,27 @@ to a local root node.
 orthographic camera helpers, and a BroadcastChannel-backed state replication
 hook for Three.js consumers.
 
+The stock shared stage lives at
+`aos://toolkit/components/desktop-world-stage/index.html`. It should be launched
+as `--surface desktop-world` and stays non-interactive. Consumers update it with
+`canvas.send` messages:
+
+```json
+{
+  "type": "desktop_world_stage.layer.upsert",
+  "payload": {
+    "id": "panel-transfer-outline",
+    "kind": "outline",
+    "frame": [1920, 64, 720, 520],
+    "label": "Move here"
+  }
+}
+```
+
+Accepted stage messages are `desktop_world_stage.layer.upsert`,
+`desktop_world_stage.layer.remove`, `desktop_world_stage.layers.replace`, and
+`desktop_world_stage.clear`.
+
 ## Import / Hosting Model
 
 Toolkit files are normally served through the AOS content server:
@@ -197,6 +218,7 @@ Current reusable toolkit components include:
 - `aos://toolkit/components/wiki-kb/index.html` - wiki graph browser with force-graph and mind-map views
 - `aos://toolkit/components/object-transform-panel/index.html` - addressable canvas object transform editor for position/scale/rotation triplets
 - `aos://toolkit/components/markdown-workbench/index.html` - Markdown source editor, rendered preview, outline, diagnostics, and explicit save handoff
+- `aos://toolkit/components/desktop-world-stage/index.html` - shared click-through DesktopWorld visual stage for non-interactive layers such as transfer outlines
 
 ### Inline Canvas Stats
 

--- a/docs/design/aos-surface-system.md
+++ b/docs/design/aos-surface-system.md
@@ -145,6 +145,12 @@ workbench use `wireDrag(..., { clampOnEnd: true })` for final single-display
 placement recovery. Cross-display destination outlines remain the next transfer
 affordance slice.
 
+The first shared DesktopWorld visual stage now lives at
+`aos://toolkit/components/desktop-world-stage/index.html`. It is a
+click-through `--surface desktop-world` canvas that accepts layer
+upsert/remove/replace/clear messages. Normal forms, editors, and workbenches
+still belong on ordinary panel canvases.
+
 ## Surface Capabilities
 
 AOS should not recreate macOS window management. It should expose the small set

--- a/packages/toolkit/CLAUDE.md
+++ b/packages/toolkit/CLAUDE.md
@@ -64,6 +64,8 @@ components/             Layer 2 — reusable Content units
     styles.css              canonical component styles (link, don't copy)
   render-performance/     live framerate + coarse renderer telemetry panel
     styles.css              canonical component styles (link, don't copy)
+  desktop-world-stage/    shared click-through DesktopWorld visual layer stage
+    styles.css              canonical component styles (link, don't copy)
   inspector-panel/        AX-element inspector (driven by `aos inspect`)
     styles.css              canonical component styles (link, don't copy)
   log-console/            scrolling timestamped log (driven by `aos log push`)

--- a/packages/toolkit/components/desktop-world-stage/index.html
+++ b/packages/toolkit/components/desktop-world-stage/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <div id="desktop-world-stage-root" class="desktop-world-stage-root" aria-hidden="true"></div>
+  <script type="module" src="./index.js"></script>
+</body>
+</html>

--- a/packages/toolkit/components/desktop-world-stage/index.js
+++ b/packages/toolkit/components/desktop-world-stage/index.js
@@ -1,0 +1,45 @@
+import { wireBridge } from '../../runtime/bridge.js'
+import { DesktopWorldSurface2D } from '../../runtime/desktop-world-surface-2d.js'
+import { declareManifest, emitReady } from '../../runtime/manifest.js'
+import {
+  applyDesktopWorldStageMessage,
+  createDesktopWorldStageState,
+  desktopWorldStageSnapshot,
+  renderDesktopWorldStageLayers,
+} from './model.js'
+
+const root = document.getElementById('desktop-world-stage-root')
+const canvasId = window.__aosSurfaceCanvasId || window.__aosCanvasId || 'aos-desktop-world-stage'
+const surface = new DesktopWorldSurface2D({ canvasId })
+const state = createDesktopWorldStageState()
+
+function render() {
+  if (!root) return
+  surface.applyWorldTransform(root)
+  root.innerHTML = renderDesktopWorldStageLayers(state)
+  window.__desktopWorldStageState = desktopWorldStageSnapshot(state)
+}
+
+declareManifest({
+  name: 'desktop-world-stage',
+  accepts: [
+    'desktop_world_stage.layer.upsert',
+    'desktop_world_stage.layer.remove',
+    'desktop_world_stage.layers.replace',
+    'desktop_world_stage.clear',
+  ],
+  emits: ['ready'],
+  surface: 'desktop-world',
+})
+
+wireBridge((message) => {
+  if (applyDesktopWorldStageMessage(state, message)) render()
+})
+
+surface.start({
+  onInit: render,
+  onTopologyChange: render,
+}).then(render)
+
+render()
+emitReady()

--- a/packages/toolkit/components/desktop-world-stage/launch.sh
+++ b/packages/toolkit/components/desktop-world-stage/launch.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# launch.sh — Create the shared click-through DesktopWorld visual stage.
+
+set -euo pipefail
+
+AOS="${AOS:-./aos}"
+CANVAS_ID="${AOS_DESKTOP_WORLD_STAGE_ID:-aos-desktop-world-stage}"
+
+$AOS show remove --id "$CANVAS_ID" 2>/dev/null || true
+
+$AOS set content.roots.toolkit packages/toolkit >/dev/null
+$AOS content wait --root toolkit --auto-start --timeout 15s >/dev/null
+
+$AOS show create --id "$CANVAS_ID" \
+  --surface desktop-world \
+  --scope global \
+  --url 'aos://toolkit/components/desktop-world-stage/index.html'
+
+$AOS show wait --id "$CANVAS_ID" --manifest desktop-world-stage --timeout 5s >/dev/null
+
+echo "DesktopWorld visual stage launched as ${CANVAS_ID}"
+echo "Send non-interactive layers with canvas.send to ${CANVAS_ID}: desktop_world_stage.layer.upsert/remove/clear"

--- a/packages/toolkit/components/desktop-world-stage/model.js
+++ b/packages/toolkit/components/desktop-world-stage/model.js
@@ -1,0 +1,170 @@
+// model.js — pure state model for the shared DesktopWorld visual stage.
+//
+// The stage is intentionally passive: consumers register/update/remove
+// non-interactive visual layers, and the surface renders them click-through.
+
+function finiteNumber(value, fallback = 0) {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : fallback
+}
+
+function text(value, fallback = '') {
+  const normalized = String(value ?? '').replace(/\s+/g, ' ').trim()
+  return normalized || fallback
+}
+
+function esc(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+}
+
+function cssNumber(value) {
+  return `${Math.round(finiteNumber(value, 0))}px`
+}
+
+function cssColor(value, fallback) {
+  const raw = text(value, fallback)
+  return /^[#(),.%\w\s-]+$/.test(raw) ? raw : fallback
+}
+
+function frameFromLayer(layer = {}) {
+  const frame = layer.frame || layer.rect || layer.bounds
+  if (Array.isArray(frame)) {
+    return [
+      finiteNumber(frame[0], 0),
+      finiteNumber(frame[1], 0),
+      Math.max(1, finiteNumber(frame[2], 1)),
+      Math.max(1, finiteNumber(frame[3], 1)),
+    ]
+  }
+  if (frame && typeof frame === 'object') {
+    return [
+      finiteNumber(frame.x ?? frame.left, 0),
+      finiteNumber(frame.y ?? frame.top, 0),
+      Math.max(1, finiteNumber(frame.w ?? frame.width, 1)),
+      Math.max(1, finiteNumber(frame.h ?? frame.height, 1)),
+    ]
+  }
+  return [0, 0, 1, 1]
+}
+
+function normalizeStyle(style = {}) {
+  return {
+    color: cssColor(style.color, 'rgba(122, 241, 255, 0.95)'),
+    fill: cssColor(style.fill, 'rgba(122, 241, 255, 0.08)'),
+    opacity: Math.max(0, Math.min(1, finiteNumber(style.opacity, 1))),
+    strokeWidth: Math.max(1, finiteNumber(style.strokeWidth ?? style.stroke_width, 2)),
+  }
+}
+
+export function normalizeStageLayer(input = {}) {
+  const id = text(input.id)
+  if (!id) return null
+  return {
+    id,
+    kind: text(input.kind, 'outline'),
+    label: text(input.label || input.title),
+    frame: frameFromLayer(input),
+    visible: input.visible !== false,
+    zIndex: Math.round(finiteNumber(input.zIndex ?? input.z_index, 0)),
+    style: normalizeStyle(input.style),
+    metadata: input.metadata && typeof input.metadata === 'object' ? { ...input.metadata } : {},
+  }
+}
+
+export function createDesktopWorldStageState({ layers = [] } = {}) {
+  const state = {
+    layers: new Map(),
+    version: 0,
+  }
+  for (const layer of layers) {
+    const normalized = normalizeStageLayer(layer)
+    if (normalized) state.layers.set(normalized.id, normalized)
+  }
+  return state
+}
+
+export function stageLayerList(state) {
+  return [...(state?.layers?.values?.() || [])]
+    .filter((layer) => layer.visible)
+    .sort((a, b) => {
+      if (a.zIndex !== b.zIndex) return a.zIndex - b.zIndex
+      return a.id.localeCompare(b.id)
+    })
+}
+
+export function applyDesktopWorldStageMessage(state, message = {}) {
+  const type = message.type || message.event
+  const payload = message.payload || message.data || message
+  if (!state?.layers || !type) return false
+
+  if (type === 'desktop_world_stage.layer.upsert') {
+    const layer = normalizeStageLayer(payload)
+    if (!layer) return false
+    state.layers.set(layer.id, layer)
+    state.version += 1
+    return true
+  }
+
+  if (type === 'desktop_world_stage.layer.remove') {
+    const id = text(payload.id)
+    if (!id || !state.layers.delete(id)) return false
+    state.version += 1
+    return true
+  }
+
+  if (type === 'desktop_world_stage.layers.replace') {
+    state.layers.clear()
+    for (const layer of payload.layers || []) {
+      const normalized = normalizeStageLayer(layer)
+      if (normalized) state.layers.set(normalized.id, normalized)
+    }
+    state.version += 1
+    return true
+  }
+
+  if (type === 'desktop_world_stage.clear') {
+    if (state.layers.size === 0) return false
+    state.layers.clear()
+    state.version += 1
+    return true
+  }
+
+  return false
+}
+
+export function renderDesktopWorldStageLayers(state) {
+  return stageLayerList(state).map((layer) => {
+    const [x, y, w, h] = layer.frame
+    const style = [
+      `left:${cssNumber(x)}`,
+      `top:${cssNumber(y)}`,
+      `width:${cssNumber(w)}`,
+      `height:${cssNumber(h)}`,
+      `z-index:${layer.zIndex}`,
+      `--stage-color:${esc(layer.style.color)}`,
+      `--stage-fill:${esc(layer.style.fill)}`,
+      `--stage-opacity:${layer.style.opacity}`,
+      `--stage-stroke-width:${layer.style.strokeWidth}px`,
+    ].join(';')
+    const label = layer.label
+      ? `<span class="desktop-world-stage-label">${esc(layer.label)}</span>`
+      : ''
+    return (
+      `<div class="desktop-world-stage-layer desktop-world-stage-${esc(layer.kind)}" `
+      + `data-layer-id="${esc(layer.id)}" style="${style}">`
+      + label
+      + '</div>'
+    )
+  }).join('')
+}
+
+export function desktopWorldStageSnapshot(state) {
+  return {
+    version: state?.version || 0,
+    layers: stageLayerList(state).map((layer) => ({ ...layer, frame: [...layer.frame] })),
+  }
+}

--- a/packages/toolkit/components/desktop-world-stage/styles.css
+++ b/packages/toolkit/components/desktop-world-stage/styles.css
@@ -1,0 +1,47 @@
+html,
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  background: transparent;
+  pointer-events: none;
+}
+
+.desktop-world-stage-root {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 1px;
+  height: 1px;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.desktop-world-stage-layer {
+  position: absolute;
+  box-sizing: border-box;
+  pointer-events: none;
+  opacity: var(--stage-opacity, 1);
+  color: var(--stage-color, rgba(122, 241, 255, 0.95));
+}
+
+.desktop-world-stage-outline,
+.desktop-world-stage-rect {
+  border: var(--stage-stroke-width, 2px) solid var(--stage-color, rgba(122, 241, 255, 0.95));
+  background: var(--stage-fill, rgba(122, 241, 255, 0.08));
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.42), 0 14px 40px rgba(0, 0, 0, 0.24);
+}
+
+.desktop-world-stage-label {
+  position: absolute;
+  left: 8px;
+  top: 7px;
+  max-width: calc(100% - 16px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: currentColor;
+  font: 650 12px/1.2 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
+}

--- a/tests/toolkit/desktop-world-stage.test.mjs
+++ b/tests/toolkit/desktop-world-stage.test.mjs
@@ -1,0 +1,84 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  applyDesktopWorldStageMessage,
+  createDesktopWorldStageState,
+  desktopWorldStageSnapshot,
+  normalizeStageLayer,
+  renderDesktopWorldStageLayers,
+  stageLayerList,
+} from '../../packages/toolkit/components/desktop-world-stage/model.js'
+
+test('normalizeStageLayer accepts array and object frame shapes', () => {
+  assert.deepEqual(normalizeStageLayer({
+    id: 'outline',
+    frame: [10.4, 20.6, 320.2, 180.8],
+  }).frame, [10.4, 20.6, 320.2, 180.8])
+
+  assert.deepEqual(normalizeStageLayer({
+    id: 'rect',
+    bounds: { x: 4, y: 5, width: 6, height: 7 },
+  }).frame, [4, 5, 6, 7])
+
+  assert.equal(normalizeStageLayer({ frame: [0, 0, 1, 1] }), null)
+})
+
+test('stage messages upsert, remove, replace, and clear visual layers', () => {
+  const state = createDesktopWorldStageState()
+
+  assert.equal(applyDesktopWorldStageMessage(state, {
+    type: 'desktop_world_stage.layer.upsert',
+    payload: {
+      id: 'panel-outline',
+      kind: 'outline',
+      frame: [700, 40, 420, 260],
+      label: 'Target display',
+      style: { color: 'rgba(122, 241, 255, 0.9)' },
+    },
+  }), true)
+  assert.equal(state.layers.size, 1)
+  assert.equal(desktopWorldStageSnapshot(state).version, 1)
+
+  assert.equal(applyDesktopWorldStageMessage(state, {
+    type: 'desktop_world_stage.layers.replace',
+    payload: { layers: [{ id: 'a', frame: [0, 0, 10, 10] }, { id: 'b', frame: [10, 0, 10, 10], zIndex: -1 }] },
+  }), true)
+  assert.deepEqual(stageLayerList(state).map((layer) => layer.id), ['b', 'a'])
+
+  assert.equal(applyDesktopWorldStageMessage(state, {
+    type: 'desktop_world_stage.layer.remove',
+    payload: { id: 'b' },
+  }), true)
+  assert.deepEqual(stageLayerList(state).map((layer) => layer.id), ['a'])
+
+  assert.equal(applyDesktopWorldStageMessage(state, { type: 'desktop_world_stage.clear' }), true)
+  assert.equal(stageLayerList(state).length, 0)
+})
+
+test('renderDesktopWorldStageLayers emits click-through DesktopWorld-positioned markup', () => {
+  const state = createDesktopWorldStageState({
+    layers: [{
+      id: 'panel-outline',
+      kind: 'outline',
+      label: '<panel>',
+      frame: [700.2, 40.8, 420.1, 260.9],
+      style: {
+        color: 'red;position:fixed',
+        fill: 'rgba(10, 20, 30, 0.2)',
+        strokeWidth: 3,
+      },
+    }],
+  })
+
+  const html = renderDesktopWorldStageLayers(state)
+
+  assert.match(html, /data-layer-id="panel-outline"/)
+  assert.match(html, /left:700px/)
+  assert.match(html, /top:41px/)
+  assert.match(html, /width:420px/)
+  assert.match(html, /height:261px/)
+  assert.match(html, /--stage-color:rgba\(122, 241, 255, 0.95\)/)
+  assert.match(html, /--stage-fill:rgba\(10, 20, 30, 0.2\)/)
+  assert.match(html, /&lt;panel&gt;/)
+})


### PR DESCRIPTION
Closes #227

## Summary
- add a shared click-through DesktopWorld visual stage component and launcher
- define layer upsert/remove/replace/clear messages for non-interactive visuals
- render DesktopWorld-positioned outline/rect layers across segmented surfaces
- document the stage as the substrate for future panel transfer outlines

## Verification
- node --check packages/toolkit/components/desktop-world-stage/model.js packages/toolkit/components/desktop-world-stage/index.js
- node --test tests/toolkit/desktop-world-stage.test.mjs tests/toolkit/desktop-world-surface.test.mjs tests/toolkit/desktop-world-surface-2d.test.mjs
- node --test tests/toolkit/*.test.mjs && git diff --check