### PR TITLE
Add wiki brain activation transition

### DIFF
--- a/apps/sigil/renderer/live-modules/main.js
+++ b/apps/sigil/renderer/live-modules/main.js
@@ -37,6 +37,7 @@ import {
 import { createFastTravelController } from './fast-travel.js';
 import { createSigilRadialGestureMenu } from './radial-gesture-menu.js';
 import { createSigilRadialActivationRequest } from './radial-menu-activation.js';
+import { createRadialActivationTransitionController } from './radial-activation-transition.js';
 import { createRadialMenuTargetSurface } from './radial-menu-target-surface.js';
 import { createSigilRadialGestureVisuals } from './radial-gesture-visuals.js';
 import { advanceMenuActivation } from './menu-activation-runtime.js';
@@ -120,7 +121,7 @@ const AGENT_TERMINAL_PARK_SCALE = 0.24;
 const WIKI_WORKBENCH_CANVAS_ID = 'sigil-wiki-workbench';
 const WIKI_WORKBENCH_DEFAULT_PATH = 'aos/concepts/employer-brand-workflow-map.md';
 const WIKI_WORKBENCH_URL = 'aos://toolkit/components/markdown-workbench/index.html';
-const WIKI_WORKBENCH_DEFAULT_URL = `${WIKI_WORKBENCH_URL}?wiki=${encodeURIComponent(WIKI_WORKBENCH_DEFAULT_PATH)}`;
+const WIKI_WORKBENCH_DEFAULT_URL = `${WIKI_WORKBENCH_URL}?wiki=${encodeURIComponent(WIKI_WORKBENCH_DEFAULT_PATH)}&transition=fade-in`;
 const RENDER_PERFORMANCE_CANVAS_ID = 'sigil-render-performance';
 const STATUS_PARK_SCALE = 0.2;
 
@@ -1074,13 +1075,22 @@ function sendActivationUpdate(activation, phase, extra = {}) {
 }
 
 async function openWikiWorkbench(path = WIKI_WORKBENCH_DEFAULT_PATH, activation = null) {
+    let currentActivation = activation;
     const canvas = await ensureUtilityCanvasVisible('wiki-workbench', { focus: true });
+    if (currentActivation) {
+        currentActivation = sendActivationUpdate(currentActivation, 'surface_transition', {
+            target_surface: currentActivation.target_surface,
+            result: {
+                canvas_id: WIKI_WORKBENCH_CANVAS_ID,
+            },
+        });
+    }
     const message = await fetchWikiMarkdownDocument(path);
     if (!canvas.created) {
         sendCanvasMessage(WIKI_WORKBENCH_CANVAS_ID, message);
     }
-    if (activation) {
-        sendActivationUpdate(activation, 'completed', {
+    if (currentActivation) {
+        sendActivationUpdate(currentActivation, 'completed', {
             result: {
                 canvas_id: WIKI_WORKBENCH_CANVAS_ID,
                 subject: message.source,
@@ -1227,6 +1237,9 @@ const fastTravel = createFastTravelController({
     },
     canCaptureDisplayImages: isPrimarySurfaceSegment,
 });
+const radialActivationTransition = createRadialActivationTransitionController({
+    now: () => state.globalTime,
+});
 const radialGestureMenu = createSigilRadialGestureMenu({
     state,
     onCommitItem(item, snapshot, context = {}) {
@@ -1240,7 +1253,7 @@ const radialGestureMenu = createSigilRadialGestureMenu({
                 source: 'sigil.avatar',
                 pointer: context.pointer || null,
             };
-        const activation = createSigilRadialActivationRequest({
+        let activation = createSigilRadialActivationRequest({
             item,
             snapshot,
             input,
@@ -1251,6 +1264,11 @@ const radialGestureMenu = createSigilRadialGestureMenu({
         });
         liveJs.lastRadialActivation = activation;
         host.post('sigil.radial_menu.activation', activation);
+        if (radialActivationTransition.start(activation, snapshot, { startedAt: state.globalTime })) {
+            activation = sendActivationUpdate(activation, 'item_transition', {
+                transition: activation.transition,
+            });
+        }
         if (item?.action === 'contextMenu') {
             openContextMenuAt(liveJs.avatarPos.x, liveJs.avatarPos.y, { force: true });
             sendActivationUpdate(activation, 'completed', { result: { opened: 'context-menu' } });
@@ -2205,6 +2223,7 @@ function clearHiddenFrame(renderAvatarPos, frameStartedAt) {
         hitTarget.sync({ x: -10000, y: -10000, valid: true }, false);
     }
     overlay.draw({ state: 'IDLE', avatarPos: null, dragOrigin: null });
+    radialActivationTransition.clear();
     radialGestureVisuals?.reset?.();
     visibilityTransition.draw({ avatarStagePos: null });
     fastTravel.draw();
@@ -2289,6 +2308,7 @@ function animate() {
     const visualActive = liveJs.avatarVisible
         || !!visibilityTransition.active
         || !!liveJs.travel
+        || radialActivationTransition.active()
         || state.appScale > 0.001;
     if (!visualActive) {
         clearHiddenFrame(renderAvatarPos, frameStartedAt);
@@ -2365,7 +2385,15 @@ function animate() {
         menuRingRadius: liveJs.menuRingRadius,
         dragCancelRadius: liveJs.dragCancelRadius,
     });
-    radialGestureVisuals?.update(liveJs.radialGestureMenu, { time: state.globalTime });
+    const activeRadialActivationTransition = radialActivationTransition.tick(state.globalTime);
+    radialGestureVisuals?.update(liveJs.radialGestureMenu, {
+        time: state.globalTime,
+        activationTransition: activeRadialActivationTransition,
+    });
+    if (activeRadialActivationTransition?.completed) {
+        radialActivationTransition.clear();
+        radialGestureVisuals?.reset?.();
+    }
     visibilityTransition.draw({ avatarStagePos });
     fastTravel.draw();
 
@@ -2416,6 +2444,7 @@ window.__sigilDebug = {
             fastTravel: fastTravel.exportSnapshot(),
             radialGestureMenu: liveJs.radialGestureMenu,
             radialGestureVisuals: radialGestureVisuals?.snapshot?.() ?? null,
+            radialActivationTransition: radialActivationTransition.snapshot(),
             avatarHover: liveJs.avatarHover,
             avatarHoverProgress: liveJs.avatarHoverProgress,
             contextMenu: contextMenu?.snapshot?.(),

--- a/apps/sigil/renderer/live-modules/main.js
+++ b/apps/sigil/renderer/live-modules/main.js
@@ -1627,8 +1627,8 @@ function handleLeftMouseUp(x, y) {
                 setInteractionState('IDLE', 'radial-release-fast-travel');
                 return;
             }
-            fastTravel.clearGesture('radial-fast-travel-cancel');
-            setInteractionState('IDLE', 'radial-fast-travel-cancel');
+            fastTravel.clearGesture(result?.committed?.type === 'item' ? 'radial-fast-travel-item' : 'radial-fast-travel-cancel');
+            setInteractionState('IDLE', result?.committed?.type === 'item' ? 'radial-fast-travel-item' : 'radial-fast-travel-cancel');
             return;
         }
         case 'GOTO':

--- a/apps/sigil/renderer/live-modules/radial-activation-transition.js
+++ b/apps/sigil/renderer/live-modules/radial-activation-transition.js
@@ -1,0 +1,161 @@
+function finite(value, fallback = 0) {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : fallback;
+}
+
+function clamp01(value) {
+    return Math.max(0, Math.min(1, finite(value, 0)));
+}
+
+function isPlainObject(value) {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cloneJson(value) {
+    if (value === undefined) return undefined;
+    return JSON.parse(JSON.stringify(value));
+}
+
+function durationMs(block) {
+    if (!isPlainObject(block)) return 0;
+    return Math.max(0, finite(block.duration_ms, 0));
+}
+
+function easeInOut(progress) {
+    const p = clamp01(progress);
+    return p < 0.5
+        ? 4 * p * p * p
+        : 1 - Math.pow(-2 * p + 2, 3) / 2;
+}
+
+function fadeOpacity(fade, progress, fallbackFrom = 1, fallbackTo = 1) {
+    const source = isPlainObject(fade) ? fade : {};
+    const from = finite(source.from, fallbackFrom);
+    const to = finite(source.to, fallbackTo);
+    return from + ((to - from) * progress);
+}
+
+function dissolveOpacity(enabled, progress) {
+    if (!enabled) return 1;
+    const p = clamp01((progress - 0.62) / 0.38);
+    const eased = p * p * (3 - (2 * p));
+    return 1 - eased;
+}
+
+export function radialActivationTransitionDuration(transition = {}) {
+    return Math.max(
+        0,
+        durationMs(transition.item),
+        durationMs(transition.menu),
+        durationMs(transition.surface),
+        durationMs(transition.cancel),
+    );
+}
+
+export function transitionRadialSnapshot(snapshot = {}) {
+    const committed = snapshot?.committed || {};
+    const itemId = committed.itemId || committed.item?.id || snapshot?.activeItemId || null;
+    const items = Array.isArray(snapshot?.items) ? snapshot.items : [];
+    const item = committed.item || items.find((candidate) => candidate.id === itemId) || null;
+    return {
+        ...cloneJson(snapshot),
+        phase: 'radial',
+        activeItemId: itemId,
+        pointer: item?.center ? cloneJson(item.center) : cloneJson(snapshot?.pointer),
+        menuProgress: 1,
+        handoffProgress: 0,
+        committed: null,
+        cancelReason: null,
+    };
+}
+
+export function radialActivationTransitionFrame(record = {}, nowSeconds = 0) {
+    const transition = record.activation?.transition;
+    if (!transition) return null;
+    const duration = Math.max(1, finite(record.duration_ms, radialActivationTransitionDuration(transition)));
+    const elapsed = Math.max(0, (finite(nowSeconds, 0) - finite(record.started_at, 0)) * 1000);
+    const progress = clamp01(elapsed / duration);
+    const eased = easeInOut(progress);
+    const item = transition.item || {};
+    const menu = transition.menu || {};
+    const surface = transition.surface || {};
+    return {
+        active: progress < 1,
+        completed: progress >= 1,
+        activation_id: record.activation?.id || null,
+        item_id: record.item_id || null,
+        preset: transition.preset || null,
+        progress,
+        eased,
+        elapsed_ms: elapsed,
+        duration_ms: duration,
+        radial: cloneJson(record.radial),
+        item: {
+            ...cloneJson(item),
+            progress,
+            eased,
+            opacity: dissolveOpacity(item.dissolve, progress) * fadeOpacity(item.fade, eased, 1, 1),
+        },
+        menu: {
+            ...cloneJson(menu),
+            progress,
+            eased,
+            opacity: fadeOpacity(menu.fade, eased, 1, 1),
+        },
+        surface: {
+            ...cloneJson(surface),
+            progress,
+            eased,
+            opacity: fadeOpacity(surface.opacity, eased, 0, 1),
+        },
+    };
+}
+
+export function createRadialActivationTransitionController({ now = () => 0 } = {}) {
+    let record = null;
+
+    function start(activation = {}, snapshot = {}, options = {}) {
+        if (!activation?.transition) {
+            record = null;
+            return null;
+        }
+        const radial = transitionRadialSnapshot(snapshot);
+        const itemId = radial.activeItemId || activation.item?.id || null;
+        record = {
+            activation: cloneJson(activation),
+            radial,
+            item_id: itemId,
+            started_at: finite(options.startedAt, now()),
+            duration_ms: Math.max(
+                1,
+                finite(options.durationMs, radialActivationTransitionDuration(activation.transition)),
+            ),
+        };
+        return radialActivationTransitionFrame(record, record.started_at);
+    }
+
+    function tick(nextNow = now()) {
+        if (!record) return null;
+        return radialActivationTransitionFrame(record, nextNow);
+    }
+
+    function clear() {
+        record = null;
+    }
+
+    function active() {
+        return !!record;
+    }
+
+    function snapshot() {
+        return record ? cloneJson(record) : null;
+    }
+
+    return {
+        start,
+        tick,
+        clear,
+        active,
+        snapshot,
+    };
+}

--- a/apps/sigil/renderer/live-modules/radial-gesture-visuals.js
+++ b/apps/sigil/renderer/live-modules/radial-gesture-visuals.js
@@ -1720,6 +1720,37 @@ function updateMaterialHighlight(material, { active, progress }) {
     });
 }
 
+function activationDisplayForItem(activationTransition, itemId) {
+    if (!activationTransition?.item_id) return null;
+    const active = activationTransition.item_id === itemId;
+    if (active) {
+        return {
+            active,
+            opacity: finite(activationTransition.item?.opacity, 1),
+            focusMode: activationTransition.item?.focus?.mode || null,
+            eased: finite(activationTransition.item?.eased, activationTransition.eased),
+        };
+    }
+    return {
+        active,
+        opacity: finite(activationTransition.menu?.opacity, 1),
+        focusMode: null,
+        eased: finite(activationTransition.menu?.eased, activationTransition.eased),
+    };
+}
+
+function applyGlyphDisplayOpacity(glyph, opacity = 1) {
+    const multiplier = clamp01(opacity);
+    if (multiplier >= 0.999) return;
+    glyph.traverse((child) => {
+        forEachMaterial(child.material, (mat) => {
+            if (typeof mat.opacity !== 'number') return;
+            mat.transparent = true;
+            mat.opacity *= multiplier;
+        });
+    });
+}
+
 function setManagedShellOpacity(glyph, opacity, display = 1) {
     const shellOpacity = clamp01(opacity);
     const displayOpacity = clamp01(display);
@@ -1902,10 +1933,12 @@ export function createSigilRadialGestureVisuals({ scene, projectPoint, projectRa
         }
     }
 
-    function update(radial, { time = 0 } = {}) {
+    function update(radial, { time = 0, activationTransition = null } = {}) {
         const dt = lastUpdateTime == null ? 1 / 60 : Math.min(0.08, Math.max(0, time - lastUpdateTime));
         lastUpdateTime = time;
-        const visualRadial = radial?.phase === 'radial' || radial?.phase === 'fastTravel' ? radial : null;
+        const transitionRadial = activationTransition?.radial || null;
+        const radialSource = transitionRadial || radial;
+        const visualRadial = radialSource?.phase === 'radial' || radialSource?.phase === 'fastTravel' ? radialSource : null;
         const activeRadial = radial?.phase === 'radial' ? radial : null;
         if (visualRadial) lastRadial = visualRadial;
         const source = visualRadial || lastRadial;
@@ -1951,7 +1984,17 @@ export function createSigilRadialGestureVisuals({ scene, projectPoint, projectRa
             const sceneRadius = projectRadius?.(item.center, itemRadius) ?? 0.24;
             const baseRadius = finite(glyph.userData.baseRadius, 0.25);
             const radiusScale = finite(item.geometry?.radiusScale ?? item.radiusScale, 1);
-            const targetScale = (sceneRadius / Math.max(0.01, baseRadius)) * radiusScale * (1 + hoverProgress * 0.08) * progress;
+            let targetScale = (sceneRadius / Math.max(0.01, baseRadius)) * radiusScale * (1 + hoverProgress * 0.08) * progress;
+            const activationDisplay = activationDisplayForItem(activationTransition, item.id || 'item');
+            if (activationDisplay?.active && activationDisplay.focusMode === 'fill-camera') {
+                const viewportWidth = finite(globalThis.window?.innerWidth, 800);
+                const viewportHeight = finite(globalThis.window?.innerHeight, 600);
+                const fillRadius = projectRadius?.(item.center, Math.min(viewportWidth, viewportHeight) * 0.56);
+                const fillMultiplier = Number.isFinite(fillRadius) && sceneRadius > 0
+                    ? Math.max(1, fillRadius / Math.max(0.001, sceneRadius))
+                    : 1;
+                targetScale *= 1 + ((fillMultiplier - 1) * clamp01(activationDisplay.eased));
+            }
             glyph.scale.setScalar(targetScale);
             applyRadialItemModelConfig(glyph);
             const effectState = updateRadialEffect(glyph, item, {
@@ -1983,13 +2026,23 @@ export function createSigilRadialGestureVisuals({ scene, projectPoint, projectRa
             glyph.rotation.x = nativeGeometry ? hoverProgress * 0.12 : 0.08 + (hoverProgress * 0.04);
             glyph.rotation.y = (nativeGeometry ? 0 : finite(item.angle, 0) * 0.004) + glyph.userData.hoverSpin;
             glyph.rotation.z = hoverProgress * 0.055;
+            if (activationDisplay) {
+                applyGlyphDisplayOpacity(glyph, activationDisplay.opacity);
+            }
         }
 
         lastState = {
             visible: true,
             count: items.length,
             itemIds: [...glyphs.keys()],
-            activeItemId: activeRadial ? (source.activeItemId || null) : null,
+            activeItemId: activeRadial || activationTransition ? (source.activeItemId || null) : null,
+            activationTransition: activationTransition ? {
+                activation_id: activationTransition.activation_id,
+                item_id: activationTransition.item_id,
+                preset: activationTransition.preset,
+                progress: activationTransition.progress,
+                completed: activationTransition.completed,
+            } : null,
             scales,
             geometry,
             effects,

--- a/packages/toolkit/components/markdown-workbench/index.js
+++ b/packages/toolkit/components/markdown-workbench/index.js
@@ -208,6 +208,11 @@ export default function MarkdownWorkbench(options = {}) {
 
   function render() {
     const root = el('div', 'markdown-workbench-root');
+    const params = typeof window !== 'undefined'
+      ? new URLSearchParams(window.location.search || '')
+      : new URLSearchParams();
+    const transition = String(options.transition || params.get('transition') || '').trim();
+    if (transition === 'fade-in') root.dataset.transition = 'fade-in';
     root.innerHTML = `
       <header class="markdown-workbench-toolbar">
         <div class="markdown-workbench-file">

--- a/packages/toolkit/components/markdown-workbench/styles.css
+++ b/packages/toolkit/components/markdown-workbench/styles.css
@@ -8,6 +8,22 @@
   background: rgba(9, 11, 16, 0.96);
 }
 
+.markdown-workbench-root[data-transition="fade-in"] {
+  animation: markdown-workbench-fade-in 260ms ease-out both;
+}
+
+@keyframes markdown-workbench-fade-in {
+  from {
+    opacity: 0;
+    filter: blur(3px);
+  }
+
+  to {
+    opacity: 1;
+    filter: blur(0);
+  }
+}
+
 .markdown-workbench-toolbar {
   flex: 0 0 auto;
   display: flex;

--- a/packages/toolkit/runtime/radial-gesture.js
+++ b/packages/toolkit/runtime/radial-gesture.js
@@ -276,20 +276,20 @@ export function createRadialGestureModel(options = {}) {
       pointer = point(nextPointer)
       lastTransition = null
 
-      if (phase === 'fastTravel') {
-        phase = 'committed'
-        activeItemId = null
-        committed = { type: 'fastTravel', origin: { ...origin }, destination: { ...pointer } }
-        lastTransition = 'commit_fast_travel'
-        return snapshot()
-      }
-
-      const item = phase === 'radial' ? hitItem(pointer) : null
+      const item = hitItem(pointer)
       if (item) {
         phase = 'committed'
         activeItemId = item.id
         committed = { type: 'item', itemId: item.id, item }
         lastTransition = 'commit_item'
+        return snapshot()
+      }
+
+      if (phase === 'fastTravel') {
+        phase = 'committed'
+        activeItemId = null
+        committed = { type: 'fastTravel', origin: { ...origin }, destination: { ...pointer } }
+        lastTransition = 'commit_fast_travel'
         return snapshot()
       }
 

--- a/tests/renderer/radial-activation-transition.test.mjs
+++ b/tests/renderer/radial-activation-transition.test.mjs
@@ -1,0 +1,107 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  createRadialActivationTransitionController,
+  radialActivationTransitionDuration,
+  radialActivationTransitionFrame,
+  transitionRadialSnapshot,
+} from '../../apps/sigil/renderer/live-modules/radial-activation-transition.js'
+
+const wikiItem = {
+  id: 'wiki-graph',
+  label: 'Wiki Graph',
+  action: 'wikiGraph',
+  center: { x: 160, y: 120 },
+}
+
+const transition = {
+  preset: 'wiki-brain-zoom-dissolve',
+  item: {
+    focus: { mode: 'fill-camera' },
+    dissolve: true,
+    duration_ms: 460,
+  },
+  menu: {
+    dissolve: true,
+    fade: { from: 1, to: 0 },
+    duration_ms: 320,
+  },
+  surface: {
+    fade: 'in',
+    opacity: { from: 0, to: 1 },
+    duration_ms: 320,
+  },
+}
+
+test('radial activation transition duration uses the longest declared slot', () => {
+  assert.equal(radialActivationTransitionDuration(transition), 460)
+})
+
+test('transitionRadialSnapshot keeps committed item geometry alive for visuals', () => {
+  const radial = transitionRadialSnapshot({
+    phase: 'committed',
+    activeItemId: 'wiki-graph',
+    pointer: { x: 0, y: 0 },
+    menuProgress: 0.6,
+    committed: {
+      type: 'item',
+      itemId: 'wiki-graph',
+      item: wikiItem,
+    },
+    items: [wikiItem],
+  })
+
+  assert.equal(radial.phase, 'radial')
+  assert.equal(radial.activeItemId, 'wiki-graph')
+  assert.deepEqual(radial.pointer, wikiItem.center)
+  assert.equal(radial.menuProgress, 1)
+  assert.equal(radial.committed, null)
+})
+
+test('radialActivationTransitionFrame computes item dissolve and surface fade', () => {
+  const frame = radialActivationTransitionFrame({
+    activation: {
+      id: 'activation-1',
+      transition,
+    },
+    item_id: 'wiki-graph',
+    started_at: 10,
+    duration_ms: 460,
+    radial: { phase: 'radial', activeItemId: 'wiki-graph', items: [wikiItem] },
+  }, 10.46)
+
+  assert.equal(frame.completed, true)
+  assert.equal(frame.item_id, 'wiki-graph')
+  assert.equal(frame.preset, 'wiki-brain-zoom-dissolve')
+  assert.equal(frame.item.opacity, 0)
+  assert.equal(frame.menu.opacity, 0)
+  assert.equal(frame.surface.opacity, 1)
+})
+
+test('radial activation transition controller starts, ticks, and clears', () => {
+  let time = 2
+  const controller = createRadialActivationTransitionController({ now: () => time })
+  const started = controller.start({
+    id: 'activation-2',
+    item: wikiItem,
+    transition,
+  }, {
+    phase: 'committed',
+    activeItemId: 'wiki-graph',
+    committed: {
+      type: 'item',
+      itemId: 'wiki-graph',
+      item: wikiItem,
+    },
+    items: [wikiItem],
+  })
+
+  assert.equal(started.progress, 0)
+  assert.equal(started.radial.phase, 'radial')
+  time = 2.23
+  assert.equal(controller.tick().completed, false)
+  time = 2.461
+  assert.equal(controller.tick().completed, true)
+  controller.clear()
+  assert.equal(controller.tick(), null)
+})

--- a/tests/renderer/radial-gesture-menu.test.mjs
+++ b/tests/renderer/radial-gesture-menu.test.mjs
@@ -226,6 +226,29 @@ test('Sigil radial menu reports fast-travel handoff and reentry', () => {
   assert.equal(reentered.snapshot.phase, 'radial')
 })
 
+test('Sigil radial menu commits item when release lands on item after fast-travel handoff', () => {
+  const { menu, commits } = createMenu()
+  const started = menu.start({ x: 200, y: 200, valid: true })
+  const wikiItem = started.items.find((item) => item.id === 'wiki-graph')
+
+  const handoff = menu.move({ x: 390, y: 200, valid: true })
+  assert.equal(handoff.enteredFastTravel, true)
+  assert.equal(handoff.snapshot.phase, 'fastTravel')
+
+  const released = menu.release({ ...wikiItem.center, valid: true }, {
+    input: {
+      kind: 'gesture',
+      source: 'sigil.avatar',
+    },
+  })
+  assert.equal(released.phase, 'committed')
+  assert.equal(released.committed.type, 'item')
+  assert.equal(released.committed.itemId, 'wiki-graph')
+  assert.equal(commits.length, 1)
+  assert.equal(commits[0].item.action, 'wikiGraph')
+  assert.deepEqual(commits[0].context.pointer, { ...wikiItem.center, valid: true })
+})
+
 test('Sigil radial menu commits fast travel only outside the handoff radius', () => {
   const { menu, commits } = createMenu()
   menu.start({ x: 0, y: 0, valid: true })

--- a/tests/toolkit/runtime-radial-gesture.test.mjs
+++ b/tests/toolkit/runtime-radial-gesture.test.mjs
@@ -91,6 +91,24 @@ test('release over a radial item commits that item', () => {
   assert.equal(released.lastTransition, 'commit_item')
 })
 
+test('release over a radial item after fast-travel handoff commits that item', () => {
+  const gesture = model()
+  const started = gesture.start({ x: 200, y: 200 })
+  const target = started.items.find((item) => item.id === 'wiki-graph').center
+
+  const handoff = gesture.move({ x: 390, y: 200 })
+  assert.equal(handoff.phase, 'fastTravel')
+  assert.equal(handoff.activeItemId, null)
+
+  const released = gesture.release(target)
+  assert.equal(released.phase, 'committed')
+  assert.deepEqual(
+    { type: released.committed.type, itemId: released.committed.itemId },
+    { type: 'item', itemId: 'wiki-graph' }
+  )
+  assert.equal(released.lastTransition, 'commit_item')
+})
+
 test('radial item pointer metrics classify outward and inward exits', () => {
   const gesture = model()
   const started = gesture.start({ x: 200, y: 200 })


### PR DESCRIPTION
## Summary
- add a Sigil radial activation transition controller that keeps committed item geometry alive during activation
- feed activation transition state into radial 3D visuals so the wiki brain can zoom toward fill-camera and dissolve via its item override
- add opt-in Markdown Workbench fade-in for the incoming wiki surface

Refs #222

## Verification
- node --check apps/sigil/renderer/live-modules/radial-activation-transition.js apps/sigil/renderer/live-modules/radial-gesture-visuals.js apps/sigil/renderer/live-modules/main.js packages/toolkit/components/markdown-workbench/index.js
- node --test tests/renderer/radial-activation-transition.test.mjs tests/renderer/radial-menu-activation.test.mjs tests/renderer/radial-gesture-visuals.test.mjs tests/renderer/radial-gesture-menu.test.mjs tests/toolkit/markdown-workbench-model.test.mjs tests/toolkit/runtime-radial-item-transition.test.mjs
- node --test tests/toolkit/*.test.mjs tests/renderer/*.test.mjs && git diff --check

## Visual sign-off needed
- Activate the Sigil wiki radial item and confirm the brain zoom/dissolve timing and workbench fade feel correct before this closes #222.