### PR TITLE
Add panel transfer outline

### DIFF
--- a/apps/sigil/radial-item-workbench/index.js
+++ b/apps/sigil/radial-item-workbench/index.js
@@ -443,8 +443,14 @@ window.headsup.receive = function receive(b64) {
 const dragController = dragHandle
     ? wireDrag(dragHandle, workbenchShell?.querySelector('.aos-window-controls'), {
         clampOnEnd: true,
+        transfer: true,
         onStart() {
             if (maximizeController.getState().maximized) maximizeController.restore();
+        },
+        onStateChange(state) {
+            const transferActive = Boolean(state.transferActive);
+            workbenchShell?.classList.toggle('aos-workbench-transfer-active', transferActive);
+            if (workbenchShell) workbenchShell.dataset.transferActive = String(transferActive);
         },
     })
     : null;

--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -972,6 +972,7 @@ Public entrypoint:
 ```js
 import {
   createDragController,
+  createPanelTransferController,
   createResizeController,
   createSplitPane,
   createMaximizeController,
@@ -983,6 +984,7 @@ import {
   SplitPane,
   Tabs,
   wireDrag,
+  wirePanelTransferDisplayGeometry,
   wireResize,
 } from 'aos://toolkit/panel/index.js'
 ```
@@ -1004,7 +1006,7 @@ Options:
 | --- | --- | --- |
 | `title` | `string` | header title |
 | `draggable` | `boolean` | whether header drag emits absolute move updates plus `drag_start` / `drag_end` lifecycle messages |
-| `drag` | `object` | optional drag controller settings; stock chrome clamps final placement by default |
+| `drag` | `object` | optional drag controller settings; stock chrome clamps final placement and enables cross-display transfer by default |
 | `close` | `boolean` | whether to show the stock close control, default `true` |
 | `minimize` | `boolean` | whether to show the stock minimize control, default `true` |
 | `maximize` | `boolean` | whether to show the stock maximize/restore control, default `false` |
@@ -1040,7 +1042,8 @@ Notes:
   `drag_end` on pointerup / cancel / lost capture
 - stock chrome clamps final drag placement to the current display work area so
   titlebars and window controls remain reachable; custom surfaces can call
-  `wireDrag(..., { clampOnEnd: true })` to opt into the same behavior
+  `wireDrag(..., { clampOnEnd: true, transfer: true })` to opt into the same
+  cross-display behavior
 - when maximize is enabled, the stock controller stores the current canvas frame,
   updates the canvas to the current display work area, and restores the stored
   frame on the next toggle
@@ -1107,9 +1110,20 @@ helper for tests and custom hosts.
 
 `wireDrag(headerEl, controlsEl, options?)` wires primary-button titlebar dragging
 to a DOM element. It ignores events originating inside `controlsEl`, emits
-`drag_start` / `drag_end`, returns the drag controller, and accepts
-`onStart` / `onEnd` hooks for custom surfaces such as workbenches that need to
-restore from maximized state before moving.
+`drag_start` / `drag_end`, returns the drag controller, and accepts `onStart` /
+`onEnd` hooks for custom surfaces such as workbenches that need to restore from
+maximized state before moving. When `transfer: true`, the controller subscribes
+to `display_geometry`, sends destination-outline layers to the shared
+DesktopWorld stage, reports `state.transferActive` while that outline is active,
+and on release moves the panel to the destination outline frame. Stock panel and
+workbench styles dim the origin surface to `0.75` opacity during transfer. The
+stage is best-effort: if it is not running, release placement still uses the
+computed destination display frame.
+
+`createPanelTransferController(options?)` is the lower-level transfer state
+machine used by `createDragController`. It computes destination display outlines
+from daemon display geometry and sends `desktop_world_stage.layer.upsert/remove`
+messages to the shared stage.
 
 ### `createMaximizeController(options?)`
 

--- a/docs/design/aos-surface-system.md
+++ b/docs/design/aos-surface-system.md
@@ -141,9 +141,8 @@ The temporary outline can initially be a short-lived canvas. Later it can become
 a layer on the desktop-world stage.
 
 Current implementation status: toolkit panel chrome and the Sigil radial item
-workbench use `wireDrag(..., { clampOnEnd: true })` for final single-display
-placement recovery. Cross-display destination outlines remain the next transfer
-affordance slice.
+workbench use `wireDrag(..., { clampOnEnd: true, transfer: true })` for final
+single-display placement recovery and cross-display destination outlines.
 
 The first shared DesktopWorld visual stage now lives at
 `aos://toolkit/components/desktop-world-stage/index.html`. It is a

--- a/packages/toolkit/CLAUDE.md
+++ b/packages/toolkit/CLAUDE.md
@@ -41,6 +41,7 @@ controls/               Layer 1a — reusable app-control behavior for WKWebView
 
 panel/                  Layer 1b — panel primitives
   chrome.js               mountChrome — pure DOM scaffold + drag/resize lifecycle + absolute drag updates, final drag clamp, resize frame updates, and optional maximize/restore state
+  drag-transfer.js        cross-display panel transfer outline + release-frame controller
   defaults.css            optional stock panel visuals (opt-in)
   router.js               createRouter — manifest-prefix dispatch
   layouts/

--- a/packages/toolkit/panel/chrome.js
+++ b/packages/toolkit/panel/chrome.js
@@ -5,6 +5,7 @@
 
 import { emit } from '../runtime/bridge.js'
 import { moveAbsolute, mutateSelf, removeSelf, spawnChild, suspendCanvas } from '../runtime/canvas.js'
+import { createPanelTransferController, wirePanelTransferDisplayGeometry } from './drag-transfer.js'
 
 export function mountChrome(container, {
   title = 'AOS',
@@ -110,8 +111,19 @@ export function mountChrome(container, {
   panel.appendChild(content)
   container.appendChild(panel)
 
+  const { onStateChange: onDragStateChange, ...dragOptions } = drag
   const dragController = draggable
-    ? wireDrag(header, controlsEl, { clampOnEnd: true, ...drag })
+    ? wireDrag(header, controlsEl, {
+      clampOnEnd: true,
+      transfer: true,
+      ...dragOptions,
+      onStateChange(state) {
+        const transferActive = Boolean(state.transferActive)
+        panel.classList.toggle('aos-panel-transfer-active', transferActive)
+        panel.dataset.transferActive = String(transferActive)
+        onDragStateChange?.(state)
+      },
+    })
     : null
   const resizeController = resizable
     ? wireResize(panel, {
@@ -229,17 +241,26 @@ export function createDragController({
   getWorkArea = () => workAreaFromWindow(),
   updateFrame = (frame) => mutateSelf({ frame }),
   clampOnEnd = false,
+  transfer = false,
+  transferController = null,
   minVisibleWidth = 160,
   minVisibleHeight = 44,
   onStateChange = null,
 } = {}) {
   let active = null
   let frame = cloneFrame(getFrame())
+  const transferOptions = transfer && typeof transfer === 'object' ? transfer : {}
+  const panelTransfer = transferController || (transfer
+    ? createPanelTransferController({ enabled: true, ...transferOptions })
+    : null)
+  if (panelTransfer && !transferController) wirePanelTransferDisplayGeometry(panelTransfer)
 
   function state(extra = {}) {
+    const transferActive = Boolean(panelTransfer?.getState?.().active)
     return {
       active: Boolean(active),
       frame: cloneFrame(frame),
+      transferActive,
       ...extra,
     }
   }
@@ -259,6 +280,7 @@ export function createDragController({
         frame: cloneFrame(getFrame()),
       }
       frame = cloneFrame(active.frame)
+      panelTransfer?.start({ frame })
       return notify({ phase: 'start' })
     },
     move(pointer = {}) {
@@ -270,13 +292,23 @@ export function createDragController({
         active.offsetY
       )
       frame = dragFrameFromPointer(pointer, active.offsetX, active.offsetY, active.frame)
+      panelTransfer?.move({
+        frame: active.frame,
+        pointer,
+        offsetX: active.offsetX,
+        offsetY: active.offsetY,
+      })
       return notify({ phase: 'move' })
     },
     end() {
       if (!active) return state({ phase: 'idle' })
       active = null
-      frame = cloneFrame(getFrame())
-      if (clampOnEnd) {
+      const transferResult = panelTransfer?.end()
+      if (transferResult?.nativeFrame) {
+        frame = cloneFrame(transferResult.nativeFrame)
+        updateFrame(frame)
+      } else if (clampOnEnd) {
+        frame = cloneFrame(getFrame())
         const clamped = clampFrameToWorkArea(frame, {
           workArea: getWorkArea(),
           minVisibleWidth,
@@ -286,6 +318,8 @@ export function createDragController({
           frame = clamped
           updateFrame(clamped)
         }
+      } else {
+        frame = cloneFrame(getFrame())
       }
       return notify({ phase: 'end' })
     },

--- a/packages/toolkit/panel/defaults.css
+++ b/packages/toolkit/panel/defaults.css
@@ -31,6 +31,11 @@
   -webkit-backdrop-filter: blur(var(--blur-radius, 20px));
   box-shadow: var(--shadow-panel, 0 18px 46px rgba(0, 0, 0, 0.34));
   overflow: hidden;
+  transition: opacity 120ms ease;
+}
+
+.aos-panel.aos-panel-transfer-active {
+  opacity: 0.75;
 }
 
 .aos-header {

--- a/packages/toolkit/panel/drag-transfer.js
+++ b/packages/toolkit/panel/drag-transfer.js
@@ -1,0 +1,225 @@
+// drag-transfer.js — cross-display transfer affordance for panel drags.
+
+import { emit, wireBridge } from '../runtime/bridge.js'
+import { subscribe } from '../runtime/subscribe.js'
+import {
+  findDisplayForPoint,
+  nativeToDesktopWorldRect,
+  normalizeDisplays,
+} from '../runtime/spatial.js'
+
+function finiteNumber(value, fallback = 0) {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : fallback
+}
+
+function displayID(display) {
+  return display?.id ?? display?.display_id ?? display?.cgID ?? null
+}
+
+function sameDisplay(a, b) {
+  return String(a) === String(b)
+}
+
+function frameToRect(frame = []) {
+  return {
+    x: finiteNumber(frame[0], 0),
+    y: finiteNumber(frame[1], 0),
+    w: Math.max(1, finiteNumber(frame[2], 1)),
+    h: Math.max(1, finiteNumber(frame[3], 1)),
+  }
+}
+
+function rectToFrame(rect = {}) {
+  return [
+    Math.round(finiteNumber(rect.x, 0)),
+    Math.round(finiteNumber(rect.y, 0)),
+    Math.round(Math.max(1, finiteNumber(rect.w ?? rect.width, 1))),
+    Math.round(Math.max(1, finiteNumber(rect.h ?? rect.height, 1))),
+  ]
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value))
+}
+
+function visibleNativeBounds(display) {
+  return display?.nativeVisibleBounds || display?.native_visible_bounds || display?.visibleBounds || display?.visible_bounds || display?.bounds || null
+}
+
+function clampFrameToDisplay(frame, display) {
+  const source = frameToRect(frame)
+  const bounds = visibleNativeBounds(display)
+  if (!bounds) return rectToFrame(source)
+  const width = Math.min(source.w, Math.max(1, finiteNumber(bounds.w ?? bounds.width, source.w)))
+  const height = Math.min(source.h, Math.max(1, finiteNumber(bounds.h ?? bounds.height, source.h)))
+  const minX = finiteNumber(bounds.x, 0)
+  const minY = finiteNumber(bounds.y, 0)
+  const maxX = minX + Math.max(0, finiteNumber(bounds.w ?? bounds.width, width) - width)
+  const maxY = minY + Math.max(0, finiteNumber(bounds.h ?? bounds.height, height) - height)
+  return [
+    Math.round(clamp(source.x, minX, maxX)),
+    Math.round(clamp(source.y, minY, maxY)),
+    Math.round(width),
+    Math.round(height),
+  ]
+}
+
+function pointerPoint(pointer = {}) {
+  return {
+    x: finiteNumber(pointer.screenX ?? pointer.x, 0),
+    y: finiteNumber(pointer.screenY ?? pointer.y, 0),
+  }
+}
+
+export function computePanelTransfer(displays = [], {
+  frame,
+  pointer,
+  offsetX = 0,
+  offsetY = 0,
+  originDisplayId = null,
+  layerId = 'aos-panel-transfer-outline',
+  label = 'Move here',
+} = {}) {
+  const normalizedDisplays = normalizeDisplays(displays)
+  if (normalizedDisplays.length < 2) return null
+  const point = pointerPoint(pointer)
+  const targetDisplay = findDisplayForPoint(normalizedDisplays, point.x, point.y, {
+    rectKey: 'nativeVisibleBounds',
+    nearest: false,
+  })
+  if (!targetDisplay) return null
+  const targetId = displayID(targetDisplay)
+  if (originDisplayId != null && sameDisplay(targetId, originDisplayId)) return null
+
+  const source = frameToRect(frame)
+  const candidate = [
+    point.x - finiteNumber(offsetX, 0),
+    point.y - finiteNumber(offsetY, 0),
+    source.w,
+    source.h,
+  ]
+  const nativeFrame = clampFrameToDisplay(candidate, targetDisplay)
+  const worldRect = nativeToDesktopWorldRect(frameToRect(nativeFrame), normalizedDisplays)
+  if (!worldRect) return null
+  const worldFrame = rectToFrame(worldRect)
+  return {
+    targetDisplayId: targetId,
+    nativeFrame,
+    frame: worldFrame,
+    layer: {
+      id: layerId,
+      kind: 'outline',
+      label,
+      frame: worldFrame,
+      zIndex: 10_000,
+      style: {
+        color: 'rgba(122, 241, 255, 0.9)',
+        fill: 'rgba(122, 241, 255, 0.08)',
+        strokeWidth: 2,
+      },
+    },
+  }
+}
+
+export function sendDesktopWorldStageLayer(stageCanvasId, message, { send = emit } = {}) {
+  if (!stageCanvasId || !message) return
+  send('canvas.send', {
+    target: stageCanvasId,
+    message,
+  })
+}
+
+export function createPanelTransferController({
+  enabled = false,
+  stageCanvasId = 'aos-desktop-world-stage',
+  layerId = null,
+  label = 'Move here',
+  getDisplays = () => [],
+  sendStageMessage = (message) => sendDesktopWorldStageLayer(stageCanvasId, message),
+} = {}) {
+  let displays = normalizeDisplays(getDisplays())
+  let originDisplayId = null
+  let active = null
+  const outlineLayerId = layerId || `aos-panel-transfer-outline-${Math.random().toString(36).slice(2, 8)}`
+
+  function updateDisplays(nextDisplays = []) {
+    displays = normalizeDisplays(nextDisplays)
+    return displays
+  }
+
+  function clear() {
+    if (!active) return
+    sendStageMessage({
+      type: 'desktop_world_stage.layer.remove',
+      payload: { id: outlineLayerId },
+    })
+    active = null
+  }
+
+  return {
+    setDisplays: updateDisplays,
+    start({ frame } = {}) {
+      if (!enabled) return null
+      const freshDisplays = normalizeDisplays(getDisplays())
+      if (freshDisplays.length) displays = freshDisplays
+      const rect = frameToRect(frame)
+      const origin = findDisplayForPoint(
+        displays,
+        rect.x + Math.min(rect.w / 2, 80),
+        rect.y + Math.min(rect.h / 2, 44),
+        { rectKey: 'nativeVisibleBounds', nearest: true }
+      )
+      originDisplayId = displayID(origin)
+      clear()
+      return originDisplayId
+    },
+    move({ frame, pointer, offsetX, offsetY } = {}) {
+      if (!enabled) return null
+      const next = computePanelTransfer(displays, {
+        frame,
+        pointer,
+        offsetX,
+        offsetY,
+        originDisplayId,
+        layerId: outlineLayerId,
+        label,
+      })
+      if (!next) {
+        clear()
+        return null
+      }
+      active = next
+      sendStageMessage({
+        type: 'desktop_world_stage.layer.upsert',
+        payload: next.layer,
+      })
+      return next
+    },
+    end() {
+      const result = active
+      clear()
+      originDisplayId = null
+      return result
+    },
+    getState() {
+      return {
+        enabled,
+        originDisplayId,
+        active,
+        displays: [...displays],
+        stageCanvasId,
+        layerId: outlineLayerId,
+      }
+    },
+  }
+}
+
+export function wirePanelTransferDisplayGeometry(controller) {
+  wireBridge((message) => {
+    const payload = message?.payload || message?.data || message
+    if (message?.type !== 'display_geometry' && payload?.type !== 'display_geometry') return
+    if (payload?.displays) controller.setDisplays(payload.displays)
+  })
+  subscribe(['display_geometry'], { snapshot: true })
+}

--- a/packages/toolkit/panel/index.js
+++ b/packages/toolkit/panel/index.js
@@ -21,6 +21,12 @@
 
 export { mountPanel } from './mount.js'
 export {
+  computePanelTransfer,
+  createPanelTransferController,
+  sendDesktopWorldStageLayer,
+  wirePanelTransferDisplayGeometry,
+} from './drag-transfer.js'
+export {
   clampFrameToWorkArea,
   createDragController,
   createMaximizeController,

--- a/packages/toolkit/workbench/defaults.css
+++ b/packages/toolkit/workbench/defaults.css
@@ -19,6 +19,11 @@ body {
   border-radius: 8px;
   background: rgba(5, 10, 14, 0.96);
   box-shadow: 0 18px 46px rgba(0, 0, 0, 0.34);
+  transition: opacity 120ms ease;
+}
+
+.aos-workbench-shell.aos-workbench-transfer-active {
+  opacity: 0.75;
 }
 
 .aos-workbench-titlebar {

--- a/tests/toolkit/panel-drag-transfer.test.mjs
+++ b/tests/toolkit/panel-drag-transfer.test.mjs
@@ -1,0 +1,118 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { createDragController } from '../../packages/toolkit/panel/chrome.js'
+import {
+  computePanelTransfer,
+  createPanelTransferController,
+} from '../../packages/toolkit/panel/drag-transfer.js'
+
+const displays = [
+  {
+    id: 'main',
+    native_bounds: { x: 0, y: 0, w: 1440, h: 900 },
+    native_visible_bounds: { x: 0, y: 24, w: 1440, h: 876 },
+    desktop_world_bounds: { x: 0, y: 0, w: 1440, h: 900 },
+    visible_desktop_world_bounds: { x: 0, y: 24, w: 1440, h: 876 },
+    is_main: true,
+  },
+  {
+    id: 'extended',
+    native_bounds: { x: 1440, y: 0, w: 1280, h: 900 },
+    native_visible_bounds: { x: 1440, y: 0, w: 1280, h: 900 },
+    desktop_world_bounds: { x: 1440, y: 0, w: 1280, h: 900 },
+    visible_desktop_world_bounds: { x: 1440, y: 0, w: 1280, h: 900 },
+  },
+]
+
+test('computePanelTransfer returns a destination-display outline in DesktopWorld coordinates', () => {
+  const transfer = computePanelTransfer(displays, {
+    frame: [100, 80, 500, 360],
+    pointer: { screenX: 1500, screenY: 40 },
+    offsetX: 80,
+    offsetY: 20,
+    originDisplayId: 'main',
+    layerId: 'test-outline',
+  })
+
+  assert.equal(transfer.targetDisplayId, 'extended')
+  assert.deepEqual(transfer.nativeFrame, [1440, 20, 500, 360])
+  assert.deepEqual(transfer.frame, [1440, 20, 500, 360])
+  assert.equal(transfer.layer.id, 'test-outline')
+  assert.equal(transfer.layer.kind, 'outline')
+})
+
+test('computePanelTransfer is inactive while pointer remains on the origin display', () => {
+  assert.equal(computePanelTransfer(displays, {
+    frame: [100, 80, 500, 360],
+    pointer: { screenX: 300, screenY: 120 },
+    offsetX: 80,
+    offsetY: 20,
+    originDisplayId: 'main',
+  }), null)
+})
+
+test('createPanelTransferController upserts outline layers and returns release frame', () => {
+  const sent = []
+  const controller = createPanelTransferController({
+    enabled: true,
+    layerId: 'outline',
+    getDisplays: () => displays,
+    sendStageMessage(message) {
+      sent.push(message)
+    },
+  })
+
+  controller.start({ frame: [100, 80, 500, 360] })
+  const active = controller.move({
+    frame: [100, 80, 500, 360],
+    pointer: { screenX: 1500, screenY: 40 },
+    offsetX: 80,
+    offsetY: 20,
+  })
+  const release = controller.end()
+
+  assert.deepEqual(active.nativeFrame, [1440, 20, 500, 360])
+  assert.deepEqual(release.nativeFrame, [1440, 20, 500, 360])
+  assert.deepEqual(sent.map((message) => message.type), [
+    'desktop_world_stage.layer.upsert',
+    'desktop_world_stage.layer.remove',
+  ])
+})
+
+test('createDragController applies transfer release frame before fallback clamp', () => {
+  let frame = [100, 80, 500, 360]
+  const updates = []
+  const states = []
+  const transferController = createPanelTransferController({
+    enabled: true,
+    layerId: 'outline',
+    getDisplays: () => displays,
+    sendStageMessage() {},
+  })
+  const controller = createDragController({
+    getFrame: () => frame,
+    getWorkArea: () => [0, 24, 1440, 876],
+    updateFrame(nextFrame) {
+      frame = nextFrame
+      updates.push(nextFrame)
+    },
+    move(screenX, screenY, offsetX, offsetY) {
+      frame = [screenX - offsetX, screenY - offsetY, frame[2], frame[3]]
+    },
+    clampOnEnd: true,
+    transferController,
+    onStateChange(state) {
+      states.push(state)
+    },
+  })
+
+  controller.start({ pointerId: 1, clientX: 80, clientY: 20 })
+  controller.move({ pointerId: 1, screenX: 1500, screenY: 40 })
+  controller.end()
+
+  assert.deepEqual(updates.at(-1), [1440, 20, 500, 360])
+  assert.deepEqual(frame, [1440, 20, 500, 360])
+  assert.equal(states.find((state) => state.phase === 'move')?.transferActive, true)
+  assert.equal(states.at(-1)?.transferActive, false)
+})

--- a/tests/toolkit/workbench-shell.test.mjs
+++ b/tests/toolkit/workbench-shell.test.mjs
@@ -59,6 +59,7 @@ test('Sigil radial item workbench is focused on object transforms only', async (
   assert.match(js, /wireDrag/);
   assert.match(js, /wireResize/);
   assert.match(js, /clampOnEnd: true/);
+  assert.match(js, /transfer: true/);
   assert.match(js, /minWidth: 760/);
   assert.doesNotMatch(js, /postRaw\(\{ type: 'move_abs'/);
 });


### PR DESCRIPTION
## Summary
- add a toolkit panel transfer controller that computes destination-display outline frames from display geometry
- send transfer outline upsert/remove messages to the shared DesktopWorld visual stage and move the panel to the destination frame on release
- enable transfer and origin dimming in stock panel chrome and the Sigil radial item workbench

Closes #226

## Verification
- node --check packages/toolkit/panel/chrome.js packages/toolkit/panel/drag-transfer.js packages/toolkit/panel/index.js apps/sigil/radial-item-workbench/index.js
- node --test tests/toolkit/panel-drag-transfer.test.mjs tests/toolkit/panel-chrome.test.mjs tests/toolkit/workbench-shell.test.mjs
- node --test tests/toolkit/*.test.mjs tests/renderer/radial-item-editor.test.mjs tests/renderer/radial-object-control.test.mjs && git diff --check