### PR TITLE
Add radial item transition presets

### DIFF
--- a/apps/sigil/renderer/live-modules/radial-menu-activation.js
+++ b/apps/sigil/renderer/live-modules/radial-menu-activation.js
@@ -1,4 +1,5 @@
 import { createMenuActivationRequest } from './menu-activation-runtime.js';
+import { resolveRadialItemActivationTransition } from './radial-transition-runtime.js';
 
 export const SIGIL_RADIAL_MENU_ID = 'sigil.radial';
 
@@ -48,20 +49,7 @@ export function sigilRadialTargetSurfaceForItem(item = {}, {
 }
 
 export function sigilRadialTransitionForItem(item = {}) {
-    if (actionForItem(item) !== 'wikiGraph') return null;
-    return {
-        preset: 'wiki-brain-zoom-dissolve',
-        item: {
-            zoom: 'fill-camera',
-            dissolve: true,
-        },
-        menu: {
-            dissolve: true,
-        },
-        surface: {
-            fade: 'in',
-        },
-    };
+    return resolveRadialItemActivationTransition(item);
 }
 
 export function sigilRadialActivationMetadata(item = {}, snapshot = {}, context = {}) {

--- a/apps/sigil/renderer/live-modules/radial-transition-runtime.js
+++ b/apps/sigil/renderer/live-modules/radial-transition-runtime.js
@@ -1,0 +1,21 @@
+const TOOLKIT_RADIAL_TRANSITION_SPECIFIER = (
+    typeof window !== 'undefined'
+    && typeof location !== 'undefined'
+    && /^https?:$/.test(location.protocol)
+)
+    ? '/toolkit/runtime/radial-item-transition.js'
+    : (
+        typeof location !== 'undefined'
+        && location.protocol === 'aos:'
+    )
+        ? 'aos://toolkit/runtime/radial-item-transition.js'
+        : '../../../../packages/toolkit/runtime/radial-item-transition.js';
+
+export const {
+    DEFAULT_RADIAL_ITEM_ACTIVATION_TRANSITION_PRESET,
+    RADIAL_ITEM_ACTIVATION_TRANSITION_PRESETS,
+    RADIAL_ITEM_ACTIVATION_TRANSITION_SCHEMA_VERSION,
+    normalizeRadialItemActivationTransition,
+    radialItemActivationTransitionPreset,
+    resolveRadialItemActivationTransition,
+} = await import(TOOLKIT_RADIAL_TRANSITION_SPECIFIER);

--- a/apps/sigil/renderer/radial-menu-defaults.js
+++ b/apps/sigil/renderer/radial-menu-defaults.js
@@ -115,6 +115,38 @@ export const DEFAULT_SIGIL_RADIAL_ITEMS = [
         label: 'Wiki Graph',
         action: 'wikiGraph',
         geometry: WIKI_BRAIN_HOLOGRAM_MODEL,
+        activationTransition: {
+            preset: 'wiki-brain-zoom-dissolve',
+            item: {
+                focus: {
+                    mode: 'fill-camera',
+                    zoom: 'fill-camera',
+                    scale: 1.0,
+                },
+                dissolve: true,
+                duration_ms: 460,
+                easing: 'ease-in-out',
+            },
+            menu: {
+                dissolve: true,
+                fade: {
+                    from: 1,
+                    to: 0,
+                },
+                duration_ms: 320,
+                easing: 'ease-in-out',
+            },
+            surface: {
+                fade: 'in',
+                starts: 'with-item',
+                opacity: {
+                    from: 0,
+                    to: 1,
+                },
+                duration_ms: 320,
+                easing: 'ease-in-out',
+            },
+        },
     },
 ];
 

--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -879,6 +879,15 @@ Use `advanceMenuActivation(request, phase, extra?)` to move through the
 lifecycle. Unknown phases throw, so provider or app mismatches fail loudly
 instead of creating ad-hoc status names.
 
+`packages/toolkit/runtime/radial-item-transition.js` defines the companion
+transition contract for 3D radial menu items. The vanilla preset,
+`radial-3d-vanilla`, describes item focus/zoom/hold, menu fade/dissolve, incoming
+surface fade, and cancel restore slots. Consumers can put an
+`activationTransition` object on a radial item to override those slots without
+mixing transition state into static geometry tuning data. Use
+`resolveRadialItemActivationTransition(item)` before attaching the result to a
+menu activation request.
+
 ### `wireBridge(handler)`
 
 Installs an inbound message handler for daemon-to-canvas messages.

--- a/packages/toolkit/CLAUDE.md
+++ b/packages/toolkit/CLAUDE.md
@@ -32,6 +32,7 @@ runtime/                Layer 1a — universal canvas runtime
   canvas.js               spawnChild, mutateSelf, removeSelf, setInteractive, evalCanvas
   manifest.js             declareManifest, emitReady, emitLifecycleComplete, onReady
   menu-activation.js      provider-neutral menu activation lifecycle envelope
+  radial-item-transition.js vanilla 3D radial item activation transition presets and overrides
   index.js                re-exports
   _smoke/                 smoke harness
   vendor/                 vendored third-party runtime modules and licenses

--- a/packages/toolkit/runtime/index.js
+++ b/packages/toolkit/runtime/index.js
@@ -59,6 +59,14 @@ export {
   normalizeMenuActivationTransition,
 } from './menu-activation.js'
 export {
+  DEFAULT_RADIAL_ITEM_ACTIVATION_TRANSITION_PRESET,
+  RADIAL_ITEM_ACTIVATION_TRANSITION_PRESETS,
+  RADIAL_ITEM_ACTIVATION_TRANSITION_SCHEMA_VERSION,
+  normalizeRadialItemActivationTransition,
+  radialItemActivationTransitionPreset,
+  resolveRadialItemActivationTransition,
+} from './radial-item-transition.js'
+export {
   createStackMenu,
   createStackMenuModel,
   applyStackMenuState,

--- a/packages/toolkit/runtime/radial-item-transition.js
+++ b/packages/toolkit/runtime/radial-item-transition.js
@@ -1,0 +1,147 @@
+export const RADIAL_ITEM_ACTIVATION_TRANSITION_SCHEMA_VERSION = '2026-05-04';
+export const DEFAULT_RADIAL_ITEM_ACTIVATION_TRANSITION_PRESET = 'radial-3d-vanilla';
+
+export const RADIAL_ITEM_ACTIVATION_TRANSITION_PRESETS = Object.freeze({
+  [DEFAULT_RADIAL_ITEM_ACTIVATION_TRANSITION_PRESET]: Object.freeze({
+    schema_version: RADIAL_ITEM_ACTIVATION_TRANSITION_SCHEMA_VERSION,
+    preset: DEFAULT_RADIAL_ITEM_ACTIVATION_TRANSITION_PRESET,
+    item: Object.freeze({
+      focus: Object.freeze({
+        mode: 'item-center',
+        zoom: 'fit-item',
+        scale: 1.08,
+      }),
+      fade: Object.freeze({
+        from: 1,
+        to: 1,
+      }),
+      hold: true,
+      duration_ms: 220,
+      easing: 'ease-out',
+    }),
+    menu: Object.freeze({
+      hold_active_item: true,
+      dissolve: false,
+      fade: Object.freeze({
+        from: 1,
+        to: 0.18,
+      }),
+      duration_ms: 180,
+      easing: 'ease-out',
+    }),
+    surface: Object.freeze({
+      fade: 'in',
+      opacity: Object.freeze({
+        from: 0,
+        to: 1,
+      }),
+      starts: 'with-menu',
+      duration_ms: 180,
+      easing: 'ease-out',
+    }),
+    cancel: Object.freeze({
+      item: Object.freeze({
+        focus: 'restore',
+        fade: Object.freeze({
+          to: 1,
+        }),
+      }),
+      menu: Object.freeze({
+        fade: Object.freeze({
+          to: 1,
+        }),
+        dissolve: false,
+      }),
+      surface: null,
+      duration_ms: 140,
+      easing: 'ease-out',
+    }),
+  }),
+});
+
+function isPlainObject(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cloneJson(value) {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function mergeJson(base, override) {
+  if (!isPlainObject(base) || !isPlainObject(override)) {
+    return cloneJson(override === undefined ? base : override);
+  }
+  const next = cloneJson(base);
+  for (const [key, value] of Object.entries(override)) {
+    next[key] = isPlainObject(next[key]) && isPlainObject(value)
+      ? mergeJson(next[key], value)
+      : cloneJson(value);
+  }
+  return next;
+}
+
+function text(value, fallback = '') {
+  const normalized = String(value ?? '').replace(/\s+/g, ' ').trim();
+  return normalized || fallback;
+}
+
+function numberOr(value, fallback) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function normalizeDuration(block) {
+  if (!isPlainObject(block)) return block;
+  const next = cloneJson(block);
+  if (next.duration_ms !== undefined) {
+    next.duration_ms = Math.max(0, numberOr(next.duration_ms, 0));
+  }
+  return next;
+}
+
+export function radialItemActivationTransitionPreset(preset = DEFAULT_RADIAL_ITEM_ACTIVATION_TRANSITION_PRESET) {
+  const key = text(preset, DEFAULT_RADIAL_ITEM_ACTIVATION_TRANSITION_PRESET);
+  return cloneJson(
+    RADIAL_ITEM_ACTIVATION_TRANSITION_PRESETS[key]
+    || RADIAL_ITEM_ACTIVATION_TRANSITION_PRESETS[DEFAULT_RADIAL_ITEM_ACTIVATION_TRANSITION_PRESET]
+  );
+}
+
+export function normalizeRadialItemActivationTransition(transition = {}) {
+  if (transition === false) return null;
+  const source = typeof transition === 'string' ? { preset: transition } : transition;
+  const override = isPlainObject(source) ? cloneJson(source) : {};
+  const requestedPreset = text(override.preset, DEFAULT_RADIAL_ITEM_ACTIVATION_TRANSITION_PRESET);
+  const base = radialItemActivationTransitionPreset(requestedPreset);
+  const merged = mergeJson(base, override);
+  const preset = text(merged.preset, requestedPreset);
+
+  return {
+    ...merged,
+    schema_version: text(merged.schema_version, RADIAL_ITEM_ACTIVATION_TRANSITION_SCHEMA_VERSION),
+    preset,
+    item: normalizeDuration(merged.item),
+    menu: normalizeDuration(merged.menu),
+    surface: normalizeDuration(merged.surface),
+    cancel: normalizeDuration(merged.cancel),
+  };
+}
+
+export function resolveRadialItemActivationTransition(item = {}, options = {}) {
+  const source = item?.activationTransition ?? options.activationTransition ?? {};
+  if (source === false) return null;
+  const fallbackPreset = options.preset || DEFAULT_RADIAL_ITEM_ACTIVATION_TRANSITION_PRESET;
+  const requested = isPlainObject(source) || typeof source === 'string'
+    ? source
+    : {};
+  const transition = normalizeRadialItemActivationTransition({
+    preset: fallbackPreset,
+    ...(typeof requested === 'string' ? { preset: requested } : requested),
+  });
+  if (!transition) return null;
+  return {
+    ...transition,
+    item_id: text(item?.id, null),
+  };
+}

--- a/tests/renderer/radial-gesture-menu.test.mjs
+++ b/tests/renderer/radial-gesture-menu.test.mjs
@@ -94,6 +94,10 @@ test('Sigil radial menu config carries native wiki model geometry', () => {
   assert.equal(wikiItem.geometry.normalizedRadius, 0.28)
   assert.equal(wikiItem.geometry.hoverSpinSpeed, undefined)
   assert.equal(wikiItem.geometry.hoverYawDegrees, undefined)
+  assert.equal(wikiItem.geometry.activationTransition, undefined)
+  assert.equal(wikiItem.activationTransition.preset, 'wiki-brain-zoom-dissolve')
+  assert.equal(wikiItem.activationTransition.item.focus.mode, 'fill-camera')
+  assert.equal(wikiItem.activationTransition.menu.dissolve, true)
   assert.deepEqual(wikiItem.geometry.radialEffect, {
     kind: 'nested-neural-tree',
     holdExitDirection: 'outward',
@@ -137,6 +141,8 @@ test('Sigil radial menu normalizes stale wiki brain item geometry from saved con
   assert.equal(wikiItem.geometry.radiusScale, 1.1502)
   assert.equal(wikiItem.geometry.hoverSpinSpeed, undefined)
   assert.equal(wikiItem.geometry.hoverYawDegrees, undefined)
+  assert.equal(wikiItem.geometry.activationTransition, undefined)
+  assert.equal(wikiItem.activationTransition.preset, 'wiki-brain-zoom-dissolve')
   assert.deepEqual(wikiItem.geometry.radialEffect, {
     kind: 'nested-neural-tree',
     holdExitDirection: 'outward',

--- a/tests/renderer/radial-menu-activation.test.mjs
+++ b/tests/renderer/radial-menu-activation.test.mjs
@@ -5,6 +5,7 @@ import {
   sigilRadialTargetSurfaceForItem,
   sigilRadialTransitionForItem,
 } from '../../apps/sigil/renderer/live-modules/radial-menu-activation.js'
+import { DEFAULT_SIGIL_RADIAL_ITEMS } from '../../apps/sigil/renderer/radial-menu-defaults.js'
 
 const snapshot = {
   phase: 'committed',
@@ -17,11 +18,10 @@ const snapshot = {
 }
 
 test('Sigil radial activation maps wiki item to generic menu activation request', () => {
+  const wikiItem = DEFAULT_SIGIL_RADIAL_ITEMS.find((item) => item.id === 'wiki-graph')
   const request = createSigilRadialActivationRequest({
     item: {
-      id: 'wiki-graph',
-      label: 'Wiki Graph',
-      action: 'wikiGraph',
+      ...wikiItem,
       center: { x: 160, y: 120 },
     },
     snapshot,
@@ -44,6 +44,9 @@ test('Sigil radial activation maps wiki item to generic menu activation request'
   assert.equal(request.target_surface.canvas_id, 'wiki-canvas')
   assert.equal(request.target_surface.subject.id, 'wiki:aos/concepts/example.md')
   assert.equal(request.transition.preset, 'wiki-brain-zoom-dissolve')
+  assert.equal(request.transition.item.focus.mode, 'fill-camera')
+  assert.equal(request.transition.menu.dissolve, true)
+  assert.equal(request.transition.surface.starts, 'with-item')
   assert.deepEqual(request.metadata.radial, {
     phase: 'committed',
     active_item_id: 'wiki-graph',
@@ -80,7 +83,8 @@ test('Sigil radial activation preserves target-surface click input metadata', ()
   assert.equal(request.source, 'sigil.radial-target-surface')
   assert.equal(request.input_source.canvas_id, 'sigil-radial-menu-avatar-main')
   assert.equal(request.target_surface.kind, 'sigil-context-menu')
-  assert.equal(request.transition, null)
+  assert.equal(request.transition.preset, 'radial-3d-vanilla')
+  assert.equal(request.transition.menu.hold_active_item, true)
 })
 
 test('Sigil radial target and transition helpers keep item behavior declarative', () => {
@@ -94,6 +98,10 @@ test('Sigil radial target and transition helpers keep item behavior declarative'
     canvas_id: 'agent-canvas',
   })
 
-  assert.equal(sigilRadialTransitionForItem({ id: 'agent-terminal', action: 'agentTerminal' }), null)
-  assert.equal(sigilRadialTransitionForItem({ id: 'wiki-graph', action: 'wikiGraph' }).preset, 'wiki-brain-zoom-dissolve')
+  assert.equal(sigilRadialTransitionForItem({ id: 'agent-terminal', action: 'agentTerminal' }).preset, 'radial-3d-vanilla')
+  assert.equal(sigilRadialTransitionForItem({
+    id: 'wiki-graph',
+    action: 'wikiGraph',
+    activationTransition: { preset: 'wiki-brain-zoom-dissolve' },
+  }).preset, 'wiki-brain-zoom-dissolve')
 })

--- a/tests/toolkit/runtime-radial-item-transition.test.mjs
+++ b/tests/toolkit/runtime-radial-item-transition.test.mjs
@@ -1,0 +1,83 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  DEFAULT_RADIAL_ITEM_ACTIVATION_TRANSITION_PRESET,
+  RADIAL_ITEM_ACTIVATION_TRANSITION_SCHEMA_VERSION,
+  normalizeRadialItemActivationTransition,
+  radialItemActivationTransitionPreset,
+  resolveRadialItemActivationTransition,
+} from '../../packages/toolkit/runtime/radial-item-transition.js'
+
+test('radial item activation transition preset defines vanilla 3D lifecycle slots', () => {
+  const transition = radialItemActivationTransitionPreset()
+
+  assert.equal(transition.schema_version, RADIAL_ITEM_ACTIVATION_TRANSITION_SCHEMA_VERSION)
+  assert.equal(transition.preset, DEFAULT_RADIAL_ITEM_ACTIVATION_TRANSITION_PRESET)
+  assert.equal(transition.item.focus.mode, 'item-center')
+  assert.equal(transition.item.focus.zoom, 'fit-item')
+  assert.equal(transition.item.hold, true)
+  assert.equal(transition.menu.hold_active_item, true)
+  assert.deepEqual(transition.menu.fade, { from: 1, to: 0.18 })
+  assert.equal(transition.surface.fade, 'in')
+  assert.equal(transition.cancel.item.focus, 'restore')
+})
+
+test('radial item activation transitions deep-merge item overrides', () => {
+  const transition = resolveRadialItemActivationTransition({
+    id: 'wiki-graph',
+    activationTransition: {
+      preset: 'wiki-brain-zoom-dissolve',
+      item: {
+        focus: {
+          mode: 'fill-camera',
+          scale: 1,
+        },
+        dissolve: true,
+        duration_ms: 460,
+      },
+      menu: {
+        dissolve: true,
+        fade: { to: 0 },
+      },
+      surface: {
+        starts: 'with-item',
+      },
+    },
+  })
+
+  assert.equal(transition.item_id, 'wiki-graph')
+  assert.equal(transition.preset, 'wiki-brain-zoom-dissolve')
+  assert.equal(transition.item.focus.mode, 'fill-camera')
+  assert.equal(transition.item.focus.zoom, 'fit-item')
+  assert.equal(transition.item.focus.scale, 1)
+  assert.equal(transition.item.dissolve, true)
+  assert.equal(transition.item.duration_ms, 460)
+  assert.equal(transition.menu.dissolve, true)
+  assert.deepEqual(transition.menu.fade, { from: 1, to: 0 })
+  assert.equal(transition.surface.starts, 'with-item')
+  assert.equal(transition.cancel.item.focus, 'restore')
+})
+
+test('radial item activation transitions are detached from preset mutation', () => {
+  const transition = radialItemActivationTransitionPreset()
+  transition.item.focus.mode = 'mutated'
+
+  assert.equal(radialItemActivationTransitionPreset().item.focus.mode, 'item-center')
+})
+
+test('radial item activation transition can be explicitly disabled', () => {
+  assert.equal(resolveRadialItemActivationTransition({
+    id: 'plain-label',
+    activationTransition: false,
+  }), null)
+})
+
+test('normalizing radial item activation transition clamps duration fields', () => {
+  const transition = normalizeRadialItemActivationTransition({
+    item: { duration_ms: -10 },
+    menu: { duration_ms: '25' },
+  })
+
+  assert.equal(transition.item.duration_ms, 0)
+  assert.equal(transition.menu.duration_ms, 25)
+})


### PR DESCRIPTION
## Summary
- add a toolkit resolver for vanilla 3D radial item activation transitions and item-level overrides
- move the wiki graph zoom/dissolve transition into top-level item activationTransition data
- attach resolved transitions through the Sigil radial activation adapter and document the contract

Closes #220

## Verification
- node --check packages/toolkit/runtime/radial-item-transition.js packages/toolkit/runtime/index.js apps/sigil/renderer/live-modules/radial-transition-runtime.js apps/sigil/renderer/live-modules/radial-menu-activation.js apps/sigil/renderer/radial-menu-defaults.js
- node --test tests/toolkit/runtime-radial-item-transition.test.mjs tests/toolkit/runtime-menu-activation.test.mjs tests/renderer/radial-menu-activation.test.mjs tests/renderer/radial-gesture-menu.test.mjs tests/renderer/radial-item-editor.test.mjs
- node --test tests/toolkit/*.test.mjs tests/renderer/*.test.mjs && git diff --check