### PR TITLE
Define menu activation lifecycle

### DIFF
--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -843,8 +843,41 @@ import {
   emitReady,
   emitLifecycleComplete,
   onReady,
+  MENU_ACTIVATION_PHASES,
+  createMenuActivationRequest,
+  advanceMenuActivation,
 } from 'aos://toolkit/runtime/index.js'
 ```
+
+### Menu Activation Model
+
+`packages/toolkit/runtime/menu-activation.js` defines the provider-neutral
+activation envelope for menu-like surfaces. It is intentionally independent of
+radial geometry, 3D rendering, and Sigil-specific actions.
+
+Canonical phases are:
+
+```js
+[
+  'requested',
+  'item_transition',
+  'menu_transition',
+  'surface_transition',
+  'completed',
+  'cancelled',
+  'failed',
+]
+```
+
+Use `createMenuActivationRequest({ menuId, item, input, source, targetSurface,
+transition })` when a menu item commits. The request keeps legacy
+`input` / `source` string fields, but also includes `input_source` for richer
+click, gesture, keyboard, or accessibility metadata. `surface` and
+`target_surface` are aliases for the requested destination surface descriptor.
+
+Use `advanceMenuActivation(request, phase, extra?)` to move through the
+lifecycle. Unknown phases throw, so provider or app mismatches fail loudly
+instead of creating ad-hoc status names.
 
 ### `wireBridge(handler)`
 

--- a/packages/toolkit/CLAUDE.md
+++ b/packages/toolkit/CLAUDE.md
@@ -31,6 +31,7 @@ runtime/                Layer 1a — universal canvas runtime
   subscribe.js            subscribe, unsubscribe to daemon streams
   canvas.js               spawnChild, mutateSelf, removeSelf, setInteractive, evalCanvas
   manifest.js             declareManifest, emitReady, emitLifecycleComplete, onReady
+  menu-activation.js      provider-neutral menu activation lifecycle envelope
   index.js                re-exports
   _smoke/                 smoke harness
   vendor/                 vendored third-party runtime modules and licenses

--- a/packages/toolkit/runtime/index.js
+++ b/packages/toolkit/runtime/index.js
@@ -47,8 +47,16 @@ export {
 } from './radial-gesture.js'
 export {
   MENU_ACTIVATION_SCHEMA_VERSION,
+  MENU_ACTIVATION_PHASES,
+  MENU_ACTIVATION_TERMINAL_PHASES,
   advanceMenuActivation,
   createMenuActivationRequest,
+  isMenuActivationPhase,
+  isTerminalMenuActivationPhase,
+  normalizeMenuActivationInput,
+  normalizeMenuActivationPhase,
+  normalizeMenuActivationSurface,
+  normalizeMenuActivationTransition,
 } from './menu-activation.js'
 export {
   createStackMenu,

--- a/packages/toolkit/runtime/menu-activation.js
+++ b/packages/toolkit/runtime/menu-activation.js
@@ -1,4 +1,18 @@
 export const MENU_ACTIVATION_SCHEMA_VERSION = '2026-05-04';
+export const MENU_ACTIVATION_PHASES = Object.freeze([
+  'requested',
+  'item_transition',
+  'menu_transition',
+  'surface_transition',
+  'completed',
+  'cancelled',
+  'failed',
+]);
+export const MENU_ACTIVATION_TERMINAL_PHASES = Object.freeze([
+  'completed',
+  'cancelled',
+  'failed',
+]);
 
 function text(value, fallback = '') {
   const normalized = String(value ?? '').replace(/\s+/g, ' ').trim();
@@ -14,6 +28,45 @@ function stableId(prefix = 'activation') {
   return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+export function isMenuActivationPhase(phase) {
+  return MENU_ACTIVATION_PHASES.includes(String(phase || ''));
+}
+
+export function isTerminalMenuActivationPhase(phase) {
+  return MENU_ACTIVATION_TERMINAL_PHASES.includes(String(phase || ''));
+}
+
+export function normalizeMenuActivationPhase(phase = 'requested') {
+  const normalized = text(phase, 'requested');
+  if (!isMenuActivationPhase(normalized)) {
+    throw new TypeError(`unknown menu activation phase: ${normalized}`);
+  }
+  return normalized;
+}
+
+export function normalizeMenuActivationInput(input = 'unknown', source = 'menu') {
+  const object = input && typeof input === 'object' ? cloneJson(input) : {};
+  const rawKind = input && typeof input === 'object'
+    ? object.kind ?? object.type ?? object.input
+    : input;
+  return {
+    ...object,
+    kind: text(rawKind, 'unknown'),
+    source: text(object.source ?? source, 'menu'),
+  };
+}
+
+export function normalizeMenuActivationSurface(surface = null) {
+  if (!surface) return null;
+  return cloneJson(surface);
+}
+
+export function normalizeMenuActivationTransition(transition = null) {
+  if (!transition) return null;
+  if (typeof transition === 'string') return { preset: text(transition) };
+  return cloneJson(transition);
+}
+
 export function createMenuActivationRequest({
   id,
   menuId,
@@ -22,30 +75,38 @@ export function createMenuActivationRequest({
   source = 'menu',
   phase = 'requested',
   surface = null,
+  targetSurface = null,
   transition = null,
   metadata = {},
 } = {}) {
   const itemId = text(item?.id || item?.action);
   if (!itemId) throw new TypeError('menu activation requires an item id or action');
+  const now = Date.now();
+  const inputSource = normalizeMenuActivationInput(input, source);
+  const target = normalizeMenuActivationSurface(targetSurface ?? surface);
+  const normalizedPhase = normalizeMenuActivationPhase(phase);
 
   return {
     type: 'aos.menu.activation',
     schema_version: MENU_ACTIVATION_SCHEMA_VERSION,
     id: text(id, stableId('menu-activation')),
     menu_id: text(menuId, 'menu'),
-    phase: text(phase, 'requested'),
-    input: text(input, 'unknown'),
-    source: text(source, 'menu'),
+    phase: normalizedPhase,
+    input: inputSource.kind,
+    source: inputSource.source,
+    input_source: inputSource,
     action: text(item?.action || itemId),
     item: {
       id: itemId,
       label: text(item?.label, itemId),
       action: text(item?.action || itemId),
     },
-    surface: surface ? cloneJson(surface) : null,
-    transition: transition ? cloneJson(transition) : null,
+    surface: target ? cloneJson(target) : null,
+    target_surface: target ? cloneJson(target) : null,
+    transition: normalizeMenuActivationTransition(transition),
     metadata: cloneJson(metadata) || {},
-    created_at: Date.now(),
+    lifecycle: [{ phase: normalizedPhase, at: now }],
+    created_at: now,
   };
 }
 
@@ -53,10 +114,16 @@ export function advanceMenuActivation(request = {}, phase = 'completed', extra =
   if (request.type !== 'aos.menu.activation') {
     throw new TypeError('advanceMenuActivation requires an aos.menu.activation request');
   }
+  const now = Date.now();
+  const normalizedPhase = normalizeMenuActivationPhase(phase);
+  const lifecycle = Array.isArray(request.lifecycle) ? cloneJson(request.lifecycle) : [];
+  lifecycle.push({ phase: normalizedPhase, at: now });
   return {
     ...cloneJson(request),
     ...cloneJson(extra),
-    phase: text(phase, 'completed'),
-    updated_at: Date.now(),
+    previous_phase: text(request.phase, 'requested'),
+    phase: normalizedPhase,
+    lifecycle,
+    updated_at: now,
   };
 }

--- a/tests/toolkit/runtime-menu-activation.test.mjs
+++ b/tests/toolkit/runtime-menu-activation.test.mjs
@@ -1,10 +1,34 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  MENU_ACTIVATION_PHASES,
   MENU_ACTIVATION_SCHEMA_VERSION,
+  MENU_ACTIVATION_TERMINAL_PHASES,
   advanceMenuActivation,
   createMenuActivationRequest,
+  isMenuActivationPhase,
+  isTerminalMenuActivationPhase,
+  normalizeMenuActivationInput,
+  normalizeMenuActivationPhase,
+  normalizeMenuActivationTransition,
 } from '../../packages/toolkit/runtime/menu-activation.js';
+
+test('menu activation phases are canonical and terminal phases are explicit', () => {
+  assert.deepEqual(MENU_ACTIVATION_PHASES, [
+    'requested',
+    'item_transition',
+    'menu_transition',
+    'surface_transition',
+    'completed',
+    'cancelled',
+    'failed',
+  ]);
+  assert.deepEqual(MENU_ACTIVATION_TERMINAL_PHASES, ['completed', 'cancelled', 'failed']);
+  assert.equal(isMenuActivationPhase('surface_transition'), true);
+  assert.equal(isTerminalMenuActivationPhase('surface_transition'), false);
+  assert.equal(isTerminalMenuActivationPhase('failed'), true);
+  assert.throws(() => normalizeMenuActivationPhase('done-ish'), /unknown menu activation phase/);
+});
 
 test('createMenuActivationRequest normalizes menu item activation', () => {
   const request = createMenuActivationRequest({
@@ -29,6 +53,11 @@ test('createMenuActivationRequest normalizes menu item activation', () => {
   assert.equal(request.id, 'activation-1');
   assert.equal(request.menu_id, 'sigil.radial');
   assert.equal(request.phase, 'requested');
+  assert.deepEqual(request.lifecycle.map((entry) => entry.phase), ['requested']);
+  assert.deepEqual(request.input_source, {
+    kind: 'gesture',
+    source: 'sigil.avatar',
+  });
   assert.equal(request.action, 'wikiGraph');
   assert.deepEqual(request.item, {
     id: 'wiki-graph',
@@ -36,7 +65,36 @@ test('createMenuActivationRequest normalizes menu item activation', () => {
     action: 'wikiGraph',
   });
   assert.equal(request.surface.kind, 'markdown-workbench');
+  assert.deepEqual(request.target_surface, request.surface);
   assert.equal(request.transition.preset, 'wiki-brain-zoom-dissolve');
+});
+
+test('menu activation descriptors accept object input and string transition shorthands', () => {
+  const request = createMenuActivationRequest({
+    id: 'activation-input',
+    menuId: 'sigil.radial',
+    input: { kind: 'click', device: 'mouse', button: 0 },
+    source: 'sigil.radial-target-surface',
+    item: { id: 'context-menu' },
+    targetSurface: { kind: 'context-menu', canvas_id: 'sigil-context-menu' },
+    transition: 'default-menu-open',
+  });
+
+  assert.deepEqual(request.input_source, {
+    kind: 'click',
+    source: 'sigil.radial-target-surface',
+    device: 'mouse',
+    button: 0,
+  });
+  assert.equal(request.input, 'click');
+  assert.equal(request.source, 'sigil.radial-target-surface');
+  assert.equal(request.surface.canvas_id, 'sigil-context-menu');
+  assert.equal(request.target_surface.canvas_id, 'sigil-context-menu');
+  assert.deepEqual(normalizeMenuActivationInput('keyboard', 'shortcut'), {
+    kind: 'keyboard',
+    source: 'shortcut',
+  });
+  assert.deepEqual(normalizeMenuActivationTransition('fade-through'), { preset: 'fade-through' });
 });
 
 test('advanceMenuActivation preserves request identity while updating phase', () => {
@@ -51,10 +109,22 @@ test('advanceMenuActivation preserves request identity while updating phase', ()
 
   assert.equal(completed.id, request.id);
   assert.equal(completed.phase, 'completed');
+  assert.equal(completed.previous_phase, 'requested');
   assert.equal(completed.result.canvas_id, 'sigil-agent-terminal');
   assert.equal(request.phase, 'requested');
+  assert.deepEqual(completed.lifecycle.map((entry) => entry.phase), ['requested', 'completed']);
 });
 
 test('createMenuActivationRequest rejects anonymous items', () => {
   assert.throws(() => createMenuActivationRequest({ item: {} }), /requires an item id or action/);
+});
+
+test('activation advancement rejects non-contract phases', () => {
+  const request = createMenuActivationRequest({
+    id: 'activation-bad-phase',
+    menuId: 'sigil.radial',
+    item: { id: 'wiki-graph' },
+  });
+
+  assert.throws(() => advanceMenuActivation(request, 'opening'), /unknown menu activation phase/);
 });


### PR DESCRIPTION
## Summary
- make menu activation phases canonical and strict
- add richer input_source metadata, target_surface aliasing, transition shorthands, and lifecycle history
- document the provider-neutral activation envelope for menu-like surfaces

Closes #218

## Verification
- node --check packages/toolkit/runtime/menu-activation.js packages/toolkit/runtime/index.js
- node --test tests/toolkit/runtime-menu-activation.test.mjs
- node --test tests/toolkit/*.test.mjs tests/renderer/radial-item-editor.test.mjs tests/renderer/radial-object-control.test.mjs && git diff --check