### PR TITLE
Toolkit panel placement and worktree-scoped surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,9 @@ creating separate workflows.
 
 - Keep this root file limited to repo-wide rules and methods.
 - Put specialized guidance in the nearest subtree-specific markdown file.
-- Prefer provider-neutral docs when adding new instructions. During migration,
-  some subtree-specific details still live in nearby `CLAUDE.md` files; treat
-  those as local detail, not root policy.
+- Prefer provider-neutral docs when adding new instructions. Historical
+  `CLAUDE.md` files are compatibility pointers for tools that still discover
+  that filename; keep subtree-specific detail in nearby `AGENTS.md` files.
 
 ## Repo Model
 
@@ -54,9 +54,10 @@ path change before using the new layer.
 Durable lessons should be recorded at the right boundary instead of scattered as
 session notes. Use this file for repo-wide operating rules, subtree `AGENTS.md`
 files for local contracts, `tests/README.md` for verification mechanics,
-`docs/recipes/` for reusable SOPs, and `shared/schemas/`, `docs/api/`, or
-`ARCHITECTURE.md` for cross-tool contracts. Prefer measured, provider-neutral
-guidance over reactive warnings. See
+`docs/recipes/` for reusable SOPs, `docs/design/` for provider-neutral plans
+and specs, and `shared/schemas/`, `docs/api/`, or `ARCHITECTURE.md` for
+cross-tool contracts. Prefer measured, provider-neutral guidance over reactive
+warnings. See
 `docs/recipes/agent-entry-paths-and-verification.md` for the working checklist.
 
 ## Design Principle: Primitives First
@@ -136,9 +137,11 @@ design context is archived at
 - Do not default to rebuilding before every test or verification step.
   Rebuild `./aos` only when the work changes Swift sources in `src/` or
   `shared/swift/ipc/`, or when the command/test you are about to run executes
-  `./aos` directly. Use `./aos dev build --no-restart` for repo builds so the
-  signing/TCC implication stays visible; call `bash build.sh` directly only when
-  `./aos` cannot run or you are fixing the build surface itself.
+  `./aos` directly.
+- Use `./aos dev build` for repo `./aos` rebuilds. It is the canonical
+  developer build control surface because it wraps signing-aware `build.sh` and
+  prints the macOS permission/TCC implication. Do not call `bash build.sh`
+  directly unless you are fixing the build surface itself or `./aos` cannot run.
 - Pure Node/TypeScript/package workflows should stay in their local loop unless
   they explicitly depend on a fresh `./aos` binary. Examples: `packages/gateway`
   build/test, `packages/host` test, and pure `node --test` suites under
@@ -159,11 +162,22 @@ design context is archived at
   of trying to fully re-verify it yourself.
 - If display work starts from stale daemons or orphaned canvases, run
   `./aos clean` first and report what was cleaned.
-- Default repo work to `main` unless the user explicitly asks for branch-based
-  work. Temporary worktrees or helper branches are fine when they materially
-  reduce risk or enable parallelism, but they should stay temporary: land the
-  final state back on `main`, then remove the transient worktree/branch refs
-  before handing the repo back.
+- Treat `main` as the integration branch, not the default work surface. For
+  substantive feature, bug, docs, or governance work, create or use a named
+  topic branch/worktree unless the user explicitly asks for direct-on-main
+  editing or the change is a tiny repo-local hygiene fix already in progress on
+  `main`. Keep branch names descriptive and short, such as
+  `codex/supervised-run-harness` or `owner/sigil-visuals`.
+- Worktree sessions share one singleton repo daemon. Do not overwrite canonical
+  `content.roots.toolkit` or `content.roots.sigil` from a topic worktree unless
+  the task explicitly targets canonical main. Use branch-scoped root names from
+  `scripts/aos-content-scope.sh`, pass explicit `toolkit-root`/`sigil-root`
+  query parameters when a surface crosses app/package roots, and prefer launch
+  scripts that preserve sibling root scope.
+- Before creating a branch, inspect the current worktree. If unrelated dirty
+  changes are present, either choose a separate worktree/branch that preserves
+  them or make a scoped path-only commit when the user has asked for the change.
+  Never discard or move user changes just to satisfy branch hygiene.
 - Before treating grep hits, old paths, or old commands as live, check for
   retirement or supersession notes in the nearest subtree docs, active plans,
   and open issues. Retired code can remain in-tree for a while after the live
@@ -195,7 +209,11 @@ source of truth at the interface boundary:
 ## Follow-On Detail
 
 - `ARCHITECTURE.md` for system architecture
+- `docs/api/aos-taxonomy.md` for classifying AOS artifact types and their
+  source-of-truth homes
+- `docs/design/` for provider-neutral plans, specs, notes, and supporting
+  design artifacts
 - nearest subtree markdown file for package or app specifics
 - `docs/recipes/aos-app-accessibility-surfaces.md` for AOS app and toolkit
   accessibility surface contracts
-- today, many of those local files are still named `CLAUDE.md`
+- historical `CLAUDE.md` files remain only as compatibility pointers

--- a/apps/sigil/AGENTS.md
+++ b/apps/sigil/AGENTS.md
@@ -8,7 +8,8 @@ Sigil is pure web — the renderer, configuration, diagnostics, and chat surface
 
 ## Run
 
-Start the AOS daemon, then launch the avatar canvas:
+For canonical `main` checks, start the AOS daemon, then launch the avatar
+canvas:
 
 ```bash
 ./aos serve                               # repo daemon (launchd normally manages this)
@@ -18,6 +19,12 @@ Start the AOS daemon, then launch the avatar canvas:
     --url 'aos://sigil/renderer/index.html' \
     --track union
 ```
+
+For topic worktrees, do not overwrite canonical `content.roots.toolkit` or
+`content.roots.sigil`. Use branch-scoped content roots from
+`scripts/aos-content-scope.sh` or a branch-aware launch script, then launch
+surfaces from the scoped Sigil root and pass the matching `toolkit-root` when a
+Sigil surface opens toolkit panels.
 
 Logs for the daemon live under `~/.config/aos/{mode}/daemon.log`. The renderer's `console.log` output is visible via Safari's Develop → Agent-OS menu (WKWebView remote inspector) when the daemon is running in a dev build.
 
@@ -127,12 +134,17 @@ The AOS daemon serves Sigil's HTML surfaces over localhost. Configure in `~/.con
 Canvases load via `aos://sigil/renderer/index.html` and other Sigil content-root URLs. No bundling required — ES modules work over HTTP.
 
 Sigil now depends on toolkit runtime modules at load time for shared spatial
-helpers, so repo-mode workflows must ensure both content roots are configured:
+helpers, so repo-mode workflows must ensure both content roots are configured.
+Use canonical roots only on `main`:
 
 ```bash
 ./aos set content.roots.toolkit packages/toolkit
 ./aos set content.roots.sigil apps/sigil
 ```
+
+Topic worktrees must use branch-scoped sibling roots such as
+`sigil_codex_example` and `toolkit_codex_example` so multiple sessions can share
+the singleton daemon without loading each other's HTML, JS, or CSS.
 
 ## Dependencies
 

--- a/apps/sigil/codex-terminal/launch.sh
+++ b/apps/sigil/codex-terminal/launch.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+source "$REPO_ROOT/scripts/aos-content-scope.sh"
 AOS="${AOS:-$REPO_ROOT/aos}"
 MODE="${MODE:-repo}"
 CANVAS_ID="${CANVAS_ID:-sigil-agent-terminal}"
@@ -16,6 +17,8 @@ AGENT_COMMAND="${AGENT_COMMAND:-${CODEX_COMMAND:-codex --no-alt-screen}}"
 STATE_DIR="${HOME}/.config/aos/${MODE}/sigil"
 BRIDGE_LOG="${STATE_DIR}/agent-terminal-bridge.log"
 BRIDGE_SESSION="${BRIDGE_SESSION:-sigil-agent-bridge-${PORT}}"
+SIGIL_CONTENT_ROOT="${AOS_SIGIL_CONTENT_ROOT:-$(aos_content_root_key_for sigil "$REPO_ROOT")}"
+TOOLKIT_CONTENT_ROOT="${AOS_TOOLKIT_CONTENT_ROOT:-$(aos_content_root_key_for toolkit "$REPO_ROOT")}"
 
 usage() {
   printf 'Usage: %s [--new|--new-codex|--new-claude|--pick|--last|--restart]\n' "$0"
@@ -61,8 +64,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 ensure_content_roots() {
-  "$AOS" set content.roots.toolkit "$REPO_ROOT/packages/toolkit" >/dev/null
-  "$AOS" set content.roots.sigil "$REPO_ROOT/apps/sigil" >/dev/null
+  aos_ensure_content_roots_live "$AOS" \
+    "$TOOLKIT_CONTENT_ROOT" "$REPO_ROOT/packages/toolkit" \
+    "$SIGIL_CONTENT_ROOT" "$REPO_ROOT/apps/sigil"
 }
 
 bridge_running() {
@@ -163,13 +167,12 @@ PY
 main() {
   ensure_content_roots
   "$AOS" service start --mode "$MODE" >/dev/null 2>&1 || true
-  "$AOS" content wait --root toolkit --root sigil --timeout 10s >/dev/null
   start_bridge
   ensure_bridge_session
 
   if ! "$AOS" show exists --id "$AVATAR_ID" >/dev/null 2>&1; then
     "$AOS" show create --id "$AVATAR_ID" \
-      --url 'aos://sigil/renderer/index.html' \
+      --url "aos://$SIGIL_CONTENT_ROOT/renderer/index.html?toolkit-root=$TOOLKIT_CONTENT_ROOT" \
       --track union >/dev/null
   fi
 
@@ -185,7 +188,7 @@ main() {
     --at "$frame" \
     --interactive \
     --focus \
-    --url "aos://sigil/agent-terminal/index.html?port=${PORT}&session=${SESSION}&cwd=${encoded_cwd}" >/dev/null
+    --url "aos://$SIGIL_CONTENT_ROOT/agent-terminal/index.html?port=${PORT}&session=${SESSION}&cwd=${encoded_cwd}&toolkit-root=$TOOLKIT_CONTENT_ROOT" >/dev/null
 
   echo "Sigil Agent terminal launched."
   echo "  canvas:  $CANVAS_ID ($frame)"

--- a/apps/sigil/context-menu/menu.js
+++ b/apps/sigil/context-menu/menu.js
@@ -1,15 +1,8 @@
-const TOOLKIT_RUNTIME_BASE = (
-    typeof window !== 'undefined'
-    && typeof location !== 'undefined'
-    && /^https?:$/.test(location.protocol)
-)
-    ? '/toolkit/runtime'
-    : (
-        typeof location !== 'undefined'
-        && location.protocol === 'aos:'
-    )
-        ? 'aos://toolkit/runtime'
-        : '../../../packages/toolkit/runtime';
+import { toolkitSpecifier } from '../renderer/live-modules/content-roots.js';
+
+const TOOLKIT_RUNTIME_BASE = toolkitSpecifier('runtime', {
+    local: '../../../packages/toolkit/runtime',
+});
 
 const { createStackMenu } = await import(`${TOOLKIT_RUNTIME_BASE}/stack-menu.js`);
 const { createDesktopWorldInteractionRouter } = await import(`${TOOLKIT_RUNTIME_BASE}/interaction-region.js`);

--- a/apps/sigil/diagnostics/interaction-trace/index.html
+++ b/apps/sigil/diagnostics/interaction-trace/index.html
@@ -2,14 +2,26 @@
 <html>
 <head>
 <meta charset="utf-8">
-<link rel="stylesheet" href="/toolkit/components/_base/theme.css">
-<link rel="stylesheet" href="/toolkit/panel/defaults.css">
 <link rel="stylesheet" href="./styles.css">
 </head>
 <body>
 <script type="module">
-import { mountPanel, Single } from '/toolkit/panel/index.js'
+import { toolkitSpecifier, toolkitUrl } from '../../renderer/live-modules/content-roots.js'
 import InteractionTrace from './index.js'
+
+for (const href of [
+  toolkitUrl('components/_base/theme.css'),
+  toolkitUrl('panel/defaults.css'),
+]) {
+  const link = document.createElement('link')
+  link.rel = 'stylesheet'
+  link.href = href
+  document.head.insertBefore(link, document.querySelector('link[href="./styles.css"]'))
+}
+
+const { mountPanel, Single } = await import(toolkitSpecifier('panel/index.js', {
+  local: '../../../../packages/toolkit/panel/index.js',
+}))
 
 mountPanel({ title: 'Sigil Interaction Trace', layout: Single(InteractionTrace) })
 </script>

--- a/apps/sigil/diagnostics/interaction-trace/index.js
+++ b/apps/sigil/diagnostics/interaction-trace/index.js
@@ -1,5 +1,11 @@
-import { esc } from '/toolkit/runtime/bridge.js'
-import { evalCanvas } from '/toolkit/runtime/canvas.js'
+import { toolkitSpecifier } from '../../renderer/live-modules/content-roots.js'
+
+const { esc } = await import(toolkitSpecifier('runtime/bridge.js', {
+  local: '../../../../packages/toolkit/runtime/bridge.js',
+}))
+const { evalCanvas } = await import(toolkitSpecifier('runtime/canvas.js', {
+  local: '../../../../packages/toolkit/runtime/canvas.js',
+}))
 
 const AVATAR_ID = 'avatar-main'
 const POLL_MS = 250

--- a/apps/sigil/diagnostics/interaction-trace/launch.sh
+++ b/apps/sigil/diagnostics/interaction-trace/launch.sh
@@ -3,10 +3,16 @@
 
 set -euo pipefail
 
-AOS="${AOS:-./aos}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null || pwd)"
+source "$ROOT/scripts/aos-content-scope.sh"
+
+AOS="${AOS:-$ROOT/aos}"
 CANVAS_ID="${AOS_SIGIL_TRACE_ID:-sigil-interaction-trace}"
 PANEL_W="${AOS_SIGIL_TRACE_W:-760}"
 PANEL_H="${AOS_SIGIL_TRACE_H:-620}"
+SIGIL_CONTENT_ROOT="${AOS_SIGIL_CONTENT_ROOT:-$(aos_content_root_key_for sigil "$ROOT")}"
+TOOLKIT_CONTENT_ROOT="${AOS_TOOLKIT_CONTENT_ROOT:-$(aos_content_root_key_for toolkit "$ROOT")}"
 
 wait_for_eval() {
   local js="$1"
@@ -28,10 +34,9 @@ raise SystemExit(0 if result in (True, 1, "1", "true") else 1)
   return 1
 }
 
-"$AOS" set content.roots.toolkit packages/toolkit >/dev/null
-"$AOS" set content.roots.sigil apps/sigil >/dev/null
-"$AOS" content wait --root toolkit --auto-start --timeout 15s >/dev/null
-"$AOS" content wait --root sigil --auto-start --timeout 15s >/dev/null
+aos_ensure_content_roots_live "$AOS" \
+  "$TOOLKIT_CONTENT_ROOT" "$ROOT/packages/toolkit" \
+  "$SIGIL_CONTENT_ROOT" "$ROOT/apps/sigil"
 
 DISPLAY_JSON="$("$AOS" graph displays --json 2>/dev/null || echo '{"data":{"displays":[]}}')"
 read -r X Y <<EOF
@@ -56,7 +61,7 @@ EOF
   --at "$X,$Y,$PANEL_W,$PANEL_H" \
   --interactive \
   --scope global \
-  --url 'aos://sigil/diagnostics/interaction-trace/index.html'
+  --url "aos://$SIGIL_CONTENT_ROOT/diagnostics/interaction-trace/index.html?toolkit-root=$TOOLKIT_CONTENT_ROOT"
 
 wait_for_eval 'document.querySelector(".sigil-interaction-trace") != null' \
   || { echo "FAIL: Sigil interaction trace panel did not initialize" >&2; exit 1; }

--- a/apps/sigil/renderer/live-modules/content-roots.js
+++ b/apps/sigil/renderer/live-modules/content-roots.js
@@ -1,0 +1,112 @@
+// content-roots.js - resolve sibling AOS content roots for worktree-safe surfaces.
+
+const ROOT_NAME_PATTERN = /[^a-zA-Z0-9_-]/g;
+
+function hasBrowserLocation() {
+    return typeof location !== 'undefined' && typeof location.protocol === 'string';
+}
+
+export function sanitizeContentRoot(value, fallback = 'toolkit') {
+    const root = String(value || '').replace(ROOT_NAME_PATTERN, '');
+    return root || fallback;
+}
+
+export function currentContentRoot({ fallback = 'sigil', loc = hasBrowserLocation() ? location : null } = {}) {
+    if (!loc) return fallback;
+    if (loc.protocol === 'aos:') {
+        return sanitizeContentRoot(loc.hostname || loc.host, fallback);
+    }
+    if (/^https?:$/.test(loc.protocol)) {
+        const first = String(loc.pathname || '')
+            .split('/')
+            .filter(Boolean)[0];
+        return sanitizeContentRoot(first, fallback);
+    }
+    return fallback;
+}
+
+export function queryContentRoot(name, { loc = hasBrowserLocation() ? location : null } = {}) {
+    if (!loc) return null;
+    const query = new URLSearchParams(loc.search || '');
+    const value = query.get(`${name}-root`) || query.get(`${name}_root`);
+    return value ? sanitizeContentRoot(value, name) : null;
+}
+
+export function siblingContentRoot({
+    fromRoot = currentContentRoot(),
+    fromPrefix = 'sigil',
+    toPrefix = 'toolkit',
+} = {}) {
+    const source = sanitizeContentRoot(fromRoot, fromPrefix);
+    if (source === fromPrefix) return toPrefix;
+    const prefix = `${fromPrefix}_`;
+    if (source.startsWith(prefix)) {
+        return `${toPrefix}_${source.slice(prefix.length)}`;
+    }
+    return toPrefix;
+}
+
+export function currentSigilRoot(options = {}) {
+    return queryContentRoot('sigil', options)
+        || currentContentRoot({ ...options, fallback: 'sigil' });
+}
+
+export function currentToolkitRoot(options = {}) {
+    return queryContentRoot('toolkit', options)
+        || siblingContentRoot({
+            fromRoot: currentSigilRoot(options),
+            fromPrefix: 'sigil',
+            toPrefix: 'toolkit',
+        });
+}
+
+export function withQuery(url, params = null) {
+    if (!params) return url;
+    const query = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+        if (value === undefined || value === null) continue;
+        query.set(key, String(value));
+    }
+    const encoded = query.toString();
+    if (!encoded) return url;
+    return `${url}${url.includes('?') ? '&' : '?'}${encoded}`;
+}
+
+export function contentUrl(root, path, {
+    query = null,
+} = {}) {
+    const safeRoot = sanitizeContentRoot(root);
+    const normalizedPath = String(path || '').replace(/^\/+/, '');
+    return withQuery(`aos://${safeRoot}/${normalizedPath}`, query);
+}
+
+export function documentContentUrl(root, path, {
+    loc = hasBrowserLocation() ? location : null,
+    query = null,
+} = {}) {
+    const safeRoot = sanitizeContentRoot(root);
+    const normalizedPath = String(path || '').replace(/^\/+/, '');
+    const base = loc && /^https?:$/.test(loc.protocol)
+        ? `/${safeRoot}/${normalizedPath}`
+        : `aos://${safeRoot}/${normalizedPath}`;
+    return withQuery(base, query);
+}
+
+export function toolkitUrl(path, options = {}) {
+    return contentUrl(currentToolkitRoot(options), path, options);
+}
+
+export function sigilUrl(path, options = {}) {
+    return contentUrl(currentSigilRoot(options), path, options);
+}
+
+export function toolkitSpecifier(path, {
+    local = null,
+    loc = hasBrowserLocation() ? location : null,
+} = {}) {
+    const normalizedPath = String(path || '').replace(/^\/+/, '');
+    if (!loc || (!/^https?:$/.test(loc.protocol) && loc.protocol !== 'aos:')) {
+        return local || `../../../../packages/toolkit/${normalizedPath}`;
+    }
+    return documentContentUrl(currentToolkitRoot({ loc }), normalizedPath, { loc });
+}

--- a/apps/sigil/renderer/live-modules/desktop-world-surface-runtime.js
+++ b/apps/sigil/renderer/live-modules/desktop-world-surface-runtime.js
@@ -1,17 +1,6 @@
-const TOOLKIT_DWS_SPECIFIER = (
-    typeof window !== 'undefined'
-    && typeof location !== 'undefined'
-    && /^https?:$/.test(location.protocol)
-)
-    ? '/toolkit/runtime/desktop-world-surface-three.js'
-    : (
-        typeof location !== 'undefined'
-        && location.protocol === 'aos:'
-    )
-        ? 'aos://toolkit/runtime/desktop-world-surface-three.js'
-        : '../../../../packages/toolkit/runtime/desktop-world-surface-three.js';
+import { toolkitSpecifier } from './content-roots.js';
 
 export const {
     DesktopWorldSurface3D,
     DesktopWorldSurfaceThree,
-} = await import(TOOLKIT_DWS_SPECIFIER);
+} = await import(toolkitSpecifier('runtime/desktop-world-surface-three.js'));

--- a/apps/sigil/renderer/live-modules/display-utils.js
+++ b/apps/sigil/renderer/live-modules/display-utils.js
@@ -10,18 +10,7 @@ const NONANT_CELLS = {
     'bottom-right': [5 / 6, 5 / 6],
 };
 
-const TOOLKIT_SPATIAL_SPECIFIER = (
-    typeof window !== 'undefined'
-    && typeof location !== 'undefined'
-    && /^https?:$/.test(location.protocol)
-)
-    ? '/toolkit/runtime/spatial.js'
-    : (
-        typeof location !== 'undefined'
-        && location.protocol === 'aos:'
-    )
-        ? 'aos://toolkit/runtime/spatial.js'
-        : '../../../../packages/toolkit/runtime/spatial.js';
+import { toolkitSpecifier } from './content-roots.js';
 
 const {
     computeDesktopWorldBounds: toolkitComputeDesktopWorldBounds,
@@ -32,7 +21,7 @@ const {
     nativeToDesktopWorldPoint: toolkitNativeToDesktopWorldPoint,
     desktopWorldToNativePoint: toolkitDesktopWorldToNativePoint,
     globalToUnionLocalPoint: toolkitGlobalToUnionLocalPoint,
-} = await import(TOOLKIT_SPATIAL_SPECIFIER);
+} = await import(toolkitSpecifier('runtime/spatial.js'));
 
 function visibleBoundsRect(display = {}) {
     return display.visible_bounds ?? display.visibleBounds ?? display.bounds ?? { x: 0, y: 0, w: 0, h: 0 };

--- a/apps/sigil/renderer/live-modules/hit-target.js
+++ b/apps/sigil/renderer/live-modules/hit-target.js
@@ -1,17 +1,6 @@
-const TOOLKIT_SURFACE_SPECIFIER = (
-    typeof window !== 'undefined'
-    && typeof location !== 'undefined'
-    && /^https?:$/.test(location.protocol)
-)
-    ? '/toolkit/runtime/interaction-surface.js'
-    : (
-        typeof location !== 'undefined'
-        && location.protocol === 'aos:'
-    )
-        ? 'aos://toolkit/runtime/interaction-surface.js'
-        : '../../../../packages/toolkit/runtime/interaction-surface.js';
+import { toolkitSpecifier } from './content-roots.js';
 
-const { createInteractionSurface } = await import(TOOLKIT_SURFACE_SPECIFIER);
+const { createInteractionSurface } = await import(toolkitSpecifier('runtime/interaction-surface.js'));
 
 function frameFor(center, size) {
     const half = size / 2;

--- a/apps/sigil/renderer/live-modules/main.js
+++ b/apps/sigil/renderer/live-modules/main.js
@@ -42,6 +42,13 @@ import { createRadialMenuTargetSurface } from './radial-menu-target-surface.js';
 import { createSigilRadialGestureVisuals } from './radial-gesture-visuals.js';
 import { advanceMenuActivation } from './menu-activation-runtime.js';
 import {
+    currentSigilRoot,
+    currentToolkitRoot,
+    sigilUrl,
+    toolkitUrl,
+    withQuery,
+} from './content-roots.js';
+import {
     SIGIL_OBJECT_CONTROL_CANVAS_ID,
     applyRadialMenuObjectTransformPatch,
     buildRadialMenuObjectRegistry,
@@ -64,13 +71,13 @@ const desktopWorldSurface = (
 const overlay = createInteractionOverlay();
 const hitTarget = createHitTargetController({
     runtime: host,
-    url: 'aos://sigil/renderer/hit-area.html',
+    url: sigilUrl('renderer/hit-area.html'),
     size: state.avatarHitRadius * 2,
     id: 'sigil-hit-avatar-main',
 });
 const radialTargetSurface = createRadialMenuTargetSurface({
     runtime: host,
-    url: 'aos://sigil/renderer/radial-menu-surface.html',
+    url: sigilUrl('renderer/radial-menu-surface.html'),
     id: 'sigil-radial-menu-avatar-main',
 });
 
@@ -116,12 +123,22 @@ const liveJs = {
 };
 const AGENT_TERMINAL_CANVAS_ID = 'sigil-agent-terminal';
 const LEGACY_CODEX_TERMINAL_CANVAS_ID = 'sigil-codex-terminal';
-const AGENT_TERMINAL_URL = 'aos://sigil/agent-terminal/index.html?port=17761&session=sigil-agent-terminal-agent-os';
+const AGENT_TERMINAL_URL = sigilUrl('agent-terminal/index.html', {
+    query: {
+        port: 17761,
+        session: 'sigil-agent-terminal-agent-os',
+    },
+});
 const AGENT_TERMINAL_PARK_SCALE = 0.24;
 const WIKI_WORKBENCH_CANVAS_ID = 'sigil-wiki-workbench';
 const WIKI_WORKBENCH_DEFAULT_PATH = 'aos/concepts/employer-brand-workflow-map.md';
-const WIKI_WORKBENCH_URL = 'aos://toolkit/components/markdown-workbench/index.html';
-const WIKI_WORKBENCH_DEFAULT_URL = `${WIKI_WORKBENCH_URL}?wiki=${encodeURIComponent(WIKI_WORKBENCH_DEFAULT_PATH)}&transition=fade-in`;
+const SIGIL_CONTENT_ROOT = currentSigilRoot();
+const TOOLKIT_CONTENT_ROOT = currentToolkitRoot();
+const WIKI_WORKBENCH_URL = toolkitUrl('components/markdown-workbench/index.html');
+const WIKI_WORKBENCH_DEFAULT_URL = withQuery(WIKI_WORKBENCH_URL, {
+    wiki: WIKI_WORKBENCH_DEFAULT_PATH,
+    transition: 'fade-in',
+});
 const RENDER_PERFORMANCE_CANVAS_ID = 'sigil-render-performance';
 const STATUS_PARK_SCALE = 0.2;
 
@@ -676,21 +693,21 @@ function utilityConfig(kind) {
     if (kind === 'log-console') {
         return {
             id: '__log__',
-            url: 'aos://toolkit/components/log-console/index.html',
+            url: toolkitUrl('components/log-console/index.html'),
             frame: utilityFrame(kind),
         };
     }
     if (kind === 'sigil-interaction-trace') {
         return {
             id: 'sigil-interaction-trace',
-            url: 'aos://sigil/diagnostics/interaction-trace/index.html',
+            url: sigilUrl('diagnostics/interaction-trace/index.html'),
             frame: utilityFrame(kind),
         };
     }
     if (kind === 'render-performance') {
         return {
             id: RENDER_PERFORMANCE_CANVAS_ID,
-            url: 'aos://toolkit/components/render-performance/index.html',
+            url: toolkitUrl('components/render-performance/index.html'),
             frame: utilityFrame(kind),
         };
     }
@@ -720,7 +737,7 @@ function utilityConfig(kind) {
     }
     return {
         id: 'canvas-inspector',
-        url: 'aos://toolkit/components/canvas-inspector/index.html',
+        url: toolkitUrl('components/canvas-inspector/index.html'),
         frame: utilityFrame(kind),
     };
 }
@@ -2435,6 +2452,14 @@ window.__sigilDebug = {
         return {
             runtime: {
                 ...SIGIL_RENDERER_RUNTIME,
+                contentRoots: {
+                    sigil: SIGIL_CONTENT_ROOT,
+                    toolkit: TOOLKIT_CONTENT_ROOT,
+                },
+                utilityUrls: {
+                    wikiWorkbench: WIKI_WORKBENCH_DEFAULT_URL,
+                    agentTerminal: AGENT_TERMINAL_URL,
+                },
                 bootFirstFrameAt: window.__sigilBootFirstFrameAt,
                 bootTraceFirstAt: window.__sigilBootTrace?.[0]?.ts ?? null,
             },
@@ -2471,6 +2496,12 @@ window.__sigilDebug = {
     },
     avatarDefinition,
     importAvatarDefinitionText,
+    utilityConfig(kind) {
+        return utilityConfig(kind);
+    },
+    openWikiWorkbench(path) {
+        return openWikiWorkbench(path || WIKI_WORKBENCH_DEFAULT_PATH);
+    },
     fastTravelPreview() {
         return fastTravel.preview();
     },
@@ -2478,6 +2509,10 @@ window.__sigilDebug = {
         return interactionTrace.snapshot({
             runtime: {
                 ...SIGIL_RENDERER_RUNTIME,
+                contentRoots: {
+                    sigil: SIGIL_CONTENT_ROOT,
+                    toolkit: TOOLKIT_CONTENT_ROOT,
+                },
                 bootFirstFrameAt: window.__sigilBootFirstFrameAt,
                 bootTraceFirstAt: window.__sigilBootTrace?.[0]?.ts ?? null,
             },

--- a/apps/sigil/renderer/live-modules/menu-activation-runtime.js
+++ b/apps/sigil/renderer/live-modules/menu-activation-runtime.js
@@ -1,18 +1,7 @@
-const TOOLKIT_MENU_ACTIVATION_SPECIFIER = (
-    typeof window !== 'undefined'
-    && typeof location !== 'undefined'
-    && /^https?:$/.test(location.protocol)
-)
-    ? '/toolkit/runtime/menu-activation.js'
-    : (
-        typeof location !== 'undefined'
-        && location.protocol === 'aos:'
-    )
-        ? 'aos://toolkit/runtime/menu-activation.js'
-        : '../../../../packages/toolkit/runtime/menu-activation.js';
+import { toolkitSpecifier } from './content-roots.js';
 
 export const {
     MENU_ACTIVATION_SCHEMA_VERSION,
     advanceMenuActivation,
     createMenuActivationRequest,
-} = await import(TOOLKIT_MENU_ACTIVATION_SPECIFIER);
+} = await import(toolkitSpecifier('runtime/menu-activation.js'));

--- a/apps/sigil/renderer/live-modules/radial-gesture-runtime.js
+++ b/apps/sigil/renderer/live-modules/radial-gesture-runtime.js
@@ -1,17 +1,6 @@
-const TOOLKIT_RADIAL_GESTURE_SPECIFIER = (
-    typeof window !== 'undefined'
-    && typeof location !== 'undefined'
-    && /^https?:$/.test(location.protocol)
-)
-    ? '/toolkit/runtime/radial-gesture.js'
-    : (
-        typeof location !== 'undefined'
-        && location.protocol === 'aos:'
-    )
-        ? 'aos://toolkit/runtime/radial-gesture.js'
-        : '../../../../packages/toolkit/runtime/radial-gesture.js';
+import { toolkitSpecifier } from './content-roots.js';
 
-const toolkit = await import(TOOLKIT_RADIAL_GESTURE_SPECIFIER);
+const toolkit = await import(toolkitSpecifier('runtime/radial-gesture.js'));
 
 export const {
     createRadialGestureModel,

--- a/apps/sigil/renderer/live-modules/radial-gesture-visuals.js
+++ b/apps/sigil/renderer/live-modules/radial-gesture-visuals.js
@@ -1,4 +1,5 @@
 import { radialItemPointerMetrics } from './radial-gesture-runtime.js';
+import { currentSigilRoot } from './content-roots.js';
 import {
     DEFAULT_RADIAL_ITEM_MODEL_TRANSFORM,
     DEFAULT_NESTED_TREE_EFFECT,
@@ -1124,7 +1125,7 @@ function resolveGeometryUrl(src) {
         && typeof location !== 'undefined'
         && /^https?:$/.test(location.protocol)
     ) {
-        return trimmed.replace(/^aos:\/\/sigil\//, '/sigil/');
+        return trimmed.replace(/^aos:\/\/sigil\//, `/${currentSigilRoot()}/`);
     }
     try {
         return new URL(trimmed, import.meta.url).href;

--- a/apps/sigil/renderer/live-modules/radial-menu-target-surface.js
+++ b/apps/sigil/renderer/live-modules/radial-menu-target-surface.js
@@ -1,45 +1,8 @@
-const TOOLKIT_SURFACE_SPECIFIER = (
-    typeof window !== 'undefined'
-    && typeof location !== 'undefined'
-    && /^https?:$/.test(location.protocol)
-)
-    ? '/toolkit/runtime/interaction-surface.js'
-    : (
-        typeof location !== 'undefined'
-        && location.protocol === 'aos:'
-    )
-        ? 'aos://toolkit/runtime/interaction-surface.js'
-        : '../../../../packages/toolkit/runtime/interaction-surface.js';
+import { toolkitSpecifier } from './content-roots.js';
 
-const TOOLKIT_SPATIAL_SPECIFIER = (
-    typeof window !== 'undefined'
-    && typeof location !== 'undefined'
-    && /^https?:$/.test(location.protocol)
-)
-    ? '/toolkit/runtime/spatial.js'
-    : (
-        typeof location !== 'undefined'
-        && location.protocol === 'aos:'
-    )
-        ? 'aos://toolkit/runtime/spatial.js'
-        : '../../../../packages/toolkit/runtime/spatial.js';
-
-const TOOLKIT_SEMANTIC_SPECIFIER = (
-    typeof window !== 'undefined'
-    && typeof location !== 'undefined'
-    && /^https?:$/.test(location.protocol)
-)
-    ? '/toolkit/runtime/semantic-targets.js'
-    : (
-        typeof location !== 'undefined'
-        && location.protocol === 'aos:'
-    )
-        ? 'aos://toolkit/runtime/semantic-targets.js'
-        : '../../../../packages/toolkit/runtime/semantic-targets.js';
-
-const { createInteractionSurface } = await import(TOOLKIT_SURFACE_SPECIFIER);
-const { desktopWorldToNativePoint } = await import(TOOLKIT_SPATIAL_SPECIFIER);
-const { normalizeSemanticTarget } = await import(TOOLKIT_SEMANTIC_SPECIFIER);
+const { createInteractionSurface } = await import(toolkitSpecifier('runtime/interaction-surface.js'));
+const { desktopWorldToNativePoint } = await import(toolkitSpecifier('runtime/spatial.js'));
+const { normalizeSemanticTarget } = await import(toolkitSpecifier('runtime/semantic-targets.js'));
 
 const DEFAULT_TARGET_MIN_SIZE = 56;
 const DEFAULT_FRAME_PADDING = 10;

--- a/apps/sigil/renderer/live-modules/radial-transition-runtime.js
+++ b/apps/sigil/renderer/live-modules/radial-transition-runtime.js
@@ -1,15 +1,4 @@
-const TOOLKIT_RADIAL_TRANSITION_SPECIFIER = (
-    typeof window !== 'undefined'
-    && typeof location !== 'undefined'
-    && /^https?:$/.test(location.protocol)
-)
-    ? '/toolkit/runtime/radial-item-transition.js'
-    : (
-        typeof location !== 'undefined'
-        && location.protocol === 'aos:'
-    )
-        ? 'aos://toolkit/runtime/radial-item-transition.js'
-        : '../../../../packages/toolkit/runtime/radial-item-transition.js';
+import { toolkitSpecifier } from './content-roots.js';
 
 export const {
     DEFAULT_RADIAL_ITEM_ACTIVATION_TRANSITION_PRESET,
@@ -18,4 +7,4 @@ export const {
     normalizeRadialItemActivationTransition,
     radialItemActivationTransitionPreset,
     resolveRadialItemActivationTransition,
-} = await import(TOOLKIT_RADIAL_TRANSITION_SPECIFIER);
+} = await import(toolkitSpecifier('runtime/radial-item-transition.js'));

--- a/apps/sigil/renderer/radial-menu-surface.html
+++ b/apps/sigil/renderer/radial-menu-surface.html
@@ -62,19 +62,11 @@ body {
 <script type="module">
 window.headsup = window.headsup || {};
 
-const TOOLKIT_SEMANTIC_SPECIFIER = (
-    typeof location !== 'undefined'
-    && /^https?:$/.test(location.protocol)
-)
-    ? '/toolkit/runtime/semantic-targets.js'
-    : (
-        typeof location !== 'undefined'
-        && location.protocol === 'aos:'
-    )
-        ? 'aos://toolkit/runtime/semantic-targets.js'
-        : '../../../packages/toolkit/runtime/semantic-targets.js';
+import { toolkitSpecifier } from './live-modules/content-roots.js';
 
-const { applySemanticTargetAttributes } = await import(TOOLKIT_SEMANTIC_SPECIFIER);
+const { applySemanticTargetAttributes } = await import(toolkitSpecifier('runtime/semantic-targets.js', {
+    local: '../../../packages/toolkit/runtime/semantic-targets.js',
+}));
 
 const PARAMS = new URLSearchParams(window.location.search);
 const PARENT_ID = PARAMS.get('parent') || 'avatar-main';

--- a/apps/sigil/workbench/index.html
+++ b/apps/sigil/workbench/index.html
@@ -3,12 +3,6 @@
 <head>
 <meta charset="utf-8">
 <title>SIGIL</title>
-<link rel="stylesheet" href="/toolkit/components/_base/theme.css">
-<link rel="stylesheet" href="/toolkit/panel/defaults.css">
-<link rel="stylesheet" href="/toolkit/components/canvas-inspector/styles.css">
-<link rel="stylesheet" href="/toolkit/components/log-console/styles.css">
-<link rel="stylesheet" href="/toolkit/components/integration-hub/styles.css">
-<link rel="stylesheet" href="/toolkit/components/wiki-kb/styles.css">
 <style>
 /* Iframe surfaces — workbench-specific content for Studio + Chat tabs */
 .surface-shell {
@@ -57,13 +51,41 @@
 </head>
 <body>
 <script type="module">
-  import { mountPanel, Tabs } from '/toolkit/panel/index.js'
-  import { evalCanvas, subscribe, wireBridge } from '/toolkit/runtime/index.js'
-  import CanvasInspector from '/toolkit/components/canvas-inspector/index.js'
-  import IntegrationHub from '/toolkit/components/integration-hub/index.js'
-  import LogConsole from '/toolkit/components/log-console/index.js'
-  import WikiKB from '/toolkit/components/wiki-kb/index.js'
-  import { resolveBirthplace } from '/sigil/renderer/birthplace-resolver.js'
+  import { toolkitSpecifier, toolkitUrl, sigilUrl } from '../renderer/live-modules/content-roots.js'
+  import { resolveBirthplace } from '../renderer/birthplace-resolver.js'
+
+  for (const href of [
+    toolkitUrl('components/_base/theme.css'),
+    toolkitUrl('panel/defaults.css'),
+    toolkitUrl('components/canvas-inspector/styles.css'),
+    toolkitUrl('components/log-console/styles.css'),
+    toolkitUrl('components/integration-hub/styles.css'),
+    toolkitUrl('components/wiki-kb/styles.css'),
+  ]) {
+    const link = document.createElement('link')
+    link.rel = 'stylesheet'
+    link.href = href
+    document.head.append(link)
+  }
+
+  const { mountPanel, Tabs } = await import(toolkitSpecifier('panel/index.js', {
+    local: '../../../packages/toolkit/panel/index.js',
+  }))
+  const { evalCanvas, subscribe, wireBridge } = await import(toolkitSpecifier('runtime/index.js', {
+    local: '../../../packages/toolkit/runtime/index.js',
+  }))
+  const { default: CanvasInspector } = await import(toolkitSpecifier('components/canvas-inspector/index.js', {
+    local: '../../../packages/toolkit/components/canvas-inspector/index.js',
+  }))
+  const { default: IntegrationHub } = await import(toolkitSpecifier('components/integration-hub/index.js', {
+    local: '../../../packages/toolkit/components/integration-hub/index.js',
+  }))
+  const { default: LogConsole } = await import(toolkitSpecifier('components/log-console/index.js', {
+    local: '../../../packages/toolkit/components/log-console/index.js',
+  }))
+  const { default: WikiKB } = await import(toolkitSpecifier('components/wiki-kb/index.js', {
+    local: '../../../packages/toolkit/components/wiki-kb/index.js',
+  }))
 
   const AVATAR_ID = 'avatar-main'
   const workbenchState = {
@@ -314,13 +336,13 @@
     iframeContent({
       name: 'sigil-studio',
       title: 'Studio',
-      src: '/sigil/studio/index.html',
+      src: sigilUrl('studio/index.html'),
       description: 'Roster, geometry, color, effects, agent state.',
     }),
     iframeContent({
       name: 'sigil-chat',
       title: 'Chat',
-      src: '/sigil/chat/index.html',
+      src: sigilUrl('chat/index.html'),
       description: 'Conversation surface.',
     }),
     () => IntegrationHub({ brokerUrl: 'http://127.0.0.1:47231' }),

--- a/apps/sigil/workbench/launch.sh
+++ b/apps/sigil/workbench/launch.sh
@@ -8,16 +8,20 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+source "$REPO_ROOT/scripts/aos-content-scope.sh"
 AOS="${AOS:-$REPO_ROOT/aos}"
 MODE="${MODE:-repo}"
 WORKBENCH_ID="${WORKBENCH_ID:-sigil-workbench}"
 AVATAR_ID="${AVATAR_ID:-avatar-main}"
+SIGIL_CONTENT_ROOT="${AOS_SIGIL_CONTENT_ROOT:-$(aos_content_root_key_for sigil "$REPO_ROOT")}"
+TOOLKIT_CONTENT_ROOT="${AOS_TOOLKIT_CONTENT_ROOT:-$(aos_content_root_key_for toolkit "$REPO_ROOT")}"
 
 # --- helpers ----------------------------------------------------------------
 
 ensure_content_roots() {
-  "$AOS" set content.roots.toolkit packages/toolkit >/dev/null
-  "$AOS" set content.roots.sigil apps/sigil >/dev/null
+  aos_ensure_content_roots_live "$AOS" \
+    "$TOOLKIT_CONTENT_ROOT" "$REPO_ROOT/packages/toolkit" \
+    "$SIGIL_CONTENT_ROOT" "$REPO_ROOT/apps/sigil"
 }
 
 # --- geometry ---------------------------------------------------------------
@@ -88,9 +92,9 @@ bootstrap_tabs() {
 main() {
   ensure_content_roots
   "$AOS" service start --mode "$MODE" >/dev/null 2>&1 || true
-  if ! "$AOS" content wait --root toolkit --root sigil --timeout 10s >/dev/null 2>&1; then
+  if ! "$AOS" content wait --root "$TOOLKIT_CONTENT_ROOT" --root "$SIGIL_CONTENT_ROOT" --timeout 10s >/dev/null 2>&1; then
     echo "The running daemon does not have live toolkit+sigil content roots." >&2
-    echo "Restart the daemon to apply content.roots.toolkit and content.roots.sigil, then rerun launch.sh." >&2
+    echo "Restart the daemon to apply scoped toolkit+sigil roots, then rerun launch.sh." >&2
     return 1
   fi
   "$REPO_ROOT/apps/sigil/sigilctl-seed.sh" --mode "$MODE" >/dev/null
@@ -105,11 +109,11 @@ main() {
   avatar_home="$(echo "$geometry" | tail -1)"
 
   "$AOS" show create --id "$AVATAR_ID" \
-    --url 'aos://sigil/renderer/index.html' --track union >/dev/null
+    --url "aos://$SIGIL_CONTENT_ROOT/renderer/index.html?toolkit-root=$TOOLKIT_CONTENT_ROOT" --track union >/dev/null
 
   "$AOS" show create --id "$WORKBENCH_ID" \
     --at "$frame" --interactive --focus \
-    --url 'aos://sigil/workbench/index.html' >/dev/null
+    --url "aos://$SIGIL_CONTENT_ROOT/workbench/index.html?toolkit-root=$TOOLKIT_CONTENT_ROOT" >/dev/null
 
   "$AOS" show wait --id "$AVATAR_ID" --js 'typeof window.liveJs === "object"' --timeout 5s >/dev/null \
     || { echo "Avatar canvas did not finish mounting." >&2; return 1; }

--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -32,7 +32,7 @@ first move.
 
 Use `./aos dev classify --json` and `./aos dev recommend --json` to route repo
 changes through the manifest-backed developer workflow before choosing a build,
-test, canvas reload, or readiness loop. Use `./aos dev build --no-restart`
+test, canvas reload, or readiness loop. Use `./aos dev build`
 instead of raw `bash build.sh` unless `./aos` is missing or the build surface is
 itself under repair.
 
@@ -135,7 +135,7 @@ Typical consumer loop:
 ./aos dev classify --json
 ./aos dev recommend --json
 ./aos dev recommend --paths src/main.swift,packages/toolkit/runtime/canvas.js --json
-./aos dev build --no-restart
+./aos dev build
 ```
 
 `classify` reports changed files, matched rules, classes, actions, and whether
@@ -162,6 +162,10 @@ aos show remove --id demo
 ```
 
 ### 3. Load Toolkit Content Through the Content Server
+
+Use the canonical `toolkit` root for `main` or installed examples. Topic
+worktrees should use branch-scoped root names so one singleton daemon can serve
+multiple sessions without root collisions.
 
 ```bash
 aos set content.roots.toolkit packages/toolkit
@@ -778,6 +782,10 @@ Minimal setup:
 ```bash
 aos set content.roots.toolkit packages/toolkit
 ```
+
+In topic worktrees, use `scripts/aos-content-scope.sh` or a branch-aware launch
+script to derive a root such as `toolkit_codex_example` instead of overwriting
+canonical `toolkit`.
 
 Then:
 

--- a/docs/design/aos-panel-window-placement-contract.md
+++ b/docs/design/aos-panel-window-placement-contract.md
@@ -1,0 +1,142 @@
+# AOS Panel Window Placement Contract
+
+**Date:** 2026-05-05
+**Status:** Design note and handoff map. The first toolkit slice exists on
+`codex/wiki-workbench-layout-polish`, but the platform contract is not complete.
+
+## Plain-English Model
+
+AOS can put rectangles on the desktop. Some rectangles are ambient visuals, like
+the Sigil avatar and radial menu. Other rectangles are windows, like Canvas
+Inspector, wiki workbenches, terminals, editors, and settings panels.
+
+The toolkit should be the standard window kit for those window-shaped canvases:
+title bar, drag, resize, close, minimize, maximize, restore, and safe placement
+on displays. Apps should use that kit instead of each app inventing its own
+window behavior.
+
+In this sense, a "toolkit window" does not mean "a window owned by
+`packages/toolkit`." It means any AOS canvas, including app canvases under
+`apps/`, that opts into toolkit panel/window behavior.
+
+## Why This Matters
+
+The observed bug class was inconsistent placement when dragging windows between
+a main display and an extended display. Canvas Inspector, Agent Terminal, older
+Sigil editors, and minimized chips could differ because they do not all share
+one placement path.
+
+This is not primarily a worktree issue. Stale content roots can make an old
+version stay on screen, but the deeper issue is multiple window systems
+coexisting:
+
+- shared toolkit panel chrome;
+- standalone minimized chip drag/restore logic;
+- app-owned titlebars that emit raw `move_abs`;
+- daemon native window movement and drag finalization;
+- DesktopWorld visuals for outlines, minimaps, avatar, and radial menu.
+
+## Ownership Boundary
+
+The intended boundary is:
+
+- **Daemon:** owns physical canvas lifecycle, native macOS frames, display
+  geometry snapshots, and the actual window-server mutation.
+- **Toolkit panel/window layer:** owns policy for window-shaped canvases:
+  draggable titlebars, resize handles, minimize chips, maximize/restore,
+  cross-display transfer affordances, and final safe clamping.
+- **Apps:** opt into toolkit behavior and provide content, actions, theme
+  overrides, and app-specific layout. Apps should not hand-roll drag/drop/chrome
+  unless the surface is explicitly not a panel window.
+- **DesktopWorld stage:** owns click-through visual layers for avatar, radial
+  menu graphics, transfer outlines, spotlights, and telemetry. It is not the
+  place for text inputs or normal window controls.
+
+## Current Implementation Slice
+
+The current branch has a useful partial extraction:
+
+- `packages/toolkit/panel/chrome.js` provides shared panel chrome, drag, resize,
+  minimize, maximize, restore, and close behavior.
+- `packages/toolkit/panel/placement.js` provides shared display-owner,
+  work-area, clamp, chip-frame, and restore helpers.
+- `packages/toolkit/panel/drag-transfer.js` provides cross-display outline and
+  release-frame behavior.
+- `packages/toolkit/panel/layouts/split-pane.js` provides reusable split panes
+  and accordion-style collapsed panes.
+- Canvas Inspector now uses toolkit chrome and split-pane footer behavior.
+- The wiki workbench now opens graph-first and reveals markdown content as a
+  second pane.
+
+This is a convergence slice, not a finished contract.
+
+## Glaring Discohesion Found During Audit
+
+The following surfaces still carry private or parallel behavior:
+
+- `apps/sigil/codex-terminal/index.html`
+  - Private titlebar, private window buttons, and raw
+    `drag_start` / `move_abs` / `drag_end`.
+  - This can behave differently from Canvas Inspector.
+- `apps/sigil/chat/index.html`
+  - Same older private drag/chrome pattern.
+- `apps/sigil/radial-item-editor/index.js`
+  - Older private drag logic using raw `move_abs`.
+- `apps/sigil/radial-item-workbench/index.js`
+  - Better: uses toolkit `wireDrag` and `wireResize`.
+  - Still owns a custom workbench shell instead of mounting fully through the
+    panel/window contract.
+- `packages/toolkit/panel/minimized-chip.html`
+  - Owns a small alternate drag/restore loop. It should become a first-class
+    toolkit placement primitive instead of a special HTML page with private
+    movement policy.
+- `src/display/canvas.swift`
+  - Correctly owns native movement, but currently also performs drag-end
+    finalization. That must be reconciled with toolkit final-placement policy so
+    the daemon and toolkit do not both independently decide the final resting
+    frame.
+
+## Contract Shape Needed
+
+AOS needs a small, explicit panel placement contract. It should define:
+
+- coordinate space for panel frames: native global CG coordinates;
+- coordinate space for DesktopWorld visuals: re-anchored display-union
+  coordinates;
+- panel rest policy: normal panels rest on one display, clamped to that
+  display's visible work area unless a surface explicitly opts out;
+- drag authority: active drag movement can remain direct/native, but final
+  placement should have one authoritative policy path;
+- display ownership: during drag, the release/cursor display should win over a
+  seam-adjacent top-left inference;
+- cross-display transfer: outline behavior is a toolkit policy rendered through
+  the DesktopWorld stage;
+- minimize/restore ownership: chip placement and restore should use the same
+  display/work-area helper as drag and maximize;
+- app integration: app windows opt into `mountPanel` or the equivalent
+  panel/window controller instead of emitting raw `move_abs`.
+
+## Short-Term Exit Criteria
+
+The next implementable slice should be small and testable:
+
+- one public toolkit API for panel/window placement policy;
+- minimized chip restore routed through that API;
+- Agent Terminal and Sigil chat migrated off private drag/chrome or wrapped by
+  the shared controller;
+- tests covering stacked displays, side-by-side displays, mixed-DPI displays,
+  off-left/off-right/off-bottom drops, minimize/restore across displays, and
+  maximize work-area clamping;
+- Canvas Inspector and Agent Terminal behave the same for drag/drop/minimize
+  when launched from the same branch root.
+
+## Related Work
+
+- Issue #261 tracks the focused placement-contract and private-drag migration
+  follow-up.
+- Issue #45 tracks opt-in AOS canvas chrome.
+- Issue #124 tracks DesktopWorld slots versus app-owned mega-canvas
+  composition.
+- Issue #260 tracks daemon-scoped content routing for parallel worktrees.
+- The current branch's scoped-root slice reduces stale-worktree confusion but
+  does not solve this placement contract by itself.

--- a/docs/design/aos-surface-system.md
+++ b/docs/design/aos-surface-system.md
@@ -124,6 +124,11 @@ Canvas Inspector and future surface managers.
 Panels and workbenches should be single-display surfaces at rest. They should
 not become desktop-world canvases by default.
 
+The detailed placement ownership boundary and migration plan live in
+[`aos-panel-window-placement-contract.md`](./aos-panel-window-placement-contract.md).
+That note is the handoff source for reconciling toolkit chrome, minimized chips,
+app-owned drag code, daemon frame movement, and DesktopWorld transfer visuals.
+
 During drag, AOS should preserve macOS-like transfer behavior:
 
 1. Dragging within the origin display moves the live canvas normally.

--- a/docs/design/worktree-session-scope.md
+++ b/docs/design/worktree-session-scope.md
@@ -1,8 +1,8 @@
 # Worktree Session Scope Idea Capture
 
 **Date:** 2026-05-02
-**Status:** Idea capture and diagnostic guidance. This is not an implementation
-plan and should not add command surface by itself.
+**Status:** Design guidance with one active implementation slice. This is not a
+full session-control-plane plan and should not add command surface by itself.
 
 ## Prompt
 
@@ -61,6 +61,24 @@ The useful non-disruptive work is smaller:
   obscured/covered canvas where possible.
 - Treat `show to-front` help/implementation mismatch as a separate small fix if
   it still exists.
+
+## Active Content-Root Slice
+
+The first implemented slice is scoped content roots:
+
+- `scripts/aos-content-scope.sh` derives branch-scoped root names such as
+  `sigil_codex_example` and `toolkit_codex_example`.
+- Sigil renderer code resolves sibling toolkit URLs from the Sigil root it was
+  loaded from, or from explicit `toolkit-root` / `sigil-root` query parameters.
+- Topic worktree launchers should register scoped roots and open surfaces from
+  those roots instead of overwriting canonical `toolkit` and `sigil`.
+
+This does not solve every parallel-session problem. Canvas IDs, status-item
+ownership, cleanup policy, and TTL-backed session records remain separate
+session-scope concerns. It does prevent the common bug where a canvas opened
+from one worktree silently imports HTML, JS, or CSS from another checkout.
+
+Follow-up issue: #260 tracks the daemon-level scope-aware content router.
 
 ## Relationship To Current Work
 

--- a/docs/dev/workflow-rules.json
+++ b/docs/dev/workflow-rules.json
@@ -43,7 +43,7 @@
       "commands": [
         {
           "id": "dev-build",
-          "command": "./aos dev build --no-restart",
+          "command": "./aos dev build",
           "reason": "Swift source changes require a current repo-mode ./aos binary. The dev wrapper preserves the signing/TCC warning surface."
         }
       ],

--- a/packages/toolkit/CLAUDE.md
+++ b/packages/toolkit/CLAUDE.md
@@ -81,9 +81,15 @@ components/             Layer 2 — reusable Content units
 
 ## Content Server
 
-Components are served via the AOS content server over `aos://toolkit/...` URLs.
+Components are served via the AOS content server over `aos://toolkit/...` URLs
+on `main`. Topic worktrees should use branch-scoped toolkit roots, for example
+`aos://toolkit_codex_example/...`, so parallel sessions do not overwrite the
+canonical `toolkit` root.
 
-**Setup:** `aos set content.roots.toolkit packages/toolkit`
+**Setup on main:** `aos set content.roots.toolkit packages/toolkit`
+
+**Setup in a topic worktree:** source `scripts/aos-content-scope.sh` or use the
+component launch script so the root name is derived from the branch.
 
 **Loading a component standalone:** `aos show create --id <id> --url aos://toolkit/components/<name>/index.html`
 

--- a/packages/toolkit/components/_base/theme.css
+++ b/packages/toolkit/components/_base/theme.css
@@ -7,24 +7,27 @@
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
 :root {
-  --bg-panel: rgba(18, 18, 28, 0.93);
-  --bg-hover: rgba(60, 60, 90, 0.15);
-  --border-panel: rgba(100, 100, 140, 0.35);
-  --border-subtle: rgba(80, 80, 120, 0.2);
-  --text-primary: #e0e0e0;
-  --text-secondary: #999;
-  --text-muted: #666;
-  --text-label: #888;
-  --text-header: #556;
-  --accent-blue: #8ab4ff;
-  --accent-green: #6a9;
+  --bg-panel: rgba(5, 10, 14, 0.96);
+  --bg-panel-header: rgba(7, 18, 23, 0.96);
+  --bg-hover: rgba(7, 25, 31, 0.84);
+  --border-panel: rgba(122, 241, 255, 0.26);
+  --border-subtle: rgba(122, 241, 255, 0.18);
+  --text-primary: rgba(235, 255, 255, 0.94);
+  --text-secondary: rgba(220, 255, 255, 0.68);
+  --text-muted: rgba(220, 255, 255, 0.46);
+  --text-label: rgba(220, 255, 255, 0.62);
+  --text-header: rgba(220, 255, 255, 0.78);
+  --accent-blue: #7af1ff;
+  --accent-green: #6fe8c4;
   --accent-yellow: #da6;
   --accent-red: #e66;
-  --accent-purple: rgba(80, 120, 255, 0.25);
+  --accent-purple: rgba(122, 241, 255, 0.16);
+  --shadow-panel: 0 18px 46px rgba(0, 0, 0, 0.34);
   --font-mono: "SF Mono", "Menlo", "Courier New", monospace;
-  --font-size-base: 11px;
+  --font-ui: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-size-base: 12px;
   --font-size-small: 10px;
-  --font-size-header: 9px;
+  --font-size-header: 12px;
   --blur-radius: 20px;
   --radius-panel: 8px;
 }

--- a/packages/toolkit/components/canvas-inspector/index.html
+++ b/packages/toolkit/components/canvas-inspector/index.html
@@ -11,7 +11,13 @@
 import { mountPanel, Single } from '../../panel/index.js'
 import CanvasInspector from './index.js'
 
-mountPanel({ title: 'Canvas Inspector', layout: Single(CanvasInspector) })
+mountPanel({
+  title: 'Canvas Inspector',
+  layout: Single(CanvasInspector),
+  maximize: true,
+  resizable: true,
+  resize: { minWidth: 300, minHeight: 220 },
+})
 </script>
 </body>
 </html>

--- a/packages/toolkit/components/canvas-inspector/index.js
+++ b/packages/toolkit/components/canvas-inspector/index.js
@@ -9,9 +9,11 @@
 // docs/archive/superpowers/plans/2026-04-18-canvas-inspector-pivot.md.
 
 import { emit, esc } from '../../runtime/bridge.js'
-import { evalCanvas } from '../../runtime/canvas.js'
+import { evalCanvas, mutateSelf } from '../../runtime/canvas.js'
 import { canvasLifecycleCanvasID, mergeCanvasLifecycleCanvas } from '../../runtime/canvas-lifecycle.js'
 import { normalizeCanvasInputMessage } from '../../runtime/input-events.js'
+import { createSplitPane } from '../../panel/layouts/split-pane.js'
+import { cloneFrame, resizeFrameFromTopLeft } from '../../panel/placement.js'
 import { subscribe, unsubscribe } from '../../runtime/subscribe.js'
 import {
   nativeToDesktopWorldPoint,
@@ -59,7 +61,8 @@ const TINT_COLORS = [
 const TINT_OVERLAY_ID = '__aos_canvas_inspector_tint__'
 const TREE_INDENT_PX = 12
 const SEE_BUNDLE_HOTKEY_LABEL = 'ctrl+opt+c'
-const MIN_EXPANDED_LIST_HEIGHT = 220
+const LIST_PANE_CLOSED_HEIGHT = 28
+const LIST_PANE_OPEN_HEIGHT = 240
 
 function escapeHTML(value) {
   if (value === null || value === undefined) return ''
@@ -247,8 +250,20 @@ function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+function verticalMargins(element) {
+  if (!element) return 0
+  const style = window.getComputedStyle?.(element)
+  if (!style) return 0
+  return (Number.parseFloat(style.marginTop) || 0) + (Number.parseFloat(style.marginBottom) || 0)
+}
+
 export default function CanvasInspector() {
   let contentEl = null
+  let minimapPaneEl = null
+  let listPaneEl = null
+  let splitController = null
+  let currentSelfFrame = null
+  let pendingSelfResizeFrame = 0
   let displays = []
   let canvases = []
   let cursor = { x: 0, y: 0, valid: false }
@@ -267,10 +282,6 @@ export default function CanvasInspector() {
   let dynamicAnimationFrame = 0
   let bundleHotkeyLabel = SEE_BUNDLE_HOTKEY_LABEL
   let listCollapsed = true
-  let expandedCanvasHeight = null
-  let collapsedCanvasHeight = null
-  let pendingResizeFrame = 0
-  let lastResizeRequest = null
   let bundleCapture = {
     status: 'idle',
     message: `bundle ${bundleHotkeyLabel}`,
@@ -357,6 +368,47 @@ export default function CanvasInspector() {
     }
   }
 
+  function currentFrameFallback() {
+    if (currentSelfFrame) return currentSelfFrame
+    return cloneFrame([
+      window.screenX ?? window.screenLeft ?? 0,
+      window.screenY ?? window.screenTop ?? 0,
+      window.outerWidth || window.innerWidth || 320,
+      window.outerHeight || window.innerHeight || 480,
+    ])
+  }
+
+  function desiredPanelHeightForListState() {
+    const panel = contentEl?.closest?.('.aos-panel')
+    const header = panel?.querySelector?.('.aos-header')
+    const headerHeight = Math.ceil(header?.getBoundingClientRect?.().height || 44)
+    const minimap = minimapPaneEl?.querySelector?.('.minimap')
+    const minimapHeight = Math.ceil(minimap?.getBoundingClientRect?.().height || 180) + verticalMargins(minimap)
+    const dividerSize = Number.parseFloat(getComputedStyle(splitController?.divider || contentEl)?.flexBasis) || 8
+    const listHeight = listCollapsed ? LIST_PANE_CLOSED_HEIGHT : LIST_PANE_OPEN_HEIGHT
+    return Math.ceil(headerHeight + minimapHeight + dividerSize + listHeight)
+  }
+
+  function resizeSelfToListState() {
+    pendingSelfResizeFrame = 0
+    const source = currentFrameFallback()
+    const height = desiredPanelHeightForListState()
+    const nextFrame = resizeFrameFromTopLeft(source, {
+      height,
+      minWidth: 280,
+      minHeight: 220,
+      maxHeight: 900,
+    })
+    if (!nextFrame || source.every((value, index) => value === nextFrame[index])) return
+    currentSelfFrame = nextFrame
+    mutateSelf({ frame: nextFrame })
+  }
+
+  function scheduleSelfResizeToListState() {
+    if (pendingSelfResizeFrame) return
+    pendingSelfResizeFrame = window.requestAnimationFrame(resizeSelfToListState)
+  }
+
   function syncInputSubscription({ snapshot = false } = {}) {
     const wantsInput = cursorTrackingEnabled || mouseEventsEnabled
     if (!wantsInput) {
@@ -431,20 +483,24 @@ export default function CanvasInspector() {
 
   function rerender() {
     if (!contentEl) return
-    const priorListRegion = contentEl.querySelector('.canvas-list-region')
+    const priorListRegion = listPaneEl?.querySelector?.('.canvas-list-region')
     const priorListScrollTop = priorListRegion?.scrollTop ?? 0
-    contentEl.innerHTML = renderMinimap(minimapCanvases())
-      + `<div class="canvas-list-region" ${listCollapsed ? 'hidden' : ''}>${renderTree()}</div>`
-      + renderStatusBar()
-    const nextListRegion = contentEl.querySelector('.canvas-list-region')
+    if (minimapPaneEl) {
+      const minimapHTML = renderMinimap(minimapCanvases())
+      minimapPaneEl.innerHTML = minimapHTML || '<div class="empty-state">Waiting for display geometry...</div>'
+    }
+    if (listPaneEl) {
+      listPaneEl.innerHTML = renderStatusBar()
+        + `<div class="canvas-list-region" ${listCollapsed ? 'hidden' : ''}>${renderTree()}</div>`
+    }
+    const nextListRegion = listPaneEl?.querySelector?.('.canvas-list-region')
     if (nextListRegion && !listCollapsed) nextListRegion.scrollTop = priorListScrollTop
     syncMinimapDynamicLayer()
     syncDebugState()
-    schedulePanelResize()
   }
 
   function getMinimapWidth() {
-    return Math.max(120, (contentEl?.clientWidth || 296) - 16)
+    return Math.max(120, (minimapPaneEl?.clientWidth || contentEl?.clientWidth || 296) - 16)
   }
 
   function minimapCanvases() {
@@ -464,47 +520,6 @@ export default function CanvasInspector() {
       && a.x + a.w > b.x
       && a.y < b.y + b.h
       && a.y + a.h > b.y
-  }
-
-  function desiredCanvasHeight() {
-    if (!contentEl) return null
-    if (!listCollapsed) {
-      return Number.isFinite(expandedCanvasHeight)
-        ? expandedCanvasHeight
-        : Math.max(window.innerHeight, (collapsedCanvasHeight || collapsedLayoutHeight()) + MIN_EXPANDED_LIST_HEIGHT)
-    }
-    collapsedCanvasHeight = collapsedLayoutHeight()
-    return collapsedCanvasHeight
-  }
-
-  function collapsedLayoutHeight() {
-    const panel = contentEl.closest('.aos-panel')
-    const status = contentEl.querySelector('.status-bar')
-    if (!panel || !status) return null
-    const panelTop = panel.getBoundingClientRect().top
-    const statusBottom = status.getBoundingClientRect().bottom
-    return Math.ceil(statusBottom - panelTop)
-  }
-
-  function requestPanelResize() {
-    pendingResizeFrame = 0
-    const width = Math.round(window.innerWidth)
-    const height = desiredCanvasHeight()
-    if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) return
-    if (Math.abs(height - window.innerHeight) <= 2) return
-    const next = `${width}x${height}`
-    if (lastResizeRequest === next) return
-    lastResizeRequest = next
-    window.webkit?.messageHandlers?.headsup?.postMessage({
-      type: 'request_resize',
-      width,
-      height,
-    })
-  }
-
-  function schedulePanelResize() {
-    if (pendingResizeFrame) return
-    pendingResizeFrame = window.requestAnimationFrame(requestPanelResize)
   }
 
   function renderMinimap(list) {
@@ -690,16 +705,10 @@ export default function CanvasInspector() {
       const btn = event.target?.closest?.('button')
       if (!btn || !contentEl.contains(btn)) return
       if (btn.classList.contains('canvas-list-toggle')) {
-        if (!listCollapsed) {
-          expandedCanvasHeight = Math.max(window.innerHeight, (collapsedCanvasHeight || collapsedLayoutHeight()) + MIN_EXPANDED_LIST_HEIGHT)
-        }
-        listCollapsed = !listCollapsed
-        if (!listCollapsed && !Number.isFinite(expandedCanvasHeight)) {
-          const collapsedBase = collapsedCanvasHeight || window.innerHeight
-          expandedCanvasHeight = Math.max(window.innerHeight, collapsedBase + MIN_EXPANDED_LIST_HEIGHT)
-        }
-        lastResizeRequest = null
+        splitController?.togglePane('end')
+        listCollapsed = !splitController?.isPaneOpen('end')
         rerender()
+        scheduleSelfResizeToListState()
         return
       }
       if (btn.classList.contains('cursor-toggle-btn')) {
@@ -753,6 +762,7 @@ export default function CanvasInspector() {
     const existing = canvases.find(c => c.id === id) || null
     const next = mergeCanvasLifecycleCanvas(existing, data)
     if (!next) return
+    if (id === SELF_ID) currentSelfFrame = cloneFrame(next.at)
 
     const existingIndex = canvases.findIndex(c => c.id === id)
     if (existingIndex >= 0) {
@@ -777,7 +787,29 @@ export default function CanvasInspector() {
       host.contentEl.style.overflow = 'hidden'
       contentEl = document.createElement('div')
       contentEl.className = 'canvas-inspector-body'
-      contentEl.innerHTML = '<div class="empty-state">Waiting for canvases...</div>'
+      const splitRoot = document.createElement('div')
+      minimapPaneEl = document.createElement('section')
+      listPaneEl = document.createElement('section')
+      splitRoot.className = 'canvas-inspector-split'
+      minimapPaneEl.className = 'canvas-inspector-minimap-pane'
+      listPaneEl.className = 'canvas-inspector-list-pane'
+      contentEl.appendChild(splitRoot)
+      splitController = createSplitPane({
+        root: splitRoot,
+        startPane: minimapPaneEl,
+        endPane: listPaneEl,
+        orientation: 'vertical',
+        initialRatio: 0.6,
+        restoreState: { ratio: 0.6, closedPane: 'end' },
+        minStart: 150,
+        minEnd: 120,
+        closedEndSize: LIST_PANE_CLOSED_HEIGHT,
+        dividerSize: 8,
+        ariaLabel: 'Resize minimap and canvas list',
+        onChange(state) {
+          listCollapsed = state.closedPane === 'end'
+        },
+      })
       window.__canvasInspectorDebug = {
         tintCanvas(id, color = TINT_COLORS[0]) {
           return applyTint(id, color)
@@ -786,6 +818,12 @@ export default function CanvasInspector() {
         setMouseEventsEnabled,
         requestSeeBundle,
         toggleStats,
+        toggleCanvasList() {
+          splitController?.togglePane('end')
+          listCollapsed = !splitController?.isPaneOpen('end')
+          rerender()
+          scheduleSelfResizeToListState()
+        },
       }
       bindListEvents()
       emit('canvas_inspector.request_bundle_config')
@@ -799,6 +837,8 @@ export default function CanvasInspector() {
       resizeObserver.observe(contentEl)
       window.__canvasInspectorMounted = true
       syncDebugState()
+      rerender()
+      scheduleSelfResizeToListState()
       return contentEl
     },
 

--- a/packages/toolkit/components/canvas-inspector/launch.sh
+++ b/packages/toolkit/components/canvas-inspector/launch.sh
@@ -5,15 +5,20 @@
 
 set -euo pipefail
 
-AOS="${AOS:-./aos}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null || pwd)"
+source "$ROOT/scripts/aos-content-scope.sh"
+
+AOS="${AOS:-$ROOT/aos}"
 CANVAS_ID="canvas-inspector"
 PANEL_W="${AOS_CANVAS_INSPECTOR_W:-320}"
 PANEL_H="${AOS_CANVAS_INSPECTOR_H:-480}"
+TOOLKIT_CONTENT_ROOT="${AOS_TOOLKIT_CONTENT_ROOT:-$(aos_content_root_key_for toolkit "$ROOT")}"
 
 $AOS show remove --id "$CANVAS_ID" 2>/dev/null || true
 
-$AOS set content.roots.toolkit packages/toolkit >/dev/null
-$AOS content wait --root toolkit --auto-start --timeout 15s >/dev/null
+aos_ensure_content_roots_live "$AOS" \
+  "$TOOLKIT_CONTENT_ROOT" "$ROOT/packages/toolkit"
 
 # Position flush bottom-right of the main display's visible bounds for operator
 # convenience. This panel placement does not define DesktopWorld.
@@ -40,7 +45,7 @@ $AOS show create --id "$CANVAS_ID" \
   --at "$X,$Y,$PANEL_W,$PANEL_H" \
   --interactive \
   --scope global \
-  --url 'aos://toolkit/components/canvas-inspector/index.html'
+  --url "aos://$TOOLKIT_CONTENT_ROOT/components/canvas-inspector/index.html"
 
 $AOS show wait --id "$CANVAS_ID" --manifest canvas-inspector --timeout 5s >/dev/null
 

--- a/packages/toolkit/components/canvas-inspector/styles.css
+++ b/packages/toolkit/components/canvas-inspector/styles.css
@@ -2,12 +2,43 @@
  * Canonical source for canvas-inspector visual presentation.
  * Host pages <link> this file; override via cascade as needed. */
 
- .canvas-inspector-body {
+.canvas-inspector-body {
   height: 100%;
   min-height: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+
+.canvas-inspector-split {
+  flex: 1;
+  min-height: 0;
+}
+
+.canvas-inspector-minimap-pane,
+.canvas-inspector-list-pane {
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.canvas-inspector-minimap-pane {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.canvas-inspector-list-pane {
+  display: flex;
+  flex-direction: column;
+}
+
+.canvas-inspector-split[data-closed-pane="end"] .canvas-inspector-list-pane {
+  overflow: hidden;
+}
+
+.canvas-inspector-split[data-closed-pane="end"] .canvas-list-region {
+  display: none;
 }
 
 /* Minimap */
@@ -155,7 +186,8 @@
 .canvas-list-region {
   flex: 1;
   min-height: 0;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 .canvas-list-region[hidden] {
   display: none;
@@ -195,8 +227,14 @@
   border-bottom: 5px solid currentColor;
 }
 
-.canvas-list { padding: 0 0 8px; }
+.canvas-list {
+  min-width: 0;
+  padding: 0 0 8px;
+}
 .tree-row {
+  box-sizing: border-box;
+  max-width: 100%;
+  min-width: 0;
   display: flex;
   align-items: center;
   gap: 6px;
@@ -279,7 +317,14 @@
   background: var(--accent-purple);
   opacity: 0.95;
 }
-.canvas-id { color: var(--accent-blue); font-weight: 600; flex-shrink: 0; }
+.canvas-id {
+  min-width: 0;
+  color: var(--accent-blue);
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .canvas-kind {
   color: var(--accent-green);
   font-family: var(--font-mono);
@@ -293,9 +338,14 @@
   flex-shrink: 0;
 }
 .canvas-dims {
+  flex: 0 1 auto;
+  min-width: 0;
   color: var(--text-muted);
   font-family: var(--font-mono);
   font-size: 9px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .seg-index { color: var(--text-muted); flex-shrink: 0; }
 .seg-display { color: var(--text-secondary); flex-shrink: 0; }
@@ -346,6 +396,8 @@
 .status-bar {
   position: relative;
   padding: 4px 10px;
+  min-height: 28px;
+  box-sizing: border-box;
   font-size: 8px;
   color: var(--text-header);
   text-transform: uppercase;

--- a/packages/toolkit/components/desktop-world-stage/launch.sh
+++ b/packages/toolkit/components/desktop-world-stage/launch.sh
@@ -3,18 +3,23 @@
 
 set -euo pipefail
 
-AOS="${AOS:-./aos}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null || pwd)"
+source "$ROOT/scripts/aos-content-scope.sh"
+
+AOS="${AOS:-$ROOT/aos}"
 CANVAS_ID="${AOS_DESKTOP_WORLD_STAGE_ID:-aos-desktop-world-stage}"
+TOOLKIT_CONTENT_ROOT="${AOS_TOOLKIT_CONTENT_ROOT:-$(aos_content_root_key_for toolkit "$ROOT")}"
 
 $AOS show remove --id "$CANVAS_ID" 2>/dev/null || true
 
-$AOS set content.roots.toolkit packages/toolkit >/dev/null
-$AOS content wait --root toolkit --auto-start --timeout 15s >/dev/null
+aos_ensure_content_roots_live "$AOS" \
+  "$TOOLKIT_CONTENT_ROOT" "$ROOT/packages/toolkit"
 
 $AOS show create --id "$CANVAS_ID" \
   --surface desktop-world \
   --scope global \
-  --url 'aos://toolkit/components/desktop-world-stage/index.html'
+  --url "aos://$TOOLKIT_CONTENT_ROOT/components/desktop-world-stage/index.html"
 
 $AOS show wait --id "$CANVAS_ID" --manifest desktop-world-stage --timeout 5s >/dev/null
 

--- a/packages/toolkit/components/markdown-workbench/index.html
+++ b/packages/toolkit/components/markdown-workbench/index.html
@@ -4,6 +4,8 @@
 <meta charset="utf-8">
 <link rel="stylesheet" href="../_base/theme.css">
 <link rel="stylesheet" href="../../panel/defaults.css">
+<link rel="stylesheet" href="../../workbench/defaults.css">
+<link rel="stylesheet" href="../wiki-kb/styles.css">
 <link rel="stylesheet" href="./styles.css">
 </head>
 <body>
@@ -11,7 +13,19 @@
 import { mountPanel, Single } from '../../panel/index.js'
 import MarkdownWorkbench from './index.js'
 
-mountPanel({ title: 'Markdown Workbench', layout: Single(MarkdownWorkbench) })
+try {
+  mountPanel({
+    title: 'Wiki Workbench',
+    layout: Single(MarkdownWorkbench),
+    maximize: true,
+    resizable: true,
+    resize: { minWidth: 760, minHeight: 520 },
+  })
+} catch (error) {
+  document.body.dataset.mountError = String(error?.message || error)
+  document.body.innerHTML = `<pre style="padding:12px;color:#ffd166;background:#050a0e;height:100%;overflow:auto">${String(error?.stack || error)}</pre>`
+  throw error
+}
 </script>
 </body>
 </html>

--- a/packages/toolkit/components/markdown-workbench/index.js
+++ b/packages/toolkit/components/markdown-workbench/index.js
@@ -1,4 +1,5 @@
 import { renderMarkdown } from '../../markdown/render.js';
+import WikiKB from '../wiki-kb/index.js';
 import {
   indentMarkdownSelection,
   outdentMarkdownSelection,
@@ -22,6 +23,13 @@ function el(tag, className, textContent) {
 export default function MarkdownWorkbench(options = {}) {
   let host = null;
   let initialUrlOpenStarted = false;
+  let viewMode = options.viewMode === 'source' ? 'source' : 'preview';
+  let outlineOpen = false;
+  let splitOpen = Boolean(options.openContent);
+  let graphHost = null;
+  let graphWorkbench = null;
+  let graphLoadTimer = null;
+  let graphFitTimers = [];
   const state = createMarkdownWorkbenchState(options.document || {});
   const dom = {};
 
@@ -30,7 +38,8 @@ export default function MarkdownWorkbench(options = {}) {
   }
 
   function syncTitle() {
-    host?.setTitle?.(`Markdown - ${state.path}${state.dirty ? ' *' : ''}`);
+    const prefix = state.source?.kind === 'wiki' ? 'Wiki / Workbench' : 'Markdown / Workbench';
+    host?.setTitle?.(`${prefix}${state.dirty ? ' *' : ''}`);
   }
 
   function syncDiagnostics() {
@@ -57,6 +66,55 @@ export default function MarkdownWorkbench(options = {}) {
     dom.preview.innerHTML = renderMarkdown(state.content);
   }
 
+  function syncViewMode() {
+    dom.root.dataset.viewMode = viewMode;
+    const previewActive = viewMode === 'preview';
+    dom.previewPane.hidden = !previewActive;
+    dom.sourcePane.hidden = previewActive;
+    for (const button of dom.root.querySelectorAll('[data-view-mode]')) {
+      const active = button.dataset.viewMode === viewMode;
+      button.classList.toggle('active', active);
+      button.setAttribute('aria-pressed', String(active));
+    }
+  }
+
+  function syncOutline() {
+    dom.outlinePanel.hidden = !outlineOpen;
+    dom.outlineToggle.setAttribute('aria-expanded', String(outlineOpen));
+    dom.outlineToggle.classList.toggle('active', outlineOpen);
+  }
+
+  function syncSplit() {
+    dom.root.dataset.splitOpen = String(splitOpen);
+    dom.documentPane.setAttribute('aria-hidden', String(!splitOpen));
+    dom.closeContentButton.hidden = !splitOpen;
+  }
+
+  function syncGraphStatus(text) {
+    if (dom.graphStatus) dom.graphStatus.textContent = text;
+  }
+
+  function collapseEmbeddedGraphControls() {
+    const toggle = dom.graph?.querySelector?.('.wiki-kb-controls-toggle');
+    if (!toggle || !/hide controls/i.test(toggle.textContent || '')) return;
+    toggle.click();
+  }
+
+  function scheduleEmbeddedGraphFit(delays = [80]) {
+    if (!graphWorkbench || !graphHost || typeof window === 'undefined') return;
+    for (const timer of graphFitTimers) window.clearTimeout(timer);
+    graphFitTimers = [];
+
+    const fitDelays = Array.isArray(delays) ? delays : [delays];
+    for (const delay of fitDelays) {
+      const timer = window.setTimeout(() => {
+        graphFitTimers = graphFitTimers.filter((entry) => entry !== timer);
+        graphWorkbench?.onMessage?.({ type: 'fit-view' }, graphHost);
+      }, Math.max(0, Number(delay) || 0));
+      graphFitTimers.push(timer);
+    }
+  }
+
   function sync({ replaceEditorValue = false } = {}) {
     dom.path.textContent = state.path;
     // Reassigning textarea.value during native input clears WKWebView/browser
@@ -65,11 +123,14 @@ export default function MarkdownWorkbench(options = {}) {
     if (replaceEditorValue && dom.editor.value !== state.content) {
       dom.editor.value = state.content;
     }
-    dom.dirty.textContent = state.dirty ? 'Unsaved changes' : 'Saved';
-    dom.dirty.dataset.dirty = state.dirty ? 'true' : 'false';
+    dom.saveButton.disabled = !state.dirty;
+    dom.saveButton.setAttribute('aria-disabled', String(!state.dirty));
     syncTitle();
     syncDiagnostics();
     syncPreview();
+    syncViewMode();
+    syncOutline();
+    syncSplit();
     window.__markdownWorkbenchState = markdownWorkbenchSnapshot(state);
   }
 
@@ -91,40 +152,113 @@ export default function MarkdownWorkbench(options = {}) {
     return frontmatter;
   }
 
+  function embeddedWikiGraphPayload(payload = {}) {
+    const config = payload.config && typeof payload.config === 'object' ? payload.config : {};
+    const graphView = config.graphView && typeof config.graphView === 'object' ? config.graphView : {};
+    return {
+      ...payload,
+      config: {
+        ...config,
+        graphView: {
+          ...graphView,
+          controls: {
+            ...(graphView.controls || {}),
+            collapsed: true,
+          },
+          defaults: {
+            ...(graphView.defaults || {}),
+            labelMode: 'hover',
+          },
+        },
+      },
+    };
+  }
+
+  async function openWikiPath(wikiPath, { syncEditor = true, openContent = false } = {}) {
+    const path = String(wikiPath || '').replace(/^\/+/, '').trim();
+    if (!path) return null;
+    try {
+      const response = await fetch(`/wiki/${path}`, { cache: 'no-store' });
+      if (!response.ok) throw new Error(`wiki fetch failed for ${path}: ${response.status}`);
+      const content = await response.text();
+      openMarkdownDocument(state, {
+        type: 'markdown_document.open',
+        path,
+        source: {
+          kind: 'wiki',
+          path,
+          page: {
+            path,
+            frontmatter: parseWikiFrontmatter(content),
+          },
+        },
+        content,
+      });
+      splitOpen = Boolean(openContent);
+      sync({ replaceEditorValue: syncEditor });
+      void loadWikiGraph({ revealCurrent: splitOpen });
+      return markdownWorkbenchSnapshot(state);
+    } catch (error) {
+      state.lastResult = {
+        type: 'markdown_document.open.result',
+        status: 'rejected',
+        path,
+        message: String(error?.message || error),
+      };
+      sync();
+      console.warn('[markdown-workbench] initial wiki open failed:', error);
+      return null;
+    }
+  }
+
   async function openInitialWikiFromUrl() {
     if (initialUrlOpenStarted || typeof window === 'undefined') return;
     const params = new URLSearchParams(window.location.search || '');
     const wikiPath = String(params.get('wiki') || '').replace(/^\/+/, '').trim();
     if (!wikiPath) return;
     initialUrlOpenStarted = true;
-    try {
-      const response = await fetch(`/wiki/${wikiPath}`, { cache: 'no-store' });
-      if (!response.ok) throw new Error(`wiki fetch failed for ${wikiPath}: ${response.status}`);
-      const content = await response.text();
-      openMarkdownDocument(state, {
-        type: 'markdown_document.open',
-        path: wikiPath,
-        source: {
-          kind: 'wiki',
-          path: wikiPath,
-          page: {
-            path: wikiPath,
-            frontmatter: parseWikiFrontmatter(content),
-          },
-        },
-        content,
-      });
-      sync({ replaceEditorValue: true });
-    } catch (error) {
-      state.lastResult = {
-        type: 'markdown_document.open.result',
-        status: 'rejected',
-        path: wikiPath,
-        message: String(error?.message || error),
-      };
-      sync();
-      console.warn('[markdown-workbench] initial wiki open failed:', error);
+    await openWikiPath(wikiPath, { syncEditor: true });
+  }
+
+  function revealCurrentWikiNode() {
+    if (state.source?.kind !== 'wiki' || !state.source.path || !graphWorkbench) return;
+    graphWorkbench.onMessage?.({
+      type: 'reveal',
+      payload: {
+        path: state.source.path,
+        view: 'graph',
+      },
+    }, graphHost);
+  }
+
+  async function loadWikiGraph({ revealCurrent = false } = {}) {
+    if (!graphWorkbench || !graphHost) return;
+    if (state.source?.kind !== 'wiki') {
+      syncGraphStatus('Open a wiki page to load graph');
+      return;
     }
+    syncGraphStatus('Loading graph...');
+    try {
+      const response = await fetch('/wiki/.graph?raw=1', { cache: 'no-store' });
+      if (!response.ok) throw new Error(`wiki graph request failed: ${response.status}`);
+      const payload = embeddedWikiGraphPayload(await response.json());
+      graphWorkbench.onMessage?.({ type: 'graph', payload }, graphHost);
+      collapseEmbeddedGraphControls();
+      syncGraphStatus('Wiki graph');
+      if (revealCurrent) revealCurrentWikiNode();
+      scheduleEmbeddedGraphFit([80, 360, 900]);
+    } catch (error) {
+      syncGraphStatus('Graph unavailable');
+      console.warn('[markdown-workbench] wiki graph load failed:', error);
+    }
+  }
+
+  function scheduleGraphReload() {
+    if (graphLoadTimer) window.clearTimeout(graphLoadTimer);
+    graphLoadTimer = window.setTimeout(() => {
+      graphLoadTimer = null;
+      void loadWikiGraph({ revealCurrent: splitOpen });
+    }, 150);
   }
 
   function setContent(content) {
@@ -208,51 +342,124 @@ export default function MarkdownWorkbench(options = {}) {
 
   function render() {
     const root = el('div', 'markdown-workbench-root');
+    dom.root = root;
     const params = typeof window !== 'undefined'
       ? new URLSearchParams(window.location.search || '')
       : new URLSearchParams();
     const transition = String(options.transition || params.get('transition') || '').trim();
     if (transition === 'fade-in') root.dataset.transition = 'fade-in';
     root.innerHTML = `
-      <header class="markdown-workbench-toolbar">
-        <div class="markdown-workbench-file">
-          <strong data-role="path"></strong>
-          <span data-role="dirty"></span>
-        </div>
-        <div class="markdown-workbench-actions">
-          <button type="button" data-action="revert">Revert</button>
-          <button type="button" data-action="save">Save</button>
-        </div>
-      </header>
-      <main class="markdown-workbench-main">
-        <section class="markdown-workbench-source" aria-label="Markdown source">
-          <textarea spellcheck="true" aria-label="Markdown source editor"></textarea>
+      <main class="aos-workbench-main markdown-workbench-main">
+        <section class="aos-workbench-preview-pane markdown-workbench-graph-pane" aria-label="Wiki graph">
+          <div class="markdown-workbench-graph" data-role="graph"></div>
         </section>
-        <section class="markdown-workbench-preview-pane" aria-label="Rendered Markdown preview">
-          <div class="markdown-workbench-preview"></div>
+        <section class="aos-workbench-controls-pane markdown-workbench-document-pane" aria-label="Wiki page content">
+          <header class="aos-workbench-toolbar markdown-workbench-document-toolbar" data-density="compact" role="toolbar" aria-label="Document tools">
+            <div class="markdown-workbench-file" title="Current document">
+              <strong data-role="path"></strong>
+            </div>
+            <div class="markdown-workbench-view-toggle" role="group" aria-label="Document view">
+              <button type="button" class="active" data-view-mode="preview" aria-label="Preview" title="Preview" aria-pressed="true">
+                <svg class="markdown-workbench-mode-icon" aria-hidden="true" viewBox="0 0 20 20">
+                  <path d="M2.5 10s2.7-4.8 7.5-4.8S17.5 10 17.5 10 14.8 14.8 10 14.8 2.5 10 2.5 10Z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
+                  <circle cx="10" cy="10" r="2.2" fill="none" stroke="currentColor" stroke-width="1.6"/>
+                </svg>
+              </button>
+              <button type="button" data-view-mode="source" aria-label="Edit" title="Edit" aria-pressed="false">
+                <span class="markdown-workbench-code-icon" aria-hidden="true">&lt;/&gt;</span>
+              </button>
+            </div>
+            <div class="markdown-workbench-actions">
+              <button type="button" class="markdown-workbench-icon-button" data-action="toggle-outline" aria-label="Index" title="Index" aria-expanded="false">
+                <svg aria-hidden="true" viewBox="0 0 20 20">
+                  <path d="M5 5.5h10M5 10h10M5 14.5h10" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+                  <circle cx="2.8" cy="5.5" r="0.9" fill="currentColor"/>
+                  <circle cx="2.8" cy="10" r="0.9" fill="currentColor"/>
+                  <circle cx="2.8" cy="14.5" r="0.9" fill="currentColor"/>
+                </svg>
+              </button>
+              <button type="button" data-action="revert">Revert</button>
+              <button type="button" data-action="save">Save</button>
+            </div>
+            <button type="button" class="aos-window-button aos-window-close markdown-workbench-close-content" data-action="close-content" aria-label="Close content view" title="Close content view">x</button>
+          </header>
+          <div class="markdown-workbench-document-body">
+            <section class="markdown-workbench-source" aria-label="Markdown source">
+              <textarea spellcheck="true" aria-label="Markdown source editor"></textarea>
+            </section>
+            <section class="markdown-workbench-preview-pane" aria-label="Rendered Markdown preview">
+              <div class="markdown-workbench-preview"></div>
+            </section>
+            <aside class="markdown-workbench-outline-panel" aria-label="Document index" hidden>
+              <div class="markdown-workbench-outline-title">Index</div>
+              <ol data-role="outline"></ol>
+            </aside>
+            <footer class="markdown-workbench-document-status" aria-label="Document status">
+              <span data-role="stats"></span>
+              <span data-role="mermaid"></span>
+              <span class="markdown-workbench-warning" data-role="warning" hidden>Unclosed fenced code block</span>
+            </footer>
+          </div>
         </section>
-        <aside class="markdown-workbench-inspector" aria-label="Markdown diagnostics">
-          <strong>Diagnostics</strong>
-          <p data-role="stats"></p>
-          <p data-role="mermaid"></p>
-          <p class="markdown-workbench-warning" data-role="warning" hidden>Unclosed fenced code block</p>
-          <strong>Outline</strong>
-          <ol data-role="outline"></ol>
-        </aside>
       </main>
     `;
     dom.path = root.querySelector('[data-role="path"]');
-    dom.dirty = root.querySelector('[data-role="dirty"]');
     dom.editor = root.querySelector('textarea');
+    dom.sourcePane = root.querySelector('.markdown-workbench-source');
+    dom.previewPane = root.querySelector('.markdown-workbench-preview-pane');
     dom.preview = root.querySelector('.markdown-workbench-preview');
     dom.stats = root.querySelector('[data-role="stats"]');
     dom.mermaid = root.querySelector('[data-role="mermaid"]');
     dom.warning = root.querySelector('[data-role="warning"]');
     dom.outline = root.querySelector('[data-role="outline"]');
+    dom.outlinePanel = root.querySelector('.markdown-workbench-outline-panel');
+    dom.outlineToggle = root.querySelector('[data-action="toggle-outline"]');
+    dom.documentPane = root.querySelector('.markdown-workbench-document-pane');
+    dom.closeContentButton = root.querySelector('[data-action="close-content"]');
+    dom.saveButton = root.querySelector('[data-action="save"]');
+    dom.graph = root.querySelector('[data-role="graph"]');
+    dom.graphStatus = root.querySelector('[data-role="graph-status"]');
+
+    graphWorkbench = WikiKB({ chrome: 'embedded', views: ['graph'] });
+    graphHost = {
+      contentEl: dom.graph,
+      setTitle() {},
+      emit(type, payload) {
+        if (type === 'selection' && payload?.path && payload.path !== state.source?.path) {
+          void openWikiPath(payload.path, { syncEditor: true, openContent: true });
+        } else if (type === 'selection' && payload?.path) {
+          splitOpen = true;
+          sync();
+          scheduleEmbeddedGraphFit([260, 520]);
+        }
+        emit(`graph.${type}`, payload);
+      },
+    };
+    const graphRoot = graphWorkbench.render(graphHost);
+    dom.graph.replaceChildren(graphRoot);
+    requestAnimationFrame(collapseEmbeddedGraphControls);
 
     dom.editor.addEventListener('input', () => setContent(dom.editor.value));
     dom.editor.addEventListener('keydown', handleEditorKeydown);
-    root.querySelector('[data-action="save"]').addEventListener('click', requestSave);
+    for (const button of root.querySelectorAll('[data-view-mode]')) {
+      button.addEventListener('click', () => {
+        viewMode = button.dataset.viewMode === 'source' ? 'source' : 'preview';
+        syncViewMode();
+        if (viewMode === 'source') dom.editor.focus();
+      });
+    }
+    dom.outlineToggle.addEventListener('click', () => {
+      outlineOpen = !outlineOpen;
+      syncOutline();
+    });
+    dom.closeContentButton.addEventListener('click', () => {
+      splitOpen = false;
+      outlineOpen = false;
+      graphWorkbench?.onMessage?.({ type: 'clear-selection' }, graphHost);
+      sync();
+      scheduleEmbeddedGraphFit([260, 520]);
+    });
+    dom.saveButton.addEventListener('click', requestSave);
     root.querySelector('[data-action="revert"]').addEventListener('click', () => {
       state.content = state.savedContent;
       state.dirty = false;
@@ -266,13 +473,25 @@ export default function MarkdownWorkbench(options = {}) {
     const type = message.type || message.payload?.type;
     if (type === 'markdown_document.open') {
       openMarkdownDocument(state, message);
+      splitOpen = true;
       sync({ replaceEditorValue: true });
+      void loadWikiGraph({ revealCurrent: true });
     } else if (type === 'markdown_document.text.patch') {
       applyMarkdownTextPatch(state, message);
       sync({ replaceEditorValue: true });
     } else if (type === 'markdown_document.save.result') {
       applyMarkdownSaveResult(state, message);
       sync();
+    } else if (type === 'wiki_page_changed') {
+      scheduleGraphReload();
+    } else if (type === 'set-view') {
+      const nextMode = message?.payload?.view || message?.payload?.mode || message?.view || message?.mode;
+      if (nextMode === 'source' || nextMode === 'preview') {
+        viewMode = nextMode;
+        syncViewMode();
+      }
+    } else {
+      graphWorkbench?.onMessage?.(message, graphHost);
     }
   }
 
@@ -284,6 +503,7 @@ export default function MarkdownWorkbench(options = {}) {
       emits: ['markdown-workbench/save.requested', 'markdown-workbench/save.result'],
       channelPrefix: 'markdown-workbench',
       defaultSize: { w: 1120, h: 720 },
+      requires: ['wiki_page_changed'],
     },
 
     render(host_) {

--- a/packages/toolkit/components/markdown-workbench/styles.css
+++ b/packages/toolkit/components/markdown-workbench/styles.css
@@ -4,8 +4,9 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  color: var(--text-primary);
-  background: rgba(9, 11, 16, 0.96);
+  color: rgba(235, 255, 255, 0.94);
+  background: rgba(5, 10, 14, 0.96);
+  font: 12px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 .markdown-workbench-root[data-transition="fade-in"] {
@@ -15,81 +16,209 @@
 @keyframes markdown-workbench-fade-in {
   from {
     opacity: 0;
-    filter: blur(3px);
+    transform: scale(0.992);
   }
-
   to {
     opacity: 1;
-    filter: blur(0);
+    transform: scale(1);
   }
-}
-
-.markdown-workbench-toolbar {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 8px 10px;
-  border-bottom: 1px solid var(--border-subtle);
-  background: rgba(18, 20, 30, 0.96);
-}
-
-.markdown-workbench-file {
-  min-width: 0;
-  flex: 1;
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
-}
-
-.markdown-workbench-file strong {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font: 650 11px/1.3 var(--font-mono);
-}
-
-.markdown-workbench-file span,
-.markdown-workbench-inspector p,
-.markdown-workbench-inspector li {
-  color: var(--text-muted);
-  font: 10px/1.45 var(--font-mono);
-}
-
-.markdown-workbench-file span[data-dirty="true"] {
-  color: #ffd166;
-}
-
-.markdown-workbench-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.markdown-workbench-actions button {
-  min-height: 28px;
-  border: 1px solid rgba(138, 180, 255, 0.28);
-  border-radius: 6px;
-  background: rgba(26, 31, 44, 0.9);
-  color: var(--text-primary);
-  font: 650 10px/1.3 var(--font-mono);
-  cursor: pointer;
 }
 
 .markdown-workbench-main {
   flex: 1;
   min-height: 0;
   display: grid;
-  grid-template-columns: minmax(320px, 1fr) minmax(320px, 1fr) minmax(220px, 0.42fr);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 0fr);
+  transition: grid-template-columns 240ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.markdown-workbench-root[data-split-open="true"] .markdown-workbench-main {
+  grid-template-columns: minmax(0, 1fr) minmax(420px, 1fr);
+}
+
+.markdown-workbench-graph-pane,
+.markdown-workbench-document-pane {
+  min-width: 0;
+  min-height: 0;
+}
+
+.markdown-workbench-graph-pane {
+  display: flex;
+  flex-direction: column;
+  background: radial-gradient(circle at center, #102028 0%, #05080b 68%, #020304 100%);
+}
+
+.markdown-workbench-graph {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.markdown-workbench-graph .wiki-kb-root,
+.markdown-workbench-graph .wiki-kb-shell {
+  height: 100%;
+  background: transparent;
+}
+
+.markdown-workbench-graph .wiki-kb-body {
+  flex: 1;
+  min-height: 0;
+}
+
+.markdown-workbench-graph .wiki-kb-sidebar {
+  display: none;
+}
+
+.markdown-workbench-document-pane {
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid rgba(122, 241, 255, 0.18);
+  background: rgba(12, 14, 22, 0.94);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity 180ms ease,
+    visibility 180ms ease,
+    border-color 180ms ease;
+}
+
+.markdown-workbench-root[data-split-open="true"] .markdown-workbench-document-pane {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.markdown-workbench-document-toolbar {
+  min-height: 40px;
+  flex-wrap: nowrap;
+  gap: 6px;
+  overflow: hidden;
+  border-bottom-color: rgba(122, 241, 255, 0.14);
+}
+
+.markdown-workbench-document-toolbar button {
+  min-height: 28px;
+  padding: 3px 7px;
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.markdown-workbench-file {
+  flex: 1 1 120px;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.markdown-workbench-file strong {
+  min-width: 0;
+  overflow: hidden;
+  color: rgba(235, 255, 255, 0.9);
+  font: 680 11px/1.3 var(--font-mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.markdown-workbench-document-status,
+.markdown-workbench-outline-panel li {
+  color: rgba(220, 255, 255, 0.62);
+  font: 10px/1.45 var(--font-mono);
+}
+
+.markdown-workbench-view-toggle {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  padding: 2px;
+  border: 1px solid rgba(122, 241, 255, 0.22);
+  border-radius: 8px;
+  background: rgba(1, 8, 11, 0.86);
+}
+
+.markdown-workbench-actions {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.markdown-workbench-view-toggle button {
+  width: 30px;
+  min-width: 30px;
+  min-height: 26px;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+}
+
+.markdown-workbench-icon-button {
+  width: 30px;
+  min-width: 30px;
+  padding: 0;
+  justify-content: center;
+}
+
+.markdown-workbench-icon-button svg {
+  width: 16px;
+  height: 16px;
+}
+
+.markdown-workbench-mode-icon {
+  width: 17px;
+  height: 17px;
+}
+
+.markdown-workbench-code-icon {
+  font: 760 10px/1 var(--font-mono);
+  letter-spacing: 0;
+}
+
+.markdown-workbench-view-toggle button.active,
+.markdown-workbench-actions button.active {
+  background: rgba(20, 68, 78, 0.72);
+  color: #ffffff;
+}
+
+.markdown-workbench-document-toolbar button:disabled {
+  opacity: 0.42;
+  cursor: default;
+}
+
+.markdown-workbench-close-content {
+  flex: 0 0 auto;
+  width: 28px;
+  height: 28px;
+  min-width: 28px;
+  padding: 0;
+  line-height: 1;
+}
+
+.markdown-workbench-document-body {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  background: #242422;
 }
 
 .markdown-workbench-source,
-.markdown-workbench-preview-pane,
-.markdown-workbench-inspector {
+.markdown-workbench-preview-pane {
+  position: absolute;
+  inset: 0;
   min-width: 0;
   min-height: 0;
-  overflow: hidden;
+}
+
+.markdown-workbench-source[hidden],
+.markdown-workbench-preview-pane[hidden],
+.markdown-workbench-outline-panel[hidden],
+.markdown-workbench-warning[hidden] {
+  display: none;
 }
 
 .markdown-workbench-source textarea {
@@ -98,68 +227,117 @@
   resize: none;
   box-sizing: border-box;
   border: 0;
-  border-right: 1px solid var(--border-subtle);
   outline: none;
-  padding: 16px;
-  background: rgba(4, 6, 10, 0.92);
-  color: var(--text-primary);
-  font: 12px/1.55 var(--font-mono);
+  padding: 16px 18px 58px;
+  background: #242422;
+  color: #f0f1ea;
+  font: 12px/1.65 var(--font-mono);
+  tab-size: 2;
+}
+
+.markdown-workbench-source textarea::selection {
+  background: rgba(122, 241, 255, 0.28);
 }
 
 .markdown-workbench-preview-pane {
-  border-right: 1px solid var(--border-subtle);
   overflow: auto;
-  background: rgba(12, 14, 20, 0.92);
+  background: #282825;
 }
 
 .markdown-workbench-preview {
   max-width: 760px;
-  padding: 20px 24px 48px;
-  color: #e7eef8;
-  font: 13px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0 auto;
+  padding: 28px 28px 70px;
+  color: #f0eee6;
+  font: 13px/1.58 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 .markdown-workbench-preview h1,
 .markdown-workbench-preview h2,
 .markdown-workbench-preview h3 {
-  margin: 1.1em 0 0.45em;
+  margin: 1.16em 0 0.45em;
   color: #ffffff;
+  font-weight: 700;
   letter-spacing: 0;
+}
+
+.markdown-workbench-preview h1 {
+  margin-top: 0;
+  font-size: 22px;
+}
+
+.markdown-workbench-preview h2 {
+  font-size: 18px;
+}
+
+.markdown-workbench-preview h3 {
+  font-size: 15px;
 }
 
 .markdown-workbench-preview p,
 .markdown-workbench-preview ul,
 .markdown-workbench-preview ol {
-  margin: 0.55em 0;
+  margin: 0.6em 0;
+}
+
+.markdown-workbench-preview ul,
+.markdown-workbench-preview ol {
+  padding-left: 1.4em;
+}
+
+.markdown-workbench-preview hr {
+  height: 1px;
+  border: 0;
+  margin: 24px 0;
+  background: rgba(255, 255, 255, 0.2);
 }
 
 .markdown-workbench-preview code {
   padding: 1px 4px;
   border-radius: 4px;
-  background: rgba(138, 180, 255, 0.12);
-  color: #cbe2ff;
+  background: rgba(122, 241, 255, 0.1);
+  color: #d5f7ff;
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+}
+
+.markdown-workbench-preview pre {
+  overflow: auto;
+  padding: 12px;
+  border-radius: 7px;
+  background: rgba(3, 8, 10, 0.82);
+  font: 12px/1.55 var(--font-mono);
 }
 
 .markdown-workbench-preview a {
-  color: #8ab4ff;
+  color: #8eeeff;
 }
 
-.markdown-workbench-inspector {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 14px;
+.markdown-workbench-outline-panel {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 4;
+  width: min(300px, calc(100% - 24px));
+  max-height: calc(100% - 58px);
   overflow: auto;
-  background: rgba(15, 17, 24, 0.94);
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid rgba(122, 241, 255, 0.24);
+  border-radius: 8px;
+  background: rgba(6, 14, 18, 0.92);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.34);
+  backdrop-filter: blur(16px);
 }
 
-.markdown-workbench-inspector strong {
-  color: var(--text-secondary);
-  font: 650 10px/1.3 var(--font-mono);
+.markdown-workbench-outline-title {
+  color: rgba(235, 255, 255, 0.88);
+  font: 700 10px/1.3 var(--font-mono);
   text-transform: uppercase;
 }
 
-.markdown-workbench-inspector ol {
+.markdown-workbench-outline-panel ol {
   display: grid;
   gap: 6px;
   padding: 0;
@@ -167,27 +345,53 @@
   list-style: none;
 }
 
-.markdown-workbench-inspector li {
+.markdown-workbench-outline-panel li {
   padding-left: calc((var(--depth, 1) - 1) * 10px);
 }
 
+.markdown-workbench-document-status {
+  position: absolute;
+  left: auto;
+  right: 10px;
+  bottom: 8px;
+  z-index: 3;
+  display: block;
+  min-width: 0;
+  color: rgba(220, 255, 255, 0.46);
+  pointer-events: none;
+}
+
+.markdown-workbench-document-status [data-role="stats"],
+.markdown-workbench-document-status [data-role="mermaid"] {
+  display: none;
+}
+
 .markdown-workbench-warning {
-  color: #ffd166 !important;
+  display: inline-flex;
+  padding: 3px 7px;
+  border: 1px solid rgba(255, 209, 102, 0.32);
+  border-radius: 6px;
+  background: rgba(48, 35, 8, 0.72);
+  color: #ffd166;
 }
 
 .markdown-workbench-empty {
-  color: var(--text-muted);
+  color: rgba(220, 255, 255, 0.46);
 }
 
 @media (max-width: 940px) {
   .markdown-workbench-main {
     grid-template-columns: 1fr;
-    grid-template-rows: minmax(240px, 1fr) minmax(240px, 1fr) minmax(180px, 0.6fr);
+    grid-template-rows: minmax(0, 1fr) minmax(0, 0fr);
   }
 
-  .markdown-workbench-source textarea,
-  .markdown-workbench-preview-pane {
-    border-right: 0;
-    border-bottom: 1px solid var(--border-subtle);
+  .markdown-workbench-root[data-split-open="true"] .markdown-workbench-main {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(300px, 1fr) minmax(320px, 1fr);
+  }
+
+  .markdown-workbench-document-pane {
+    border-left: 0;
+    border-top: 1px solid rgba(122, 241, 255, 0.18);
   }
 }

--- a/packages/toolkit/components/object-transform-panel/launch.sh
+++ b/packages/toolkit/components/object-transform-panel/launch.sh
@@ -5,18 +5,20 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null || pwd)"
+source "$ROOT/scripts/aos-content-scope.sh"
 AOS="${AOS:-$ROOT/aos}"
 CANVAS_ID="${CANVAS_ID:-object-transform-panel}"
 PANEL_W="${AOS_OBJECT_TRANSFORM_PANEL_W:-620}"
 PANEL_H="${AOS_OBJECT_TRANSFORM_PANEL_H:-420}"
+TOOLKIT_CONTENT_ROOT="${AOS_TOOLKIT_CONTENT_ROOT:-$(aos_content_root_key_for toolkit "$ROOT")}"
 
 if [[ ! -x "$AOS" ]]; then
   echo "aos binary not found at $AOS" >&2
   exit 1
 fi
 
-"$AOS" set content.roots.toolkit packages/toolkit >/dev/null
-"$AOS" content wait --root toolkit --auto-start --timeout 15s >/dev/null
+aos_ensure_content_roots_live "$AOS" \
+  "$TOOLKIT_CONTENT_ROOT" "$ROOT/packages/toolkit"
 
 DISPLAY_JSON="$("$AOS" graph displays --json 2>/dev/null || echo '{"data":{"displays":[]}}')"
 GEOMETRY="$(
@@ -45,7 +47,7 @@ read -r X Y W H <<<"$GEOMETRY"
   --at "$X,$Y,$W,$H" \
   --interactive \
   --scope global \
-  --url 'aos://toolkit/components/object-transform-panel/index.html' >/dev/null
+  --url "aos://$TOOLKIT_CONTENT_ROOT/components/object-transform-panel/index.html" >/dev/null
 
 "$AOS" show wait \
   --id "$CANVAS_ID" \

--- a/packages/toolkit/components/spatial-telemetry/launch.sh
+++ b/packages/toolkit/components/spatial-telemetry/launch.sh
@@ -3,10 +3,15 @@
 
 set -euo pipefail
 
-AOS="${AOS:-./aos}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null || pwd)"
+source "$ROOT/scripts/aos-content-scope.sh"
+
+AOS="${AOS:-$ROOT/aos}"
 CANVAS_ID="${AOS_SPATIAL_TELEMETRY_ID:-spatial-telemetry}"
 PANEL_W="${AOS_SPATIAL_TELEMETRY_W:-920}"
 PANEL_H="${AOS_SPATIAL_TELEMETRY_H:-620}"
+TOOLKIT_CONTENT_ROOT="${AOS_TOOLKIT_CONTENT_ROOT:-$(aos_content_root_key_for toolkit "$ROOT")}"
 
 wait_for_eval() {
   local js="$1"
@@ -28,8 +33,8 @@ raise SystemExit(0 if result in (True, 1, "1", "true") else 1)
   return 1
 }
 
-$AOS set content.roots.toolkit packages/toolkit >/dev/null
-$AOS content wait --root toolkit --auto-start --timeout 15s >/dev/null
+aos_ensure_content_roots_live "$AOS" \
+  "$TOOLKIT_CONTENT_ROOT" "$ROOT/packages/toolkit"
 
 DISPLAY_JSON="$($AOS graph displays --json 2>/dev/null || echo '{"data":{"displays":[]}}')"
 read -r X Y <<EOF
@@ -55,7 +60,7 @@ $AOS show create --id "$CANVAS_ID" \
   --at "$X,$Y,$PANEL_W,$PANEL_H" \
   --interactive \
   --scope global \
-  --url 'aos://toolkit/components/spatial-telemetry/index.html'
+  --url "aos://$TOOLKIT_CONTENT_ROOT/components/spatial-telemetry/index.html"
 
 wait_for_eval 'typeof window.__spatialTelemetryState === "object"' \
   || { echo "FAIL: spatial telemetry canvas did not initialize" >&2; exit 1; }

--- a/packages/toolkit/components/wiki-kb/index.js
+++ b/packages/toolkit/components/wiki-kb/index.js
@@ -21,6 +21,13 @@ const VIEW_DEFS = [
   { id: 'mindmap', label: 'Mind Map', factory: MindmapView },
 ]
 
+function resolveViewDefs(viewIds) {
+  if (!Array.isArray(viewIds) || viewIds.length === 0) return VIEW_DEFS
+  const allowed = new Set(viewIds.map((id) => String(id)))
+  const defs = VIEW_DEFS.filter((entry) => allowed.has(entry.id))
+  return defs.length > 0 ? defs : VIEW_DEFS
+}
+
 function canonicalMessageType(type) {
   if (type === 'graph' || type === 'wiki/graph' || type === 'wiki-kb/graph') return 'graph'
   if (type === 'graph/update' || type === 'wiki/graph/update' || type === 'wiki-kb/graph/update') {
@@ -48,11 +55,13 @@ function buildRelatedNodes(state, nodeId) {
   return [...related.values()]
 }
 
-export default function WikiKB() {
+export default function WikiKB(options = {}) {
+  const chromeMode = options.chrome === 'embedded' ? 'embedded' : 'default'
+  const viewDefs = resolveViewDefs(options.views)
   let host = null
   let rootEl = null
   let contentEl = null
-  let activeViewId = 'graph'
+  let activeViewId = viewDefs[0]?.id || 'graph'
   let sidebarMode = 'markdown'
   let selectedNodeId = null
   let graphState = normalizeGraphPayload({})
@@ -244,7 +253,7 @@ export default function WikiKB() {
     const existing = viewInstances.get(id)
     if (existing) return existing
 
-    const definition = VIEW_DEFS.find((entry) => entry.id === id)
+    const definition = viewDefs.find((entry) => entry.id === id)
     if (!definition) throw new Error(`Unknown wiki-kb view '${id}'`)
 
     const instance = definition.factory({
@@ -277,7 +286,8 @@ export default function WikiKB() {
     for (const button of rootEl.querySelectorAll('.wiki-kb-view-tab')) {
       const isActive = button.dataset.view === id
       button.classList.toggle('active', isActive)
-      const view = VIEW_DEFS.find((entry) => entry.id === button.dataset.view)
+      button.setAttribute('aria-selected', String(isActive))
+      const view = viewDefs.find((entry) => entry.id === button.dataset.view)
       applyWikiKBSemanticTarget(button, {
         id: `view-tab-${button.dataset.view}`,
         role: 'AXTab',
@@ -285,6 +295,17 @@ export default function WikiKB() {
         action: 'set_view',
         aosRef: wikiKBAosRef('tab', button.dataset.view),
         selected: isActive,
+      })
+    }
+    if (dom.viewSelectEl) {
+      dom.viewSelectEl.value = id
+      const view = viewDefs.find((entry) => entry.id === id)
+      applyWikiKBSemanticTarget(dom.viewSelectEl, {
+        id: 'view-select',
+        role: 'AXPopUpButton',
+        name: 'Wiki graph view',
+        action: 'set_view',
+        value: view?.label || id,
       })
     }
     focusActiveViewOnSelection()
@@ -350,24 +371,45 @@ export default function WikiKB() {
     }
   }
 
+  function onRootChange(event) {
+    const viewSelect = event.target.closest('.wiki-kb-view-select')
+    if (viewSelect) {
+      switchView(viewSelect.value)
+    }
+  }
+
   function buildDOM() {
     rootEl.innerHTML = `
       <div class="wiki-kb-shell">
-        <div class="wiki-kb-tab-strip" role="tablist" aria-label="Wiki KB Views">
-          ${VIEW_DEFS.map((view, index) => `
-            <button
-              type="button"
-              id="wiki-kb-tab-${view.id}"
-              class="wiki-kb-view-tab${index === 0 ? ' active' : ''}"
-              data-view="${view.id}"
-              role="tab"
-              aria-selected="${index === 0 ? 'true' : 'false'}"
-              aria-controls="wiki-kb-panel-${view.id}"
-            >${view.label}</button>
-          `).join('')}
-          <div class="wiki-kb-tab-spacer"></div>
-          <span class="wiki-kb-status" role="status" aria-live="polite"></span>
-        </div>
+        ${chromeMode === 'embedded' ? `
+          ${viewDefs.length > 1 ? `
+            <div class="wiki-kb-compact-chrome" aria-label="Wiki graph view controls">
+              <label class="wiki-kb-view-menu" title="Select graph view">
+                <span>View</span>
+                <select class="wiki-kb-view-select" aria-label="Wiki graph view">
+                  ${viewDefs.map((view) => `<option value="${view.id}">${view.label}</option>`).join('')}
+                </select>
+              </label>
+              <span class="wiki-kb-status" role="status" aria-live="polite"></span>
+            </div>
+          ` : `<span class="wiki-kb-status wiki-kb-floating-status" role="status" aria-live="polite"></span>`}
+        ` : `
+          <div class="wiki-kb-tab-strip" role="tablist" aria-label="Wiki KB Views">
+            ${viewDefs.map((view, index) => `
+              <button
+                type="button"
+                id="wiki-kb-tab-${view.id}"
+                class="wiki-kb-view-tab${index === 0 ? ' active' : ''}"
+                data-view="${view.id}"
+                role="tab"
+                aria-selected="${index === 0 ? 'true' : 'false'}"
+                aria-controls="wiki-kb-panel-${view.id}"
+              >${view.label}</button>
+            `).join('')}
+            <div class="wiki-kb-tab-spacer"></div>
+            <span class="wiki-kb-status" role="status" aria-live="polite"></span>
+          </div>
+        `}
         <div class="wiki-kb-body">
           <div class="wiki-kb-content"></div>
           <aside class="wiki-kb-sidebar" aria-label="Selected node details">
@@ -396,6 +438,7 @@ export default function WikiKB() {
 
     contentEl = rootEl.querySelector('.wiki-kb-content')
     dom.statusEl = rootEl.querySelector('.wiki-kb-status')
+    dom.viewSelectEl = rootEl.querySelector('.wiki-kb-view-select')
     dom.sidebarEl = rootEl.querySelector('.wiki-kb-sidebar')
     dom.sidebarTypeEl = rootEl.querySelector('.wiki-kb-sidebar-type')
     dom.sidebarNameEl = rootEl.querySelector('.wiki-kb-sidebar-name')
@@ -414,6 +457,7 @@ export default function WikiKB() {
     syncSidebarToggle()
 
     rootEl.addEventListener('click', onRootClick)
+    rootEl.addEventListener('change', onRootChange)
     updateStatus()
     switchView(activeViewId)
   }
@@ -422,7 +466,7 @@ export default function WikiKB() {
     manifest: {
       name: 'wiki-kb',
       title: 'Wiki KB',
-      accepts: ['graph', 'graph/update', 'reveal', 'clear-selection', 'set-view'],
+      accepts: ['graph', 'graph/update', 'reveal', 'clear-selection', 'set-view', 'fit-view'],
       emits: ['selection'],
       channelPrefix: 'wiki-kb',
       defaultSize: { w: 860, h: 580 },
@@ -432,6 +476,7 @@ export default function WikiKB() {
       host = host_
       rootEl = document.createElement('div')
       rootEl.className = 'wiki-kb-root'
+      rootEl.dataset.chrome = chromeMode
       buildDOM()
       return rootEl
     },
@@ -452,9 +497,14 @@ export default function WikiKB() {
         }
         if (msg?.type === 'set-view') {
           const view = msg?.payload?.view || msg?.payload?.id || msg?.payload
-          if (typeof view === 'string' && VIEW_DEFS.some((entry) => entry.id === view)) {
+          if (typeof view === 'string' && viewDefs.some((entry) => entry.id === view)) {
             switchView(view)
           }
+          return
+        }
+        if (msg?.type === 'fit-view') {
+          const activeView = viewInstances.get(activeViewId)
+          activeView?.instance.fit?.()
           return
         }
         return

--- a/packages/toolkit/components/wiki-kb/launch.sh
+++ b/packages/toolkit/components/wiki-kb/launch.sh
@@ -5,9 +5,11 @@ set -euo pipefail
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null || pwd)"
+source "$ROOT/scripts/aos-content-scope.sh"
 AOS="${AOS:-$ROOT/aos}"
 CANVAS_ID="${CANVAS_ID:-wiki-kb-demo}"
 EVENT_FILE="${EVENT_FILE:-$DIR/sample-graph.event.json}"
+TOOLKIT_CONTENT_ROOT="${AOS_TOOLKIT_CONTENT_ROOT:-$(aos_content_root_key_for toolkit "$ROOT")}"
 
 if [[ ! -x "$AOS" ]]; then
   echo "aos binary not found at $AOS" >&2
@@ -21,8 +23,8 @@ fi
 
 "$AOS" show remove --id "$CANVAS_ID" 2>/dev/null || true
 
-"$AOS" set content.roots.toolkit packages/toolkit >/dev/null
-"$AOS" content wait --root toolkit --auto-start --timeout 15s >/dev/null
+aos_ensure_content_roots_live "$AOS" \
+  "$TOOLKIT_CONTENT_ROOT" "$ROOT/packages/toolkit"
 
 DISPLAY_JSON="$("$AOS" graph displays --json 2>/dev/null || echo '{"displays":[]}')"
 GEOMETRY="$(
@@ -57,7 +59,7 @@ Y=$((DISPLAY_Y + (DISPLAY_H - PANEL_H) / 2))
   --at "$X,$Y,$PANEL_W,$PANEL_H" \
   --interactive \
   --focus \
-  --url 'aos://toolkit/components/wiki-kb/index.html' >/dev/null
+  --url "aos://$TOOLKIT_CONTENT_ROOT/components/wiki-kb/index.html" >/dev/null
 
 "$AOS" show wait \
   --id "$CANVAS_ID" \

--- a/packages/toolkit/components/wiki-kb/styles.css
+++ b/packages/toolkit/components/wiki-kb/styles.css
@@ -8,10 +8,67 @@
 }
 
 .wiki-kb-shell {
+  position: relative;
   display: flex;
   flex-direction: column;
   height: 100%;
   overflow: hidden;
+}
+
+.wiki-kb-compact-chrome {
+  position: absolute;
+  top: 10px;
+  right: 54px;
+  z-index: 11;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: min(360px, calc(100% - 72px));
+  padding: 4px 6px;
+  border: 1px solid rgba(122, 241, 255, 0.18);
+  border-radius: 7px;
+  background: rgba(4, 14, 18, 0.72);
+  backdrop-filter: blur(12px);
+}
+
+.wiki-kb-view-menu {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  color: rgba(220, 255, 255, 0.68);
+  font: 650 9px/1.3 var(--font-mono);
+  text-transform: uppercase;
+}
+
+.wiki-kb-view-menu select {
+  min-width: 94px;
+  border: 1px solid rgba(122, 241, 255, 0.22);
+  border-radius: 5px;
+  background: rgba(1, 8, 11, 0.86);
+  color: rgba(235, 255, 255, 0.9);
+  padding: 3px 6px;
+  font: inherit;
+}
+
+.wiki-kb-view-static {
+  color: rgba(235, 255, 255, 0.82);
+  font: inherit;
+}
+
+.wiki-kb-floating-status {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 10;
+  padding: 3px 6px;
+  border: 1px solid rgba(122, 241, 255, 0.14);
+  border-radius: 6px;
+  background: rgba(4, 14, 18, 0.52);
+  color: rgba(220, 255, 255, 0.42);
+  font: 650 9px/1.3 var(--font-mono);
+  backdrop-filter: blur(8px);
+  pointer-events: none;
 }
 
 .wiki-kb-tab-strip {
@@ -133,6 +190,10 @@
   box-shadow: 0 12px 28px rgba(0, 0, 0, 0.24);
 }
 
+.wiki-kb-controls-panel[hidden] {
+  display: none;
+}
+
 .wiki-kb-controls-header,
 .wiki-kb-controls-label-row {
   display: flex;
@@ -149,7 +210,6 @@
   text-transform: uppercase;
 }
 
-.wiki-kb-controls-summary,
 .wiki-kb-controls-caption,
 .wiki-kb-controls-empty {
   color: var(--text-muted);
@@ -646,4 +706,69 @@
   height: 6px;
   border-radius: 50%;
   flex-shrink: 0;
+}
+
+.wiki-kb-root[data-chrome="embedded"] .wiki-kb-controls-shell {
+  top: 0;
+  right: auto;
+  bottom: 0;
+  left: 0;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 0;
+  max-width: min(356px, 72%);
+  pointer-events: none;
+}
+
+.wiki-kb-root[data-chrome="embedded"] .wiki-kb-controls-toggle {
+  position: absolute;
+  z-index: 2;
+  left: 18px;
+  top: 18px;
+  width: 34px;
+  height: 34px;
+  margin: 0;
+  padding: 0;
+  color: transparent;
+  overflow: hidden;
+  pointer-events: auto;
+}
+
+.wiki-kb-root[data-chrome="embedded"] .wiki-kb-controls-shell.collapsed .wiki-kb-controls-toggle {
+  position: relative;
+  left: auto;
+  top: auto;
+  margin: 10px 0 0 10px;
+}
+
+.wiki-kb-root[data-chrome="embedded"] .wiki-kb-controls-toggle::before {
+  content: "";
+  position: absolute;
+  left: 9px;
+  top: 10px;
+  width: 14px;
+  height: 10px;
+  border-block: 2px solid rgba(220, 255, 255, 0.82);
+}
+
+.wiki-kb-root[data-chrome="embedded"] .wiki-kb-controls-toggle::after {
+  content: "";
+  position: absolute;
+  left: 9px;
+  top: 16px;
+  width: 14px;
+  height: 2px;
+  background: rgba(220, 255, 255, 0.82);
+}
+
+.wiki-kb-root[data-chrome="embedded"] .wiki-kb-controls-panel {
+  width: min(304px, calc(100vw - 96px));
+  max-height: calc(100% - 20px);
+  margin: 10px 0 10px 10px;
+  padding-top: 52px;
+  pointer-events: auto;
+}
+
+.wiki-kb-root[data-chrome="embedded"] .wiki-kb-graph-view:has(.wiki-kb-controls-shell:not(.collapsed)) .wiki-kb-legend {
+  left: min(326px, calc(100% - 136px));
 }

--- a/packages/toolkit/components/wiki-kb/views/graph.js
+++ b/packages/toolkit/components/wiki-kb/views/graph.js
@@ -329,6 +329,7 @@ export default function GraphView({ onSelectNode }) {
     dom.controlsPanelEl?.toggleAttribute('hidden', !controlsOpen)
     if (dom.controlsToggleEl) {
       dom.controlsToggleEl.textContent = controlsOpen ? 'Hide Controls' : 'Show Controls'
+      dom.controlsToggleEl.title = controlsOpen ? 'Hide graph controls' : 'Show graph controls'
       applyGraphSemanticTarget(dom.controlsToggleEl, 'controls-toggle', {
         name: controlsOpen ? 'Hide graph controls' : 'Show graph controls',
         action: 'toggle_graph_controls',
@@ -535,7 +536,9 @@ export default function GraphView({ onSelectNode }) {
       }
     }
 
-    dom.summaryEl.textContent = `${filteredGraph.stats.visibleNodes}/${filteredGraph.stats.totalNodes} nodes · ${filteredGraph.stats.visibleLinks}/${filteredGraph.stats.totalLinks} links`
+    if (dom.summaryEl) {
+      dom.summaryEl.textContent = `${filteredGraph.stats.visibleNodes}/${filteredGraph.stats.totalNodes} nodes · ${filteredGraph.stats.visibleLinks}/${filteredGraph.stats.totalLinks} links`
+    }
     dom.isolatedToggleRowEl.toggleAttribute('hidden', !graphViewConfig.features.isolated)
     dom.showIsolatedInput.checked = showIsolated
     applyGraphSemanticTarget(dom.showIsolatedInput, 'show-isolated', {
@@ -686,7 +689,7 @@ export default function GraphView({ onSelectNode }) {
   function fitGraph() {
     const bounds = simulation.bounds()
     if (!bounds) return
-    viewport.fitBounds(size.width, size.height, bounds, { padding: 36 })
+    viewport.fitBounds(size.width, size.height, bounds, { padding: 54 })
     draw()
   }
 
@@ -1061,7 +1064,6 @@ export default function GraphView({ onSelectNode }) {
           <div class="wiki-kb-controls-panel">
             <div class="wiki-kb-controls-header">
               <span class="wiki-kb-controls-title">Graph Controls</span>
-              <span class="wiki-kb-controls-summary"></span>
             </div>
             <div class="wiki-kb-controls-section wiki-kb-controls-section-search">
               <label class="wiki-kb-controls-label" for="wiki-kb-search-input">Search</label>
@@ -1244,6 +1246,10 @@ export default function GraphView({ onSelectNode }) {
         renderControls()
         draw()
       }
+    },
+
+    fit() {
+      fitGraph()
     },
 
     onActivate() {

--- a/packages/toolkit/components/wiki-kb/views/mindmap.js
+++ b/packages/toolkit/components/wiki-kb/views/mindmap.js
@@ -330,6 +330,11 @@ export default function MindmapView({ onSelectNode }) {
       draw()
     },
 
+    fit() {
+      viewport.reset()
+      draw()
+    },
+
     onActivate() {
       resize()
     },

--- a/packages/toolkit/panel/chrome.js
+++ b/packages/toolkit/panel/chrome.js
@@ -3,9 +3,27 @@
 // Knows nothing about messaging or contents. Just builds the visual frame
 // and reports absolute drag updates through the runtime canvas helper.
 
-import { emit } from '../runtime/bridge.js'
+import { emit, wireBridge } from '../runtime/bridge.js'
 import { moveAbsolute, mutateSelf, removeSelf, spawnChild, suspendCanvas } from '../runtime/canvas.js'
+import { normalizeCanvasInputMessage } from '../runtime/input-events.js'
+import { subscribe, unsubscribe } from '../runtime/subscribe.js'
 import { createPanelTransferController, wirePanelTransferDisplayGeometry } from './drag-transfer.js'
+import {
+  chipFrameForPanelFrame,
+  clampFrameToWorkArea as placementClampFrameToWorkArea,
+  cloneFrame as placementCloneFrame,
+  finiteNumber,
+  frameFromWindow as placementFrameFromWindow,
+  normalizePanelDisplays,
+  positiveNumber,
+  workAreaForFrameTopLeft as placementWorkAreaForFrameTopLeft,
+  workAreaForPoint as placementWorkAreaForPoint,
+  workAreaFromWindow as placementWorkAreaFromWindow,
+} from './placement.js'
+
+let displayGeometryWired = false
+let panelDisplays = []
+let currentPanelFrame = null
 
 export function mountChrome(container, {
   title = 'AOS',
@@ -30,6 +48,10 @@ export function mountChrome(container, {
   header.className = 'aos-header'
   header.dataset.draggable = String(draggable)
 
+  const gripEl = document.createElement('span')
+  gripEl.className = 'aos-panel-grip'
+  gripEl.setAttribute('aria-hidden', 'true')
+
   const titleEl = document.createElement('span')
   titleEl.className = 'aos-title'
   titleEl.textContent = title
@@ -42,6 +64,7 @@ export function mountChrome(container, {
 
   const windowControlsEl = document.createElement('span')
   windowControlsEl.className = 'aos-window-controls'
+  wirePanelDisplayGeometry()
 
   let maximizeController = null
   if (maximize) {
@@ -101,6 +124,7 @@ export function mountChrome(container, {
   controlsEl.appendChild(customControlsEl)
   controlsEl.appendChild(windowControlsEl)
 
+  header.appendChild(gripEl)
   header.appendChild(titleEl)
   header.appendChild(controlsEl)
 
@@ -110,6 +134,15 @@ export function mountChrome(container, {
   panel.appendChild(header)
   panel.appendChild(content)
   container.appendChild(panel)
+
+  if (maximizeController) {
+    header.addEventListener('dblclick', (event) => {
+      const NodeCtor = globalThis.Node
+      if ((!NodeCtor || event.target instanceof NodeCtor) && controlsEl?.contains?.(event.target)) return
+      event.preventDefault()
+      maximizeController.toggle()
+    })
+  }
 
   const { onStateChange: onDragStateChange, ...dragOptions } = drag
   const dragController = draggable
@@ -151,42 +184,16 @@ export function mountChrome(container, {
   }
 }
 
-function finiteNumber(value, fallback = null) {
-  const number = Number(value)
-  return Number.isFinite(number) ? number : fallback
-}
-
-function positiveNumber(value, fallback = 1) {
-  const number = finiteNumber(value, fallback)
-  return Math.max(1, number)
-}
-
-function cloneFrame(frame) {
-  return [
-    Math.round(finiteNumber(frame?.[0], 0)),
-    Math.round(finiteNumber(frame?.[1], 0)),
-    Math.round(positiveNumber(frame?.[2], 1)),
-    Math.round(positiveNumber(frame?.[3], 1)),
-  ]
-}
+const cloneFrame = placementCloneFrame
 
 export function frameFromWindow(view = window) {
-  return cloneFrame([
-    finiteNumber(view.screenX ?? view.screenLeft, 0),
-    finiteNumber(view.screenY ?? view.screenTop, 0),
-    positiveNumber(view.outerWidth || view.innerWidth || view.document?.documentElement?.clientWidth, 1),
-    positiveNumber(view.outerHeight || view.innerHeight || view.document?.documentElement?.clientHeight, 1),
-  ])
+  return placementFrameFromWindow(view, {
+    currentFrame: typeof window !== 'undefined' && view === window ? currentPanelFrame : null,
+  })
 }
 
 export function workAreaFromWindow(view = window) {
-  const screen = view.screen || {}
-  const fallbackFrame = frameFromWindow(view)
-  const x = finiteNumber(screen.availLeft ?? screen.left, fallbackFrame[0])
-  const y = finiteNumber(screen.availTop ?? screen.top, fallbackFrame[1])
-  const width = positiveNumber(screen.availWidth || screen.width, fallbackFrame[2])
-  const height = positiveNumber(screen.availHeight || screen.height, fallbackFrame[3])
-  return cloneFrame([x, y, width, height])
+  return placementWorkAreaFromWindow(view, frameFromWindow(view))
 }
 
 function clamp(value, min, max) {
@@ -198,26 +205,26 @@ function finiteLimit(value, fallback) {
   return Number.isFinite(number) ? number : fallback
 }
 
-export function clampFrameToWorkArea(frame, {
-  workArea = null,
-  minVisibleWidth = 120,
-  minVisibleHeight = 44,
-} = {}) {
-  const next = cloneFrame(frame)
-  if (!workArea) return next
-  const area = cloneFrame(workArea)
-  const areaRight = area[0] + area[2]
-  const areaBottom = area[1] + area[3]
-  next[2] = Math.min(next[2], area[2])
-  next[3] = Math.min(next[3], area[3])
-  const maxX = Math.max(area[0], areaRight - next[2])
-  const maxY = Math.max(area[1], areaBottom - next[3])
-  if (next[2] <= area[2]) next[0] = clamp(next[0], area[0], maxX)
-  else next[0] = clamp(next[0], area[0] - next[2] + minVisibleWidth, areaRight - minVisibleWidth)
-  if (next[3] <= area[3]) next[1] = clamp(next[1], area[1], maxY)
-  else next[1] = clamp(next[1], area[1] - next[3] + minVisibleHeight, areaBottom - minVisibleHeight)
-  return cloneFrame(next)
+export function workAreaForFrameTopLeft(frame = frameFromWindow(), displays = panelDisplays, fallback = null) {
+  return placementWorkAreaForFrameTopLeft(frame, displays, fallback)
 }
+
+export function workAreaForWindowTopLeft(view = window, displays = panelDisplays) {
+  return workAreaForFrameTopLeft(frameFromWindow(view), displays, workAreaFromWindow(view))
+}
+
+function screenPoint(pointer = null) {
+  const x = finiteNumber(pointer?.screenX ?? pointer?.x, null)
+  const y = finiteNumber(pointer?.screenY ?? pointer?.y, null)
+  return x == null || y == null ? null : { x, y }
+}
+
+function updateSelfFrame(frame) {
+  currentPanelFrame = cloneFrame(frame)
+  mutateSelf({ frame: currentPanelFrame })
+}
+
+export const clampFrameToWorkArea = placementClampFrameToWorkArea
 
 function framesEqual(lhs, rhs) {
   const a = cloneFrame(lhs)
@@ -238,8 +245,11 @@ export function dragFrameFromPointer(pointer = {}, offsetX = 0, offsetY = 0, fra
 export function createDragController({
   move = moveAbsolute,
   getFrame = () => frameFromWindow(),
-  getWorkArea = () => workAreaFromWindow(),
-  updateFrame = (frame) => mutateSelf({ frame }),
+  getWorkArea = (frame = frameFromWindow()) => workAreaForFrameTopLeft(frame, panelDisplays, workAreaFromWindow()),
+  getDragWorkArea = (frame = frameFromWindow(), pointer = null) => (
+    placementWorkAreaForPoint(pointer, panelDisplays, getWorkArea(frame))
+  ),
+  updateFrame = updateSelfFrame,
   clampOnEnd = false,
   transfer = false,
   transferController = null,
@@ -273,18 +283,32 @@ export function createDragController({
 
   return {
     start(pointer = {}) {
+      const startPoint = screenPoint(pointer)
       active = {
         pointerId: pointer.pointerId ?? null,
         offsetX: finiteNumber(pointer.clientX, 0),
         offsetY: finiteNumber(pointer.clientY, 0),
         frame: cloneFrame(getFrame()),
+        lastPointer: startPoint,
       }
       frame = cloneFrame(active.frame)
-      panelTransfer?.start({ frame })
+      panelTransfer?.start({ frame, pointer })
       return notify({ phase: 'start' })
     },
     move(pointer = {}) {
       if (!active) return state({ phase: 'idle' })
+      active.lastPointer = screenPoint(pointer) || active.lastPointer
+      const transferResult = panelTransfer?.move({
+        frame: active.frame,
+        pointer,
+        offsetX: active.offsetX,
+        offsetY: active.offsetY,
+      })
+      if (transferResult?.mode === 'outline') {
+        frame = cloneFrame(active.frame)
+        return notify({ phase: 'move' })
+      }
+
       move(
         finiteNumber(pointer.screenX, active.frame[0] + active.offsetX),
         finiteNumber(pointer.screenY, active.frame[1] + active.offsetY),
@@ -292,25 +316,20 @@ export function createDragController({
         active.offsetY
       )
       frame = dragFrameFromPointer(pointer, active.offsetX, active.offsetY, active.frame)
-      panelTransfer?.move({
-        frame: active.frame,
-        pointer,
-        offsetX: active.offsetX,
-        offsetY: active.offsetY,
-      })
       return notify({ phase: 'move' })
     },
-    end() {
+    end(pointer = {}) {
       if (!active) return state({ phase: 'idle' })
+      const releasePointer = screenPoint(pointer) || active.lastPointer
       active = null
       const transferResult = panelTransfer?.end()
       if (transferResult?.nativeFrame) {
         frame = cloneFrame(transferResult.nativeFrame)
         updateFrame(frame)
       } else if (clampOnEnd) {
-        frame = cloneFrame(getFrame())
+        frame = cloneFrame(frame)
         const clamped = clampFrameToWorkArea(frame, {
-          workArea: getWorkArea(),
+          workArea: getDragWorkArea(frame, releasePointer),
           minVisibleWidth,
           minVisibleHeight,
         })
@@ -394,8 +413,8 @@ export function resizeFrame(frame, edge, deltaX = 0, deltaY = 0, {
 
 export function createResizeController({
   getFrame = () => frameFromWindow(),
-  getWorkArea = () => workAreaFromWindow(),
-  updateFrame = (frame) => mutateSelf({ frame }),
+  getWorkArea = (frame = frameFromWindow()) => workAreaForFrameTopLeft(frame, panelDisplays, workAreaFromWindow()),
+  updateFrame = updateSelfFrame,
   minWidth = 240,
   minHeight = 160,
   maxWidth = Infinity,
@@ -444,7 +463,7 @@ export function createResizeController({
         minHeight,
         maxWidth,
         maxHeight,
-        workArea: getWorkArea(),
+        workArea: getWorkArea(active.frame),
       }), { phase: 'move' })
     },
     end() {
@@ -459,7 +478,7 @@ export function createResizeController({
         minHeight,
         maxWidth,
         maxHeight,
-        workArea: getWorkArea(),
+        workArea: getWorkArea(getFrame()),
       }), { phase: 'resize', edge: normalizeResizeEdge(edge) })
     },
     getState() {
@@ -470,8 +489,8 @@ export function createResizeController({
 
 export function createMaximizeController({
   getFrame = () => frameFromWindow(),
-  getWorkArea = () => workAreaFromWindow(),
-  updateFrame = (frame) => mutateSelf({ frame }),
+  getWorkArea = (frame = frameFromWindow()) => workAreaForFrameTopLeft(frame, panelDisplays, workAreaFromWindow()),
+  updateFrame = updateSelfFrame,
   onStateChange = null,
 } = {}) {
   let maximized = false
@@ -492,7 +511,7 @@ export function createMaximizeController({
     if (maximized) return state()
     restoreFrame = cloneFrame(getFrame())
     maximized = true
-    updateFrame(cloneFrame(getWorkArea()))
+    updateFrame(cloneFrame(getWorkArea(restoreFrame)))
     notify()
     return state()
   }
@@ -537,30 +556,44 @@ function defaultClose() {
 }
 
 function chipFrame() {
-  const x = Number(window.screenX ?? window.screenLeft ?? 80)
-  const y = Number(window.screenY ?? window.screenTop ?? 80)
-  const width = Math.min(280, Math.max(180, Number(window.innerWidth || 240) * 0.42))
-  return [
-    Math.round(Number.isFinite(x) ? x : 80),
-    Math.round(Number.isFinite(y) ? y : 80),
-    Math.round(width),
-    38,
-  ]
+  return chipFrameFromWindow(window)
 }
 
-function chipUrl({ target, title }) {
-  const url = new URL(window.location.href)
+export function chipFrameFromWindow(view = window, {
+  margin = 10,
+  minWidth = 180,
+  maxWidth = 280,
+  height = 38,
+  displays = panelDisplays,
+} = {}) {
+  const frame = frameFromWindow(view)
+  return chipFrameForPanelFrame(frame, {
+    displays,
+    fallbackWorkArea: workAreaFromWindow(view),
+    sourceWidth: view.innerWidth || frame[2],
+    margin,
+    minWidth,
+    maxWidth,
+    height,
+  })
+}
+
+function chipUrl({ target, title, restoreFrame, chipId = null, chipFrame = null }) {
+  let url = new URL(window.location.href)
   const path = url.pathname || ''
   if (path.includes('/panel/')) {
     url.pathname = `${path.slice(0, path.indexOf('/panel/') + '/panel/'.length)}minimized-chip.html`
   } else if (path.includes('/components/')) {
     url.pathname = `${path.slice(0, path.indexOf('/components/'))}/panel/minimized-chip.html`
   } else {
-    return new URL('./minimized-chip.html', window.location.href).href
+    url = new URL('./minimized-chip.html', window.location.href)
   }
   url.hash = ''
   url.searchParams.set('target', target)
   url.searchParams.set('title', title)
+  if (restoreFrame) url.searchParams.set('restoreFrame', JSON.stringify(cloneFrame(restoreFrame)))
+  if (chipId) url.searchParams.set('chip', chipId)
+  if (chipFrame) url.searchParams.set('chipFrame', JSON.stringify(cloneFrame(chipFrame)))
   return url.href
 }
 
@@ -571,10 +604,12 @@ function defaultMinimize({ title = 'AOS' } = {}) {
     return
   }
   const chipId = `aos-chip-${target}-${Date.now().toString(36)}`
+  const restoreFrame = frameFromWindow(window)
+  const minimizedFrame = chipFrame()
   spawnChild({
     id: chipId,
-    url: chipUrl({ target, title }),
-    frame: chipFrame(),
+    url: chipUrl({ target, title, restoreFrame, chipId, chipFrame: minimizedFrame }),
+    frame: minimizedFrame,
     interactive: true,
     focus: false,
     parent: target,
@@ -586,19 +621,68 @@ function defaultMinimize({ title = 'AOS' } = {}) {
     })
 }
 
+function wirePanelDisplayGeometry() {
+  if (displayGeometryWired || typeof window === 'undefined') return
+  displayGeometryWired = true
+  wireBridge((message) => {
+    const payload = message?.payload || message?.data || message
+    const type = message?.type || payload?.type
+    if (type === 'display_geometry' && payload?.displays) {
+      panelDisplays = normalizePanelDisplays(payload.displays)
+      return
+    }
+    if (type !== 'canvas_lifecycle') return
+    const id = payload?.canvas_id || payload?.id || payload?.canvas?.id || null
+    if (!id || id !== currentCanvasId()) return
+    const frame = payload?.at || payload?.canvas?.at || null
+    if (Array.isArray(frame) && frame.length >= 4) currentPanelFrame = cloneFrame(frame)
+  })
+  subscribe(['display_geometry', 'canvas_lifecycle'], { snapshot: true })
+}
+
 export function wireDrag(header, controlsEl, {
   controller = null,
   move = moveAbsolute,
+  globalInput = true,
   onStart = null,
   onEnd = null,
   ...controllerOptions
 } = {}) {
   const dragController = controller || createDragController({ move, ...controllerOptions })
+  let activePointerId = null
+  let finishDrag = null
+  let inputBridgeInstalled = false
+
+  function installInputBridge() {
+    if (inputBridgeInstalled || !globalInput) return
+    inputBridgeInstalled = true
+    wireBridge((message) => {
+      if (!finishDrag) return
+      const input = normalizeCanvasInputMessage(message)
+      if (!input) return
+      const eventType = input.type || input.eventKind || input.sourceEvent
+      const x = Number(input.x)
+      const y = Number(input.y)
+      if ((eventType === 'left_mouse_dragged' || eventType === 'mouse_moved') && Number.isFinite(x) && Number.isFinite(y)) {
+        dragController.move({
+          pointerId: activePointerId,
+          screenX: x,
+          screenY: y,
+        })
+        return
+      }
+      if (eventType === 'left_mouse_up' || eventType === 'pointer_cancel' || eventType === 'mouse_cancel') {
+        finishDrag({ pointerId: activePointerId, screenX: x, screenY: y, source: 'input_event' })
+      }
+    })
+  }
+
   header.addEventListener('pointerdown', (e) => {
     if (e.button !== 0) return
     const NodeCtor = globalThis.Node
     if ((!NodeCtor || e.target instanceof NodeCtor) && controlsEl?.contains?.(e.target)) return
     const pointerId = e.pointerId
+    activePointerId = pointerId
     header.dataset.dragging = 'true'
     e.preventDefault()
     // Drag lifecycle matters to the daemon: mixed-DPI seam placement keeps a
@@ -607,6 +691,8 @@ export function wireDrag(header, controlsEl, {
     emit('drag_start')
     onStart?.(e, dragController)
     dragController.start(e)
+    installInputBridge()
+    if (globalInput) subscribe(['input_event'])
 
     try { header.setPointerCapture(pointerId) } catch {}
 
@@ -617,23 +703,36 @@ export function wireDrag(header, controlsEl, {
 
     const onUp = (ev) => {
       if (ev && ev.pointerId !== pointerId) return
+      finishDrag?.(ev)
+    }
+
+    const onLostPointerCapture = (ev) => {
+      if (globalInput) return
+      onUp(ev)
+    }
+
+    finishDrag = (ev) => {
+      if (!finishDrag) return
       delete header.dataset.dragging
       header.removeEventListener('pointermove', onMove)
       header.removeEventListener('pointerup', onUp)
       header.removeEventListener('pointercancel', onUp)
-      header.removeEventListener('lostpointercapture', onUp)
+      header.removeEventListener('lostpointercapture', onLostPointerCapture)
       try {
         if (header.hasPointerCapture(pointerId)) header.releasePointerCapture(pointerId)
       } catch {}
       dragController.end(ev)
       emit('drag_end')
+      if (globalInput) unsubscribe(['input_event'])
+      activePointerId = null
+      finishDrag = null
       onEnd?.(ev, dragController)
     }
 
     header.addEventListener('pointermove', onMove)
     header.addEventListener('pointerup', onUp)
     header.addEventListener('pointercancel', onUp)
-    header.addEventListener('lostpointercapture', onUp)
+    header.addEventListener('lostpointercapture', onLostPointerCapture)
   })
   return dragController
 }

--- a/packages/toolkit/panel/defaults.css
+++ b/packages/toolkit/panel/defaults.css
@@ -62,6 +62,14 @@
   cursor: grabbing;
 }
 
+.aos-panel-grip {
+  flex: 0 0 auto;
+  width: 18px;
+  height: 10px;
+  border-block: 2px solid rgba(183, 252, 255, 0.58);
+  opacity: 0.72;
+}
+
 .aos-title {
   min-width: 0;
   flex: 1;
@@ -226,6 +234,10 @@
 .aos-split-pane-pane[hidden],
 .aos-split-pane-divider[hidden] {
   display: none !important;
+}
+
+.aos-split-pane[data-collapse-mode="accordion"][data-closed-pane] > .aos-split-pane-pane {
+  overflow: hidden;
 }
 
 .aos-split-pane-divider {

--- a/packages/toolkit/panel/drag-transfer.js
+++ b/packages/toolkit/panel/drag-transfer.js
@@ -1,6 +1,7 @@
 // drag-transfer.js — cross-display transfer affordance for panel drags.
 
 import { emit, wireBridge } from '../runtime/bridge.js'
+import { spawnChild } from '../runtime/canvas.js'
 import { subscribe } from '../runtime/subscribe.js'
 import {
   findDisplayForPoint,
@@ -47,6 +48,28 @@ function visibleNativeBounds(display) {
   return display?.nativeVisibleBounds || display?.native_visible_bounds || display?.visibleBounds || display?.visible_bounds || display?.bounds || null
 }
 
+function boundsSize(bounds = {}) {
+  return {
+    w: Math.max(1, finiteNumber(bounds.w ?? bounds.width, 1)),
+    h: Math.max(1, finiteNumber(bounds.h ?? bounds.height, 1)),
+  }
+}
+
+function rectFullyContainedByDisplay(frame, display) {
+  const source = frameToRect(frame)
+  const bounds = visibleNativeBounds(display)
+  if (!bounds) return false
+  const size = boundsSize(bounds)
+  const minX = finiteNumber(bounds.x, 0)
+  const minY = finiteNumber(bounds.y, 0)
+  const maxX = minX + size.w
+  const maxY = minY + size.h
+  return source.x >= minX
+    && source.y >= minY
+    && source.x + source.w <= maxX
+    && source.y + source.h <= maxY
+}
+
 function clampFrameToDisplay(frame, display) {
   const source = frameToRect(frame)
   const bounds = visibleNativeBounds(display)
@@ -70,6 +93,57 @@ function pointerPoint(pointer = {}) {
     x: finiteNumber(pointer.screenX ?? pointer.x, 0),
     y: finiteNumber(pointer.screenY ?? pointer.y, 0),
   }
+}
+
+function hasPointerPoint(pointer = {}) {
+  return Number.isFinite(Number(pointer.screenX ?? pointer.x))
+    && Number.isFinite(Number(pointer.screenY ?? pointer.y))
+}
+
+const stageEnsurePromises = new Map()
+
+export function defaultDesktopWorldStageUrl() {
+  if (typeof window === 'undefined' || !window.location?.href) {
+    return 'aos://toolkit/components/desktop-world-stage/index.html'
+  }
+  try {
+    const url = new URL(window.location.href)
+    const path = url.pathname || ''
+    const componentsIndex = path.indexOf('/components/')
+    if (componentsIndex >= 0) {
+      url.pathname = `${path.slice(0, componentsIndex)}/components/desktop-world-stage/index.html`
+      url.search = ''
+      url.hash = ''
+      return url.href
+    }
+  } catch {}
+  return 'aos://toolkit/components/desktop-world-stage/index.html'
+}
+
+export function ensureDesktopWorldStage({
+  id = 'aos-desktop-world-stage',
+  url = defaultDesktopWorldStageUrl(),
+  createStage = spawnChild,
+} = {}) {
+  if (!id || typeof createStage !== 'function') return Promise.resolve(false)
+  const key = `${id}:${url}`
+  if (!stageEnsurePromises.has(key)) {
+    stageEnsurePromises.set(key, Promise.resolve().then(() => createStage({
+      id,
+      url,
+      surface: 'desktop-world',
+      scope: 'global',
+      interactive: false,
+      focus: false,
+      cascade: false,
+    })).then(() => true).catch((error) => {
+      const message = String(error?.message || error)
+      if (/already exists|exists|duplicate/i.test(message)) return false
+      console.warn('[aos-panel] desktop-world transfer stage unavailable', error)
+      return false
+    }))
+  }
+  return stageEnsurePromises.get(key)
 }
 
 export function computePanelTransfer(displays = [], {
@@ -99,11 +173,14 @@ export function computePanelTransfer(displays = [], {
     source.w,
     source.h,
   ]
+  if (rectFullyContainedByDisplay(candidate, targetDisplay)) return null
+
   const nativeFrame = clampFrameToDisplay(candidate, targetDisplay)
   const worldRect = nativeToDesktopWorldRect(frameToRect(nativeFrame), normalizedDisplays)
   if (!worldRect) return null
   const worldFrame = rectToFrame(worldRect)
   return {
+    mode: 'outline',
     targetDisplayId: targetId,
     nativeFrame,
     frame: worldFrame,
@@ -133,6 +210,9 @@ export function sendDesktopWorldStageLayer(stageCanvasId, message, { send = emit
 export function createPanelTransferController({
   enabled = false,
   stageCanvasId = 'aos-desktop-world-stage',
+  stageUrl = defaultDesktopWorldStageUrl(),
+  ensureStage = 'auto',
+  createStage = spawnChild,
   layerId = null,
   label = 'Move here',
   getDisplays = () => [],
@@ -159,15 +239,31 @@ export function createPanelTransferController({
 
   return {
     setDisplays: updateDisplays,
-    start({ frame } = {}) {
+    start({ frame, pointer } = {}) {
       if (!enabled) return null
+      const shouldEnsureStage = ensureStage === 'auto'
+        ? typeof window !== 'undefined'
+        : Boolean(ensureStage)
+      if (shouldEnsureStage) {
+        ensureDesktopWorldStage({
+          id: stageCanvasId,
+          url: stageUrl,
+          createStage,
+        })
+      }
       const freshDisplays = normalizeDisplays(getDisplays())
       if (freshDisplays.length) displays = freshDisplays
       const rect = frameToRect(frame)
+      const originPoint = hasPointerPoint(pointer)
+        ? pointerPoint(pointer)
+        : {
+          x: rect.x + Math.min(rect.w / 2, 80),
+          y: rect.y + Math.min(rect.h / 2, 44),
+        }
       const origin = findDisplayForPoint(
         displays,
-        rect.x + Math.min(rect.w / 2, 80),
-        rect.y + Math.min(rect.h / 2, 44),
+        originPoint.x,
+        originPoint.y,
         { rectKey: 'nativeVisibleBounds', nearest: true }
       )
       originDisplayId = displayID(origin)

--- a/packages/toolkit/panel/index.js
+++ b/packages/toolkit/panel/index.js
@@ -23,11 +23,14 @@ export { mountPanel } from './mount.js'
 export {
   computePanelTransfer,
   createPanelTransferController,
+  defaultDesktopWorldStageUrl,
+  ensureDesktopWorldStage,
   sendDesktopWorldStageLayer,
   wirePanelTransferDisplayGeometry,
 } from './drag-transfer.js'
 export {
   clampFrameToWorkArea,
+  chipFrameFromWindow,
   createDragController,
   createMaximizeController,
   createResizeController,
@@ -38,8 +41,18 @@ export {
   resizeFrame,
   syncMaximizeButton,
   wireResize,
+  workAreaForFrameTopLeft,
+  workAreaForWindowTopLeft,
   workAreaFromWindow,
 } from './chrome.js'
+export {
+  chipFrameForPanelFrame,
+  resizeFrameFromTopLeft,
+  displayOwnerForTopLeft,
+  normalizePanelDisplays,
+  restoredPanelFrameForChip,
+  workAreaForPoint,
+} from './placement.js'
 export { Single } from './layouts/single.js'
 export {
   clampSplitPaneState,

--- a/packages/toolkit/panel/layouts/split-pane.js
+++ b/packages/toolkit/panel/layouts/split-pane.js
@@ -72,6 +72,7 @@ function cloneState(state) {
     endSize: state.endSize,
     availableSize: state.availableSize,
     closedPane: state.closedPane,
+    closedSize: state.closedSize,
   }
 }
 
@@ -171,6 +172,8 @@ export function createSplitPane({
   minEnd = 160,
   maxStart = Infinity,
   maxEnd = Infinity,
+  closedStartSize = 0,
+  closedEndSize = 0,
   keyboardStep = 24,
   ariaLabel = 'Resize panes',
   onChange = null,
@@ -198,6 +201,13 @@ export function createSplitPane({
   setStyle(rootEl, '--aos-split-divider-size', `${positiveNumber(dividerSize, 8)}px`)
   setStyle(rootEl, '--aos-split-min-start', `${Math.max(0, finiteNumber(minStart, 0))}px`)
   setStyle(rootEl, '--aos-split-min-end', `${Math.max(0, finiteNumber(minEnd, 0))}px`)
+  const accordionStartSize = Math.max(0, finiteNumber(closedStartSize, 0))
+  const accordionEndSize = Math.max(0, finiteNumber(closedEndSize, 0))
+  if (accordionStartSize > 0 || accordionEndSize > 0) {
+    rootEl.dataset.collapseMode = 'accordion'
+    setStyle(rootEl, '--aos-split-closed-start-size', `${accordionStartSize}px`)
+    setStyle(rootEl, '--aos-split-closed-end-size', `${accordionEndSize}px`)
+  }
 
   dividerEl.setAttribute('role', 'separator')
   dividerEl.setAttribute('tabindex', '0')
@@ -219,6 +229,7 @@ export function createSplitPane({
     startSize: 0,
     endSize: 0,
     availableSize: 0,
+    closedSize: 0,
   }
 
   function bounds() {
@@ -232,19 +243,22 @@ export function createSplitPane({
     if (state.closedPane) {
       state.restoreRatio = state.ratio
       const fullSize = positiveNumber(rect[splitAxis.size], 1)
+      const closedSize = state.closedPane === 'start' ? accordionStartSize : accordionEndSize
       const startOpen = state.closedPane !== 'start'
       const endOpen = state.closedPane !== 'end'
-      state.startSize = startOpen ? fullSize : 0
-      state.endSize = endOpen ? fullSize : 0
+      state.closedSize = closedSize
+      state.startSize = startOpen ? Math.max(0, fullSize - closedSize) : closedSize
+      state.endSize = endOpen ? Math.max(0, fullSize - closedSize) : closedSize
       state.availableSize = fullSize
 
-      startEl.hidden = !startOpen
-      endEl.hidden = !endOpen
+      startEl.hidden = !startOpen && closedSize === 0
+      endEl.hidden = !endOpen && closedSize === 0
       dividerEl.hidden = true
-      setStyle(startEl, 'flex', startOpen ? '1 1 0' : '0 0 0px')
-      setStyle(endEl, 'flex', endOpen ? '1 1 0' : '0 0 0px')
+      setStyle(startEl, 'flex', `0 0 ${state.startSize}px`)
+      setStyle(endEl, 'flex', `0 0 ${state.endSize}px`)
       setStyle(dividerEl, 'flex', '0 0 0px')
       setData(rootEl, 'closedPane', state.closedPane)
+      setData(rootEl, 'closedSize', closedSize)
       setData(rootEl, 'ratio', state.ratio.toFixed(4))
       dividerEl.setAttribute('aria-valuemin', '0')
       dividerEl.setAttribute('aria-valuemax', '100')
@@ -259,7 +273,9 @@ export function createSplitPane({
     startEl.hidden = false
     endEl.hidden = false
     dividerEl.hidden = false
+    state.closedSize = 0
     removeData(rootEl, 'closedPane')
+    removeData(rootEl, 'closedSize')
     const next = clampSplitPaneState({
       ratio: state.ratio,
       size: rect[splitAxis.size],

--- a/packages/toolkit/panel/minimized-chip.html
+++ b/packages/toolkit/panel/minimized-chip.html
@@ -76,23 +76,88 @@
     <button type="button" class="close" id="close" aria-label="Close panel" title="Close">x</button>
   </div>
   <script type="module">
+    import { emit, wireBridge } from '../runtime/bridge.js';
+    import { subscribe } from '../runtime/subscribe.js';
+    import {
+      cloneFrame,
+      frameFromWindow,
+      normalizePanelDisplays,
+      restoredPanelFrameForChip,
+      workAreaFromWindow,
+    } from './placement.js';
+
     const params = new URLSearchParams(location.search);
     const target = params.get('target') || '';
     const title = params.get('title') || target || 'AOS';
+    const chipId = params.get('chip') || currentCanvasId();
+    const restoreFrame = parseFrame(params.get('restoreFrame'));
+    const initialChipFrame = parseFrame(params.get('chipFrame'));
+    let currentChipFrame = initialChipFrame;
+    let panelDisplays = [];
     const chip = document.getElementById('chip');
     document.getElementById('title').textContent = title;
 
     function post(type, payload) {
-      const body = payload === undefined ? { type } : { type, payload };
-      window.webkit?.messageHandlers?.headsup?.postMessage(body);
+      emit(type, payload);
     }
 
     function removeSelf() {
       post('canvas.remove', { orphan_children: true });
     }
 
+    function currentCanvasId() {
+      return window.__aosCanvasId || window.__aosSurfaceCanvasId || null;
+    }
+
+    function finiteNumber(value, fallback = 0) {
+      const number = Number(value);
+      return Number.isFinite(number) ? number : fallback;
+    }
+
+    function parseFrame(value) {
+      if (!value) return null;
+      try {
+        const frame = JSON.parse(value);
+        if (!Array.isArray(frame) || frame.length < 4) return null;
+        return cloneFrame(frame);
+      } catch {
+        return null;
+      }
+    }
+
+    function fallbackChipFrame() {
+      return currentChipFrame || frameFromWindow(window);
+    }
+
+    function wirePlacementGeometry() {
+      wireBridge((message) => {
+        const payload = message?.payload || message?.data || message;
+        const type = message?.type || payload?.type;
+        if (type === 'display_geometry' && payload?.displays) {
+          panelDisplays = normalizePanelDisplays(payload.displays);
+          return;
+        }
+        if (type !== 'canvas_lifecycle') return;
+        const id = payload?.canvas_id || payload?.id || payload?.canvas?.id || null;
+        if (!id || id !== chipId) return;
+        const frame = payload?.at || payload?.canvas?.at || null;
+        if (Array.isArray(frame) && frame.length >= 4) currentChipFrame = cloneFrame(frame);
+      });
+      subscribe(['display_geometry', 'canvas_lifecycle'], { snapshot: true });
+    }
+
     function restore() {
-      if (target) post('canvas.resume', { id: target });
+      if (target) {
+        const chipFrame = fallbackChipFrame();
+        const frame = restoredPanelFrameForChip({
+          restoreFrame,
+          chipFrame,
+          displays: panelDisplays,
+          fallbackWorkArea: workAreaFromWindow(window, chipFrame),
+        });
+        if (frame) post('canvas.update', { id: target, frame });
+        post('canvas.resume', { id: target });
+      }
       removeSelf();
     }
 
@@ -130,6 +195,13 @@
         offsetX: drag.offsetX,
         offsetY: drag.offsetY,
       });
+      const source = fallbackChipFrame();
+      currentChipFrame = cloneFrame([
+        finiteNumber(event.screenX, source[0] + drag.offsetX) - drag.offsetX,
+        finiteNumber(event.screenY, source[1] + drag.offsetY) - drag.offsetY,
+        source[2],
+        source[3],
+      ]);
       event.preventDefault();
     });
 
@@ -145,9 +217,13 @@
     chip.addEventListener('pointerup', endDrag);
     chip.addEventListener('pointercancel', endDrag);
     chip.addEventListener('lostpointercapture', endDrag);
-    chip.addEventListener('dblclick', restore);
+    chip.addEventListener('dblclick', (event) => {
+      if (event.target?.closest?.('button')) return;
+      restore();
+    });
     document.getElementById('restore').addEventListener('click', restore);
     document.getElementById('close').addEventListener('click', closeTarget);
+    wirePlacementGeometry();
   </script>
 </body>
 </html>

--- a/packages/toolkit/panel/placement.js
+++ b/packages/toolkit/panel/placement.js
@@ -1,0 +1,179 @@
+// placement.js — shared panel/window placement policy.
+//
+// The daemon owns display geometry and canvas frames. Toolkit chrome consumes
+// that truth here so panels, chips, maximize, resize, and restore do not each
+// invent their own display ownership rules.
+
+import { findDisplayForPoint, normalizeDisplays } from '../runtime/spatial.js'
+
+export function finiteNumber(value, fallback = null) {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : fallback
+}
+
+export function positiveNumber(value, fallback = 1) {
+  const number = finiteNumber(value, fallback)
+  return Math.max(1, number)
+}
+
+export function cloneFrame(frame) {
+  return [
+    Math.round(finiteNumber(frame?.[0], 0)),
+    Math.round(finiteNumber(frame?.[1], 0)),
+    Math.round(positiveNumber(frame?.[2], 1)),
+    Math.round(positiveNumber(frame?.[3], 1)),
+  ]
+}
+
+export function frameFromRect(rect = {}) {
+  return cloneFrame([rect.x, rect.y, rect.w ?? rect.width, rect.h ?? rect.height])
+}
+
+export function frameFromWindow(view = window, { currentFrame = null } = {}) {
+  if (currentFrame) return cloneFrame(currentFrame)
+  return cloneFrame([
+    finiteNumber(view.screenX ?? view.screenLeft, 0),
+    finiteNumber(view.screenY ?? view.screenTop, 0),
+    positiveNumber(view.outerWidth || view.innerWidth || view.document?.documentElement?.clientWidth, 1),
+    positiveNumber(view.outerHeight || view.innerHeight || view.document?.documentElement?.clientHeight, 1),
+  ])
+}
+
+export function workAreaFromWindow(view = window, fallbackFrame = frameFromWindow(view)) {
+  const screen = view.screen || {}
+  const x = finiteNumber(screen.availLeft ?? screen.left, fallbackFrame[0])
+  const y = finiteNumber(screen.availTop ?? screen.top, fallbackFrame[1])
+  const width = positiveNumber(screen.availWidth || screen.width, fallbackFrame[2])
+  const height = positiveNumber(screen.availHeight || screen.height, fallbackFrame[3])
+  return cloneFrame([x, y, width, height])
+}
+
+export function normalizePanelDisplays(displays = []) {
+  return normalizeDisplays(Array.isArray(displays) ? displays : [])
+}
+
+export function displayOwnerForTopLeft(frame = [0, 0, 1, 1], displays = []) {
+  const source = cloneFrame(frame)
+  const normalized = normalizePanelDisplays(displays)
+  if (normalized.length === 0) return null
+  return findDisplayForPoint(normalized, source[0], source[1], {
+    rectKey: 'nativeBounds',
+    nearest: true,
+  })
+}
+
+export function displayOwnerForPoint(point = null, displays = [], { rectKey = 'nativeBounds', nearest = true } = {}) {
+  const x = finiteNumber(point?.x, null)
+  const y = finiteNumber(point?.y, null)
+  const normalized = normalizePanelDisplays(displays)
+  if (x == null || y == null || normalized.length === 0) return null
+  return findDisplayForPoint(normalized, x, y, { rectKey, nearest })
+}
+
+export function sameDisplay(lhs, rhs) {
+  if (!lhs || !rhs) return false
+  const lhsID = lhs.id ?? lhs.display_id
+  const rhsID = rhs.id ?? rhs.display_id
+  if (lhsID === undefined || rhsID === undefined) return false
+  return String(lhsID) === String(rhsID)
+}
+
+export function workAreaForFrameTopLeft(frame = [0, 0, 1, 1], displays = [], fallback = null) {
+  const owner = displayOwnerForTopLeft(frame, displays)
+  if (owner?.nativeVisibleBounds) return frameFromRect(owner.nativeVisibleBounds)
+  if (owner?.native_visible_bounds) return frameFromRect(owner.native_visible_bounds)
+  return fallback ? cloneFrame(fallback) : null
+}
+
+export function workAreaForPoint(point = null, displays = [], fallback = null) {
+  const owner = displayOwnerForPoint(point, displays)
+  if (owner?.nativeVisibleBounds) return frameFromRect(owner.nativeVisibleBounds)
+  if (owner?.native_visible_bounds) return frameFromRect(owner.native_visible_bounds)
+  return fallback ? cloneFrame(fallback) : null
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value))
+}
+
+export function clampFrameToWorkArea(frame, {
+  workArea = null,
+  minVisibleWidth = 120,
+  minVisibleHeight = 44,
+} = {}) {
+  const next = cloneFrame(frame)
+  if (!workArea) return next
+  const area = cloneFrame(workArea)
+  const areaRight = area[0] + area[2]
+  const areaBottom = area[1] + area[3]
+  next[2] = Math.min(next[2], area[2])
+  next[3] = Math.min(next[3], area[3])
+  const maxX = Math.max(area[0], areaRight - next[2])
+  const maxY = Math.max(area[1], areaBottom - next[3])
+  if (next[2] <= area[2]) next[0] = clamp(next[0], area[0], maxX)
+  else next[0] = clamp(next[0], area[0] - next[2] + minVisibleWidth, areaRight - minVisibleWidth)
+  if (next[3] <= area[3]) next[1] = clamp(next[1], area[1], maxY)
+  else next[1] = clamp(next[1], area[1] - next[3] + minVisibleHeight, areaBottom - minVisibleHeight)
+  return cloneFrame(next)
+}
+
+export function resizeFrameFromTopLeft(frame, {
+  width = null,
+  height = null,
+  minWidth = 1,
+  minHeight = 1,
+  maxWidth = Infinity,
+  maxHeight = Infinity,
+  workArea = null,
+} = {}) {
+  const source = cloneFrame(frame)
+  const nextWidth = width == null
+    ? source[2]
+    : Math.max(finiteNumber(minWidth, 1), Math.min(finiteNumber(maxWidth, Infinity), positiveNumber(width, source[2])))
+  const nextHeight = height == null
+    ? source[3]
+    : Math.max(finiteNumber(minHeight, 1), Math.min(finiteNumber(maxHeight, Infinity), positiveNumber(height, source[3])))
+  return clampFrameToWorkArea([source[0], source[1], nextWidth, nextHeight], { workArea })
+}
+
+export function chipFrameForPanelFrame(frame, {
+  displays = [],
+  fallbackWorkArea = null,
+  sourceWidth = null,
+  margin = 10,
+  minWidth = 180,
+  maxWidth = 280,
+  height = 38,
+} = {}) {
+  const source = cloneFrame(frame)
+  const area = workAreaForFrameTopLeft(source, displays, fallbackWorkArea) || cloneFrame(source)
+  const widthSource = positiveNumber(sourceWidth ?? source[2], minWidth)
+  const width = Math.min(maxWidth, Math.max(minWidth, widthSource * 0.42))
+  const minX = area[0] + margin
+  const minY = area[1] + margin
+  const maxX = area[0] + area[2] - width - margin
+  const maxY = area[1] + area[3] - height - margin
+  return [
+    Math.round(clamp(source[0], Math.min(minX, maxX), Math.max(minX, maxX))),
+    Math.round(clamp(source[1], Math.min(minY, maxY), Math.max(minY, maxY))),
+    Math.round(width),
+    Math.round(height),
+  ]
+}
+
+export function restoredPanelFrameForChip({
+  restoreFrame = null,
+  chipFrame = [0, 0, 280, 38],
+  displays = [],
+  fallbackWorkArea = null,
+} = {}) {
+  const chip = cloneFrame(chipFrame)
+  const saved = restoreFrame ? cloneFrame(restoreFrame) : [chip[0], chip[1], 640, 420]
+  const chipOwner = displayOwnerForTopLeft(chip, displays)
+  const restoreOwner = displayOwnerForTopLeft(saved, displays)
+  const desired = chipOwner && restoreOwner && sameDisplay(chipOwner, restoreOwner)
+    ? saved
+    : [chip[0], chip[1], saved[2], saved[3]]
+  const area = workAreaForFrameTopLeft(chip, displays, fallbackWorkArea)
+  return clampFrameToWorkArea(desired, { workArea: area })
+}

--- a/packages/toolkit/workbench/defaults.css
+++ b/packages/toolkit/workbench/defaults.css
@@ -210,6 +210,10 @@ body {
   background: rgba(183, 252, 255, 0.42);
 }
 
+.aos-workbench-main.aos-split-pane[data-collapse-mode="accordion"][data-closed-pane] > .aos-split-pane-pane {
+  overflow: hidden;
+}
+
 .aos-workbench-preview-pane {
   min-width: 0;
   min-height: 0;

--- a/scripts/aos-content-scope.sh
+++ b/scripts/aos-content-scope.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Shared content-root helpers for one singleton daemon with many worktrees.
+
+aos_content_root_key_for() {
+  local prefix="$1"
+  local repo_root="$2"
+  local branch suffix
+
+  branch="$(git -C "$repo_root" branch --show-current 2>/dev/null || true)"
+  if [[ -z "$branch" || "$branch" == "main" ]]; then
+    printf '%s\n' "$prefix"
+    return
+  fi
+
+  suffix="$(
+    printf '%s' "$branch" \
+      | tr '[:upper:]' '[:lower:]' \
+      | sed -E 's/[^a-z0-9]+/_/g; s/^_+//; s/_+$//'
+  )"
+  printf '%s_%s\n' "$prefix" "${suffix:-worktree}"
+}
+
+aos_content_roots_live() {
+  local aos_bin="$1"
+  shift
+
+  "$aos_bin" content status --json 2>/dev/null \
+    | python3 -c '
+import json
+import pathlib
+import sys
+
+pairs = sys.argv[1:]
+if len(pairs) % 2:
+    raise SystemExit(1)
+
+try:
+    roots = json.load(sys.stdin).get("roots", {})
+except Exception:
+    raise SystemExit(1)
+
+def norm(path):
+    return str(pathlib.Path(path).expanduser().resolve(strict=False))
+
+for index in range(0, len(pairs), 2):
+    name = pairs[index]
+    expected = pairs[index + 1]
+    active = roots.get(name)
+    if not active or norm(active) != norm(expected):
+        raise SystemExit(1)
+' "$@"
+}
+
+aos_ensure_content_roots_live() {
+  local aos_bin="$1"
+  shift
+
+  if [ $(( $# % 2 )) -ne 0 ]; then
+    echo "aos_ensure_content_roots_live requires root/path pairs" >&2
+    return 2
+  fi
+
+  (
+    while [ "$#" -gt 0 ]; do
+      "$aos_bin" set "content.roots.$1" "$2" >/dev/null || exit $?
+      shift 2
+    done
+  ) || return $?
+
+  if ! aos_content_roots_live "$aos_bin" "$@"; then
+    echo "Refreshing repo daemon so scoped content roots are live." >&2
+    "$aos_bin" service restart --mode repo >/dev/null
+  fi
+
+  (
+    while [ "$#" -gt 0 ]; do
+      "$aos_bin" content wait --root "$1" --auto-start --timeout 15s >/dev/null || exit $?
+      shift 2
+    done
+  )
+}

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -7,7 +7,7 @@ Unified binary for macOS perception, display, action, and voice.
 ## Build
 
 ```bash
-./aos dev build --no-restart
+./aos dev build
 ```
 
 Only rebuild when you changed Swift in `src/` or `shared/swift/ipc/`, or when
@@ -243,6 +243,10 @@ aos content wait --root sigil             # Wait until the daemon is serving tha
 aos show wait --id demo --manifest foo    # Wait until a canvas bridge + manifest are live
 ```
 
+Use canonical root names only on `main`. Topic worktrees should use
+branch-scoped sibling roots via `scripts/aos-content-scope.sh` so parallel
+sessions do not make the daemon serve another checkout's content.
+
 Canvases load via URL: `aos://sigil/studio/index.html` (rewritten to `http://127.0.0.1:PORT/...` by the daemon). The `aos://` prefix works in `--url` arguments and `toggle_url` config.
 
 ### Wiki (aos wiki)
@@ -296,4 +300,5 @@ State is scoped per runtime mode at `~/.config/aos/{repo|installed}/`.
 
 ### Spec
 
-See `docs/superpowers/specs/2026-04-05-aos-unified-architecture-and-perception-daemon.md`
+See `ARCHITECTURE.md` for the live architecture overview. Historical context is
+archived under `docs/archive/superpowers/`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,7 +14,7 @@ For the repo-wide entry-path model behind these choices, see
 
 ## Rebuild `./aos` First
 
-Rebuild with `./aos dev build --no-restart` when both of these are true:
+Rebuild with `./aos dev build` when both of these are true:
 
 - the work changed Swift sources in `src/` or `shared/swift/ipc/`
 - the command or test you are about to run executes `./aos`

--- a/tests/dev-workflow-router.sh
+++ b/tests/dev-workflow-router.sh
@@ -23,7 +23,7 @@ assert "docs-only" in summary["rule_ids"], summary
 assert summary["requires_swift_build"] is True, summary
 assert summary["tcc_identity_sensitive"] is True, summary
 assert summary["hot_swappable"] is False, summary
-assert any(item["command"] == "./aos dev build --no-restart" for item in summary["commands"]), summary
+assert any(item["command"] == "./aos dev build" for item in summary["commands"]), summary
 assert any(item["command"] == "./aos ready" for item in summary["verification"]), summary
 PY
 then

--- a/tests/renderer/sigil-content-roots.test.mjs
+++ b/tests/renderer/sigil-content-roots.test.mjs
@@ -1,0 +1,73 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+import {
+  currentContentRoot,
+  currentToolkitRoot,
+  documentContentUrl,
+  sigilUrl,
+  siblingContentRoot,
+  toolkitSpecifier,
+  toolkitUrl,
+} from '../../apps/sigil/renderer/live-modules/content-roots.js'
+
+test('Sigil content roots infer branch-scoped toolkit root from current Sigil root', () => {
+  const loc = new URL('http://127.0.0.1:54526/sigil_codex_wiki_workbench_layout_polish/renderer/index.html')
+
+  assert.equal(currentContentRoot({ loc }), 'sigil_codex_wiki_workbench_layout_polish')
+  assert.equal(currentToolkitRoot({ loc }), 'toolkit_codex_wiki_workbench_layout_polish')
+  assert.equal(
+    toolkitUrl('components/markdown-workbench/index.html', { loc }),
+    'aos://toolkit_codex_wiki_workbench_layout_polish/components/markdown-workbench/index.html',
+  )
+  assert.equal(
+    documentContentUrl(currentToolkitRoot({ loc }), 'components/markdown-workbench/index.html', { loc }),
+    '/toolkit_codex_wiki_workbench_layout_polish/components/markdown-workbench/index.html',
+  )
+  assert.equal(
+    sigilUrl('renderer/hit-area.html', { loc }),
+    'aos://sigil_codex_wiki_workbench_layout_polish/renderer/hit-area.html',
+  )
+})
+
+test('Sigil content roots accept explicit toolkit root override', () => {
+  const loc = new URL('http://127.0.0.1:54526/sigil/renderer/index.html?toolkit-root=toolkit_preview')
+
+  assert.equal(currentToolkitRoot({ loc }), 'toolkit_preview')
+  assert.equal(
+    toolkitUrl('runtime/spatial.js', { loc }),
+    'aos://toolkit_preview/runtime/spatial.js',
+  )
+})
+
+test('Sigil content roots preserve aos scheme when loaded before URL rewrite', () => {
+  const loc = new URL('aos://sigil_codex_example/renderer/index.html')
+
+  assert.equal(currentContentRoot({ loc }), 'sigil_codex_example')
+  assert.equal(siblingContentRoot({ fromRoot: 'sigil_codex_example' }), 'toolkit_codex_example')
+  assert.equal(
+    toolkitUrl('runtime/menu-activation.js', { loc }),
+    'aos://toolkit_codex_example/runtime/menu-activation.js',
+  )
+})
+
+test('Sigil toolkit specifier keeps local Node tests on filesystem imports', () => {
+  assert.equal(
+    toolkitSpecifier('runtime/spatial.js', { loc: null }),
+    '../../../../packages/toolkit/runtime/spatial.js',
+  )
+  assert.equal(
+    toolkitSpecifier('runtime/spatial.js', { loc: null, local: '../../../packages/toolkit/runtime/spatial.js' }),
+    '../../../packages/toolkit/runtime/spatial.js',
+  )
+})
+
+test('Sigil renderer routes wiki workbench through scoped toolkit resolver', async () => {
+  const source = await readFile(new URL('../../apps/sigil/renderer/live-modules/main.js', import.meta.url), 'utf8')
+
+  assert.match(source, /toolkitUrl\('components\/markdown-workbench\/index\.html'\)/)
+  assert.doesNotMatch(source, /WIKI_WORKBENCH_URL\s*=\s*['"]aos:\/\/toolkit\/components\/markdown-workbench\/index\.html/)
+  assert.match(source, /sigilUrl\('renderer\/hit-area\.html'\)/)
+  assert.match(source, /openWikiWorkbench\(path \|\| WIKI_WORKBENCH_DEFAULT_PATH\)/)
+})

--- a/tests/schemas/dev-workflow-rules.test.mjs
+++ b/tests/schemas/dev-workflow-rules.test.mjs
@@ -80,7 +80,7 @@ test('canonical rules preserve the expected V0 routing contracts', async () => {
   assert.equal(rules.get('swift-core')?.tcc_identity_sensitive, true);
   assert.equal(
     rules.get('swift-core')?.commands?.[0]?.command,
-    './aos dev build --no-restart',
+    './aos dev build',
   );
   assert.equal(
     rules.get('command-contract-docs')?.commands?.[0]?.command,

--- a/tests/toolkit/canvas-inspector.test.mjs
+++ b/tests/toolkit/canvas-inspector.test.mjs
@@ -1,11 +1,16 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 import {
   computeMinimapLayout,
   normalizeDisplays,
   projectPointToMinimap,
   resolveCanvasFrames,
 } from '../../packages/toolkit/components/canvas-inspector/index.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
 const displays = [
   {
@@ -219,4 +224,27 @@ test('normalizeDisplays accepts display_geometry payloads', () => {
       height: 982,
     },
   ]);
+});
+
+test('Canvas Inspector consumes toolkit panel chrome and split-pane footer primitives', () => {
+  const html = readFileSync(path.join(repoRoot, 'packages/toolkit/components/canvas-inspector/index.html'), 'utf8');
+  const source = readFileSync(path.join(repoRoot, 'packages/toolkit/components/canvas-inspector/index.js'), 'utf8');
+  const styles = readFileSync(path.join(repoRoot, 'packages/toolkit/components/canvas-inspector/styles.css'), 'utf8');
+
+  assert.match(html, /panel\/defaults\.css/);
+  assert.match(html, /mountPanel\(\{\s*title: 'Canvas Inspector'/);
+  assert.match(html, /maximize:\s*true/);
+  assert.match(html, /resizable:\s*true/);
+  assert.match(html, /minWidth:\s*300/);
+  assert.match(source, /createSplitPane/);
+  assert.match(source, /resizeFrameFromTopLeft/);
+  assert.match(source, /mutateSelf\(\{ frame: nextFrame \}\)/);
+  assert.match(source, /orientation: 'vertical'/);
+  assert.match(source, /closedEndSize: LIST_PANE_CLOSED_HEIGHT/);
+  assert.doesNotMatch(source, /request_resize/);
+  assert.doesNotMatch(source, /MIN_EXPANDED_LIST_HEIGHT/);
+  assert.match(styles, /\.canvas-inspector-split/);
+  assert.match(styles, /\.canvas-inspector-list-pane/);
+  assert.match(styles, /overflow-x:\s*hidden/);
+  assert.match(styles, /text-overflow:\s*ellipsis/);
 });

--- a/tests/toolkit/markdown-workbench-layout.test.mjs
+++ b/tests/toolkit/markdown-workbench-layout.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const repo = new URL('../../', import.meta.url);
+
+async function repoText(path) {
+  return readFile(new URL(path, repo), 'utf8');
+}
+
+test('markdown workbench embeds wiki graph as the primary pane', async () => {
+  const js = await repoText('packages/toolkit/components/markdown-workbench/index.js');
+  const css = await repoText('packages/toolkit/components/markdown-workbench/styles.css');
+  const html = await repoText('packages/toolkit/components/markdown-workbench/index.html');
+  const wikiJs = await repoText('packages/toolkit/components/wiki-kb/index.js');
+  const wikiCss = await repoText('packages/toolkit/components/wiki-kb/styles.css');
+
+  assert.match(js, /import WikiKB from '\.\.\/wiki-kb\/index\.js'/);
+  assert.match(html, /\.\.\/wiki-kb\/styles\.css/);
+  assert.match(html, /maximize:\s*true/);
+  assert.match(html, /resizable:\s*true/);
+  assert.match(html, /minWidth:\s*760/);
+  assert.match(js, /class="aos-workbench-preview-pane markdown-workbench-graph-pane"/);
+  assert.match(js, /data-role="graph"/);
+  assert.match(js, /WikiKB\(\{ chrome: 'embedded', views: \['graph'\] \}\)/);
+  assert.match(js, /collapseEmbeddedGraphControls/);
+  assert.match(js, /scheduleEmbeddedGraphFit/);
+  assert.match(js, /type:\s*'fit-view'/);
+  assert.match(js, /embeddedWikiGraphPayload/);
+  assert.match(js, /labelMode:\s*'hover'/);
+  assert.match(js, /collapsed:\s*true/);
+  assert.match(wikiJs, /accepts:\s*\[[^\]]*'fit-view'/s);
+  assert.match(wikiJs, /wiki-kb-compact-chrome/);
+  assert.match(wikiCss, /\.wiki-kb-root\[data-chrome="embedded"\]\s+\.wiki-kb-controls-shell/);
+  assert.match(wikiCss, /\.wiki-kb-root\[data-chrome="embedded"\]\s+\.wiki-kb-controls-shell\s*\{[\s\S]*left:\s*0/);
+  assert.match(wikiCss, /\.wiki-kb-root\[data-chrome="embedded"\]\s+\.wiki-kb-controls-shell\.collapsed\s+\.wiki-kb-controls-toggle/);
+  assert.match(wikiCss, /\.wiki-kb-root\[data-chrome="embedded"\]\s+\.wiki-kb-graph-view:has\(\.wiki-kb-controls-shell:not\(\.collapsed\)\)\s+\.wiki-kb-legend/);
+  assert.match(wikiCss, /\.wiki-kb-controls-panel\[hidden\]\s*\{\s*display:\s*none/);
+  assert.doesNotMatch(wikiJs, /wiki-kb-graph-stats/);
+  assert.match(wikiCss, /\.wiki-kb-floating-status\s*\{[\s\S]*top:\s*10px/);
+  assert.match(css, /\.markdown-workbench-main\s*\{[\s\S]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s*minmax\(0,\s*0fr\)/);
+  assert.match(css, /\.markdown-workbench-root\[data-split-open="true"\]\s+\.markdown-workbench-main/);
+});
+
+test('markdown workbench toggles source and preview in the content pane', async () => {
+  const js = await repoText('packages/toolkit/components/markdown-workbench/index.js');
+
+  const documentPane = js.match(/<section class="aos-workbench-controls-pane markdown-workbench-document-pane"[\s\S]*?<\/section>\s*<\/main>/)?.[0] || '';
+
+  assert.match(js, /data-view-mode="preview"/);
+  assert.match(js, /data-view-mode="source"/);
+  assert.match(js, /aria-label="Preview" title="Preview"/);
+  assert.match(js, /aria-label="Edit" title="Edit"/);
+  assert.match(js, /markdown-workbench-mode-icon/);
+  assert.match(js, /markdown-workbench-code-icon/);
+  assert.match(js, /class="markdown-workbench-icon-button" data-action="toggle-outline" aria-label="Index" title="Index"/);
+  assert.match(documentPane, /data-role="path"/);
+  assert.doesNotMatch(documentPane, /data-role="dirty"/);
+  assert.match(js, /dom\.saveButton\.disabled = !state\.dirty/);
+  assert.match(documentPane, /markdown-workbench-document-toolbar/);
+  assert.match(js, /syncViewMode/);
+  assert.match(js, /dom\.previewPane\.hidden = !previewActive/);
+  assert.match(js, /dom\.sourcePane\.hidden = previewActive/);
+  assert.doesNotMatch(js, /markdown-workbench-toolbar/);
+  assert.doesNotMatch(js, /markdown-workbench-pane-toolbar/);
+});
+
+test('markdown workbench folds index into the content pane and can close it', async () => {
+  const js = await repoText('packages/toolkit/components/markdown-workbench/index.js');
+  const css = await repoText('packages/toolkit/components/markdown-workbench/styles.css');
+
+  assert.match(js, /class="markdown-workbench-outline-panel"/);
+  assert.match(js, /data-action="toggle-outline"/);
+  assert.match(js, /data-action="close-content"/);
+  assert.match(js, /class="aos-window-button aos-window-close markdown-workbench-close-content"/);
+  assert.match(js, /splitOpen = false/);
+  assert.match(css, /\.markdown-workbench-outline-panel\s*\{/);
+  assert.doesNotMatch(js, /markdown-workbench-inspector/);
+});
+
+test('markdown source editor leaves native undo and redo key chords alone', async () => {
+  const js = await repoText('packages/toolkit/components/markdown-workbench/index.js');
+  const keydownBody = js.match(/function handleEditorKeydown\(event\) \{[\s\S]*?\n  \}/)?.[0] || '';
+
+  assert.match(js, /<textarea spellcheck="true" aria-label="Markdown source editor"><\/textarea>/);
+  assert.match(keydownBody, /key === 's'/);
+  assert.match(keydownBody, /event\.key !== 'Tab'/);
+  assert.doesNotMatch(keydownBody, /key === 'z'/);
+  assert.doesNotMatch(keydownBody, /key === 'y'/);
+  assert.doesNotMatch(keydownBody, /undo/i);
+  assert.doesNotMatch(keydownBody, /redo/i);
+});

--- a/tests/toolkit/panel-chrome.test.mjs
+++ b/tests/toolkit/panel-chrome.test.mjs
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   clampFrameToWorkArea,
+  chipFrameFromWindow,
   createDragController,
   createMaximizeController,
   createResizeController,
@@ -12,8 +13,14 @@ import {
   syncMaximizeButton,
   wireDrag,
   wireResize,
+  workAreaForFrameTopLeft,
   workAreaFromWindow,
 } from '../../packages/toolkit/panel/chrome.js';
+import {
+  resizeFrameFromTopLeft,
+  restoredPanelFrameForChip,
+  workAreaForPoint,
+} from '../../packages/toolkit/panel/placement.js';
 
 class FakeNode {}
 
@@ -111,6 +118,34 @@ class FakeButton {
   }
 }
 
+const panelDisplays = [
+  {
+    id: 'main',
+    native_bounds: { x: 0, y: 0, w: 1512, h: 982 },
+    native_visible_bounds: { x: 0, y: 33, w: 1512, h: 949 },
+    is_main: true,
+  },
+  {
+    id: 'extended',
+    native_bounds: { x: 1512, y: 0, w: 1920, h: 1080 },
+    native_visible_bounds: { x: 1512, y: 0, w: 1920, h: 1040 },
+  },
+];
+
+const stackedDisplays = [
+  {
+    id: 'extended-bottom',
+    native_bounds: { x: -207, y: 982, w: 1920, h: 1080 },
+    native_visible_bounds: { x: -207, y: 1012, w: 1920, h: 976 },
+  },
+  {
+    id: 'main-top',
+    native_bounds: { x: 0, y: 0, w: 1512, h: 982 },
+    native_visible_bounds: { x: 0, y: 33, w: 1512, h: 949 },
+    is_main: true,
+  },
+];
+
 test('frame and work area helpers normalize current window geometry', () => {
   const view = {
     screenX: 22.3,
@@ -134,6 +169,71 @@ test('frame and work area helpers normalize current window geometry', () => {
     innerHeight: 320,
     screen: { availWidth: 1200, availHeight: 800 },
   }), [300, 140, 1200, 800]);
+});
+
+test('chip frame helper avoids menu bar and clamps to available work area', () => {
+  assert.deepEqual(chipFrameFromWindow({
+    screenX: 0,
+    screenY: 0,
+    innerWidth: 1200,
+    innerHeight: 760,
+    screen: {
+      availLeft: 0,
+      availTop: 33,
+      availWidth: 1512,
+      availHeight: 949,
+    },
+  }), [10, 43, 280, 38]);
+
+  assert.deepEqual(chipFrameFromWindow({
+    screenX: 1500,
+    screenY: 1016,
+    innerWidth: 400,
+    innerHeight: 240,
+    screen: {
+      availLeft: -207,
+      availTop: 1012,
+      availWidth: 1920,
+      availHeight: 976,
+    },
+  }), [1500, 1022, 180, 38]);
+});
+
+test('panel work area inference uses the frame top-left display', () => {
+  assert.deepEqual(
+    workAreaForFrameTopLeft([1510, 80, 640, 420], panelDisplays, [0, 0, 1, 1]),
+    [0, 33, 1512, 949],
+  );
+  assert.deepEqual(
+    workAreaForFrameTopLeft([1512, 80, 640, 420], panelDisplays, [0, 0, 1, 1]),
+    [1512, 0, 1920, 1040],
+  );
+});
+
+test('pointer work area inference keeps stacked-display drags on the cursor display', () => {
+  assert.deepEqual(
+    workAreaForFrameTopLeft([100, 980, 320, 480], stackedDisplays, [0, 0, 1, 1]),
+    [0, 33, 1512, 949],
+  );
+  assert.deepEqual(
+    workAreaForPoint({ x: 120, y: 2050 }, stackedDisplays, [0, 0, 1, 1]),
+    [-207, 1012, 1920, 976],
+  );
+});
+
+test('chip frame helper uses top-left display inference when display geometry is available', () => {
+  assert.deepEqual(chipFrameFromWindow({
+    screenX: 1520,
+    screenY: 5,
+    innerWidth: 500,
+    innerHeight: 240,
+    screen: {
+      availLeft: 0,
+      availTop: 33,
+      availWidth: 1512,
+      availHeight: 949,
+    },
+  }, { displays: panelDisplays }), [1522, 10, 210, 38]);
 });
 
 test('createMaximizeController toggles work-area frame and restores previous frame', () => {
@@ -168,6 +268,73 @@ test('createMaximizeController toggles work-area frame and restores previous fra
     [40, 70, 500, 360],
   ]);
   assert.deepEqual(states.at(-1), { maximized: false, restoreFrame: null });
+});
+
+test('createMaximizeController can use top-left inferred display work area', () => {
+  let frame = [1520, 80, 600, 420];
+  const controller = createMaximizeController({
+    getFrame: () => frame,
+    getWorkArea: () => workAreaForFrameTopLeft(frame, panelDisplays),
+    updateFrame(nextFrame) {
+      frame = nextFrame;
+    },
+  });
+
+  assert.deepEqual(controller.maximize(), {
+    maximized: true,
+    restoreFrame: [1520, 80, 600, 420],
+  });
+  assert.deepEqual(frame, [1512, 0, 1920, 1040]);
+  controller.restore();
+  assert.deepEqual(frame, [1520, 80, 600, 420]);
+});
+
+test('minimized chip restore keeps saved frame when chip and panel share a display', () => {
+  assert.deepEqual(
+    restoredPanelFrameForChip({
+      restoreFrame: [40, 70, 500, 360],
+      chipFrame: [42, 80, 220, 38],
+      displays: panelDisplays,
+    }),
+    [40, 70, 500, 360],
+  );
+});
+
+test('minimized chip restore follows the chip display when moved across displays', () => {
+  assert.deepEqual(
+    restoredPanelFrameForChip({
+      restoreFrame: [40, 70, 500, 360],
+      chipFrame: [1520, 80, 220, 38],
+      displays: panelDisplays,
+    }),
+    [1520, 80, 500, 360],
+  );
+});
+
+test('minimized chip restore clamps to the chip display visible work area', () => {
+  assert.deepEqual(
+    restoredPanelFrameForChip({
+      restoreFrame: [40, 70, 500, 360],
+      chipFrame: [3390, 1020, 220, 38],
+      displays: panelDisplays,
+    }),
+    [2932, 680, 500, 360],
+  );
+});
+
+test('resizeFrameFromTopLeft preserves panel origin and clamps resized frame', () => {
+  assert.deepEqual(
+    resizeFrameFromTopLeft([40, 70, 500, 360], { height: 620 }),
+    [40, 70, 500, 620],
+  );
+  assert.deepEqual(
+    resizeFrameFromTopLeft([40, 70, 500, 360], {
+      height: 2000,
+      maxHeight: 900,
+      workArea: [0, 33, 1512, 949],
+    }),
+    [40, 70, 500, 900],
+  );
 });
 
 test('resize geometry handles edges, corners, constraints, and work-area clamp', () => {
@@ -222,6 +389,33 @@ test('drag geometry derives pointer frames and clamps final placement', () => {
   assert.deepEqual(updates.at(-1), [560, 440, 240, 160]);
   assert.deepEqual(frame, [560, 440, 240, 160]);
   assert.deepEqual(states.map((state) => state.phase), ['start', 'move', 'end']);
+});
+
+test('drag end clamps to the cursor display instead of a seam-adjacent top-left display', () => {
+  let frame = [100, 980, 320, 480];
+  const updates = [];
+  const controller = createDragController({
+    move(screenX, screenY, offsetX, offsetY) {
+      frame = [screenX - offsetX, screenY - offsetY, frame[2], frame[3]];
+    },
+    getFrame: () => frame,
+    getWorkArea: (nextFrame) => workAreaForFrameTopLeft(nextFrame, stackedDisplays),
+    getDragWorkArea: (nextFrame, pointer) => (
+      workAreaForPoint(pointer, stackedDisplays, workAreaForFrameTopLeft(nextFrame, stackedDisplays))
+    ),
+    updateFrame(nextFrame) {
+      frame = nextFrame;
+      updates.push(nextFrame);
+    },
+    clampOnEnd: true,
+  });
+
+  controller.start({ pointerId: 1, clientX: 20, clientY: 1070, screenX: 120, screenY: 1000 });
+  controller.move({ pointerId: 1, screenX: 120, screenY: 2050 });
+  controller.end({ pointerId: 1, screenX: 120, screenY: 2050 });
+
+  assert.deepEqual(updates.at(-1), [100, 1012, 320, 480]);
+  assert.deepEqual(frame, [100, 1012, 320, 480]);
 });
 
 test('createResizeController updates frames from pointer deltas', () => {
@@ -293,6 +487,7 @@ test('wireDrag emits absolute drag updates with the original pointer offset', as
   const controls = new FakeElement();
   const moves = [];
   const controller = wireDrag(header, controls, {
+    globalInput: false,
     move(screenX, screenY, offsetX, offsetY) {
       moves.push({ screenX, screenY, offsetX, offsetY });
     },
@@ -351,6 +546,7 @@ test('wireDrag ignores pointerdown events originating from controls', async (t) 
   const controls = new FakeElement();
   const moves = [];
   wireDrag(header, controls, {
+    globalInput: false,
     move(...args) {
       moves.push(args);
     },
@@ -367,6 +563,66 @@ test('wireDrag ignores pointerdown events originating from controls', async (t) 
   assert.equal(moves.length, 0);
   assert.equal('dragging' in header.dataset, false);
   assert.equal(emitted.length, 0);
+});
+
+test('wireDrag follows daemon input events while the cursor leaves the canvas', async (t) => {
+  const previousNode = globalThis.Node;
+  const previousWindow = globalThis.window;
+  const previousAtob = globalThis.atob;
+  globalThis.Node = FakeNode;
+  const emitted = [];
+  globalThis.window = {
+    headsup: {},
+    webkit: {
+      messageHandlers: {
+        headsup: {
+          postMessage(message) {
+            emitted.push(message);
+          },
+        },
+      },
+    },
+  };
+  globalThis.atob = (value) => Buffer.from(value, 'base64').toString('utf8');
+  t.after(() => {
+    globalThis.Node = previousNode;
+    globalThis.window = previousWindow;
+    globalThis.atob = previousAtob;
+  });
+
+  const header = new FakeElement();
+  const controls = new FakeElement();
+  const moves = [];
+  const controller = wireDrag(header, controls, {
+    move(screenX, screenY, offsetX, offsetY) {
+      moves.push({ screenX, screenY, offsetX, offsetY });
+    },
+  });
+
+  header.dispatch('pointerdown', {
+    button: 0,
+    pointerId: 7,
+    clientX: 24,
+    clientY: 10,
+    target: header,
+  });
+  assert.equal(controller.getState().active, true);
+
+  const sendInput = (message) => {
+    window.headsup.receive(Buffer.from(JSON.stringify(message)).toString('base64'));
+  };
+  sendInput({ type: 'input_event', payload: { type: 'left_mouse_dragged', x: 500, y: 1040 } });
+  assert.deepEqual(moves, [{ screenX: 500, screenY: 1040, offsetX: 24, offsetY: 10 }]);
+
+  sendInput({ type: 'input_event', payload: { type: 'left_mouse_up', x: 500, y: 1040 } });
+  assert.equal(controller.getState().active, false);
+  assert.equal('dragging' in header.dataset, false);
+  assert.deepEqual(emitted.map((message) => message.type), [
+    'drag_start',
+    'subscribe',
+    'drag_end',
+    'unsubscribe',
+  ]);
 });
 
 test('wireResize creates edge handles and emits resize lifecycle messages', async (t) => {

--- a/tests/toolkit/panel-drag-transfer.test.mjs
+++ b/tests/toolkit/panel-drag-transfer.test.mjs
@@ -5,6 +5,7 @@ import { createDragController } from '../../packages/toolkit/panel/chrome.js'
 import {
   computePanelTransfer,
   createPanelTransferController,
+  ensureDesktopWorldStage,
 } from '../../packages/toolkit/panel/drag-transfer.js'
 
 const displays = [
@@ -52,6 +53,16 @@ test('computePanelTransfer is inactive while pointer remains on the origin displ
   }), null)
 })
 
+test('computePanelTransfer is inactive once the whole panel fits on the destination display', () => {
+  assert.equal(computePanelTransfer(displays, {
+    frame: [100, 80, 500, 360],
+    pointer: { screenX: 1600, screenY: 80 },
+    offsetX: 80,
+    offsetY: 20,
+    originDisplayId: 'main',
+  }), null)
+})
+
 test('createPanelTransferController upserts outline layers and returns release frame', () => {
   const sent = []
   const controller = createPanelTransferController({
@@ -80,10 +91,57 @@ test('createPanelTransferController upserts outline layers and returns release f
   ])
 })
 
+test('ensureDesktopWorldStage creates the shared non-interactive desktop-world stage', async () => {
+  const created = []
+  const result = await ensureDesktopWorldStage({
+    id: 'stage-test',
+    url: 'aos://toolkit-preview/components/desktop-world-stage/index.html',
+    createStage(payload) {
+      created.push(payload)
+      return Promise.resolve({ id: payload.id })
+    },
+  })
+
+  assert.equal(result, true)
+  assert.deepEqual(created, [{
+    id: 'stage-test',
+    url: 'aos://toolkit-preview/components/desktop-world-stage/index.html',
+    surface: 'desktop-world',
+    scope: 'global',
+    interactive: false,
+    focus: false,
+    cascade: false,
+  }])
+})
+
+test('createPanelTransferController can ensure the shared transfer stage on drag start', async () => {
+  const created = []
+  const controller = createPanelTransferController({
+    enabled: true,
+    stageCanvasId: 'stage-start-test',
+    stageUrl: 'aos://toolkit/components/desktop-world-stage/index.html',
+    ensureStage: true,
+    createStage(payload) {
+      created.push(payload)
+      return Promise.resolve({ id: payload.id })
+    },
+    getDisplays: () => displays,
+    sendStageMessage() {},
+  })
+
+  controller.start({ frame: [100, 80, 500, 360] })
+  await Promise.resolve()
+
+  assert.equal(created.length, 1)
+  assert.equal(created[0].id, 'stage-start-test')
+  assert.equal(created[0].surface, 'desktop-world')
+})
+
 test('createDragController applies transfer release frame before fallback clamp', () => {
   let frame = [100, 80, 500, 360]
   const updates = []
   const states = []
+  const moves = []
   const transferController = createPanelTransferController({
     enabled: true,
     layerId: 'outline',
@@ -98,6 +156,7 @@ test('createDragController applies transfer release frame before fallback clamp'
       updates.push(nextFrame)
     },
     move(screenX, screenY, offsetX, offsetY) {
+      moves.push({ screenX, screenY, offsetX, offsetY })
       frame = [screenX - offsetX, screenY - offsetY, frame[2], frame[3]]
     },
     clampOnEnd: true,
@@ -109,10 +168,42 @@ test('createDragController applies transfer release frame before fallback clamp'
 
   controller.start({ pointerId: 1, clientX: 80, clientY: 20 })
   controller.move({ pointerId: 1, screenX: 1500, screenY: 40 })
+  assert.deepEqual(moves, [])
   controller.end()
 
   assert.deepEqual(updates.at(-1), [1440, 20, 500, 360])
   assert.deepEqual(frame, [1440, 20, 500, 360])
   assert.equal(states.find((state) => state.phase === 'move')?.transferActive, true)
   assert.equal(states.at(-1)?.transferActive, false)
+})
+
+test('createDragController resumes direct drag once the destination display can contain the panel', () => {
+  let frame = [100, 80, 500, 360]
+  const moves = []
+  const transferController = createPanelTransferController({
+    enabled: true,
+    layerId: 'outline',
+    getDisplays: () => displays,
+    sendStageMessage() {},
+  })
+  const controller = createDragController({
+    getFrame: () => frame,
+    getWorkArea: () => [1440, 0, 1280, 900],
+    updateFrame(nextFrame) {
+      frame = nextFrame
+    },
+    move(screenX, screenY, offsetX, offsetY) {
+      moves.push({ screenX, screenY, offsetX, offsetY })
+      frame = [screenX - offsetX, screenY - offsetY, frame[2], frame[3]]
+    },
+    clampOnEnd: true,
+    transferController,
+  })
+
+  controller.start({ pointerId: 1, clientX: 80, clientY: 20 })
+  controller.move({ pointerId: 1, screenX: 1600, screenY: 80 })
+  controller.end()
+
+  assert.deepEqual(moves, [{ screenX: 1600, screenY: 80, offsetX: 80, offsetY: 20 }])
+  assert.deepEqual(frame, [1520, 60, 500, 360])
 })

--- a/tests/toolkit/split-pane-layout.test.mjs
+++ b/tests/toolkit/split-pane-layout.test.mjs
@@ -234,6 +234,7 @@ test('createSplitPane wires existing panes with separator semantics and restored
     endSize: 400,
     availableSize: 1000,
     closedPane: null,
+    closedSize: 0,
   });
 });
 
@@ -298,6 +299,7 @@ test('split pane can close and reopen a sidebar while preserving prior ratio', (
   assert.equal(closed.closedPane, 'end');
   assert.equal(closed.startSize, 808);
   assert.equal(closed.endSize, 0);
+  assert.equal(closed.closedSize, 0);
   assert.equal(split.endPane.hidden, true);
   assert.equal(split.divider.hidden, true);
   assert.equal(split.isPaneOpen('end'), false);
@@ -308,11 +310,55 @@ test('split pane can close and reopen a sidebar while preserving prior ratio', (
   assert.equal(reopened.closedPane, null);
   assert.equal(reopened.startSize, 440);
   assert.equal(reopened.endSize, 360);
+  assert.equal(reopened.closedSize, 0);
   assert.equal(split.endPane.hidden, false);
   assert.equal(split.divider.hidden, false);
   assert.equal(split.isPaneOpen('end'), true);
   assert.equal(split.root.dataset.closedPane, undefined);
   assert.deepEqual(changes.map((state) => state.closedPane), ['end', null]);
+});
+
+test('split pane can collapse sidebars to fixed accordion rails', () => {
+  const documentRef = new FakeDocument();
+  const horizontal = createSplitPane({
+    document: documentRef,
+    initialRatio: 0.5,
+    minStart: 120,
+    minEnd: 160,
+    dividerSize: 8,
+    closedEndSize: 52,
+  });
+  horizontal.root.rect = { left: 0, top: 0, width: 808, height: 500 };
+  horizontal.setRatio(0.5, { notify: false, persist: false });
+
+  const closedEnd = horizontal.closePane('end');
+  assert.equal(horizontal.root.dataset.collapseMode, 'accordion');
+  assert.equal(horizontal.root.dataset.closedPane, 'end');
+  assert.equal(horizontal.root.dataset.closedSize, '52');
+  assert.equal(closedEnd.startSize, 756);
+  assert.equal(closedEnd.endSize, 52);
+  assert.equal(closedEnd.closedSize, 52);
+  assert.equal(horizontal.endPane.hidden, false);
+  assert.equal(horizontal.divider.hidden, true);
+
+  const vertical = createSplitPane({
+    document: documentRef,
+    orientation: 'vertical',
+    initialRatio: 0.5,
+    dividerSize: 8,
+    closedStartSize: 44,
+  });
+  vertical.root.rect = { left: 0, top: 0, width: 800, height: 608 };
+  vertical.setRatio(0.5, { notify: false, persist: false });
+
+  const closedStart = vertical.closePane('start');
+  assert.equal(vertical.root.dataset.collapseMode, 'accordion');
+  assert.equal(vertical.root.dataset.closedPane, 'start');
+  assert.equal(closedStart.startSize, 44);
+  assert.equal(closedStart.endSize, 564);
+  assert.equal(closedStart.closedSize, 44);
+  assert.equal(vertical.startPane.hidden, false);
+  assert.equal(vertical.divider.hidden, true);
 });
 
 test('SplitPane layout mounts two content factories into start and end panes', async (t) => {

--- a/tests/toolkit/workbench-shell.test.mjs
+++ b/tests/toolkit/workbench-shell.test.mjs
@@ -10,6 +10,9 @@ async function repoText(path) {
 
 test('workbench defaults define shell, toolbar, and pane primitives', async () => {
   const css = await repoText('packages/toolkit/workbench/defaults.css');
+  const panelCss = await repoText('packages/toolkit/panel/defaults.css');
+  const panelChrome = await repoText('packages/toolkit/panel/chrome.js');
+  const themeCss = await repoText('packages/toolkit/components/_base/theme.css');
 
   for (const selector of [
     '.aos-workbench-shell',
@@ -23,6 +26,10 @@ test('workbench defaults define shell, toolbar, and pane primitives', async () =
   ]) {
     assert.match(css, new RegExp(`${selector.replace('.', '\\.')}\\s*\\{`));
   }
+  assert.match(panelChrome, /aos-panel-grip/);
+  assert.match(panelCss, /\.aos-panel-grip\s*\{/);
+  assert.match(themeCss, /--bg-panel:\s*rgba\(5,\s*10,\s*14,\s*0\.96\)/);
+  assert.match(themeCss, /--accent-blue:\s*#7af1ff/);
 });
 
 test('Sigil radial item workbench keeps editor controls out of titlebar chrome', async () => {


### PR DESCRIPTION
## Summary

- scope Sigil/AOS content roots so worktree sessions can load the branch-local surface bundle instead of stale main-root files
- unify toolkit panel/window placement helpers and apply them to shared chrome paths
- capture the panel window placement contract and remaining private-drag migration work in docs

## Handoff Notes

This branch is intentionally a convergence slice, not a final windowing-system rewrite. The latest architectural insight is secured in `docs/design/aos-panel-window-placement-contract.md` and tracked by #261.

The remaining work is to migrate or wrap private drag/chrome paths such as Agent Terminal, Sigil chat, older radial editors, minimized chips, and daemon drag-end finalization so they all route through one toolkit placement policy.

## Verification

- `node --test tests/toolkit/canvas-inspector.test.mjs tests/toolkit/panel-chrome.test.mjs tests/toolkit/panel-drag-transfer.test.mjs tests/toolkit/markdown-workbench-layout.test.mjs tests/toolkit/split-pane-layout.test.mjs tests/toolkit/workbench-shell.test.mjs` passed: 51/51
- broader toolkit/renderer test run earlier in this branch passed: 176/176
- live AOS display checks were used during the layout/placement pass; final cross-display behavior still needs human visual sign-off after the remaining migration in #261
