### PR TITLE
Employer Brand Audit demo runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ packages/gateway/.env.local
 # Real @playwright/cli requires these paths to live under an allowed root
 # (CWD or ~/.playwright-cli); see src/browser/playwright-process.swift.
 .aos-browser-tmp/
+
+# Employer Brand Audit demo outputs
+Employer_Brand_Audit/artifacts/demo/
+Employer_Brand_Audit/scripts/report-data.generated.js

--- a/Employer_Brand_Audit/README-demo.md
+++ b/Employer_Brand_Audit/README-demo.md
@@ -1,0 +1,25 @@
+# Employer Brand Audit Demo Runner
+
+This is a narrow boss-demo harness for an automated Employer Brand Audit pass.
+It proves the loop without claiming final strategic analysis quality.
+
+Run:
+
+```sh
+node Employer_Brand_Audit/scripts/employer-brand-demo.mjs
+open Employer_Brand_Audit/demo.html
+```
+
+The runner:
+
+1. opens the configured public source URLs with Playwright,
+2. captures visible text, HTML, and screenshots,
+3. writes artifacts under `Employer_Brand_Audit/artifacts/demo/latest/`,
+4. generates `Employer_Brand_Audit/scripts/report-data.generated.js`, and
+5. renders the report through `Employer_Brand_Audit/demo.html`.
+
+The current default run compares Symphony Talent, Phenom, and Radancy using
+public homepage sources. It intentionally uses lightweight keyword-based KILOS
+classification so the demo is explainable and fast. A production workflow should
+add richer source manifests, retry/repair, human review gates, and stronger
+analysis before a client-facing deliverable.

--- a/Employer_Brand_Audit/demo.html
+++ b/Employer_Brand_Audit/demo.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Employer Brand Competitive Audit Demo</title>
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+  <script src="https://unpkg.com/@popperjs/core@2"></script>
+  <script src="https://unpkg.com/tippy.js@6"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@microlink/vanilla@latest/dist/microlink.min.js"></script>
+  <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
+  <script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>
+
+  <link rel="stylesheet" href="./styles/audit.css" />
+</head>
+<body x-data="brandAudit()" x-init="init()" class="antialiased bg-[--clr-slate]">
+  <div x-show="lightboxImage" x-transition @keydown.escape.window="lightboxImage = null" class="fixed inset-0 bg-black/80 flex items-center justify-center z-[9999] p-4" x-cloak>
+    <div @click.self="lightboxImage = null" class="absolute inset-0"></div>
+    <div x-show="lightboxImage" x-transition class="relative bg-white p-2 rounded-lg max-w-4xl max-h-[90vh] overflow-auto">
+      <img :src="lightboxImage" alt="Zoomed Evidence" class="max-w-none max-h-none">
+      <button @click="lightboxImage = null" class="absolute top-0 right-0 -mt-3 -mr-3 bg-white text-slate-800 rounded-full h-8 w-8 flex items-center justify-center text-2xl font-bold shadow-lg hover:scale-110 transition-transform">×</button>
+    </div>
+  </div>
+
+  <header id="main-header" class="bg-slate-900/80 backdrop-blur-lg sticky top-0 z-50 shadow-lg text-white">
+    <div class="container mx-auto px-4 md:px-8">
+      <nav class="flex justify-between items-center gap-4">
+        <div class="flex items-center space-x-4 md:space-x-6 -mb-px overflow-x-auto">
+          <button @click="setViewAndScroll('overview')" :class="{'border-b-2 border-[--clr-aqua] text-white': activeView === 'overview', 'text-slate-400 hover:text-white': activeView !== 'overview'}" class="py-4 font-bold transition-colors whitespace-nowrap">Overview</button>
+          <button @click="setViewAndScroll('summary')" :class="{'border-b-2 border-[--clr-aqua] text-white': activeView === 'summary', 'text-slate-400 hover:text-white': activeView !== 'summary'}" class="py-4 font-bold transition-colors whitespace-nowrap">Executive Summary</button>
+          <button @click="setViewAndScroll('competition')" :class="{'border-b-2 border-[--clr-aqua] text-white': activeView === 'competition', 'text-slate-400 hover:text-white': activeView !== 'competition'}" class="py-4 font-bold transition-colors whitespace-nowrap">Competition</button>
+          <button @click="setViewAndScroll('kilos', '#kilos-matrix')" :class="{'border-b-2 border-[--clr-aqua] text-white': activeView === 'kilos', 'text-slate-400 hover:text-white': activeView !== 'kilos'}" class="py-4 font-bold transition-colors whitespace-nowrap">KILOS</button>
+          <button @click="setViewAndScroll('deepdives', `#${slug(client.companyName)}`)" :class="{'border-b-2 border-[--clr-aqua] text-white': activeView === 'deepdives' && activeDeepDive === slug(client.companyName), 'text-slate-400 hover:text-white': activeView !== 'deepdives'}" class="py-4 font-bold transition-colors whitespace-nowrap" x-text="client.companyName || 'Client Company'"></button>
+        </div>
+        <a href="https://symphonytalent.com" target="_blank" rel="noopener" class="shrink-0">
+          <img :src="assetUrl(templateMeta.headerLogo, 'Symphony Talent Logo', 280, 72, '#08203E', '#FFFFFF')" alt="Symphony Talent Logo" class="h-8 object-contain">
+        </a>
+      </nav>
+    </div>
+    <div id="sub-nav-container" x-show="showDeepDiveNav" x-transition class="bg-slate-800/80 border-t border-slate-700">
+    </div>
+  </header>
+
+  <main class="flex-grow">
+    <section x-show="activeView === 'overview'" x-transition id="overview-view" class="h-[calc(100vh-60px)] min-h-[700px] bg-cover bg-center flex flex-col" x-cloak></section>
+    <section x-show="activeView === 'summary'" x-transition id="summary-view" class="min-h-[calc(100vh-60px)] bg-cover bg-center bg-fixed flex flex-col" x-cloak>
+      <div id="summary-content-wrapper" class="flex-grow flex items-center justify-center container mx-auto w-full px-4 md:px-8 py-8"></div>
+      <footer class="text-center p-4 bg-slate-900/50 text-white text-sm" x-text="templateMeta.footerText || 'Replace footer text in scripts/report-data.generated.js'"></footer>
+    </section>
+    <section x-show="activeView === 'competition' || activeView === 'kilos'" x-transition id="competition-view" class="min-h-[calc(100vh-60px)] bg-cover bg-center bg-fixed" x-cloak>
+      <div id="competition-content-wrapper" class="container mx-auto w-full px-4 md:px-8 py-8 space-y-8"></div>
+    </section>
+    <section x-show="activeView === 'deepdives'" x-transition id="deepdives-view" class="min-h-[calc(100vh-108px)] bg-cover bg-center bg-fixed" x-cloak>
+      <div id="deepdives-content-wrapper" class="container mx-auto w-full px-4 md:px-8 py-8 space-y-16"></div>
+    </section>
+  </main>
+
+  <script src="./scripts/report-data.generated.js"></script>
+  <script src="./scripts/app.js"></script>
+</body>
+</html>

--- a/Employer_Brand_Audit/run-demo.sh
+++ b/Employer_Brand_Audit/run-demo.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+node Employer_Brand_Audit/scripts/employer-brand-demo.mjs
+open Employer_Brand_Audit/demo.html

--- a/Employer_Brand_Audit/scripts/employer-brand-demo.mjs
+++ b/Employer_Brand_Audit/scripts/employer-brand-demo.mjs
@@ -1,0 +1,339 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import path from 'node:path'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const auditRoot = path.resolve(__dirname, '..')
+const generatedDataPath = path.join(auditRoot, 'scripts', 'report-data.generated.js')
+const latestArtifactDir = path.join(auditRoot, 'artifacts', 'demo', 'latest')
+
+const KILOS = {
+  Kinship: ['belong', 'culture', 'inclusive', 'diverse', 'community', 'team', 'collaboration', 'wellbeing', 'values'],
+  Impact: ['impact', 'purpose', 'mission', 'change', 'transform', 'innovation', 'customers', 'society', 'future'],
+  Lifestyle: ['benefits', 'flexible', 'remote', 'hybrid', 'balance', 'wellness', 'health', 'support', 'life'],
+  Opportunity: ['grow', 'growth', 'career', 'learning', 'develop', 'development', 'mobility', 'mentor', 'advance'],
+  Status: ['leader', 'award', 'recognized', 'global', 'trusted', 'reputation', 'industry', 'heritage', 'best'],
+}
+
+export const defaultRun = {
+  client: {
+    name: 'Symphony Talent',
+    urls: ['https://www.symphonytalent.com/'],
+  },
+  competitors: [
+    { name: 'Phenom', urls: ['https://www.phenom.com/'] },
+    { name: 'Radancy', urls: ['https://www.radancy.com/en/'] },
+  ],
+}
+
+function slug(text) {
+  return String(text || 'unknown')
+    .toLowerCase()
+    .replace(/&/g, 'and')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'unknown'
+}
+
+function cleanText(text, max = 900) {
+  return String(text || '')
+    .replace(/\s+/g, ' ')
+    .replace(/[^\S\r\n]+/g, ' ')
+    .trim()
+    .slice(0, max)
+}
+
+function scoreDimension(text, keywords) {
+  const source = ` ${String(text || '').toLowerCase()} `
+  return keywords.reduce((score, keyword) => {
+    const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const matches = source.match(new RegExp(`\\b${escaped}\\w*\\b`, 'g'))
+    return score + (matches?.length || 0)
+  }, 0)
+}
+
+export function classifyKilos(text) {
+  const scores = Object.fromEntries(Object.entries(KILOS).map(([dimension, keywords]) => [
+    dimension,
+    scoreDimension(text, keywords),
+  ]))
+  return Object.entries(scores)
+    .sort((a, b) => b[1] - a[1])
+    .map(([dimension, score]) => ({
+      dimension,
+      score,
+      rating: score >= 5 ? 'Strong' : score >= 2 ? 'Present' : score === 1 ? 'Weak' : 'Absent',
+    }))
+}
+
+function bestExcerpt(text, dimension) {
+  const keywords = KILOS[dimension] || []
+  const sentences = String(text || '')
+    .replace(/\s+/g, ' ')
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.trim())
+    .filter((sentence) => sentence.length > 40 && sentence.length < 260)
+  return sentences.find((sentence) => keywords.some((keyword) => sentence.toLowerCase().includes(keyword)))
+    || sentences[0]
+    || cleanText(text, 220)
+}
+
+function domainFromUrl(url) {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '')
+  } catch {
+    return 'unknown-source'
+  }
+}
+
+function globalPlaywrightModulePath() {
+  const globalRoot = execFileSync('npm', ['root', '-g'], { encoding: 'utf8' }).trim()
+  const candidate = path.join(globalRoot, 'playwright', 'index.mjs')
+  if (existsSync(candidate)) return pathToFileURL(candidate).href
+  throw new Error('Playwright is not available. Install @playwright/test or playwright before running the demo.')
+}
+
+async function loadPlaywright() {
+  try {
+    return await import('playwright')
+  } catch {
+    return import(globalPlaywrightModulePath())
+  }
+}
+
+async function collectPage(browser, company, url, companyDir) {
+  const page = await browser.newPage({ viewport: { width: 1440, height: 1100 } })
+  const safeDomain = slug(domainFromUrl(url))
+  const screenshotPath = path.join(companyDir, `${safeDomain}.png`)
+  const textPath = path.join(companyDir, `${safeDomain}.txt`)
+  const htmlPath = path.join(companyDir, `${safeDomain}.html`)
+  const startedAt = new Date().toISOString()
+  try {
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 })
+    await page.waitForTimeout(1400)
+    await page.locator('button, [role="button"], a').filter({ hasText: /accept|agree|allow all|got it/i }).first().click({ timeout: 1500 }).catch(() => {})
+    const title = await page.title().catch(() => '')
+    const headline = await page.locator('h1').first().innerText({ timeout: 3000 }).catch(() => '')
+    const bodyText = await page.locator('body').innerText({ timeout: 5000 }).catch(() => '')
+    const html = await page.content().catch(() => '')
+    await page.screenshot({ path: screenshotPath, fullPage: false }).catch(() => null)
+    writeFileSync(textPath, bodyText)
+    writeFileSync(htmlPath, html)
+    return {
+      status: 'collected',
+      company: company.name,
+      url: page.url(),
+      requested_url: url,
+      domain: domainFromUrl(page.url()),
+      title,
+      headline: cleanText(headline, 180),
+      text: cleanText(bodyText, 2200),
+      screenshot: path.relative(auditRoot, screenshotPath).replaceAll(path.sep, '/'),
+      textArtifact: path.relative(auditRoot, textPath).replaceAll(path.sep, '/'),
+      htmlArtifact: path.relative(auditRoot, htmlPath).replaceAll(path.sep, '/'),
+      started_at: startedAt,
+      completed_at: new Date().toISOString(),
+    }
+  } catch (error) {
+    return {
+      status: 'failed',
+      company: company.name,
+      requested_url: url,
+      url,
+      domain: domainFromUrl(url),
+      title: '',
+      headline: '',
+      text: '',
+      error: String(error?.message || error),
+      started_at: startedAt,
+      completed_at: new Date().toISOString(),
+    }
+  } finally {
+    await page.close().catch(() => {})
+  }
+}
+
+export async function collectArtifacts(run = defaultRun, outputDir = latestArtifactDir) {
+  mkdirSync(outputDir, { recursive: true })
+  const { chromium } = await loadPlaywright()
+  let browser
+  try {
+    browser = await chromium.launch({ headless: true })
+  } catch (error) {
+    if (!String(error?.message || error).includes('Executable doesn')) throw error
+    browser = await chromium.launch({ channel: 'chrome', headless: true })
+  }
+  const companies = [run.client, ...(run.competitors || [])]
+  const records = []
+  try {
+    for (const company of companies) {
+      const companyDir = path.join(outputDir, slug(company.name))
+      mkdirSync(companyDir, { recursive: true })
+      for (const url of company.urls || []) {
+        records.push(await collectPage(browser, company, url, companyDir))
+      }
+    }
+  } finally {
+    await browser.close().catch(() => {})
+  }
+  writeFileSync(path.join(outputDir, 'collection-records.json'), `${JSON.stringify(records, null, 2)}\n`)
+  return records
+}
+
+function ratingFor(companyRecords, dimension) {
+  const text = companyRecords.map((record) => `${record.headline} ${record.text}`).join('\n')
+  return classifyKilos(text).find((entry) => entry.dimension === dimension)?.rating || 'Absent'
+}
+
+function companyProfile(company, records) {
+  const companyRecords = records.filter((record) => record.company === company.name)
+  const combinedText = companyRecords.map((record) => `${record.headline}. ${record.text}`).join('\n')
+  const classes = classifyKilos(combinedText)
+  const primary = classes.find((entry) => entry.score > 0) || classes[0]
+  const sourceUrls = companyRecords.map((record) => record.url || record.requested_url).filter(Boolean)
+  const primaryRecord = companyRecords.find((record) => record.headline) || companyRecords[0] || {}
+  const evidenceByDomain = {}
+  for (const record of companyRecords) {
+    const key = record.domain || domainFromUrl(record.url || record.requested_url)
+    evidenceByDomain[key] = {
+      sourceDomain: key,
+      images: record.screenshot ? [{
+        localPath: `./${record.screenshot}`,
+        description: `${company.name} source capture from ${key}`,
+        sourceURL: record.url || record.requested_url,
+      }] : [],
+      textualEvidence: [{
+        sourceURL: record.url || record.requested_url,
+        type: 'browser_capture_excerpt',
+        context: record.title || key,
+        content: { text: cleanText(record.text, 420) },
+      }],
+    }
+  }
+
+  const kilosFrameworkAnalysis = {}
+  for (const { dimension, rating } of classes) {
+    const excerpt = bestExcerpt(combinedText, dimension)
+    kilosFrameworkAnalysis[dimension] = {
+      presence: rating !== 'Absent',
+      summary: rating === 'Absent'
+        ? `${dimension} was not a clear signal in the captured source material.`
+        : `${dimension} appears as a ${rating.toLowerCase()} signal in the captured source material.`,
+      sourceURLs: sourceUrls,
+      supportingEvidence: excerpt ? [{
+        evidenceText: excerpt,
+        evidenceType: 'browser_capture_excerpt',
+        theme: `${dimension} signal`,
+        sourceURL: sourceUrls[0] || '',
+      }] : [],
+    }
+  }
+
+  return {
+    companyName: company.name,
+    companyLogo: { description: `${company.name} logo placeholder`, sourceURL: sourceUrls[0] || '' },
+    companyEvidence: evidenceByDomain,
+    analysis: {
+      scientificTalentValueProposition: {
+        primaryHeadline: {
+          text: primaryRecord.headline || primaryRecord.title || `${company.name} careers source`,
+          sourceURL: primaryRecord.url || primaryRecord.requested_url || '',
+        },
+        keyPillarStatements: classes
+          .filter((entry) => entry.score > 0)
+          .slice(0, 3)
+          .map((entry) => ({
+            statement: `${entry.dimension}: ${entry.rating} signal detected from automated browser collection.`,
+            sourceURL: sourceUrls[0] || '',
+          })),
+        summary: `${company.name} shows its strongest automated signal around ${primary.dimension}. This is a demo-quality first pass based on captured public web text, intended to prove the collection-to-report loop rather than final strategy.`,
+        sourceURLs: sourceUrls,
+      },
+      kilosFrameworkAnalysis,
+    },
+  }
+}
+
+export function buildReportData(records, run = defaultRun) {
+  const client = companyProfile(run.client, records)
+  const competitors = (run.competitors || []).map((company) => companyProfile(company, records))
+  const companies = [run.client, ...(run.competitors || [])]
+  const matrix = Object.keys(KILOS).map((dimension) => ({
+    theme: `${dimension} signal`,
+    dimension,
+    companyScores: Object.fromEntries(companies.map((company) => [
+      company.name,
+      ratingFor(records.filter((record) => record.company === company.name), dimension),
+    ])),
+  }))
+  const sourceURLs = records.map((record) => record.url || record.requested_url).filter(Boolean)
+  return {
+    templateMeta: {
+      reportTitle: 'Employer Brand Competitive Audit',
+      reportSubtitle: `${run.client.name} automated source-artifact demo run`,
+      footerText: `© ${new Date().getFullYear()} Symphony Talent, LLC. Demo output generated by agent-os.`,
+      headerLogo: './assets/branding/symphony-talent-header.png',
+      heroLogo: './assets/branding/symphony-talent-hero.png',
+      overviewBackground: './assets/backgrounds/overview-bg.jpg',
+      contentBackground: './assets/backgrounds/content-bg.jpg',
+      watermarkGraphic: '',
+    },
+    client,
+    competitors,
+    comparison: {
+      executiveSummary: {
+        sharedThemes: 'This automated pass collected public web artifacts and converted them into a KILOS-oriented evidence map. The current output is suitable for demo review, not final client strategy.',
+        keyDifferentiators: `${client.companyName} and the comparison set differ most in which KILOS signals appear first in captured homepage messaging. The generated deep dives show source screenshots and excerpts so a strategist can validate the machine pass.`,
+        whiteSpaceOpportunities: 'The next step is to add company-specific careers subpages, social proof, review sources, and human QA gates so weak or missing signals become either real gaps or recipe repair work.',
+        sourceURLs,
+      },
+      kilosMessagingMatrix: matrix,
+    },
+    introContent: {
+      auditPreamble: {
+        title: `${run.client.name}: automated employer brand audit run`,
+        introduction: 'This demo shows an end-to-end automated run: browser collection, evidence artifact capture, heuristic KILOS classification, and branded report generation.',
+        methodologyTitle: 'Demo Methodology',
+        methodology: 'A Playwright-backed collector opened each source URL, captured visible text and a screenshot, stored raw artifacts, and generated this static report from the resulting evidence records.',
+        methodologyFocusAreas: [
+          'Owned web messaging on public company and careers-adjacent pages',
+          'Visible headline and page-copy signals that map to KILOS dimensions',
+          'Traceability from report claims back to captured source URLs and artifacts',
+        ],
+        closing: 'This proves the report-producing loop while leaving strategic interpretation and final scoring to a later, human-reviewed workflow.',
+        frameworkIntroduction: 'KILOS scoring in this demo is intentionally lightweight: keyword signals are grouped into Kinship, Impact, Lifestyle, Opportunity, and Status.',
+      },
+    },
+  }
+}
+
+export function writeReportData(reportData, filename = generatedDataPath) {
+  const js = [
+    '// Generated by Employer_Brand_Audit/scripts/employer-brand-demo.mjs',
+    `const templateMeta = ${JSON.stringify(reportData.templateMeta, null, 2)};`,
+    `const client = ${JSON.stringify(reportData.client, null, 2)};`,
+    `const competitors = ${JSON.stringify(reportData.competitors, null, 2)};`,
+    `const comparison = ${JSON.stringify(reportData.comparison, null, 2)};`,
+    `const introContent = ${JSON.stringify(reportData.introContent, null, 2)};`,
+    '',
+  ].join('\n\n')
+  writeFileSync(filename, js)
+}
+
+export async function runDemo() {
+  console.log('[employer-brand-demo] collecting browser artifacts...')
+  const records = await collectArtifacts()
+  console.log(`[employer-brand-demo] collected ${records.filter((record) => record.status === 'collected').length}/${records.length} sources`)
+  const reportData = buildReportData(records)
+  writeReportData(reportData)
+  console.log(`[employer-brand-demo] wrote ${path.relative(process.cwd(), generatedDataPath)}`)
+  console.log(`[employer-brand-demo] report: ${path.join(auditRoot, 'demo.html')}`)
+  console.log(`[employer-brand-demo] artifacts: ${latestArtifactDir}`)
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  runDemo().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/tests/employer-brand-demo.test.mjs
+++ b/tests/employer-brand-demo.test.mjs
@@ -1,0 +1,45 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildReportData, classifyKilos } from '../Employer_Brand_Audit/scripts/employer-brand-demo.mjs'
+
+test('classifyKilos maps visible employer-brand signals into demo ratings', () => {
+  const result = classifyKilos('Our inclusive culture helps teams belong, grow careers, and make an impact through innovation.')
+  const byDimension = Object.fromEntries(result.map((entry) => [entry.dimension, entry]))
+  assert.equal(byDimension.Kinship.rating, 'Present')
+  assert.equal(byDimension.Impact.rating, 'Present')
+  assert.equal(byDimension.Opportunity.rating, 'Present')
+})
+
+test('buildReportData creates report shell data from browser collection records', () => {
+  const run = {
+    client: { name: 'ClientCo', urls: ['https://client.example/careers'] },
+    competitors: [{ name: 'RivalCo', urls: ['https://rival.example/careers'] }],
+  }
+  const records = [
+    {
+      status: 'collected',
+      company: 'ClientCo',
+      url: 'https://client.example/careers',
+      domain: 'client.example',
+      title: 'ClientCo Careers',
+      headline: 'Grow your career and make an impact',
+      text: 'Grow your career with learning, mentorship, innovation, and impact for customers.',
+      screenshot: 'artifacts/demo/latest/clientco/client-example.png',
+    },
+    {
+      status: 'collected',
+      company: 'RivalCo',
+      url: 'https://rival.example/careers',
+      domain: 'rival.example',
+      title: 'RivalCo Careers',
+      headline: 'Inclusive teams and flexible work',
+      text: 'Our inclusive team culture supports belonging, flexibility, wellness, and benefits.',
+      screenshot: 'artifacts/demo/latest/rivalco/rival-example.png',
+    },
+  ]
+  const data = buildReportData(records, run)
+  assert.equal(data.client.companyName, 'ClientCo')
+  assert.equal(data.competitors[0].companyName, 'RivalCo')
+  assert.equal(data.comparison.kilosMessagingMatrix.length, 5)
+  assert.equal(data.client.companyEvidence['client.example'].images[0].sourceURL, 'https://client.example/careers')
+})


### PR DESCRIPTION
## Summary
- Add a narrow Employer Brand Audit demo runner that uses Playwright to collect public web source artifacts.
- Generate a Symphony Talent-branded static report data payload for the existing HTML report shell.
- Add a demo HTML entrypoint, run script, ignored output locations, and focused tests for the KILOS-lite report model.

## Demo
- `Employer_Brand_Audit/run-demo.sh`
- Or: `node Employer_Brand_Audit/scripts/employer-brand-demo.mjs && open Employer_Brand_Audit/demo.html`

## Verification
- `node --test tests/employer-brand-demo.test.mjs`
- `git diff --check`
- Ran the demo locally: collected 3/3 sources and rendered `Employer_Brand_Audit/demo.html` with Chrome/Playwright screenshot check.

Draft because this is a boss-demo slice and should be reviewed for demo framing before landing.