### PR TITLE
Add radial activation adapter

### DIFF
--- a/apps/sigil/renderer/live-modules/main.js
+++ b/apps/sigil/renderer/live-modules/main.js
@@ -36,12 +36,10 @@ import {
 } from './display-utils.js';
 import { createFastTravelController } from './fast-travel.js';
 import { createSigilRadialGestureMenu } from './radial-gesture-menu.js';
+import { createSigilRadialActivationRequest } from './radial-menu-activation.js';
 import { createRadialMenuTargetSurface } from './radial-menu-target-surface.js';
 import { createSigilRadialGestureVisuals } from './radial-gesture-visuals.js';
-import {
-    advanceMenuActivation,
-    createMenuActivationRequest,
-} from './menu-activation-runtime.js';
+import { advanceMenuActivation } from './menu-activation-runtime.js';
 import {
     SIGIL_OBJECT_CONTROL_CANVAS_ID,
     applyRadialMenuObjectTransformPatch,
@@ -1231,36 +1229,25 @@ const fastTravel = createFastTravelController({
 });
 const radialGestureMenu = createSigilRadialGestureMenu({
     state,
-    onCommitItem(item, snapshot) {
-        const activation = createMenuActivationRequest({
-            menuId: 'sigil.radial',
+    onCommitItem(item, snapshot, context = {}) {
+        const input = context.input && typeof context.input === 'object'
+            ? {
+                ...context.input,
+                pointer: context.input.pointer || context.pointer || null,
+            }
+            : context.input || {
+                kind: 'gesture',
+                source: 'sigil.avatar',
+                pointer: context.pointer || null,
+            };
+        const activation = createSigilRadialActivationRequest({
             item,
-            input: snapshot?.phase === 'committed' ? 'gesture' : 'radial',
-            source: 'sigil.avatar',
-            surface: item?.action === 'wikiGraph' ? {
-                kind: 'markdown-workbench',
-                canvas_id: WIKI_WORKBENCH_CANVAS_ID,
-                subject: {
-                    id: `wiki:${WIKI_WORKBENCH_DEFAULT_PATH}`,
-                    source: {
-                        kind: 'wiki',
-                        path: WIKI_WORKBENCH_DEFAULT_PATH,
-                    },
-                },
-            } : null,
-            transition: item?.action === 'wikiGraph' ? {
-                preset: 'wiki-brain-zoom-dissolve',
-                item: {
-                    zoom: 'fill-camera',
-                    dissolve: true,
-                },
-                menu: {
-                    dissolve: true,
-                },
-                surface: {
-                    fade: 'in',
-                },
-            } : null,
+            snapshot,
+            input,
+            source: context.source || 'sigil.avatar',
+            agentTerminalCanvasId: AGENT_TERMINAL_CANVAS_ID,
+            wikiWorkbenchCanvasId: WIKI_WORKBENCH_CANVAS_ID,
+            wikiPath: WIKI_WORKBENCH_DEFAULT_PATH,
         });
         liveJs.lastRadialActivation = activation;
         host.post('sigil.radial_menu.activation', activation);
@@ -1594,14 +1581,28 @@ function handleLeftMouseUp(x, y) {
             setInteractionState('GOTO', 'press-click');
             return;
         case 'RADIAL': {
-            const result = radialGestureMenu.release({ x, y, valid: true });
+            const result = radialGestureMenu.release({ x, y, valid: true }, {
+                input: {
+                    kind: 'gesture',
+                    source: 'sigil.avatar',
+                    pointer: { x, y },
+                    state: liveJs.currentState,
+                },
+            });
             clearGestureState();
             fastTravel.clearGesture(result?.committed?.type === 'item' ? 'radial-item' : 'radial-release');
             setInteractionState('IDLE', result?.committed?.type === 'item' ? 'radial-release-item' : 'radial-release-cancel');
             return;
         }
         case 'FAST_TRAVEL': {
-            const result = radialGestureMenu.release({ x, y, valid: true });
+            const result = radialGestureMenu.release({ x, y, valid: true }, {
+                input: {
+                    kind: 'gesture',
+                    source: 'sigil.avatar',
+                    pointer: { x, y },
+                    state: liveJs.currentState,
+                },
+            });
             clearGestureState();
             if (result?.committed?.type === 'fastTravel') {
                 queueFastTravel(x, y);
@@ -1834,7 +1835,16 @@ function handleRadialTargetSurfaceEvent(payload = {}) {
         });
         return;
     }
-    const result = radialGestureMenu.release({ ...item.center, valid: true });
+    const result = radialGestureMenu.release({ ...item.center, valid: true }, {
+        input: {
+            kind: 'click',
+            source: 'sigil.radial-target-surface',
+            pointer: { x: item.center.x, y: item.center.y },
+            item_id: payload.itemId,
+            canvas_id: radialTargetSurface.id,
+        },
+        source: 'sigil.radial-target-surface',
+    });
     clearGestureState();
     fastTravel.clearGesture(result?.committed?.type === 'item' ? 'radial-surface-item' : 'radial-surface-release');
     setInteractionState('IDLE', result?.committed?.type === 'item' ? 'radial-surface-item' : 'radial-surface-release');

--- a/apps/sigil/renderer/live-modules/radial-gesture-menu.js
+++ b/apps/sigil/renderer/live-modules/radial-gesture-menu.js
@@ -74,11 +74,14 @@ export function createSigilRadialGestureMenu({ state, onCommitItem } = {}) {
         };
     }
 
-    function release(pointer) {
+    function release(pointer, context = {}) {
         if (!model) return null;
         snapshot = decorateSnapshot(model.release(pointer));
         if (snapshot.committed?.type === 'item') {
-            onCommitItem?.(snapshot.committed.item, snapshot);
+            onCommitItem?.(snapshot.committed.item, snapshot, {
+                ...context,
+                pointer,
+            });
         }
         const result = snapshot;
         model = null;

--- a/apps/sigil/renderer/live-modules/radial-menu-activation.js
+++ b/apps/sigil/renderer/live-modules/radial-menu-activation.js
@@ -1,0 +1,111 @@
+import { createMenuActivationRequest } from './menu-activation-runtime.js';
+
+export const SIGIL_RADIAL_MENU_ID = 'sigil.radial';
+
+function actionForItem(item = {}) {
+    return String(item.action || item.id || 'unknown');
+}
+
+function clonePoint(point = null) {
+    const x = Number(point?.x);
+    const y = Number(point?.y);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+    return { x, y };
+}
+
+export function sigilRadialTargetSurfaceForItem(item = {}, {
+    agentTerminalCanvasId = 'sigil-agent-terminal',
+    wikiWorkbenchCanvasId = 'sigil-wiki-workbench',
+    wikiPath = 'aos/concepts/employer-brand-workflow-map.md',
+} = {}) {
+    const action = actionForItem(item);
+    if (action === 'agentTerminal' || action === 'codexTerminal') {
+        return {
+            kind: 'agent-terminal',
+            canvas_id: agentTerminalCanvasId,
+        };
+    }
+    if (action === 'wikiGraph') {
+        return {
+            kind: 'markdown-workbench',
+            canvas_id: wikiWorkbenchCanvasId,
+            subject: {
+                id: `wiki:${wikiPath}`,
+                source: {
+                    kind: 'wiki',
+                    path: wikiPath,
+                },
+            },
+        };
+    }
+    if (action === 'contextMenu') {
+        return {
+            kind: 'sigil-context-menu',
+            parent_canvas_id: 'avatar-main',
+        };
+    }
+    return null;
+}
+
+export function sigilRadialTransitionForItem(item = {}) {
+    if (actionForItem(item) !== 'wikiGraph') return null;
+    return {
+        preset: 'wiki-brain-zoom-dissolve',
+        item: {
+            zoom: 'fill-camera',
+            dissolve: true,
+        },
+        menu: {
+            dissolve: true,
+        },
+        surface: {
+            fade: 'in',
+        },
+    };
+}
+
+export function sigilRadialActivationMetadata(item = {}, snapshot = {}, context = {}) {
+    return {
+        radial: {
+            phase: snapshot?.phase ?? null,
+            active_item_id: snapshot?.activeItemId ?? null,
+            committed_type: snapshot?.committed?.type ?? null,
+            committed_item_id: snapshot?.committed?.itemId ?? item?.id ?? null,
+            origin: clonePoint(snapshot?.origin),
+            release_point: clonePoint(context?.pointer),
+            item_center: clonePoint(item?.center),
+        },
+    };
+}
+
+export function createSigilRadialActivationRequest({
+    item,
+    snapshot,
+    input = { kind: 'gesture', source: 'sigil.avatar' },
+    source = null,
+    agentTerminalCanvasId,
+    wikiWorkbenchCanvasId,
+    wikiPath,
+    metadata = {},
+} = {}) {
+    const inputSource = input && typeof input === 'object'
+        ? { ...input, source: input.source || source || 'sigil.avatar' }
+        : { kind: input || 'gesture', source: source || 'sigil.avatar' };
+    const targetSurface = sigilRadialTargetSurfaceForItem(item, {
+        agentTerminalCanvasId,
+        wikiWorkbenchCanvasId,
+        wikiPath,
+    });
+    return createMenuActivationRequest({
+        menuId: SIGIL_RADIAL_MENU_ID,
+        item,
+        input: inputSource,
+        source: inputSource.source,
+        targetSurface,
+        transition: sigilRadialTransitionForItem(item),
+        metadata: {
+            ...sigilRadialActivationMetadata(item, snapshot, { pointer: inputSource.pointer }),
+            ...metadata,
+        },
+    });
+}

--- a/tests/renderer/radial-gesture-menu.test.mjs
+++ b/tests/renderer/radial-gesture-menu.test.mjs
@@ -25,8 +25,8 @@ function createMenu(options = {}) {
       },
       ...options.state,
     },
-    onCommitItem(item, snapshot) {
-      commits.push({ item, snapshot })
+    onCommitItem(item, snapshot, context) {
+      commits.push({ item, snapshot, context })
     },
   })
   return { menu, commits }
@@ -46,7 +46,26 @@ test('Sigil radial menu commits configured context item on release', () => {
   assert.equal(released.committed.type, 'item')
   assert.equal(commits.length, 1)
   assert.equal(commits[0].item.action, 'contextMenu')
+  assert.deepEqual(commits[0].context.pointer, { ...contextItem.center, valid: true })
   assert.equal(menu.snapshot(), null)
+})
+
+test('Sigil radial menu preserves release context for activation adapters', () => {
+  const { menu, commits } = createMenu()
+  const started = menu.start({ x: 200, y: 200, valid: true })
+  const contextItem = started.items.find((item) => item.id === 'context-menu')
+
+  menu.move({ ...contextItem.center, valid: true })
+  menu.release({ ...contextItem.center, valid: true }, {
+    input: {
+      kind: 'click',
+      source: 'sigil.radial-target-surface',
+    },
+  })
+
+  assert.equal(commits.length, 1)
+  assert.equal(commits[0].context.input.kind, 'click')
+  assert.equal(commits[0].context.input.source, 'sigil.radial-target-surface')
 })
 
 test('Sigil radial menu config carries native wiki model geometry', () => {

--- a/tests/renderer/radial-menu-activation.test.mjs
+++ b/tests/renderer/radial-menu-activation.test.mjs
@@ -1,0 +1,99 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  createSigilRadialActivationRequest,
+  sigilRadialTargetSurfaceForItem,
+  sigilRadialTransitionForItem,
+} from '../../apps/sigil/renderer/live-modules/radial-menu-activation.js'
+
+const snapshot = {
+  phase: 'committed',
+  activeItemId: 'wiki-graph',
+  origin: { x: 100, y: 120 },
+  committed: {
+    type: 'item',
+    itemId: 'wiki-graph',
+  },
+}
+
+test('Sigil radial activation maps wiki item to generic menu activation request', () => {
+  const request = createSigilRadialActivationRequest({
+    item: {
+      id: 'wiki-graph',
+      label: 'Wiki Graph',
+      action: 'wikiGraph',
+      center: { x: 160, y: 120 },
+    },
+    snapshot,
+    input: {
+      kind: 'gesture',
+      source: 'sigil.avatar',
+      pointer: { x: 160, y: 120 },
+    },
+    wikiWorkbenchCanvasId: 'wiki-canvas',
+    wikiPath: 'aos/concepts/example.md',
+  })
+
+  assert.equal(request.type, 'aos.menu.activation')
+  assert.equal(request.menu_id, 'sigil.radial')
+  assert.equal(request.action, 'wikiGraph')
+  assert.equal(request.input_source.kind, 'gesture')
+  assert.equal(request.input_source.source, 'sigil.avatar')
+  assert.deepEqual(request.input_source.pointer, { x: 160, y: 120 })
+  assert.equal(request.target_surface.kind, 'markdown-workbench')
+  assert.equal(request.target_surface.canvas_id, 'wiki-canvas')
+  assert.equal(request.target_surface.subject.id, 'wiki:aos/concepts/example.md')
+  assert.equal(request.transition.preset, 'wiki-brain-zoom-dissolve')
+  assert.deepEqual(request.metadata.radial, {
+    phase: 'committed',
+    active_item_id: 'wiki-graph',
+    committed_type: 'item',
+    committed_item_id: 'wiki-graph',
+    origin: { x: 100, y: 120 },
+    release_point: { x: 160, y: 120 },
+    item_center: { x: 160, y: 120 },
+  })
+})
+
+test('Sigil radial activation preserves target-surface click input metadata', () => {
+  const request = createSigilRadialActivationRequest({
+    item: {
+      id: 'context-menu',
+      label: 'Context Menu',
+      action: 'contextMenu',
+      center: { x: 80, y: 96 },
+    },
+    snapshot: {
+      ...snapshot,
+      activeItemId: 'context-menu',
+      committed: { type: 'item', itemId: 'context-menu' },
+    },
+    input: {
+      kind: 'click',
+      source: 'sigil.radial-target-surface',
+      pointer: { x: 80, y: 96 },
+      canvas_id: 'sigil-radial-menu-avatar-main',
+    },
+  })
+
+  assert.equal(request.input, 'click')
+  assert.equal(request.source, 'sigil.radial-target-surface')
+  assert.equal(request.input_source.canvas_id, 'sigil-radial-menu-avatar-main')
+  assert.equal(request.target_surface.kind, 'sigil-context-menu')
+  assert.equal(request.transition, null)
+})
+
+test('Sigil radial target and transition helpers keep item behavior declarative', () => {
+  assert.deepEqual(sigilRadialTargetSurfaceForItem({
+    id: 'agent-terminal',
+    action: 'agentTerminal',
+  }, {
+    agentTerminalCanvasId: 'agent-canvas',
+  }), {
+    kind: 'agent-terminal',
+    canvas_id: 'agent-canvas',
+  })
+
+  assert.equal(sigilRadialTransitionForItem({ id: 'agent-terminal', action: 'agentTerminal' }), null)
+  assert.equal(sigilRadialTransitionForItem({ id: 'wiki-graph', action: 'wikiGraph' }).preset, 'wiki-brain-zoom-dissolve')
+})


### PR DESCRIPTION
## Summary
- add a Sigil radial activation adapter that maps committed radial items to the generic menu activation request shape
- preserve gesture and transparent target-surface click input metadata before item-specific behavior runs
- pass release context through radial gesture commits with focused renderer tests

Closes #219

## Verification
- node --check apps/sigil/renderer/live-modules/radial-menu-activation.js apps/sigil/renderer/live-modules/radial-gesture-menu.js apps/sigil/renderer/live-modules/main.js
- node --test tests/renderer/radial-menu-activation.test.mjs tests/renderer/radial-gesture-menu.test.mjs tests/renderer/radial-menu-target-surface.test.mjs tests/toolkit/runtime-menu-activation.test.mjs
- node --test tests/toolkit/*.test.mjs tests/renderer/*.test.mjs && git diff --check