### PR TITLE
Sigil Agent Terminal uses toolkit panel chrome

### DIFF
--- a/apps/sigil/AGENTS.md
+++ b/apps/sigil/AGENTS.md
@@ -60,7 +60,7 @@ doc lands at `~/.config/aos/{mode}/wiki/sigil/agents/default.md`.
 | `agent-terminal/` | Canonical Agent Terminal entrypoint. Launch with `apps/sigil/agent-terminal/launch.sh`; the implementation currently delegates through the historical `codex-terminal/` path for compatibility. |
 | `codex-terminal/` | Compatibility implementation path for the Agent Terminal evolved from the Codex-only MVP. A Sigil canvas fronts a named tmux session through a dependency-free local bridge, lists local Codex/Claude Code sessions, and resumes provider CLI commands into the terminal carrier. tmux is preferred for durable resume/reattach, with a process fallback for machines without tmux. |
 | `studio/` | Historical URL/path for the avatar configuration surface. Do not use the old product name in new user-facing copy. |
-| `chat/` | Bidirectional conversational canvas (see Chat Canvas Protocol below). |
+| `chat/` | Legacy conversational canvas prototype. Do not extend it as the product chat path; a future Sigil Chat 2 should be rebuilt from Agent Terminal/toolkit primitives instead. See Chat Canvas Legacy Notes below. |
 | `workbench/` | Historical multi-tab surface. Do not use as the standard launch or verification path for current Sigil work unless the task explicitly targets that surface. |
 | `renderer/hit-area.html` | Minimal interactive child canvas the renderer spawns at the avatar's position so clicks/drags on the dot land somewhere while the parent canvas stays click-through. Exposes the avatar as an AOS semantic target via `aos see capture --canvas <hit-id> --xray`. |
 | `renderer/radial-menu-surface.html` | Minimal interactive child canvas the renderer spawns around live radial-menu items so `aos see capture --canvas <radial-id> --xray` can discover labeled item targets and `aos do` can act on them. |
@@ -151,9 +151,25 @@ the singleton daemon without loading each other's HTML, JS, or CSS.
 - **AOS daemon** (`aos serve`) — canvas management, IPC, pub/sub, content server
 - **Three.js r128** — 3D rendering engine. Vendored at `renderer/vendor/three.min.js` (loaded by `renderer/index.html` and `tests/appearance-roundtrip.html`). No CDN at boot.
 
-## Chat Canvas Protocol
+## Chat Canvas Legacy Notes
 
-The chat canvas (`chat/index.html`) is a bidirectional conversational surface. Agents project into it — the canvas does not run its own Claude API client.
+The historical chat canvas (`chat/index.html`) is a bidirectional conversational
+prototype. Agents projected into it; the canvas did not run its own Claude API
+client. That surface is superseded for current product work by the Agent
+Terminal direction.
+
+Do not keep evolving `apps/sigil/chat/` as a second, competing shell. If Sigil
+needs a chat-native surface again, build "Sigil Chat 2" as a new consumer of
+the shared pieces extracted for Agent Terminal:
+
+- toolkit panel/window chrome;
+- fixed sidebar or split-pane primitives;
+- session catalog and provider adapter plumbing;
+- shared transcript/message rendering if and when that becomes a durable
+  contract.
+
+The legacy protocol below is kept only so agents can understand old canvases,
+tests, and archived plans without mistaking them for the forward path.
 
 ### Sending to canvas
 

--- a/apps/sigil/codex-terminal/index.html
+++ b/apps/sigil/codex-terminal/index.html
@@ -21,27 +21,12 @@
     }
     .shell {
       position: relative;
-      height: 100vh;
+      height: 100%;
       display: grid;
-      grid-template-rows: 42px 1fr;
+      grid-template-rows: 1fr;
       background: rgba(8, 11, 13, 0.99);
-      border: 1px solid rgba(255,255,255,0.14);
-      border-radius: 10px;
-      box-shadow: 0 18px 56px rgba(0,0,0,0.42);
       overflow: hidden;
     }
-    .header {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      padding: 0 12px;
-      border-bottom: 1px solid rgba(255,255,255,0.1);
-      background: rgba(34, 38, 42, 0.92);
-      cursor: grab;
-      user-select: none;
-      -webkit-user-select: none;
-    }
-    .header:active { cursor: grabbing; }
     .avatar {
       position: relative;
       width: 22px;
@@ -58,26 +43,6 @@
       content: "";
       display: none;
     }
-    .title {
-      min-width: 0;
-      display: flex;
-      flex-direction: column;
-      gap: 1px;
-      flex: 1;
-    }
-    .title strong {
-      font-size: 13px;
-      font-weight: 650;
-      line-height: 1.1;
-    }
-    .title span {
-      overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      color: #9aa6ad;
-      font-size: 11px;
-      line-height: 1.1;
-    }
     .status {
       width: 8px;
       height: 8px;
@@ -87,46 +52,6 @@
     }
     .status.ready { background: #32d583; }
     .status.error { background: #ff5f57; }
-    .window-controls {
-      flex: 0 0 auto;
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      margin-left: 2px;
-    }
-    .window-button {
-      appearance: none;
-      width: 28px;
-      height: 26px;
-      display: inline-grid;
-      place-items: center;
-      border: 1px solid rgba(255,255,255,0.13);
-      border-radius: 7px;
-      background: rgba(255,255,255,0.045);
-      color: #d7e0e4;
-      cursor: pointer;
-      font-size: 12px;
-      font-weight: 750;
-      line-height: 1;
-    }
-    .window-button:hover {
-      background: rgba(255,255,255,0.09);
-      border-color: rgba(255,255,255,0.2);
-    }
-    .window-button:focus-visible {
-      outline: 2px solid rgba(137,220,235,0.78);
-      outline-offset: 2px;
-    }
-    .window-button.close:hover {
-      border-color: rgba(255, 95, 87, 0.7);
-      background: rgba(120, 32, 32, 0.58);
-      color: #fff;
-    }
-    .window-button.minimize:hover {
-      border-color: rgba(255, 209, 102, 0.68);
-      background: rgba(99, 72, 20, 0.52);
-      color: #fff;
-    }
     .content {
       min-height: 0;
       display: grid;
@@ -404,18 +329,6 @@
 </head>
 <body>
   <main class="shell" id="shell">
-    <header class="header" id="dragHandle">
-      <button class="avatar" id="avatarButton" title="Return to avatar" aria-label="Return to avatar"></button>
-      <div class="title">
-        <strong>Sigil</strong>
-        <span id="subtitle">Agent terminal</span>
-      </div>
-      <span class="status" id="status"></span>
-      <span class="window-controls" aria-label="Agent terminal window controls">
-        <button class="window-button minimize" id="minimizeTerminal" type="button" aria-label="Minimize terminal to avatar" title="Minimize">-</button>
-        <button class="window-button close" id="closeTerminal" type="button" aria-label="Close agent terminal" title="Close">x</button>
-      </span>
-    </header>
     <section class="content">
       <section class="terminal-wrap" aria-label="Agent terminal pane">
         <div id="terminal"></div>
@@ -457,23 +370,59 @@
 
   <script src="./node_modules/@xterm/xterm/lib/xterm.js"></script>
   <script src="./node_modules/@xterm/addon-fit/lib/addon-fit.js"></script>
-  <script>
+  <script type="module">
+    import { toolkitSpecifier, toolkitUrl } from '../renderer/live-modules/content-roots.js';
+
+    for (const href of [
+      toolkitUrl('components/_base/theme.css'),
+      toolkitUrl('panel/defaults.css'),
+    ]) {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = href;
+      document.head.append(link);
+    }
+
+    const { mountChrome } = await import(toolkitSpecifier('panel/index.js', {
+      local: '../../../../packages/toolkit/panel/index.js',
+    }));
+
     const params = new URLSearchParams(location.search);
     const port = params.get('port') || '17761';
     const session = params.get('session') || 'sigil-agent-terminal-agent-os';
     let currentCwd = params.get('cwd') || '';
     let activeLabel = 'Agent terminal';
     const shell = document.getElementById('shell');
-    const subtitle = document.getElementById('subtitle');
-    const statusDot = document.getElementById('status');
+    const chrome = mountChrome(document.body, {
+      title: 'Sigil / Agent Terminal',
+      draggable: true,
+      drag: { clampOnEnd: true, transfer: true },
+      close: true,
+      minimize: true,
+      maximize: true,
+      resizable: true,
+      resize: { minWidth: 720, minHeight: 420 },
+      onMinimize() {
+        emit({ type: 'agent_terminal.avatar_toggle' });
+      },
+    });
+    chrome.contentEl.append(shell);
+
+    const avatarButton = document.createElement('button');
+    avatarButton.type = 'button';
+    avatarButton.className = 'avatar';
+    avatarButton.title = 'Return to avatar';
+    avatarButton.setAttribute('aria-label', 'Return to avatar');
+    const statusDot = document.createElement('span');
+    statusDot.className = 'status';
+    statusDot.id = 'status';
+    chrome.customControlsEl.append(avatarButton, statusDot);
+
     const sessionList = document.getElementById('sessionList');
     const sessionInspector = document.getElementById('sessionInspector');
     const providerFilter = document.getElementById('providerFilter');
     const sessionSort = document.getElementById('sessionSort');
     const railToggle = document.getElementById('railToggle');
-    let dragging = false;
-    let dragOffsetX = 0;
-    let dragOffsetY = 0;
     let terminal = null;
     let fitAddon = null;
     let socket = null;
@@ -493,7 +442,7 @@
 
     function setStatus(kind, text) {
       statusDot.className = `status ${kind || ''}`;
-      subtitle.textContent = text;
+      chrome.setTitle(`Sigil / Agent Terminal - ${text}`);
     }
 
     function resizeTerminal() {
@@ -953,54 +902,18 @@
       scheduleRefit();
     });
 
-    document.getElementById('avatarButton').addEventListener('click', (event) => {
+    avatarButton.addEventListener('click', (event) => {
       event.preventDefault();
       event.stopPropagation();
       emit({ type: 'agent_terminal.avatar_toggle' });
-    });
-
-    document.getElementById('minimizeTerminal').addEventListener('click', (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      emit({ type: 'agent_terminal.avatar_toggle' });
-    });
-
-    document.getElementById('closeTerminal').addEventListener('click', (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      emit({ type: 'close' });
-    });
-
-    document.getElementById('dragHandle').addEventListener('mousedown', (event) => {
-      if (event.target.closest('button, select')) return;
-      dragging = true;
-      dragOffsetX = event.clientX;
-      dragOffsetY = event.clientY;
-      emit({ type: 'drag_start', offsetX: dragOffsetX, offsetY: dragOffsetY });
-      event.preventDefault();
-    });
-
-    document.addEventListener('mousemove', (event) => {
-      if (!dragging) return;
-      emit({
-        type: 'move_abs',
-        screenX: event.screenX,
-        screenY: event.screenY,
-        offsetX: dragOffsetX,
-        offsetY: dragOffsetY,
-      });
-    });
-
-    document.addEventListener('mouseup', () => {
-      if (!dragging) return;
-      dragging = false;
-      emit({ type: 'drag_end' });
     });
 
     window.addEventListener('resize', resizeTerminal);
     new ResizeObserver(scheduleRefit).observe(document.getElementById('terminal'));
     window.headsup = window.headsup || {};
+    const previousHeadsupReceive = window.headsup.receive;
     window.headsup.receive = function receive(b64) {
+      previousHeadsupReceive?.(b64);
       let msg = null;
       try { msg = JSON.parse(atob(b64)); } catch (_) {}
       if (msg?.type === 'lifecycle' && msg.action === 'resume') {
@@ -1026,7 +939,7 @@
       payload: {
         name: 'agent-terminal',
         accepts: ['keyboard', 'agent_terminal.refresh_sessions'],
-        emits: ['ready', 'close', 'drag_start', 'move_abs', 'drag_end'],
+        emits: ['ready', 'agent_terminal.avatar_toggle'],
       },
     });
 

--- a/apps/sigil/codex-terminal/index.html
+++ b/apps/sigil/codex-terminal/index.html
@@ -54,12 +54,7 @@
     .status.error { background: #ff5f57; }
     .content {
       min-height: 0;
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) 340px;
       background: #050708;
-    }
-    .shell.rail-collapsed .content {
-      grid-template-columns: minmax(0, 1fr) 42px;
     }
     .terminal-wrap {
       min-width: 0;
@@ -126,8 +121,8 @@
       gap: 8px;
       padding: 8px;
     }
-    .shell.rail-collapsed .rail-title,
-    .shell.rail-collapsed .rail-content {
+    .content[data-sidebar-open="false"] .rail-title,
+    .content[data-sidebar-open="false"] .rail-content {
       display: none;
     }
     .new-actions {
@@ -383,7 +378,7 @@
       document.head.append(link);
     }
 
-    const { mountChrome } = await import(toolkitSpecifier('panel/index.js', {
+    const { createFixedSidebarPane, mountChrome } = await import(toolkitSpecifier('panel/index.js', {
       local: '../../../../packages/toolkit/panel/index.js',
     }));
 
@@ -407,6 +402,9 @@
       },
     });
     chrome.contentEl.append(shell);
+    const content = shell.querySelector('.content');
+    const terminalPane = shell.querySelector('.terminal-wrap');
+    const railPane = shell.querySelector('.rail');
 
     const avatarButton = document.createElement('button');
     avatarButton.type = 'button';
@@ -423,6 +421,22 @@
     const providerFilter = document.getElementById('providerFilter');
     const sessionSort = document.getElementById('sessionSort');
     const railToggle = document.getElementById('railToggle');
+    const railController = createFixedSidebarPane({
+      root: content,
+      mainPane: terminalPane,
+      sidebarPane: railPane,
+      toggleButton: railToggle,
+      side: 'end',
+      openSize: 340,
+      closedSize: 42,
+      minMain: 360,
+      dividerSize: 0,
+      expandedLabel: 'Collapse sessions rail',
+      collapsedLabel: 'Expand sessions rail',
+      onChange() {
+        scheduleRefit();
+      },
+    });
     let terminal = null;
     let fitAddon = null;
     let socket = null;
@@ -893,14 +907,6 @@
     });
 
     sessionSort.addEventListener('change', renderSessions);
-
-    railToggle.addEventListener('click', () => {
-      const collapsed = shell.classList.toggle('rail-collapsed');
-      railToggle.textContent = collapsed ? '<' : '>';
-      railToggle.setAttribute('aria-expanded', String(!collapsed));
-      railToggle.setAttribute('aria-label', collapsed ? 'Expand sessions rail' : 'Collapse sessions rail');
-      scheduleRefit();
-    });
 
     avatarButton.addEventListener('click', (event) => {
       event.preventDefault();

--- a/docs/design/aos-panel-window-placement-contract.md
+++ b/docs/design/aos-panel-window-placement-contract.md
@@ -122,8 +122,9 @@ The next implementable slice should be small and testable:
 
 - one public toolkit API for panel/window placement policy;
 - minimized chip restore routed through that API;
-- Agent Terminal and Sigil chat migrated off private drag/chrome or wrapped by
-  the shared controller;
+- Agent Terminal migrated off private drag/chrome;
+- legacy Sigil chat marked parked, with any future "Sigil Chat 2" rebuilt from
+  Agent Terminal/toolkit primitives instead of extending the old private shell;
 - tests covering stacked displays, side-by-side displays, mixed-DPI displays,
   off-left/off-right/off-bottom drops, minimize/restore across displays, and
   maximize work-area clamping;

--- a/packages/toolkit/panel/defaults.css
+++ b/packages/toolkit/panel/defaults.css
@@ -277,6 +277,29 @@
   background: rgba(122, 241, 255, 0.18);
 }
 
+.aos-fixed-sidebar {
+  background: var(--bg-panel-content, transparent);
+}
+
+.aos-fixed-sidebar-main,
+.aos-fixed-sidebar-pane {
+  min-width: 0;
+  min-height: 0;
+}
+
+.aos-fixed-sidebar-pane {
+  border-color: var(--border-subtle, rgba(122, 241, 255, 0.18));
+  background: var(--bg-panel-sidebar, rgba(9, 17, 21, 0.88));
+}
+
+.aos-fixed-sidebar[data-sidebar-side="end"] > .aos-fixed-sidebar-pane {
+  border-left: 1px solid var(--border-subtle, rgba(122, 241, 255, 0.18));
+}
+
+.aos-fixed-sidebar[data-sidebar-side="start"] > .aos-fixed-sidebar-pane {
+  border-right: 1px solid var(--border-subtle, rgba(122, 241, 255, 0.18));
+}
+
 .aos-tabs {
   display: flex;
   align-items: center;

--- a/packages/toolkit/panel/index.js
+++ b/packages/toolkit/panel/index.js
@@ -56,6 +56,7 @@ export {
 export { Single } from './layouts/single.js'
 export {
   clampSplitPaneState,
+  createFixedSidebarPane,
   createSplitPane,
   SplitPane,
 } from './layouts/split-pane.js'

--- a/packages/toolkit/panel/layouts/split-pane.js
+++ b/packages/toolkit/panel/layouts/split-pane.js
@@ -443,6 +443,119 @@ export function createSplitPane({
   }
 }
 
+export function createFixedSidebarPane({
+  root = null,
+  mainPane = null,
+  sidebarPane = null,
+  toggleButton = null,
+  document: documentRef = null,
+  side = 'end',
+  openSize = 340,
+  closedSize = 42,
+  minMain = 320,
+  dividerSize = 0,
+  storageKey = '',
+  storage = null,
+  initiallyOpen = true,
+  ariaLabel = 'Resize main and sidebar panes',
+  expandedLabel = 'Collapse sidebar',
+  collapsedLabel = 'Expand sidebar',
+  expandedText = '>',
+  collapsedText = '<',
+  onChange = null,
+} = {}) {
+  const doc = documentRef || root?.ownerDocument || globalThis.document
+  if (!doc?.createElement) throw new Error('createFixedSidebarPane: document with createElement is required')
+
+  const sidebarSide = side === 'start' ? 'start' : 'end'
+  const rootEl = root || doc.createElement('div')
+  const mainEl = mainPane || doc.createElement('section')
+  const sidebarEl = sidebarPane || doc.createElement('aside')
+  const rootSize = positiveNumber(rootEl.getBoundingClientRect?.().width, 1000)
+  const sidebarOpenSize = positiveNumber(openSize, 340)
+  const sidebarClosedSize = Math.max(0, finiteNumber(closedSize, 42))
+  const mainMin = Math.max(1, finiteNumber(minMain, 320))
+  const initialMainSize = Math.max(mainMin, rootSize - sidebarOpenSize - Math.max(0, finiteNumber(dividerSize, 0)))
+  const initialRatio = sidebarSide === 'start'
+    ? sidebarOpenSize / rootSize
+    : initialMainSize / rootSize
+
+  const split = createSplitPane({
+    root: rootEl,
+    startPane: sidebarSide === 'start' ? sidebarEl : mainEl,
+    endPane: sidebarSide === 'start' ? mainEl : sidebarEl,
+    document: doc,
+    orientation: 'horizontal',
+    initialRatio,
+    storage,
+    storageKey,
+    dividerSize,
+    minStart: sidebarSide === 'start' ? sidebarOpenSize : mainMin,
+    maxStart: sidebarSide === 'start' ? sidebarOpenSize : Infinity,
+    minEnd: sidebarSide === 'start' ? mainMin : sidebarOpenSize,
+    maxEnd: sidebarSide === 'start' ? Infinity : sidebarOpenSize,
+    closedStartSize: sidebarSide === 'start' ? sidebarClosedSize : 0,
+    closedEndSize: sidebarSide === 'end' ? sidebarClosedSize : 0,
+    ariaLabel,
+    onChange(state) {
+      syncSidebarState()
+      onChange?.(state)
+    },
+  })
+
+  addClass(rootEl, 'aos-fixed-sidebar')
+  addClass(sidebarEl, 'aos-fixed-sidebar-pane')
+  addClass(mainEl, 'aos-fixed-sidebar-main')
+  rootEl.dataset.sidebarSide = sidebarSide
+
+  const toggleHandler = () => toggleSidebar()
+  if (toggleButton) {
+    toggleButton.setAttribute('type', toggleButton.getAttribute?.('type') || 'button')
+    toggleButton.addEventListener('click', toggleHandler)
+  }
+
+  function syncSidebarState() {
+    const open = split.isPaneOpen(sidebarSide)
+    rootEl.dataset.sidebarOpen = String(open)
+    sidebarEl.dataset.sidebarOpen = String(open)
+    if (toggleButton) {
+      toggleButton.textContent = open ? expandedText : collapsedText
+      toggleButton.setAttribute('aria-expanded', String(open))
+      toggleButton.setAttribute('aria-label', open ? expandedLabel : collapsedLabel)
+      toggleButton.title = open ? expandedLabel : collapsedLabel
+    }
+    return open
+  }
+
+  function setSidebarOpen(open, options = {}) {
+    const result = open ? split.openPane(sidebarSide, options) : split.closePane(sidebarSide, options)
+    syncSidebarState()
+    return result
+  }
+
+  function toggleSidebar(options = {}) {
+    return setSidebarOpen(!split.isPaneOpen(sidebarSide), options)
+  }
+
+  setSidebarOpen(Boolean(initiallyOpen), { notify: false, persist: false })
+
+  return {
+    ...split,
+    mainPane: mainEl,
+    sidebarPane: sidebarEl,
+    toggleButton,
+    getSidebarOpen() {
+      return split.isPaneOpen(sidebarSide)
+    },
+    setSidebarOpen,
+    toggleSidebar,
+    destroy() {
+      if (toggleButton) toggleButton.removeEventListener?.('click', toggleHandler)
+      split.destroy()
+    },
+  }
+}
+
 export function SplitPane(startFactory, endFactory, options = {}) {
   if (!startFactory || !endFactory) {
     throw new Error('SplitPane: requires start and end content factories')

--- a/tests/renderer/agent-terminal-chrome.test.mjs
+++ b/tests/renderer/agent-terminal-chrome.test.mjs
@@ -7,6 +7,7 @@ const html = readFileSync(new URL('../../apps/sigil/codex-terminal/index.html', 
 test('Agent Terminal opts into toolkit panel chrome', () => {
   assert.match(html, /import \{ toolkitSpecifier, toolkitUrl \}/)
   assert.match(html, /await import\(toolkitSpecifier\('panel\/index\.js'/)
+  assert.match(html, /createFixedSidebarPane/)
   assert.match(html, /mountChrome\(document\.body/)
   assert.match(html, /draggable:\s*true/)
   assert.match(html, /minimize:\s*true/)
@@ -22,6 +23,18 @@ test('Agent Terminal no longer owns private drag or close controls', () => {
   assert.doesNotMatch(html, /type:\s*'move_abs'/)
   assert.doesNotMatch(html, /addEventListener\('mousemove'/)
   assert.doesNotMatch(html, /addEventListener\('mouseup'/)
+})
+
+test('Agent Terminal sessions rail uses toolkit fixed sidebar behavior', () => {
+  assert.match(html, /createFixedSidebarPane\(\{/)
+  assert.match(html, /root:\s*content/)
+  assert.match(html, /mainPane:\s*terminalPane/)
+  assert.match(html, /sidebarPane:\s*railPane/)
+  assert.match(html, /toggleButton:\s*railToggle/)
+  assert.match(html, /openSize:\s*340/)
+  assert.match(html, /closedSize:\s*42/)
+  assert.doesNotMatch(html, /classList\.toggle\('rail-collapsed'\)/)
+  assert.doesNotMatch(html, /shell\.rail-collapsed/)
 })
 
 test('Agent Terminal keeps avatar-toggle minimize behavior as a toolkit override', () => {

--- a/tests/renderer/agent-terminal-chrome.test.mjs
+++ b/tests/renderer/agent-terminal-chrome.test.mjs
@@ -4,20 +4,32 @@ import assert from 'node:assert/strict'
 
 const html = readFileSync(new URL('../../apps/sigil/codex-terminal/index.html', import.meta.url), 'utf8')
 
-test('Agent Terminal exposes direct window controls', () => {
-  assert.match(html, /id="minimizeTerminal"/)
-  assert.match(html, /aria-label="Minimize terminal to avatar"/)
-  assert.match(html, /id="closeTerminal"/)
-  assert.match(html, /aria-label="Close agent terminal"/)
-  assert.match(html, /class="window-controls"/)
+test('Agent Terminal opts into toolkit panel chrome', () => {
+  assert.match(html, /import \{ toolkitSpecifier, toolkitUrl \}/)
+  assert.match(html, /await import\(toolkitSpecifier\('panel\/index\.js'/)
+  assert.match(html, /mountChrome\(document\.body/)
+  assert.match(html, /draggable:\s*true/)
+  assert.match(html, /minimize:\s*true/)
+  assert.match(html, /maximize:\s*true/)
+  assert.match(html, /resizable:\s*true/)
+  assert.match(html, /drag:\s*\{\s*clampOnEnd:\s*true,\s*transfer:\s*true\s*\}/)
 })
 
-test('Agent Terminal close button uses the daemon close protocol', () => {
-  assert.match(html, /getElementById\('closeTerminal'\)\.addEventListener\('click'/)
-  assert.match(html, /emit\(\{\s*type:\s*'close'\s*\}\)/)
+test('Agent Terminal no longer owns private drag or close controls', () => {
+  assert.doesNotMatch(html, /id="dragHandle"/)
+  assert.doesNotMatch(html, /id="minimizeTerminal"/)
+  assert.doesNotMatch(html, /id="closeTerminal"/)
+  assert.doesNotMatch(html, /type:\s*'move_abs'/)
+  assert.doesNotMatch(html, /addEventListener\('mousemove'/)
+  assert.doesNotMatch(html, /addEventListener\('mouseup'/)
 })
 
-test('Agent Terminal minimize button reuses the avatar toggle path', () => {
-  assert.match(html, /getElementById\('minimizeTerminal'\)\.addEventListener\('click'/)
+test('Agent Terminal keeps avatar-toggle minimize behavior as a toolkit override', () => {
+  assert.match(html, /onMinimize\(\)/)
   assert.match(html, /emit\(\{\s*type:\s*'agent_terminal\.avatar_toggle'\s*\}\)/)
+})
+
+test('Agent Terminal preserves toolkit bridge handlers when adding app messages', () => {
+  assert.match(html, /const previousHeadsupReceive = window\.headsup\.receive/)
+  assert.match(html, /previousHeadsupReceive\?\.\(b64\)/)
 })

--- a/tests/toolkit/split-pane-layout.test.mjs
+++ b/tests/toolkit/split-pane-layout.test.mjs
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   clampSplitPaneState,
+  createFixedSidebarPane,
   createSplitPane,
   SplitPane,
 } from '../../packages/toolkit/panel/layouts/split-pane.js';
@@ -359,6 +360,60 @@ test('split pane can collapse sidebars to fixed accordion rails', () => {
   assert.equal(closedStart.closedSize, 44);
   assert.equal(vertical.startPane.hidden, false);
   assert.equal(vertical.divider.hidden, true);
+});
+
+test('fixed sidebar pane presets split constraints and toggle semantics', () => {
+  const documentRef = new FakeDocument();
+  const root = documentRef.createElement('main');
+  const mainPane = documentRef.createElement('section');
+  const sidebarPane = documentRef.createElement('aside');
+  const toggleButton = documentRef.createElement('button');
+  root.appendChild(mainPane);
+  root.appendChild(sidebarPane);
+  root.rect = { left: 0, top: 0, width: 1000, height: 640 };
+
+  const changes = [];
+  const sidebar = createFixedSidebarPane({
+    root,
+    mainPane,
+    sidebarPane,
+    toggleButton,
+    document: documentRef,
+    side: 'end',
+    openSize: 340,
+    closedSize: 42,
+    minMain: 360,
+    dividerSize: 0,
+    onChange(state) {
+      changes.push(state);
+    },
+  });
+
+  assert.equal(root.classList.contains('aos-fixed-sidebar'), true);
+  assert.equal(mainPane.classList.contains('aos-fixed-sidebar-main'), true);
+  assert.equal(sidebarPane.classList.contains('aos-fixed-sidebar-pane'), true);
+  assert.equal(root.dataset.sidebarSide, 'end');
+  assert.equal(root.dataset.sidebarOpen, 'true');
+  assert.equal(toggleButton.getAttribute('aria-label'), 'Collapse sidebar');
+  assert.equal(toggleButton.textContent, '>');
+  assert.equal(sidebar.getState().startSize, 660);
+  assert.equal(sidebar.getState().endSize, 340);
+
+  toggleButton.dispatch('click');
+
+  assert.equal(root.dataset.sidebarOpen, 'false');
+  assert.equal(sidebarPane.dataset.sidebarOpen, 'false');
+  assert.equal(toggleButton.getAttribute('aria-label'), 'Expand sidebar');
+  assert.equal(toggleButton.textContent, '<');
+  assert.equal(sidebar.getState().startSize, 958);
+  assert.equal(sidebar.getState().endSize, 42);
+  assert.equal(sidebar.divider.hidden, true);
+  assert.equal(changes.at(-1).closedPane, 'end');
+
+  sidebar.setSidebarOpen(true);
+  assert.equal(root.dataset.sidebarOpen, 'true');
+  assert.equal(sidebar.getSidebarOpen(), true);
+  assert.equal(sidebar.getState().endSize, 340);
 });
 
 test('SplitPane layout mounts two content factories into start and end panes', async (t) => {


### PR DESCRIPTION
## Summary

- routes Sigil Agent Terminal through shared toolkit panel chrome
- removes Agent Terminal's private titlebar, private window buttons, and raw document-level drag/move handlers
- keeps the Agent Terminal-specific avatar-toggle behavior as the panel minimize override
- preserves toolkit bridge handlers when Agent Terminal registers its own incoming message handler

## Scope

This is the first focused slice for #261. It migrates Agent Terminal off private drag/chrome behavior, but does not yet migrate Sigil chat, older radial editor paths, minimized chip internals, or daemon drag-end finalization.

## Verification

- `node --test tests/renderer/agent-terminal-chrome.test.mjs tests/toolkit/panel-chrome.test.mjs tests/toolkit/panel-drag-transfer.test.mjs`
- `git diff --check`
