### PR TITLE
Add dock capability profiles and dev control surfaces

### DIFF
--- a/.docks/AGENTS.md
+++ b/.docks/AGENTS.md
@@ -1,0 +1,93 @@
+# Docked Session Contract
+
+Docks are repo-local session roots for durable agent roles. They are portable
+role/profile boundaries, not workflows, task types, skills, or entry paths.
+
+Work in `/Users/Michael/Code/agent-os` unless the task explicitly changes dock
+configuration, hooks, skills, or local instructions under `.docks/`.
+
+## Roles And Entry Paths
+
+Keep the axes separate:
+
+- A dock defines who the agent is for the session: authority, handoff contract,
+  stop conditions, lifecycle hooks, and default responsibility.
+- An entry path defines the active capability layer for the current task:
+  Agent harness, AOS developer, testing, visual diagnostics, user-input
+  diagnostics, or a narrower app-specific layer.
+- `./aos dev` is the control surface for the AOS developer entry path. It is not
+  a dock identity.
+
+State the active entry path when it changes what the session will read, modify,
+test, or skip. A role can enter or leave capability layers during a session
+without becoming a different dock.
+
+## AOS As Agent Shell
+
+Docked sessions should treat AOS as the agent shell. Prefer typed `./aos`
+control surfaces over raw provider-native shell access when a surface exists.
+Raw host shell, Node, npm, Python, and arbitrary process execution belong to the
+AOS developer or testing entry paths; they are not ambient capabilities of every
+docked role.
+
+Provider appendages are not competing shells. Gateway, Slack, future chat
+providers, and MCP adapters should be treated as external ingress or workflow
+surfaces around AOS. For agent, human, session, and channel communication, use
+daemon-native `./aos tell`, `./aos listen`, and the session service behind
+`./aos tell --register` and `./aos tell --who`.
+
+When raw process execution is necessary, keep it tied to the active task: use
+the repo root or the narrowest relevant cwd, avoid open-ended scripts, preserve
+reviewable side effects, and let command failures surface instead of papering
+over them with repeated retries.
+
+## Dock Creation Rule
+
+Do not create a new dock for a recurring task, skill, checklist, workflow,
+tool preference, or entry path. Create a dock only when the role needs a durable
+authority boundary, distinct handoff contract, separate runtime/session policy,
+or different human-supervision posture.
+
+Keep common dock behavior here. Keep role-specific authority and stop
+conditions in each dock's own `AGENTS.md`. Treat `dock.json` as the
+machine-readable profile seed and `AGENTS.md` as the human/model operating
+contract.
+
+Use `./aos dev docks explain <dock> --json` or
+`./aos dev docks capabilities <dock> --json` when the active session needs
+machine-readable role, entry-path, or capability-envelope context. These
+commands are discovery surfaces only; they do not execute capabilities or
+change permissions.
+
+## GitHub Control Surface
+
+Use `./aos dev gh` for GitHub operations when GitHub work is in scope. It shells
+out to the authenticated local `gh` CLI and should be preferred over
+connector-backed GitHub app or plugin routes in this repo.
+
+Keep GitHub operations thin and intentional:
+
+- use `./aos dev gh context --json` once when local branch, repo, auth, or PR
+  context is unclear;
+- use body files for issue and PR comments instead of inline shell strings;
+- use `./aos dev gh ci inspect --pr <n> --json` when a PR check fails and you
+  need failed GitHub Actions logs;
+- use `./aos dev gh review-comments --pr <n> --json` when review-thread
+  resolution state matters.
+
+Do not turn GitHub work into repeated preflight loops. Let `gh` errors surface,
+then handle them with normal software-development judgment. Use external
+connector tools only when the user explicitly asks for them or when `gh` cannot
+represent the needed operation.
+
+Foreman is the default git/GitHub steward. GDI and Operator should perform
+GitHub operations only when the assigned goal or handoff explicitly includes
+that work.
+
+## Cross-Session Handoffs
+
+For cross-session handoffs, pipe the raw target message through
+`scripts/dock-handoff-clipboard --target-dock <dock>` from the repo root and use
+the script output as the final chat reply. GDI is the only target dock that
+receives a `/goal ` prefix; non-GDI handoffs remain plain supervised or steering
+instructions.

--- a/.docks/README.md
+++ b/.docks/README.md
@@ -26,11 +26,30 @@ Codex then discovers the dock's `AGENTS.md`, `.codex/hooks.json`, and any other
 project-local configuration from that launch root. Source edits and tests still
 belong in the real repo root unless the dock says otherwise.
 
+The active instruction ladder is root `AGENTS.md`, shared `.docks/AGENTS.md`,
+then the role-local `<dock>/AGENTS.md`. Keep common docked-session behavior in
+`.docks/AGENTS.md` and keep each role file focused on that role's authority,
+handoff contract, and stop conditions.
+
 Each dock owns its own hook scripts under `<dock>/hooks/`. Those scripts are
 thin wrappers around `.docks/harness/dock-hook-runner.sh`, with dock identity
 and policy in `<dock>/dock.json`. Do not route dock hooks through a shared
 `.docks/hooks/` script; role behavior should stay local to the dock metadata
 and optional pre/post scripts that install it.
+
+`<dock>/dock.json` is validated as an AOS Dock Profile. It declares the dock's
+durable role, default entry path, allowed entry paths, capability manifest, and
+allowed capability classes. Inspect profiles with:
+
+```bash
+./aos dev docks list --json
+./aos dev docks explain foreman --json
+./aos dev docks capabilities gdi --json
+```
+
+This profile is descriptive, not an executor. It keeps the portable dock
+metaphor inspectable while leaving task judgment and command failures with the
+active agent.
 
 Dock-local bespoke behavior belongs in executable scripts named
 `pre-session-start.sh`, `post-session-start.sh`, `pre-stop.sh`, or

--- a/.docks/foreman/AGENTS.md
+++ b/.docks/foreman/AGENTS.md
@@ -70,10 +70,3 @@ coordination edits. Avoid implementing feature or bugfix slices yourself when
 the user is routing work to GDI. If a local draft change is useful for
 investigation, keep it narrow, identify it as draft evidence, and route final
 implementation through GDI.
-
-For cross-session handoffs, pipe the raw target message through
-`scripts/dock-handoff-clipboard --target-dock <dock>` from the repo root and use
-the script output as the final chat reply. GDI is the only target dock that
-receives a `/goal ` prefix; Operator and other non-GDI docks receive plain
-instructions so supervised/HITL sessions can stop for ambiguity instead of
-forcing autonomous goal completion.

--- a/.docks/foreman/AGENTS.md
+++ b/.docks/foreman/AGENTS.md
@@ -55,9 +55,15 @@ blocker with the safe recovery path.
 ## Work-Card Routing
 
 For non-trivial GDI implementation work, create or update a Markdown work card
-under `docs/design/work-cards/` and hand off only a thin goal line:
+under `docs/design/work-cards/` and hand off only a thin plain instruction:
 
-`attn: GDI, follow the instructions in docs/design/work-cards/<card>.md`
+`follow the instructions in docs/design/work-cards/<card>.md`
+
+Foreman-to-GDI clipboard payloads are a role-specific exception to any generic
+handoff helper that adds command or addressee prefixes. Do not prepend `/goal`,
+`attn: GDI`, or similar ceremony to the clipboard text. If a shared helper would
+inject that preamble, use a Foreman-specific plain clipboard copy path and
+report the copied payload plus timestamp in the same chat-visible shape.
 
 Use `docs/recipes/gdi-work-card-authoring.md` as the flexible authoring shape:
 fresh context, read-first files, state rediscovery, exact files to inspect,
@@ -72,7 +78,7 @@ clearly in the work card so GDI knows whether to retain, amend, supersede, or
 revert it.
 
 When routing non-trivial GDI implementation work, keep the clipboard payload to
-the thin `attn: GDI...` goal, then add human-facing manual steps in Foreman's
+the thin plain work-card instruction, then add human-facing manual steps in Foreman's
 chat response. The default helper is:
 
 - paste/send the clipboard contents to GDI;

--- a/.docks/foreman/AGENTS.md
+++ b/.docks/foreman/AGENTS.md
@@ -36,7 +36,10 @@ the report as an input to Foreman's next-step loop:
 4. If exactly one next slice is implied by the active plan, create/update that
    work card and hand it off. If several plausible slices exist, recommend the
    best one and state the tradeoff instead of silently stopping.
-5. Pause only for decisions that require human judgment, irreversible git/GitHub
+5. When accepted work has a clear reversible checkpoint, take it before moving
+   on. Keep the checkpoint scoped and reviewable so the worktree stays
+   understandable for the next handoff.
+6. Pause only for decisions that require human judgment, irreversible git/GitHub
    action, credential or permission changes, or a real ambiguity in product
    direction.
 
@@ -62,6 +65,24 @@ Do not paste long implementation instructions directly into the clipboard goal
 unless the task is genuinely small. If Foreman creates draft evidence, label it
 clearly in the work card so GDI knows whether to retain, amend, supersede, or
 revert it.
+
+When routing non-trivial GDI implementation work, keep the clipboard payload to
+the thin `attn: GDI...` goal, then add human-facing manual steps in Foreman's
+chat response. The default helper is:
+
+- paste/send the clipboard contents to GDI;
+- after GDI reports completion, optionally send `/review` in that same GDI
+  session when the slice is complex enough to benefit from adversarial review;
+- bring the final copied GDI tail response back to Foreman, either review
+  results or the GDI work report. Do not require the human to copy separate
+  completion and review messages; Foreman should rediscover diff, status, and
+  verification evidence locally when deciding acceptance, correction routing,
+  same-session follow-up, whether to recommend another review round, or
+  next-slice selection.
+
+Do not make GDI self-accept a non-trivial review. Tiny mechanical review fixes
+may stay with GDI, but behavioral, architectural, or priority-bearing review
+findings come back to Foreman.
 
 ## Implementation Boundary
 

--- a/.docks/foreman/AGENTS.md
+++ b/.docks/foreman/AGENTS.md
@@ -39,7 +39,12 @@ the report as an input to Foreman's next-step loop:
 5. When accepted work has a clear reversible checkpoint, take it before moving
    on. Keep the checkpoint scoped and reviewable so the worktree stays
    understandable for the next handoff.
-6. Pause only for decisions that require human judgment, irreversible git/GitHub
+6. If live runtime verification is the next meaningful step and `./aos ready`
+   reports a repo-mode TCC/input-tap blocker, stop treating it as background
+   noise. State the blocker directly, use the safe permission handoff path from
+   the repo-wide contract, and avoid routing more live-dependent work until the
+   human has either resolved it or explicitly chosen a deterministic-only slice.
+7. Pause only for decisions that require human judgment, irreversible git/GitHub
    action, credential or permission changes, or a real ambiguity in product
    direction.
 

--- a/.docks/gdi/AGENTS.md
+++ b/.docks/gdi/AGENTS.md
@@ -28,9 +28,6 @@ handoff to Foreman instead of inventing scope.
 
 Do not commit, push, open PRs, close issues, or rewrite branch history unless
 the assigned `/goal` explicitly requests it. Foreman is the default git/GitHub
-steward.
-
-For cross-session handoffs, pipe the raw target message through
-`scripts/dock-handoff-clipboard --target-dock <dock>` from the repo root and use
-the script output as the final chat reply. The helper preserves the GDI-only
-`/goal ` convention when GDI is the target.
+steward. If a goal explicitly assigns GitHub, CI, or issue-comment work, use
+the shared docked-session GitHub control surface, `./aos dev gh`, and report the
+exact operation and result in the completion summary.

--- a/.docks/gdi/dock.json
+++ b/.docks/gdi/dock.json
@@ -1,7 +1,37 @@
 {
+  "$schema": "../../shared/schemas/aos-dock-profile-v0.schema.json",
+  "type": "aos.dock_profile",
+  "schema_version": "2026-05-dock-profile-v0",
   "name": "gdi",
   "role": "gdi",
   "harness": "codex",
+  "summary": "Goal-driven implementation for assigned deterministic slices with focused verification.",
+  "default_entry_path": "aos_developer",
+  "allowed_entry_paths": [
+    "agent_harness",
+    "aos_developer",
+    "testing",
+    "visual_diagnostics",
+    "user_input_diagnostics",
+    "app_specific"
+  ],
+  "capability_manifest": "docs/dev/agent-capabilities.json",
+  "allowed_capability_classes": [
+    "read_only",
+    "repo_write",
+    "runtime_mutation",
+    "host_write"
+  ],
+  "allowed_capabilities": [
+    "dev.github.context",
+    "dev.github.ci_inspect",
+    "dev.github.review_comments",
+    "dev.build.aos",
+    "dev.test.schema_node"
+  ],
+  "requires_explicit_assignment_for": [
+    "host_write"
+  ],
   "hook_timeout_seconds": 8,
   "stop_notice": "GDI finished.",
   "handoff": {

--- a/.docks/operator/AGENTS.md
+++ b/.docks/operator/AGENTS.md
@@ -25,7 +25,10 @@ Operator owns supervised runtime/HITL verification for the assigned handoff:
 Operator does not own workstream coordination, work-card authoring, GitHub issue
 state, PR management, branch hygiene, commits, or pushes unless the handoff
 explicitly assigns that responsibility. Foreman is the default coordinator and
-git/GitHub steward; GDI is the default deterministic implementer.
+git/GitHub steward; GDI is the default deterministic implementer. If a supervised
+handoff explicitly assigns GitHub, CI, or comment work, use the shared
+docked-session GitHub control surface, `./aos dev gh`, and report the exact
+operation and result as part of the evidence.
 
 ## Scope
 
@@ -66,8 +69,3 @@ When consuming supervised execution artifacts:
    target and report accept/reject/needs-review with concise evidence.
 7. Leave handoff notes that name the artifact consumed, decisions made, blockers
    found, and any required next dock.
-
-For cross-session handoffs, pipe the raw target message through
-`scripts/dock-handoff-clipboard --target-dock <dock>` from the repo root and use
-the script output as the final chat reply. Do not add `/goal ` to Operator
-handoffs; the helper only adds that prefix when GDI is the target dock.

--- a/.docks/operator/dock.json
+++ b/.docks/operator/dock.json
@@ -1,7 +1,30 @@
 {
+  "$schema": "../../shared/schemas/aos-dock-profile-v0.schema.json",
+  "type": "aos.dock_profile",
+  "schema_version": "2026-05-dock-profile-v0",
   "name": "operator",
   "role": "operator",
   "harness": "codex",
+  "summary": "Supervised human-in-the-loop operation, live-surface inspection, and evidence capture.",
+  "default_entry_path": "agent_harness",
+  "allowed_entry_paths": [
+    "agent_harness",
+    "aos_developer",
+    "visual_diagnostics",
+    "user_input_diagnostics",
+    "app_specific"
+  ],
+  "capability_manifest": "docs/dev/agent-capabilities.json",
+  "allowed_capability_classes": [
+    "read_only",
+    "runtime_mutation"
+  ],
+  "allowed_capabilities": [
+    "dev.github.context",
+    "dev.github.ci_inspect",
+    "dev.github.review_comments"
+  ],
+  "requires_explicit_assignment_for": [],
   "hook_timeout_seconds": 8,
   "stop_notice": "Operator finished.",
   "handoff": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,20 @@ HOW to deliver it. See `ARCHITECTURE.md` for the full rationale. Historical
 design context is archived at
 `docs/archive/superpowers/specs/2026-04-15-tell-hear-coordination-verbs-design.md`.
 
+## Host Shell Boundary
+
+AOS is the intended agent shell. The base harness should prefer typed AOS
+primitives and control surfaces over raw host process execution. `see`, `do`,
+`show`, `tell`, and `listen` are the base agent shell; `./aos dev ...` is the
+developer control surface when the AOS developer entry path is active.
+
+Raw host shell, Node, npm, Python, and arbitrary process execution are elevated
+developer/testing capabilities, not base agent primitives. Use them only when
+the active task genuinely needs repo development or verification power, keep
+cwd and scope narrow, use timeouts where available, and inspect side effects.
+When a typed AOS surface exists, prefer it over provider-native shell snippets
+or ad hoc scripts.
+
 ## Repo-Wide Methods
 
 - `aos` CLI is the canonical interface for development inside agent-os. MCP tools

--- a/docs/design/agent-capability-manifest-v0.md
+++ b/docs/design/agent-capability-manifest-v0.md
@@ -1,0 +1,122 @@
+# Agent Capability Manifest v0
+
+## Problem
+
+Agent sessions need a portable way to describe what operations are available
+without making raw Bash, Node, npm, Python, or provider-specific tools the
+default agent shell. Docks define durable role/profile boundaries. Entry paths
+define active capability layers. Neither should hardcode every command an agent
+might run.
+
+The missing layer is a small capability manifest: a runtime-neutral description
+of operations, adapters, mutability, scope, and audit expectations.
+
+## Direction
+
+AOS should be the shell agents target. Host process execution remains available
+for development and testing, but it should be represented as an explicit
+capability with scope and audit metadata rather than an ambient power.
+
+The V0 schema lives at
+[`shared/schemas/aos-agent-capability-manifest-v0.schema.json`](../../shared/schemas/aos-agent-capability-manifest-v0.schema.json).
+It is intentionally declarative. It does not execute commands or grant
+permissions.
+
+The canonical repo-development manifest lives at
+[`docs/dev/agent-capabilities.json`](../dev/agent-capabilities.json). Agents can
+inspect it through the read-only discovery surface:
+
+```bash
+./aos dev capabilities list --json
+./aos dev capabilities explain dev.github.issue_comment --json
+```
+
+## Concept Model
+
+An agent instance is a runtime composition:
+
+```text
+dock role/profile
++ active entry path
++ assigned task
++ capability manifest
++ runtime adapter
++ evidence contract
+```
+
+The dock answers "who is this agent and what may it decide?" The entry path
+answers "what capability layer is active?" The capability manifest answers
+"what operations exist and how risky are they?" The adapter answers "how does
+this runtime perform that operation?"
+
+## Capability Classes
+
+Use these classes when classifying repeated agent behavior:
+
+| Adapter kind | Use when | Default posture |
+| --- | --- | --- |
+| `aos_cli` | A typed AOS control surface exists or should exist | Preferred |
+| `local_cli` | A stable external CLI is wrapped by policy | Acceptable with scope |
+| `node` / `python` | A repo-owned deterministic script or test is needed | Developer/testing only |
+| `http` / `mcp` | A protocol-backed external service is the stable interface | Depends on mutability |
+| `manual` | Human action is the operation | Requires explicit handoff |
+| `shell` | Arbitrary host shell is unavoidable | Break-glass or tightly scoped dev/test |
+
+Repeated raw shell clusters are design pressure. If agents keep running the
+same command sequence, either define a typed AOS control surface or register a
+capability with narrow execution policy.
+
+## V0 Safety Boundary
+
+The schema enforces the first hard boundary:
+
+- `execution.raw_process=true` cannot be used by the base `agent_harness`
+  entry path.
+- Raw process capabilities must be scoped to `aos_developer`, `testing`, or
+  `break_glass`.
+- Raw process capabilities must require explicit assignment.
+- Raw process capabilities must declare cwd policy, timeout, and audit posture.
+
+This is not complete security. It is a durable contract that prevents the
+platform vocabulary from treating arbitrary host process execution as a base
+agent primitive.
+
+## Initial Candidates
+
+`./aos dev gh` is the reference example. It regularizes GitHub work through an
+AOS developer control surface while still using the authenticated local `gh`
+CLI underneath.
+
+Other candidates to inventory next:
+
+- focused Node schema tests;
+- package-local Node tests;
+- Swift build through `./aos dev build`;
+- readiness and permission-reset checks;
+- screenshot or capture helpers;
+- browser/Playwright runs.
+
+## Relationship To Future `./aos dev run`
+
+Do not build `./aos dev run` until the manifest has been useful on paper. A
+future runner should read capability manifests, enforce cwd/timeout/mutability
+metadata, and preserve audit output. It should not become a thin rename for
+arbitrary Bash.
+
+The first implementation is read-only:
+
+```bash
+./aos dev capabilities list --json
+./aos dev capabilities explain dev.github.issue_comment --json
+./aos dev docks capabilities foreman --json
+```
+
+Execution can come later, once the schema and real capability inventory have
+settled.
+
+Dock profiles live in `.docks/<dock>/dock.json` and validate against
+[`shared/schemas/aos-dock-profile-v0.schema.json`](../../shared/schemas/aos-dock-profile-v0.schema.json).
+They resolve role, default entry path, allowed entry paths, and allowed
+capability classes against the capability manifest. This keeps the dock layer
+declarative and portable while avoiding duplicated role-specific command lists
+in every `AGENTS.md`.

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -5,6 +5,12 @@
 layers, package loops, schema tests, and local-contract delegation, but do not
 encode app-specific playbooks here.
 
+`agent-capabilities.json` is the source of truth for typed developer
+capabilities exposed through `./aos dev capabilities`. `.docks/*/dock.json`
+profiles resolve against that manifest through `./aos dev docks`, so dock
+identity and capability envelopes stay declarative instead of being repeated in
+role instructions.
+
 Validate routing changes with:
 
 ```bash

--- a/docs/dev/agent-capabilities.json
+++ b/docs/dev/agent-capabilities.json
@@ -1,0 +1,296 @@
+{
+  "$schema": "../../shared/schemas/aos-agent-capability-manifest-v0.schema.json",
+  "type": "aos.agent_capability_manifest",
+  "schema_version": "2026-05-agent-capability-manifest-v0",
+  "id": "agent-os.dev-capabilities",
+  "label": "agent-os Developer Capabilities",
+  "summary": "Canonical capability manifest for typed repo-development operations exposed to docked sessions and AOS developer entry paths.",
+  "applies_to": {
+    "roles": ["foreman", "gdi", "operator"],
+    "entry_paths": ["aos_developer", "testing"]
+  },
+  "capabilities": [
+    {
+      "id": "dev.github.context",
+      "label": "GitHub Context",
+      "summary": "Inspect local git and gh authentication context through the AOS developer control surface.",
+      "status": "active",
+      "roles": ["foreman", "gdi", "operator"],
+      "entry_paths": ["aos_developer"],
+      "adapter": {
+        "kind": "aos_cli",
+        "command": ["./aos", "dev", "gh", "context", "--json"]
+      },
+      "mutability": {
+        "class": "read_only",
+        "side_effects": [],
+        "requires_explicit_assignment": false,
+        "requires_human_approval": false,
+        "requires_body_file": false
+      },
+      "execution": {
+        "cwd_policy": "repo_root",
+        "timeout_seconds": 30,
+        "network": "allowed",
+        "raw_process": false,
+        "audit": "recommended"
+      },
+      "outputs": [
+        {
+          "name": "context_json",
+          "summary": "Repository, branch, upstream, dirty state, and gh availability/authentication status.",
+          "required": true,
+          "schema": {
+            "type": "object"
+          }
+        }
+      ],
+      "failure_policy": {
+        "bubble_up": true,
+        "retry": "none"
+      }
+    },
+    {
+      "id": "dev.github.issue_comment",
+      "label": "GitHub Issue Comment",
+      "summary": "Write a GitHub issue comment through a body file using ./aos dev gh.",
+      "status": "active",
+      "roles": ["foreman"],
+      "entry_paths": ["aos_developer"],
+      "adapter": {
+        "kind": "aos_cli",
+        "command": ["./aos", "dev", "gh", "issue", "comment"]
+      },
+      "mutability": {
+        "class": "external_write",
+        "side_effects": ["github_issue_comment"],
+        "requires_explicit_assignment": true,
+        "requires_human_approval": false,
+        "requires_body_file": true
+      },
+      "execution": {
+        "cwd_policy": "repo_root",
+        "timeout_seconds": 30,
+        "network": "required",
+        "raw_process": false,
+        "audit": "required"
+      },
+      "inputs": [
+        {
+          "name": "issue_number",
+          "summary": "GitHub issue number.",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        {
+          "name": "body_file",
+          "summary": "Markdown file containing the comment body.",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "comment_url",
+          "summary": "GitHub URL for the posted comment.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "failure_policy": {
+        "bubble_up": true,
+        "retry": "none"
+      }
+    },
+    {
+      "id": "dev.github.ci_inspect",
+      "label": "GitHub CI Inspect",
+      "summary": "Inspect PR checks and retrieve failed GitHub Actions logs through ./aos dev gh.",
+      "status": "active",
+      "roles": ["foreman", "gdi", "operator"],
+      "entry_paths": ["aos_developer", "testing"],
+      "adapter": {
+        "kind": "aos_cli",
+        "command": ["./aos", "dev", "gh", "ci", "inspect"]
+      },
+      "mutability": {
+        "class": "read_only",
+        "side_effects": [],
+        "requires_explicit_assignment": true,
+        "requires_human_approval": false,
+        "requires_body_file": false
+      },
+      "execution": {
+        "cwd_policy": "repo_root",
+        "timeout_seconds": 120,
+        "network": "required",
+        "raw_process": false,
+        "audit": "recommended"
+      },
+      "inputs": [
+        {
+          "name": "pr",
+          "summary": "GitHub PR number.",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "ci_inspection_json",
+          "summary": "PR checks and failed-check log excerpts.",
+          "required": true,
+          "schema": {
+            "type": "object"
+          }
+        }
+      ],
+      "failure_policy": {
+        "bubble_up": true,
+        "retry": "none"
+      }
+    },
+    {
+      "id": "dev.github.review_comments",
+      "label": "GitHub Review Comments",
+      "summary": "Read thread-level PR review comment state through ./aos dev gh and gh GraphQL.",
+      "status": "active",
+      "roles": ["foreman", "gdi", "operator"],
+      "entry_paths": ["aos_developer"],
+      "adapter": {
+        "kind": "aos_cli",
+        "command": ["./aos", "dev", "gh", "review-comments"]
+      },
+      "mutability": {
+        "class": "read_only",
+        "side_effects": [],
+        "requires_explicit_assignment": true,
+        "requires_human_approval": false,
+        "requires_body_file": false
+      },
+      "execution": {
+        "cwd_policy": "repo_root",
+        "timeout_seconds": 60,
+        "network": "required",
+        "raw_process": false,
+        "audit": "recommended"
+      },
+      "inputs": [
+        {
+          "name": "pr",
+          "summary": "GitHub PR number.",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "review_threads_json",
+          "summary": "Thread-level review comments and resolution state.",
+          "required": true,
+          "schema": {
+            "type": "object"
+          }
+        }
+      ],
+      "failure_policy": {
+        "bubble_up": true,
+        "retry": "none"
+      }
+    },
+    {
+      "id": "dev.build.aos",
+      "label": "AOS Developer Build",
+      "summary": "Build the repo-mode ./aos binary through the signing-aware developer control surface.",
+      "status": "active",
+      "roles": ["foreman", "gdi"],
+      "entry_paths": ["aos_developer"],
+      "adapter": {
+        "kind": "aos_cli",
+        "command": ["./aos", "dev", "build"]
+      },
+      "mutability": {
+        "class": "host_write",
+        "side_effects": ["repo_binary_rebuild", "possible_daemon_restart"],
+        "requires_explicit_assignment": true,
+        "requires_human_approval": false,
+        "requires_body_file": false
+      },
+      "execution": {
+        "cwd_policy": "repo_root",
+        "timeout_seconds": 900,
+        "network": "forbidden",
+        "raw_process": false,
+        "audit": "required"
+      },
+      "outputs": [
+        {
+          "name": "build_result",
+          "summary": "Build output and readiness/TCC note.",
+          "required": true,
+          "schema": {
+            "type": "object"
+          }
+        }
+      ],
+      "failure_policy": {
+        "bubble_up": true,
+        "retry": "none"
+      }
+    },
+    {
+      "id": "dev.test.schema_node",
+      "label": "Node Schema Test",
+      "summary": "Run the schema Node test suite as an explicit developer/testing raw-process capability.",
+      "status": "active",
+      "roles": ["foreman", "gdi"],
+      "entry_paths": ["aos_developer", "testing"],
+      "adapter": {
+        "kind": "node",
+        "command": ["node", "--test", "tests/schemas/*.test.mjs"]
+      },
+      "mutability": {
+        "class": "read_only",
+        "side_effects": [],
+        "requires_explicit_assignment": true,
+        "requires_human_approval": false,
+        "requires_body_file": false
+      },
+      "execution": {
+        "cwd_policy": "repo_root",
+        "timeout_seconds": 180,
+        "network": "forbidden",
+        "raw_process": true,
+        "audit": "recommended"
+      },
+      "outputs": [
+        {
+          "name": "tap_output",
+          "summary": "Node test TAP output.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "failure_policy": {
+        "bubble_up": true,
+        "retry": "none"
+      }
+    }
+  ]
+}

--- a/docs/dev/workflow-rules.json
+++ b/docs/dev/workflow-rules.json
@@ -176,6 +176,72 @@
       "verification": []
     },
     {
+      "id": "agent-capability-manifest",
+      "summary": "Agent capability manifest schema, canonical manifest, or tests changed.",
+      "patterns": [
+        "docs/dev/agent-capabilities.json",
+        "shared/schemas/aos-agent-capability-manifest-v0.md",
+        "shared/schemas/aos-agent-capability-manifest-v0.schema.json",
+        "shared/schemas/fixtures/aos-agent-capability-manifest-v0/**",
+        "tests/schemas/aos-agent-capability-manifest-v0.test.mjs"
+      ],
+      "classes": [
+        "capability_manifest",
+        "schema"
+      ],
+      "actions": [
+        "schema_test",
+        "focused_test"
+      ],
+      "hot_swappable": true,
+      "tcc_identity_sensitive": false,
+      "commands": [
+        {
+          "id": "agent-capability-schema-test",
+          "command": "node --test tests/schemas/aos-agent-capability-manifest-v0.test.mjs",
+          "reason": "Validate the capability manifest schema, canonical manifest, and fixtures."
+        }
+      ],
+      "verification": []
+    },
+    {
+      "id": "dock-profiles",
+      "summary": "Dock profile metadata, schema, docs, or tests changed.",
+      "patterns": [
+        ".docks/*/dock.json",
+        ".docks/dock-defaults.json",
+        ".docks/README.md",
+        ".docks/AGENTS.md",
+        "shared/schemas/aos-dock-profile-v0.md",
+        "shared/schemas/aos-dock-profile-v0.schema.json",
+        "shared/schemas/fixtures/aos-dock-profile-v0/**",
+        "tests/schemas/aos-dock-profile-v0.test.mjs"
+      ],
+      "classes": [
+        "dock_profile",
+        "schema"
+      ],
+      "actions": [
+        "schema_test",
+        "focused_test"
+      ],
+      "hot_swappable": true,
+      "tcc_identity_sensitive": false,
+      "commands": [
+        {
+          "id": "dock-profile-schema-test",
+          "command": "node --test tests/schemas/aos-dock-profile-v0.test.mjs",
+          "reason": "Validate dock profiles, fixtures, and capability-envelope semantics."
+        },
+        {
+          "id": "dev-workflow-router-test",
+          "command": "bash tests/dev-workflow-router.sh",
+          "reason": "Verify dock profile discovery remains exposed through the dev control surface."
+        }
+      ],
+      "verification": []
+    },
+    {
       "id": "package-gateway",
       "summary": "Gateway package TypeScript changed.",
       "patterns": [

--- a/docs/recipes/agent-entry-paths-and-verification.md
+++ b/docs/recipes/agent-entry-paths-and-verification.md
@@ -17,6 +17,27 @@ will read, skip, test, or modify, say the current path briefly. If the session
 pivots and the agent adds a layer, call out the change before acting through the
 new capability.
 
+## Host Shell Boundary
+
+Treat AOS as the agent shell. The base harness should use typed AOS primitives
+and control surfaces before reaching for raw host process execution.
+
+The practical layers are:
+
+- `see`, `do`, `show`, `tell`, and `listen` are the base harness shell.
+- `./aos dev ...` is the AOS developer shell for repo workflow, builds, audits,
+  and regularized integrations such as GitHub.
+- Raw Bash, Node, npm, Python, and arbitrary process execution are
+  developer/testing escape hatches. They are useful for building the platform,
+  but they should not become the default interface that user-facing agents
+  inherit.
+
+When the AOS developer or testing path needs raw process execution, keep the
+scope explicit: narrow cwd, bounded command, clear reason, and reviewable side
+effects. Prefer a typed AOS control surface when one exists. Add a new control
+surface when the same raw command cluster becomes repeated, risky, or easy to
+misuse.
+
 ### Agent Harness
 
 Start from the base harness model. The agent should prefer AOS primitives:
@@ -133,16 +154,18 @@ starting point.
 3. Skip sections outside the active path, but backtrack when the session pivots
    or the evidence requires another layer.
 4. Use AOS primitives first unless the task explicitly needs repo-level powers.
-5. Pick the smallest test loop that matches the changed behavior.
-6. For visual/display work, launch the relevant diagnostics instead of relying
+5. Treat raw shell, Node, npm, Python, and arbitrary process execution as
+   developer/testing capabilities, not base harness primitives.
+6. Pick the smallest test loop that matches the changed behavior.
+7. For visual/display work, launch the relevant diagnostics instead of relying
    on memory or screenshots alone.
-7. When a repo-owned scenario harness exists for the behavior, use that harness
+8. When a repo-owned scenario harness exists for the behavior, use that harness
    before inventing an ad hoc verification path.
-8. For real-input bugs, capture or run at least one real-input verification.
-9. If the task touches runtime knowledge, check whether the AOS wiki needs to be
+9. For real-input bugs, capture or run at least one real-input verification.
+10. If the task touches runtime knowledge, check whether the AOS wiki needs to be
    read or updated in addition to repo docs or code.
-10. Before building a new browser, workbench, editor, inspector, or artifact
+11. Before building a new browser, workbench, editor, inspector, or artifact
     panel, identify the subject's layered expressions. See
     `docs/recipes/layered-subject-expressions.md`.
-11. If a lesson should survive the session, place it using the placement rules
+12. If a lesson should survive the session, place it using the placement rules
    above before handing the work back.

--- a/docs/recipes/gdi-work-card-authoring.md
+++ b/docs/recipes/gdi-work-card-authoring.md
@@ -171,6 +171,32 @@ applicable, and the remaining follow-up recommendation when the source card has
 one. Do not require this shape for tiny one-line fixes where it would add more
 noise than review value.
 
+### Post-GDI Review Option
+
+For non-trivial implementation cards, Foreman should plan for an optional
+human-triggered GDI review after completion:
+
+- keep `/review` out of the clipboard goal unless the user explicitly asks to
+  make review part of GDI's assigned task;
+- after copying the GDI handoff, tell the human to paste/send the goal to GDI,
+  optionally send `/review` after GDI reports completion when the work is
+  complex enough to benefit from adversarial review, and return the final copied
+  GDI tail response to Foreman;
+- do not require the human to copy separate completion and review messages;
+  Foreman should rediscover diff, status, and verification evidence locally
+  when deciding acceptance or correction routing;
+- Foreman owns acceptance after reading the returned GDI tail and locally
+  inspecting the relevant diff, status, and test evidence;
+- if the returned tail is only a work report and the slice has meaningful
+  behavioral, architectural, or integration risk, Foreman may recommend a
+  `/review` round before acceptance;
+- route correction work through Foreman when review findings affect behavior,
+  architecture, scope, or priority;
+- Foreman may send a follow-up or correction prompt for the same GDI session
+  when the context is still useful and the fix is narrow;
+- let GDI address only tiny mechanical review fixes directly when no acceptance
+  judgment is needed.
+
 ## Specialty Slots
 
 Add these only when the slice needs them.

--- a/shared/schemas/aos-agent-capability-manifest-v0.md
+++ b/shared/schemas/aos-agent-capability-manifest-v0.md
@@ -1,0 +1,78 @@
+# AOS Agent Capability Manifest v0
+
+Schema:
+[`aos-agent-capability-manifest-v0.schema.json`](./aos-agent-capability-manifest-v0.schema.json)
+
+This manifest describes typed capabilities that an agent role or entry path can
+activate. It is the contract layer between role/profile policy and concrete
+tool adapters. The goal is to make AOS the agent shell while still allowing
+repo-development tools such as `gh`, Node, npm, Python, and Bash to exist as
+explicit, reviewable capabilities.
+
+## Purpose
+
+The manifest separates four concepts that should not be conflated:
+
+- **Dock/role**: who the agent is and what authority boundary it carries.
+- **Entry path**: which capability layer is active for the current task.
+- **Capability**: what operation can be performed.
+- **Adapter**: how the capability is implemented in the current runtime.
+
+For example, `dev.github.issue_comment` can be a typed capability exposed
+through `./aos dev gh issue comment`, backed by the local authenticated `gh`
+CLI. The agent depends on the AOS capability contract, not on a provider
+connector being installed.
+
+## Host Shell Boundary
+
+Raw host process execution is not a base harness primitive. Capabilities with
+`execution.raw_process=true` are only valid for the `aos_developer`, `testing`,
+or `break_glass` entry paths. They must declare a non-`none` cwd policy, a
+timeout, audit posture, and `requires_explicit_assignment=true`.
+
+This makes raw Bash, Node, npm, Python, and arbitrary process execution visible
+as elevated capabilities instead of ambient agent powers.
+
+## V0 Scope
+
+V0 is deliberately small. It records:
+
+- capability identity and status;
+- role and entry-path applicability;
+- adapter kind and command surface;
+- mutability and side-effect class;
+- cwd/network/raw-process/audit execution policy;
+- input/output metadata;
+- failure behavior.
+
+V0 does not execute capabilities, grant permissions, or replace current test
+commands. It gives future `./aos dev run` or runtime capability brokers a
+schema to target.
+
+The canonical repo-development manifest is
+`docs/dev/agent-capabilities.json`. Use `./aos dev capabilities list --json`
+and `./aos dev capabilities explain <capability-id> --json` for read-only
+discovery.
+
+## Classification Heuristic
+
+Use these defaults when deciding whether repeated agent behavior should become
+a capability:
+
+- Prefer `aos_cli` when the repo already has or should have a typed AOS control
+  surface.
+- Use `local_cli` for a stable external CLI behind a thin AOS wrapper or
+  documented command contract.
+- Use `node` or `python` for repo-owned scripts that are bounded and
+  deterministic.
+- Use `shell` only for break-glass or explicitly scoped developer/testing
+  operations. Repeated shell clusters are candidates for a typed AOS control
+  surface.
+
+## Examples
+
+Valid fixtures live in
+`shared/schemas/fixtures/aos-agent-capability-manifest-v0/valid/`.
+
+Invalid fixtures demonstrate unsafe shapes such as base-harness raw shell
+capabilities or raw-process capabilities without timeout/audit metadata.

--- a/shared/schemas/aos-agent-capability-manifest-v0.schema.json
+++ b/shared/schemas/aos-agent-capability-manifest-v0.schema.json
@@ -1,0 +1,456 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/michaelblum/agent-os/shared/schemas/aos-agent-capability-manifest-v0.schema.json",
+  "title": "AOS Agent Capability Manifest v0",
+  "description": "Declarative manifest for typed agent capabilities. It separates AOS control surfaces from raw host process escapes so docks and entry paths can reason about authority without hardcoding provider-specific tools.",
+  "type": "object",
+  "required": [
+    "type",
+    "schema_version",
+    "id",
+    "label",
+    "capabilities"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "type": {
+      "const": "aos.agent_capability_manifest"
+    },
+    "schema_version": {
+      "const": "2026-05-agent-capability-manifest-v0"
+    },
+    "id": {
+      "$ref": "#/$defs/id"
+    },
+    "label": {
+      "$ref": "#/$defs/non_empty_string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "applies_to": {
+      "$ref": "#/$defs/applies_to"
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/capability"
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "default": {}
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_.-]*$"
+    },
+    "non_empty_string": {
+      "type": "string",
+      "minLength": 1
+    },
+    "string_array": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/non_empty_string"
+      },
+      "default": []
+    },
+    "entry_path": {
+      "enum": [
+        "agent_harness",
+        "aos_developer",
+        "testing",
+        "visual_diagnostics",
+        "user_input_diagnostics",
+        "app_specific",
+        "break_glass"
+      ]
+    },
+    "role": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_.-]*$"
+    },
+    "applies_to": {
+      "type": "object",
+      "properties": {
+        "roles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/role"
+          },
+          "default": []
+        },
+        "entry_paths": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/entry_path"
+          },
+          "default": []
+        }
+      },
+      "additionalProperties": false,
+      "default": {}
+    },
+    "capability": {
+      "type": "object",
+      "required": [
+        "id",
+        "label",
+        "summary",
+        "status",
+        "entry_paths",
+        "adapter",
+        "mutability",
+        "execution",
+        "failure_policy"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/id"
+        },
+        "label": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "summary": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "status": {
+          "enum": [
+            "draft",
+            "active",
+            "deprecated"
+          ]
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/role"
+          },
+          "default": []
+        },
+        "entry_paths": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/entry_path"
+          }
+        },
+        "adapter": {
+          "$ref": "#/$defs/adapter"
+        },
+        "mutability": {
+          "$ref": "#/$defs/mutability"
+        },
+        "execution": {
+          "$ref": "#/$defs/execution"
+        },
+        "inputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/io"
+          },
+          "default": []
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/io"
+          },
+          "default": []
+        },
+        "failure_policy": {
+          "$ref": "#/$defs/failure_policy"
+        },
+        "notes": {
+          "$ref": "#/$defs/string_array"
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "execution": {
+                "properties": {
+                  "raw_process": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "raw_process"
+                ]
+              }
+            },
+            "required": [
+              "execution"
+            ]
+          },
+          "then": {
+            "properties": {
+              "entry_paths": {
+                "items": {
+                  "enum": [
+                    "aos_developer",
+                    "testing",
+                    "break_glass"
+                  ]
+                }
+              },
+              "mutability": {
+                "properties": {
+                  "requires_explicit_assignment": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "requires_explicit_assignment"
+                ]
+              },
+              "execution": {
+                "required": [
+                  "timeout_seconds",
+                  "audit"
+                ],
+                "properties": {
+                  "cwd_policy": {
+                    "not": {
+                      "const": "none"
+                    }
+                  },
+                  "audit": {
+                    "enum": [
+                      "recommended",
+                      "required"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "adapter": {
+                "properties": {
+                  "kind": {
+                    "enum": [
+                      "shell",
+                      "node",
+                      "python"
+                    ]
+                  }
+                },
+                "required": [
+                  "kind"
+                ]
+              }
+            },
+            "required": [
+              "adapter"
+            ]
+          },
+          "then": {
+            "properties": {
+              "execution": {
+                "properties": {
+                  "raw_process": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "raw_process"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "adapter": {
+      "type": "object",
+      "required": [
+        "kind"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "aos_cli",
+            "local_cli",
+            "node",
+            "python",
+            "http",
+            "mcp",
+            "manual",
+            "shell"
+          ]
+        },
+        "command": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_empty_string"
+          },
+          "default": []
+        },
+        "schema_ref": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "mutability": {
+      "type": "object",
+      "required": [
+        "class",
+        "requires_explicit_assignment"
+      ],
+      "properties": {
+        "class": {
+          "enum": [
+            "read_only",
+            "repo_write",
+            "runtime_mutation",
+            "external_write",
+            "host_write",
+            "destructive"
+          ]
+        },
+        "side_effects": {
+          "$ref": "#/$defs/string_array"
+        },
+        "requires_explicit_assignment": {
+          "type": "boolean"
+        },
+        "requires_human_approval": {
+          "type": "boolean",
+          "default": false
+        },
+        "requires_body_file": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "execution": {
+      "type": "object",
+      "required": [
+        "cwd_policy",
+        "network",
+        "raw_process",
+        "audit"
+      ],
+      "properties": {
+        "cwd_policy": {
+          "enum": [
+            "none",
+            "repo_root",
+            "declared_path",
+            "current_worktree"
+          ]
+        },
+        "timeout_seconds": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 3600
+        },
+        "network": {
+          "enum": [
+            "forbidden",
+            "allowed",
+            "required"
+          ]
+        },
+        "raw_process": {
+          "type": "boolean"
+        },
+        "audit": {
+          "enum": [
+            "none",
+            "recommended",
+            "required"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "io": {
+      "type": "object",
+      "required": [
+        "name",
+        "summary"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/id"
+        },
+        "summary": {
+          "$ref": "#/$defs/non_empty_string"
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        },
+        "schema": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "failure_policy": {
+      "type": "object",
+      "required": [
+        "bubble_up",
+        "retry"
+      ],
+      "properties": {
+        "bubble_up": {
+          "type": "boolean"
+        },
+        "retry": {
+          "enum": [
+            "none",
+            "bounded"
+          ]
+        },
+        "max_attempts": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 5
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "retry": {
+                "const": "bounded"
+              }
+            },
+            "required": [
+              "retry"
+            ]
+          },
+          "then": {
+            "required": [
+              "max_attempts"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/shared/schemas/aos-dock-profile-v0.md
+++ b/shared/schemas/aos-dock-profile-v0.md
@@ -1,0 +1,32 @@
+# AOS Dock Profile v0
+
+Dock profiles are the machine-readable seed for `.docks/<dock>/dock.json`.
+They describe the durable session role, default entry path, and capability
+envelope for a docked agent session.
+
+The profile is intentionally descriptive. It does not grant permissions,
+execute commands, or replace the human/model operating contract in
+`AGENTS.md`. It gives AOS and agents a stable way to answer: "who is this dock,
+what path does it start from, and which capability classes are in-bounds when
+the task explicitly calls for them?"
+
+## Fields
+
+- `name` is the dock directory identity, such as `foreman`, `gdi`, or
+  `operator`.
+- `role` is the durable authority boundary used by capability manifests.
+- `default_entry_path` is the entry path assumed before the task asks for a
+  deeper layer.
+- `allowed_entry_paths` is the bounded set the dock may move through when the
+  task justifies it.
+- `capability_manifest` points to the capability vocabulary, currently
+  `docs/dev/agent-capabilities.json`.
+- `allowed_capability_classes` is a coarse envelope over mutability classes.
+- `allowed_capabilities` is an optional fine-grained allowlist for named
+  capabilities in the manifest.
+- `requires_explicit_assignment_for` records classes that should not be treated
+  as ambient even when they are inside the dock envelope.
+
+Use `./aos dev docks explain <dock> --json` to inspect a profile and
+`./aos dev docks capabilities <dock> --json` to resolve the profile against the
+canonical capability manifest.

--- a/shared/schemas/aos-dock-profile-v0.schema.json
+++ b/shared/schemas/aos-dock-profile-v0.schema.json
@@ -1,0 +1,164 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/michaelblum/agent-os/shared/schemas/aos-dock-profile-v0.schema.json",
+  "title": "AOS Dock Profile v0",
+  "description": "Machine-readable profile for an AOS docked agent session. Dock profiles describe role identity, default entry path, and capability envelope without executing or granting capabilities.",
+  "type": "object",
+  "required": [
+    "type",
+    "schema_version",
+    "name",
+    "role",
+    "harness",
+    "default_entry_path",
+    "allowed_entry_paths",
+    "capability_manifest",
+    "allowed_capability_classes",
+    "allowed_capabilities",
+    "handoff"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "type": {
+      "const": "aos.dock_profile"
+    },
+    "schema_version": {
+      "const": "2026-05-dock-profile-v0"
+    },
+    "name": {
+      "$ref": "#/$defs/id"
+    },
+    "role": {
+      "$ref": "#/$defs/id"
+    },
+    "harness": {
+      "$ref": "#/$defs/id"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "default_entry_path": {
+      "$ref": "#/$defs/entry_path"
+    },
+    "allowed_entry_paths": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/entry_path"
+      }
+    },
+    "capability_manifest": {
+      "type": "string",
+      "minLength": 1
+    },
+    "allowed_capability_classes": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/mutability_class"
+      }
+    },
+    "allowed_capabilities": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/id"
+      }
+    },
+    "requires_explicit_assignment_for": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/mutability_class"
+      },
+      "default": []
+    },
+    "hook_timeout_seconds": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 120
+    },
+    "stop_notice": {
+      "$ref": "#/$defs/non_empty_string"
+    },
+    "handoff": {
+      "type": "object",
+      "required": [
+        "requires_goal_prefix"
+      ],
+      "properties": {
+        "requires_goal_prefix": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "voice": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "language": {
+          "type": "string"
+        },
+        "gender": {
+          "type": "string"
+        },
+        "voice_slot": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "quality_tiers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/non_empty_string"
+          }
+        }
+      },
+      "additionalProperties": true,
+      "default": {}
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "default": {}
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_.-]*$"
+    },
+    "non_empty_string": {
+      "type": "string",
+      "minLength": 1
+    },
+    "entry_path": {
+      "enum": [
+        "agent_harness",
+        "aos_developer",
+        "testing",
+        "visual_diagnostics",
+        "user_input_diagnostics",
+        "app_specific",
+        "break_glass"
+      ]
+    },
+    "mutability_class": {
+      "enum": [
+        "read_only",
+        "repo_write",
+        "runtime_mutation",
+        "external_write",
+        "host_write",
+        "destructive"
+      ]
+    }
+  }
+}

--- a/shared/schemas/fixtures/aos-agent-capability-manifest-v0/invalid/base-harness-raw-shell.json
+++ b/shared/schemas/fixtures/aos-agent-capability-manifest-v0/invalid/base-harness-raw-shell.json
@@ -1,0 +1,35 @@
+{
+  "type": "aos.agent_capability_manifest",
+  "schema_version": "2026-05-agent-capability-manifest-v0",
+  "id": "agent-os.invalid-base-shell",
+  "label": "Invalid Base Harness Shell",
+  "capabilities": [
+    {
+      "id": "agent.shell.anything",
+      "label": "Arbitrary Shell",
+      "summary": "Invalid because raw process execution is not a base harness capability.",
+      "status": "draft",
+      "entry_paths": ["agent_harness"],
+      "adapter": {
+        "kind": "shell",
+        "command": ["bash", "-lc", "<anything>"]
+      },
+      "mutability": {
+        "class": "host_write",
+        "side_effects": ["arbitrary_host_process"],
+        "requires_explicit_assignment": true
+      },
+      "execution": {
+        "cwd_policy": "repo_root",
+        "timeout_seconds": 60,
+        "network": "allowed",
+        "raw_process": true,
+        "audit": "required"
+      },
+      "failure_policy": {
+        "bubble_up": true,
+        "retry": "none"
+      }
+    }
+  ]
+}

--- a/shared/schemas/fixtures/aos-agent-capability-manifest-v0/invalid/node-adapter-raw-process-false.json
+++ b/shared/schemas/fixtures/aos-agent-capability-manifest-v0/invalid/node-adapter-raw-process-false.json
@@ -1,0 +1,34 @@
+{
+  "type": "aos.agent_capability_manifest",
+  "schema_version": "2026-05-agent-capability-manifest-v0",
+  "id": "agent-os.invalid-node-raw-process-false",
+  "label": "Invalid Node Raw Process False",
+  "capabilities": [
+    {
+      "id": "agent.node.base_harness",
+      "label": "Node In Base Harness",
+      "summary": "Invalid because Node adapters are host process execution and must be marked raw_process.",
+      "status": "draft",
+      "entry_paths": ["agent_harness"],
+      "adapter": {
+        "kind": "node",
+        "command": ["node", "scripts/example.mjs"]
+      },
+      "mutability": {
+        "class": "read_only",
+        "side_effects": [],
+        "requires_explicit_assignment": false
+      },
+      "execution": {
+        "cwd_policy": "none",
+        "network": "forbidden",
+        "raw_process": false,
+        "audit": "none"
+      },
+      "failure_policy": {
+        "bubble_up": true,
+        "retry": "none"
+      }
+    }
+  ]
+}

--- a/shared/schemas/fixtures/aos-agent-capability-manifest-v0/invalid/python-adapter-raw-process-false.json
+++ b/shared/schemas/fixtures/aos-agent-capability-manifest-v0/invalid/python-adapter-raw-process-false.json
@@ -1,0 +1,35 @@
+{
+  "type": "aos.agent_capability_manifest",
+  "schema_version": "2026-05-agent-capability-manifest-v0",
+  "id": "agent-os.invalid-python-raw-process-false",
+  "label": "Invalid Python Raw Process False",
+  "capabilities": [
+    {
+      "id": "dev.test.python_helper",
+      "label": "Python Helper Without Raw Process",
+      "summary": "Invalid because Python adapters are host process execution and must be marked raw_process.",
+      "status": "draft",
+      "entry_paths": ["aos_developer"],
+      "adapter": {
+        "kind": "python",
+        "command": ["python3", "scripts/example.py"]
+      },
+      "mutability": {
+        "class": "read_only",
+        "side_effects": [],
+        "requires_explicit_assignment": true
+      },
+      "execution": {
+        "cwd_policy": "repo_root",
+        "timeout_seconds": 60,
+        "network": "forbidden",
+        "raw_process": false,
+        "audit": "recommended"
+      },
+      "failure_policy": {
+        "bubble_up": true,
+        "retry": "none"
+      }
+    }
+  ]
+}

--- a/shared/schemas/fixtures/aos-agent-capability-manifest-v0/invalid/raw-process-missing-timeout.json
+++ b/shared/schemas/fixtures/aos-agent-capability-manifest-v0/invalid/raw-process-missing-timeout.json
@@ -1,0 +1,34 @@
+{
+  "type": "aos.agent_capability_manifest",
+  "schema_version": "2026-05-agent-capability-manifest-v0",
+  "id": "agent-os.invalid-raw-process-timeout",
+  "label": "Invalid Raw Process Timeout",
+  "capabilities": [
+    {
+      "id": "dev.test.raw_node",
+      "label": "Raw Node Without Timeout",
+      "summary": "Invalid because raw process execution must declare timeout and audit posture.",
+      "status": "draft",
+      "entry_paths": ["testing"],
+      "adapter": {
+        "kind": "node",
+        "command": ["node", "--test", "tests/example.test.mjs"]
+      },
+      "mutability": {
+        "class": "read_only",
+        "side_effects": [],
+        "requires_explicit_assignment": true
+      },
+      "execution": {
+        "cwd_policy": "repo_root",
+        "network": "forbidden",
+        "raw_process": true,
+        "audit": "recommended"
+      },
+      "failure_policy": {
+        "bubble_up": true,
+        "retry": "none"
+      }
+    }
+  ]
+}

--- a/shared/schemas/fixtures/aos-agent-capability-manifest-v0/invalid/raw-process-without-explicit-assignment.json
+++ b/shared/schemas/fixtures/aos-agent-capability-manifest-v0/invalid/raw-process-without-explicit-assignment.json
@@ -1,0 +1,35 @@
+{
+  "type": "aos.agent_capability_manifest",
+  "schema_version": "2026-05-agent-capability-manifest-v0",
+  "id": "agent-os.invalid-raw-process-assignment",
+  "label": "Invalid Raw Process Assignment",
+  "capabilities": [
+    {
+      "id": "dev.test.raw_python",
+      "label": "Raw Python Without Explicit Assignment",
+      "summary": "Invalid because raw process execution must require explicit assignment.",
+      "status": "draft",
+      "entry_paths": ["aos_developer"],
+      "adapter": {
+        "kind": "python",
+        "command": ["python3", "scripts/example.py"]
+      },
+      "mutability": {
+        "class": "read_only",
+        "side_effects": [],
+        "requires_explicit_assignment": false
+      },
+      "execution": {
+        "cwd_policy": "repo_root",
+        "timeout_seconds": 60,
+        "network": "forbidden",
+        "raw_process": true,
+        "audit": "required"
+      },
+      "failure_policy": {
+        "bubble_up": true,
+        "retry": "none"
+      }
+    }
+  ]
+}

--- a/shared/schemas/fixtures/aos-agent-capability-manifest-v0/valid/dev-gh.json
+++ b/shared/schemas/fixtures/aos-agent-capability-manifest-v0/valid/dev-gh.json
@@ -1,0 +1,114 @@
+{
+  "type": "aos.agent_capability_manifest",
+  "schema_version": "2026-05-agent-capability-manifest-v0",
+  "id": "agent-os.docked-github",
+  "label": "Docked GitHub Capabilities",
+  "summary": "Typed GitHub capabilities for docked repo-development sessions.",
+  "applies_to": {
+    "roles": ["foreman", "gdi", "operator"],
+    "entry_paths": ["aos_developer", "testing"]
+  },
+  "capabilities": [
+    {
+      "id": "dev.github.context",
+      "label": "GitHub Context",
+      "summary": "Inspect local git and gh authentication context through the AOS developer control surface.",
+      "status": "active",
+      "roles": ["foreman", "gdi", "operator"],
+      "entry_paths": ["aos_developer"],
+      "adapter": {
+        "kind": "aos_cli",
+        "command": ["./aos", "dev", "gh", "context", "--json"]
+      },
+      "mutability": {
+        "class": "read_only",
+        "side_effects": [],
+        "requires_explicit_assignment": false,
+        "requires_human_approval": false,
+        "requires_body_file": false
+      },
+      "execution": {
+        "cwd_policy": "repo_root",
+        "timeout_seconds": 30,
+        "network": "allowed",
+        "raw_process": false,
+        "audit": "recommended"
+      },
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "context_json",
+          "summary": "Repository, branch, upstream, dirty state, and gh availability/authentication status.",
+          "required": true,
+          "schema": {
+            "type": "object"
+          }
+        }
+      ],
+      "failure_policy": {
+        "bubble_up": true,
+        "retry": "none"
+      }
+    },
+    {
+      "id": "dev.github.issue_comment",
+      "label": "GitHub Issue Comment",
+      "summary": "Write a GitHub issue comment through a body file using the local gh CLI via ./aos dev gh.",
+      "status": "active",
+      "roles": ["foreman"],
+      "entry_paths": ["aos_developer"],
+      "adapter": {
+        "kind": "aos_cli",
+        "command": ["./aos", "dev", "gh", "issue", "comment"]
+      },
+      "mutability": {
+        "class": "external_write",
+        "side_effects": ["github_issue_comment"],
+        "requires_explicit_assignment": true,
+        "requires_human_approval": false,
+        "requires_body_file": true
+      },
+      "execution": {
+        "cwd_policy": "repo_root",
+        "timeout_seconds": 30,
+        "network": "required",
+        "raw_process": false,
+        "audit": "required"
+      },
+      "inputs": [
+        {
+          "name": "issue_number",
+          "summary": "GitHub issue number.",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        {
+          "name": "body_file",
+          "summary": "Markdown file containing the comment body.",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "comment_url",
+          "summary": "GitHub URL for the posted comment.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "failure_policy": {
+        "bubble_up": true,
+        "retry": "none"
+      }
+    }
+  ]
+}

--- a/shared/schemas/fixtures/aos-agent-capability-manifest-v0/valid/node-test.json
+++ b/shared/schemas/fixtures/aos-agent-capability-manifest-v0/valid/node-test.json
@@ -1,0 +1,64 @@
+{
+  "type": "aos.agent_capability_manifest",
+  "schema_version": "2026-05-agent-capability-manifest-v0",
+  "id": "agent-os.node-tests",
+  "label": "Node Test Capabilities",
+  "summary": "Scoped Node test execution as an explicit developer/testing capability.",
+  "applies_to": {
+    "roles": ["gdi", "foreman"],
+    "entry_paths": ["aos_developer", "testing"]
+  },
+  "capabilities": [
+    {
+      "id": "dev.test.node_schema",
+      "label": "Node Schema Test",
+      "summary": "Run a bounded Node schema test file from the repo root.",
+      "status": "draft",
+      "roles": ["gdi", "foreman"],
+      "entry_paths": ["aos_developer", "testing"],
+      "adapter": {
+        "kind": "node",
+        "command": ["node", "--test", "tests/schemas/<test>.mjs"]
+      },
+      "mutability": {
+        "class": "read_only",
+        "side_effects": [],
+        "requires_explicit_assignment": true,
+        "requires_human_approval": false,
+        "requires_body_file": false
+      },
+      "execution": {
+        "cwd_policy": "repo_root",
+        "timeout_seconds": 120,
+        "network": "forbidden",
+        "raw_process": true,
+        "audit": "recommended"
+      },
+      "inputs": [
+        {
+          "name": "test",
+          "summary": "Repo-relative schema test stem.",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "pattern": "^[a-z0-9_.-]+$"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "tap_output",
+          "summary": "Node test TAP output.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "failure_policy": {
+        "bubble_up": true,
+        "retry": "none"
+      }
+    }
+  ]
+}

--- a/shared/schemas/fixtures/aos-dock-profile-v0/invalid/missing-default-entry-path.json
+++ b/shared/schemas/fixtures/aos-dock-profile-v0/invalid/missing-default-entry-path.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../../../aos-dock-profile-v0.schema.json",
+  "type": "aos.dock_profile",
+  "schema_version": "2026-05-dock-profile-v0",
+  "name": "gdi",
+  "role": "gdi",
+  "harness": "codex",
+  "allowed_entry_paths": [
+    "aos_developer"
+  ],
+  "capability_manifest": "docs/dev/agent-capabilities.json",
+  "allowed_capability_classes": [
+    "read_only"
+  ],
+  "allowed_capabilities": [],
+  "handoff": {
+    "requires_goal_prefix": true
+  }
+}

--- a/shared/schemas/fixtures/aos-dock-profile-v0/invalid/unknown-capability-class.json
+++ b/shared/schemas/fixtures/aos-dock-profile-v0/invalid/unknown-capability-class.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "../../../aos-dock-profile-v0.schema.json",
+  "type": "aos.dock_profile",
+  "schema_version": "2026-05-dock-profile-v0",
+  "name": "operator",
+  "role": "operator",
+  "harness": "codex",
+  "default_entry_path": "agent_harness",
+  "allowed_entry_paths": [
+    "agent_harness"
+  ],
+  "capability_manifest": "docs/dev/agent-capabilities.json",
+  "allowed_capability_classes": [
+    "telepathy"
+  ],
+  "allowed_capabilities": [],
+  "handoff": {
+    "requires_goal_prefix": false
+  }
+}

--- a/shared/schemas/fixtures/aos-dock-profile-v0/valid/foreman-minimal.json
+++ b/shared/schemas/fixtures/aos-dock-profile-v0/valid/foreman-minimal.json
@@ -1,47 +1,32 @@
 {
-  "$schema": "../../shared/schemas/aos-dock-profile-v0.schema.json",
+  "$schema": "../../../aos-dock-profile-v0.schema.json",
   "type": "aos.dock_profile",
   "schema_version": "2026-05-dock-profile-v0",
   "name": "foreman",
   "role": "foreman",
   "harness": "codex",
-  "summary": "Coordination, review, work-card routing, git/GitHub hygiene, and workstream state.",
+  "summary": "Coordination profile.",
   "default_entry_path": "aos_developer",
   "allowed_entry_paths": [
     "agent_harness",
     "aos_developer",
-    "testing",
-    "visual_diagnostics",
-    "user_input_diagnostics",
-    "app_specific"
+    "testing"
   ],
   "capability_manifest": "docs/dev/agent-capabilities.json",
   "allowed_capability_classes": [
     "read_only",
-    "repo_write",
-    "runtime_mutation",
     "external_write",
     "host_write"
   ],
   "allowed_capabilities": [
     "dev.github.context",
-    "dev.github.issue_comment",
-    "dev.github.ci_inspect",
-    "dev.github.review_comments",
-    "dev.build.aos",
-    "dev.test.schema_node"
+    "dev.github.issue_comment"
   ],
   "requires_explicit_assignment_for": [
     "external_write",
     "host_write"
   ],
-  "hook_timeout_seconds": 8,
-  "stop_notice": "Foreman finished.",
   "handoff": {
     "requires_goal_prefix": false
-  },
-  "voice": {
-    "gender": "male",
-    "voice_slot": 1
   }
 }

--- a/src/commands/dev.swift
+++ b/src/commands/dev.swift
@@ -67,6 +67,33 @@ private struct DevAuditOptions {
     var manifest: String?
 }
 
+private struct DevCapabilitiesOptions {
+    var json = false
+    var repo: String?
+    var manifest: String?
+    var role: String?
+    var entryPath: String?
+    var positionals: [String] = []
+}
+
+private struct DevDocksOptions {
+    var json = false
+    var repo: String?
+    var dockRoot: String?
+    var capabilitiesManifest: String?
+    var entryPath: String?
+    var positionals: [String] = []
+}
+
+private struct DevGhOptions {
+    var json = false
+    var repo: String?
+    var cwd: String?
+    var bodyFile: String?
+    var prNumber: String?
+    var positionals: [String] = []
+}
+
 private struct DevClassifiedFile {
     let path: String
     let rules: [DevWorkflowRule]
@@ -117,6 +144,8 @@ private struct DevAuditClaim {
 }
 
 private let devWorkflowDefaultManifestRelativePath = "docs/dev/workflow-rules.json"
+private let devCapabilitiesDefaultManifestRelativePath = "docs/dev/agent-capabilities.json"
+private let devDocksDefaultRootRelativePath = ".docks"
 private let devWorkflowRuleID = "dev-workflow-manifest"
 
 func devCommand(args: [String]) {
@@ -145,6 +174,12 @@ func devCommand(args: [String]) {
         devBuildCommand(args: subArgs)
     case "audit":
         devAuditCommand(args: subArgs)
+    case "capabilities":
+        devCapabilitiesCommand(args: subArgs)
+    case "docks":
+        devDocksCommand(args: subArgs)
+    case "gh":
+        devGhCommand(args: subArgs)
     default:
         exitError("Unknown dev subcommand: \(sub)", code: "UNKNOWN_SUBCOMMAND")
     }
@@ -232,6 +267,493 @@ private func devBuildCommand(args: [String]) {
         }
     }
     exit(result.exitCode)
+}
+
+private func devCapabilitiesCommand(args: [String]) {
+    guard let action = args.first else {
+        printCommandHelp(["dev", "capabilities"], json: false)
+        exit(0)
+    }
+
+    let options = parseDevCapabilitiesOptions(Array(args.dropFirst()))
+    switch action {
+    case "list":
+        devCapabilitiesListCommand(options: options)
+    case "explain":
+        devCapabilitiesExplainCommand(options: options)
+    default:
+        exitError("Unknown dev capabilities subcommand: \(action)", code: "UNKNOWN_SUBCOMMAND")
+    }
+}
+
+private func devCapabilitiesListCommand(options: DevCapabilitiesOptions) {
+    guard options.positionals.isEmpty else {
+        exitError("dev capabilities list does not accept positional arguments", code: "UNKNOWN_ARG")
+    }
+    let loaded = loadDevCapabilityManifest(options: options)
+    let capabilities = filterDevCapabilities(loaded.capabilities, options: options)
+    let payload: [String: Any] = [
+        "status": "success",
+        "manifest": normalizeRepoRelativePath(loaded.path, repoRoot: loaded.repoRoot),
+        "manifest_id": loaded.manifest["id"] ?? NSNull(),
+        "manifest_schema_version": loaded.manifest["schema_version"] ?? NSNull(),
+        "role": devGhNullable(options.role),
+        "entry_path": devGhNullable(options.entryPath),
+        "count": capabilities.count,
+        "capabilities": capabilities.map { compactDevCapability($0) },
+    ]
+    if options.json {
+        printDevJSON(payload)
+    } else {
+        printDevCapabilitiesListText(payload)
+    }
+}
+
+private func devCapabilitiesExplainCommand(options: DevCapabilitiesOptions) {
+    guard options.positionals.count == 1, let capabilityID = options.positionals.first else {
+        exitError("dev capabilities explain requires exactly one capability id", code: "MISSING_ARG")
+    }
+    let loaded = loadDevCapabilityManifest(options: options)
+    guard let capability = loaded.capabilities.first(where: { ($0["id"] as? String) == capabilityID }) else {
+        exitError("Unknown capability id: \(capabilityID)", code: "UNKNOWN_CAPABILITY")
+    }
+    let payload: [String: Any] = [
+        "status": "success",
+        "manifest": normalizeRepoRelativePath(loaded.path, repoRoot: loaded.repoRoot),
+        "manifest_id": loaded.manifest["id"] ?? NSNull(),
+        "manifest_schema_version": loaded.manifest["schema_version"] ?? NSNull(),
+        "capability": capability,
+    ]
+    if options.json {
+        printDevJSON(payload)
+    } else {
+        printDevCapabilityExplainText(payload)
+    }
+}
+
+private func devDocksCommand(args: [String]) {
+    guard let action = args.first else {
+        printCommandHelp(["dev", "docks"], json: false)
+        exit(0)
+    }
+
+    let options = parseDevDocksOptions(Array(args.dropFirst()))
+    switch action {
+    case "list":
+        devDocksListCommand(options: options)
+    case "explain":
+        devDocksExplainCommand(options: options)
+    case "capabilities":
+        devDocksCapabilitiesCommand(options: options)
+    default:
+        exitError("Unknown dev docks subcommand: \(action)", code: "UNKNOWN_SUBCOMMAND")
+    }
+}
+
+private func devDocksListCommand(options: DevDocksOptions) {
+    guard options.positionals.isEmpty else {
+        exitError("dev docks list does not accept positional arguments", code: "UNKNOWN_ARG")
+    }
+    let loaded = loadDevDockProfiles(options: options)
+    let profiles = loaded.profiles.map { compactDevDockProfile($0) }
+    let payload: [String: Any] = [
+        "status": "success",
+        "dock_root": normalizeRepoRelativePath(loaded.dockRoot, repoRoot: loaded.repoRoot),
+        "count": profiles.count,
+        "docks": profiles,
+    ]
+    if options.json {
+        printDevJSON(payload)
+    } else {
+        printDevDocksListText(payload)
+    }
+}
+
+private func devDocksExplainCommand(options: DevDocksOptions) {
+    guard options.positionals.count == 1, let dockName = options.positionals.first else {
+        exitError("dev docks explain requires exactly one dock name", code: "MISSING_ARG")
+    }
+    let loaded = loadDevDockProfiles(options: options)
+    guard let profile = loaded.profiles.first(where: { devString($0["name"]) == dockName }) else {
+        exitError("Unknown dock profile: \(dockName)", code: "UNKNOWN_DOCK")
+    }
+    let payload: [String: Any] = [
+        "status": "success",
+        "dock_root": normalizeRepoRelativePath(loaded.dockRoot, repoRoot: loaded.repoRoot),
+        "profile": profile,
+    ]
+    if options.json {
+        printDevJSON(payload)
+    } else {
+        printDevDockExplainText(payload)
+    }
+}
+
+private func devDocksCapabilitiesCommand(options: DevDocksOptions) {
+    guard options.positionals.count == 1, let dockName = options.positionals.first else {
+        exitError("dev docks capabilities requires exactly one dock name", code: "MISSING_ARG")
+    }
+    let loaded = loadDevDockProfiles(options: options)
+    guard let profile = loaded.profiles.first(where: { devString($0["name"]) == dockName }) else {
+        exitError("Unknown dock profile: \(dockName)", code: "UNKNOWN_DOCK")
+    }
+
+    let defaultEntryPath = devString(profile["default_entry_path"]) ?? "agent_harness"
+    let activeEntryPath = options.entryPath ?? defaultEntryPath
+    let allowedEntryPaths = devStringArray(profile["allowed_entry_paths"])
+    guard allowedEntryPaths.contains(activeEntryPath) else {
+        exitError("Dock \(dockName) does not allow entry path: \(activeEntryPath)", code: "ENTRY_PATH_NOT_ALLOWED")
+    }
+
+    var capabilityOptions = DevCapabilitiesOptions()
+    capabilityOptions.repo = options.repo
+    capabilityOptions.manifest = options.capabilitiesManifest ?? devString(profile["capability_manifest"])
+    let capabilityManifest = loadDevCapabilityManifest(options: capabilityOptions)
+    let capabilities = resolveDevDockCapabilities(
+        profile: profile,
+        capabilities: capabilityManifest.capabilities,
+        entryPath: activeEntryPath)
+    let payload: [String: Any] = [
+        "status": "success",
+        "dock": dockName,
+        "role": devGhNullable(devString(profile["role"])),
+        "dock_root": normalizeRepoRelativePath(loaded.dockRoot, repoRoot: loaded.repoRoot),
+        "default_entry_path": defaultEntryPath,
+        "active_entry_path": activeEntryPath,
+        "allowed_entry_paths": allowedEntryPaths,
+        "allowed_capability_classes": devStringArray(profile["allowed_capability_classes"]),
+        "capability_manifest": normalizeRepoRelativePath(capabilityManifest.path, repoRoot: capabilityManifest.repoRoot),
+        "count": capabilities.count,
+        "capabilities": capabilities.map { compactDevCapability($0) },
+    ]
+    if options.json {
+        printDevJSON(payload)
+    } else {
+        printDevDockCapabilitiesText(payload)
+    }
+}
+
+private func devGhCommand(args: [String]) {
+    guard let group = args.first else {
+        printCommandHelp(["dev", "gh"], json: false)
+        exit(0)
+    }
+
+    let remaining = Array(args.dropFirst())
+    switch group {
+    case "context":
+        devGhContextCommand(args: remaining)
+    case "issue":
+        devGhIssueCommand(args: remaining)
+    case "pr":
+        devGhPRCommand(args: remaining)
+    case "ci":
+        devGhCICommand(args: remaining)
+    case "review-comments":
+        devGhReviewCommentsCommand(args: remaining)
+    default:
+        exitError("Unknown dev gh group: \(group)", code: "UNKNOWN_SUBCOMMAND")
+    }
+}
+
+private func devGhContextCommand(args: [String]) {
+    let options = parseDevGhOptions(args)
+    if !options.positionals.isEmpty {
+        exitError("dev gh context does not accept positional arguments", code: "UNKNOWN_ARG")
+    }
+
+    let repoRoot = resolveRepoRoot(options.cwd)
+    let repoFullName = devGhRepositoryFullName(options: options, repoRoot: repoRoot)
+    let ghPath = findExecutable("gh")
+    let auth = runGh(["auth", "status"], cwd: repoRoot)
+    let repoInfo = devGhRepositoryInfo(repoFullName: repoFullName, repoRoot: repoRoot)
+    let prInfo = devGhCurrentPRInfo(repoFullName: repoFullName, repoRoot: repoRoot)
+    let branch = runGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd: repoRoot).stdoutLines.first
+    let upstream = runGit(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], cwd: repoRoot).stdoutLines.first
+    let dirtyFiles = gitStatusFiles(repoRoot: repoRoot, untrackedOnly: false)
+    let defaultBranch = (repoInfo?["defaultBranchRef"] as? [String: Any])?["name"] as? String
+
+    let status: String
+    if ghPath == nil {
+        status = "error"
+    } else if auth.exitCode == 0 {
+        status = "success"
+    } else {
+        status = "degraded"
+    }
+
+    let payload: [String: Any] = [
+        "status": status,
+        "authority": "gh_cli",
+        "tool": "gh",
+        "repo_root": repoRoot,
+        "repository": devGhNullable(repoFullName ?? (repoInfo?["nameWithOwner"] as? String)),
+        "branch": devGhNullable(branch),
+        "upstream": devGhNullable(upstream),
+        "default_branch": devGhNullable(defaultBranch),
+        "gh": [
+            "available": ghPath != nil,
+            "path": devGhNullable(ghPath),
+            "auth_exit_code": Int(auth.exitCode),
+            "authenticated": auth.exitCode == 0,
+            "auth_stdout": devGhSanitizeAuthStatus(auth.stdout),
+            "auth_stderr": devGhSanitizeAuthStatus(auth.stderr),
+        ],
+        "current_pr": devGhNullable(prInfo),
+        "dirty": [
+            "count": dirtyFiles.count,
+            "files": dirtyFiles,
+        ],
+    ]
+
+    if options.json {
+        printDevJSON(payload)
+    } else {
+        printDevGhContextText(payload)
+    }
+}
+
+private func devGhIssueCommand(args: [String]) {
+    guard let action = args.first else {
+        exitError("dev gh issue requires a subcommand: view or comment", code: "MISSING_SUBCOMMAND")
+    }
+    let options = parseDevGhOptions(Array(args.dropFirst()))
+    let repoRoot = resolveRepoRoot(options.cwd)
+    let repoFullName = devGhRepositoryFullName(options: options, repoRoot: repoRoot)
+
+    switch action {
+    case "view":
+        guard options.positionals.count == 1, let number = options.positionals.first else {
+            exitError("dev gh issue view requires exactly one issue number", code: "MISSING_ARG")
+        }
+        var ghArgs = ["issue", "view", number]
+        devGhAppendRepo(&ghArgs, repoFullName: repoFullName)
+        if options.json {
+            ghArgs += ["--json", "number,title,state,url,body,labels,comments"]
+        }
+        devGhRunAndExit(ghArgs, cwd: repoRoot)
+    case "comment":
+        guard options.positionals.count == 1, let number = options.positionals.first else {
+            exitError("dev gh issue comment requires exactly one issue number", code: "MISSING_ARG")
+        }
+        guard let bodyFile = options.bodyFile else {
+            exitError("dev gh issue comment requires --body-file <path>", code: "MISSING_ARG")
+        }
+        let absoluteBodyFile = devGhResolveUserPath(bodyFile)
+        guard FileManager.default.fileExists(atPath: absoluteBodyFile) else {
+            exitError("Missing issue comment body file: \(absoluteBodyFile)", code: "MISSING_BODY_FILE")
+        }
+        var ghArgs = ["issue", "comment", number]
+        devGhAppendRepo(&ghArgs, repoFullName: repoFullName)
+        ghArgs += ["--body-file", absoluteBodyFile]
+        devGhRunAndExit(ghArgs, cwd: repoRoot)
+    default:
+        exitError("Unknown dev gh issue subcommand: \(action)", code: "UNKNOWN_SUBCOMMAND")
+    }
+}
+
+private func devGhPRCommand(args: [String]) {
+    guard let action = args.first else {
+        exitError("dev gh pr requires a subcommand: view, checks, or comment", code: "MISSING_SUBCOMMAND")
+    }
+    let options = parseDevGhOptions(Array(args.dropFirst()))
+    let repoRoot = resolveRepoRoot(options.cwd)
+    let repoFullName = devGhRepositoryFullName(options: options, repoRoot: repoRoot)
+
+    switch action {
+    case "view":
+        guard options.positionals.count <= 1 else {
+            exitError("dev gh pr view accepts at most one PR number", code: "UNKNOWN_ARG")
+        }
+        var ghArgs = ["pr", "view"]
+        if let number = options.positionals.first {
+            ghArgs.append(number)
+        }
+        devGhAppendRepo(&ghArgs, repoFullName: repoFullName)
+        if options.json {
+            ghArgs += ["--json", "number,title,state,url,headRefName,baseRefName,isDraft,body,comments,reviews"]
+        }
+        devGhRunAndExit(ghArgs, cwd: repoRoot)
+    case "checks":
+        guard options.positionals.count <= 1 else {
+            exitError("dev gh pr checks accepts at most one PR number", code: "UNKNOWN_ARG")
+        }
+        var ghArgs = ["pr", "checks"]
+        if let number = options.positionals.first {
+            ghArgs.append(number)
+        }
+        devGhAppendRepo(&ghArgs, repoFullName: repoFullName)
+        if options.json {
+            ghArgs += ["--json", "name,state,bucket,link,startedAt,completedAt,workflow"]
+        }
+        devGhRunAndExit(ghArgs, cwd: repoRoot)
+    case "comment":
+        guard options.positionals.count == 1, let number = options.positionals.first else {
+            exitError("dev gh pr comment requires exactly one PR number", code: "MISSING_ARG")
+        }
+        guard let bodyFile = options.bodyFile else {
+            exitError("dev gh pr comment requires --body-file <path>", code: "MISSING_ARG")
+        }
+        let absoluteBodyFile = devGhResolveUserPath(bodyFile)
+        guard FileManager.default.fileExists(atPath: absoluteBodyFile) else {
+            exitError("Missing PR comment body file: \(absoluteBodyFile)", code: "MISSING_BODY_FILE")
+        }
+        var ghArgs = ["pr", "comment", number]
+        devGhAppendRepo(&ghArgs, repoFullName: repoFullName)
+        ghArgs += ["--body-file", absoluteBodyFile]
+        devGhRunAndExit(ghArgs, cwd: repoRoot)
+    default:
+        exitError("Unknown dev gh pr subcommand: \(action)", code: "UNKNOWN_SUBCOMMAND")
+    }
+}
+
+private func devGhCICommand(args: [String]) {
+    guard let action = args.first else {
+        exitError("dev gh ci requires a subcommand: inspect", code: "MISSING_SUBCOMMAND")
+    }
+    guard action == "inspect" else {
+        exitError("Unknown dev gh ci subcommand: \(action)", code: "UNKNOWN_SUBCOMMAND")
+    }
+
+    let options = parseDevGhOptions(Array(args.dropFirst()))
+    guard options.positionals.count <= 1 else {
+        exitError("dev gh ci inspect accepts at most one PR number", code: "UNKNOWN_ARG")
+    }
+
+    let repoRoot = resolveRepoRoot(options.cwd)
+    let repoFullName = devGhRepositoryFullName(options: options, repoRoot: repoRoot)
+    let prNumber = devGhResolvePRNumber(options.prNumber ?? options.positionals.first, repoFullName: repoFullName, repoRoot: repoRoot, json: options.json)
+    var checksArgs = ["pr", "checks", prNumber]
+    devGhAppendRepo(&checksArgs, repoFullName: repoFullName)
+    checksArgs += ["--json", "name,state,bucket,link,startedAt,completedAt,workflow"]
+
+    let checksResult = runGh(checksArgs, cwd: repoRoot)
+    guard checksResult.exitCode == 0 else {
+        devGhEmitCompositeErrorAndExit(command: checksArgs, result: checksResult, json: options.json)
+    }
+    let checks = parseDevGhJSON(checksResult.stdout) as? [[String: Any]] ?? []
+    var failedLogs: [[String: Any]] = []
+    for check in checks where devGhCheckFailed(check) {
+        let link = check["link"] as? String ?? ""
+        guard let runID = devGhActionsRunID(from: link) else {
+            failedLogs.append([
+                "check": check,
+                "source": "external",
+                "status": "report_only",
+                "reason": "check link is not a GitHub Actions run URL",
+            ])
+            continue
+        }
+
+        var logArgs = ["run", "view", runID]
+        devGhAppendRepo(&logArgs, repoFullName: repoFullName)
+        logArgs.append("--log-failed")
+        let logResult = runGh(logArgs, cwd: repoRoot)
+        failedLogs.append([
+            "check": check,
+            "source": "github_actions",
+            "run_id": runID,
+            "status": logResult.exitCode == 0 ? "success" : "error",
+            "exit_code": Int(logResult.exitCode),
+            "stdout": logResult.stdout,
+            "stderr": logResult.stderr,
+        ])
+    }
+
+    let payload: [String: Any] = [
+        "status": "success",
+        "authority": "gh_cli",
+        "pr": prNumber,
+        "repository": devGhNullable(repoFullName),
+        "checks": checks,
+        "failed_logs": failedLogs,
+    ]
+    if options.json {
+        printDevJSON(payload)
+    } else {
+        printDevGhCIText(payload)
+    }
+}
+
+private func devGhReviewCommentsCommand(args: [String]) {
+    let options = parseDevGhOptions(args)
+    guard options.positionals.count <= 1 else {
+        exitError("dev gh review-comments accepts at most one PR number", code: "UNKNOWN_ARG")
+    }
+
+    let repoRoot = resolveRepoRoot(options.cwd)
+    let repoFullName = devGhRepositoryFullName(options: options, repoRoot: repoRoot)
+    guard let repoFullName else {
+        exitError("Could not infer GitHub repository. Pass --repo owner/name.", code: "MISSING_REPO")
+    }
+    guard let repoParts = devGhSplitRepoFullName(repoFullName) else {
+        exitError("Invalid GitHub repository '\(repoFullName)'. Expected owner/name.", code: "INVALID_REPO")
+    }
+
+    let prNumber = devGhResolvePRNumber(options.prNumber ?? options.positionals.first, repoFullName: repoFullName, repoRoot: repoRoot, json: options.json)
+    guard Int(prNumber) != nil else {
+        exitError("PR number must be numeric for review-comments: \(prNumber)", code: "INVALID_PR")
+    }
+
+    let query = """
+    query($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          number
+          url
+          reviewThreads(first: 100) {
+            nodes {
+              isResolved
+              isOutdated
+              path
+              line
+              startLine
+              comments(first: 50) {
+                nodes {
+                  id
+                  url
+                  body
+                  createdAt
+                  author { login }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    let graphQLArgs = [
+        "api", "graphql",
+        "-f", "owner=\(repoParts.owner)",
+        "-f", "name=\(repoParts.name)",
+        "-F", "number=\(prNumber)",
+        "-f", "query=\(query)",
+    ]
+    let result = runGh(graphQLArgs, cwd: repoRoot)
+    guard result.exitCode == 0 else {
+        devGhEmitCompositeErrorAndExit(command: graphQLArgs, result: result, json: options.json)
+    }
+
+    let raw = parseDevGhJSON(result.stdout) as? [String: Any] ?? [:]
+    let threads = devGhFlattenReviewThreads(raw)
+    let unresolved = threads.filter { ($0["is_resolved"] as? Bool) == false }
+    let payload: [String: Any] = [
+        "status": "success",
+        "authority": "gh_cli",
+        "repository": repoFullName,
+        "pr": prNumber,
+        "thread_count": threads.count,
+        "unresolved_count": unresolved.count,
+        "threads": threads,
+    ]
+
+    if options.json {
+        printDevJSON(payload)
+    } else {
+        printDevGhReviewCommentsText(payload)
+    }
 }
 
 private func runProcessCapturingOutput(_ executable: String, arguments: [String], cwd: String? = nil) -> ProcessOutput {
@@ -333,6 +855,138 @@ private func parseDevOptions(_ args: [String]) -> DevOptions {
     return options
 }
 
+private func parseDevCapabilitiesOptions(_ args: [String]) -> DevCapabilitiesOptions {
+    var options = DevCapabilitiesOptions()
+    var i = 0
+    while i < args.count {
+        let arg = args[i]
+        switch arg {
+        case "--json":
+            options.json = true
+            i += 1
+        case "--repo":
+            guard i + 1 < args.count else {
+                exitError("--repo requires a path", code: "MISSING_ARG")
+            }
+            options.repo = args[i + 1]
+            i += 2
+        case "--manifest":
+            guard i + 1 < args.count else {
+                exitError("--manifest requires a path", code: "MISSING_ARG")
+            }
+            options.manifest = args[i + 1]
+            i += 2
+        case "--role":
+            guard i + 1 < args.count else {
+                exitError("--role requires a dock role", code: "MISSING_ARG")
+            }
+            options.role = args[i + 1]
+            i += 2
+        case "--entry-path":
+            guard i + 1 < args.count else {
+                exitError("--entry-path requires an entry path", code: "MISSING_ARG")
+            }
+            options.entryPath = args[i + 1]
+            i += 2
+        default:
+            if arg.hasPrefix("--") {
+                exitError("Unknown dev capabilities flag: \(arg)", code: "UNKNOWN_FLAG")
+            }
+            options.positionals.append(arg)
+            i += 1
+        }
+    }
+    return options
+}
+
+private func parseDevDocksOptions(_ args: [String]) -> DevDocksOptions {
+    var options = DevDocksOptions()
+    var i = 0
+    while i < args.count {
+        let arg = args[i]
+        switch arg {
+        case "--json":
+            options.json = true
+            i += 1
+        case "--repo":
+            guard i + 1 < args.count else {
+                exitError("--repo requires a path", code: "MISSING_ARG")
+            }
+            options.repo = args[i + 1]
+            i += 2
+        case "--dock-root":
+            guard i + 1 < args.count else {
+                exitError("--dock-root requires a path", code: "MISSING_ARG")
+            }
+            options.dockRoot = args[i + 1]
+            i += 2
+        case "--capabilities-manifest":
+            guard i + 1 < args.count else {
+                exitError("--capabilities-manifest requires a path", code: "MISSING_ARG")
+            }
+            options.capabilitiesManifest = args[i + 1]
+            i += 2
+        case "--entry-path":
+            guard i + 1 < args.count else {
+                exitError("--entry-path requires an entry path", code: "MISSING_ARG")
+            }
+            options.entryPath = args[i + 1]
+            i += 2
+        default:
+            if arg.hasPrefix("--") {
+                exitError("Unknown dev docks flag: \(arg)", code: "UNKNOWN_FLAG")
+            }
+            options.positionals.append(arg)
+            i += 1
+        }
+    }
+    return options
+}
+
+private func parseDevGhOptions(_ args: [String]) -> DevGhOptions {
+    var options = DevGhOptions()
+    var i = 0
+    while i < args.count {
+        let arg = args[i]
+        switch arg {
+        case "--json":
+            options.json = true
+            i += 1
+        case "--repo":
+            guard i + 1 < args.count else {
+                exitError("--repo requires a GitHub repository in owner/name form", code: "MISSING_ARG")
+            }
+            options.repo = args[i + 1]
+            i += 2
+        case "--cwd":
+            guard i + 1 < args.count else {
+                exitError("--cwd requires a local checkout path", code: "MISSING_ARG")
+            }
+            options.cwd = args[i + 1]
+            i += 2
+        case "--body-file":
+            guard i + 1 < args.count else {
+                exitError("--body-file requires a path", code: "MISSING_ARG")
+            }
+            options.bodyFile = args[i + 1]
+            i += 2
+        case "--pr":
+            guard i + 1 < args.count else {
+                exitError("--pr requires a PR number", code: "MISSING_ARG")
+            }
+            options.prNumber = args[i + 1]
+            i += 2
+        default:
+            if arg.hasPrefix("--") {
+                exitError("Unknown dev gh flag: \(arg)", code: "UNKNOWN_FLAG")
+            }
+            options.positionals.append(arg)
+            i += 1
+        }
+    }
+    return options
+}
+
 private func parseDevAuditOptions(_ args: [String]) -> DevAuditOptions {
     var options = DevAuditOptions()
     var i = 0
@@ -399,6 +1053,157 @@ private func buildDevRecommendation(from classification: [String: Any]) -> [Stri
         "verification": verification,
         "notes": notes,
         "summary": summary,
+    ]
+}
+
+private func loadDevCapabilityManifest(options: DevCapabilitiesOptions) -> (
+    repoRoot: String,
+    path: String,
+    manifest: [String: Any],
+    capabilities: [[String: Any]]
+) {
+    let repoRoot = resolveRepoRoot(options.repo)
+    let manifestPath = resolveCapabilityManifestPath(options.manifest, repoRoot: repoRoot)
+    guard let data = FileManager.default.contents(atPath: manifestPath) else {
+        exitError("Missing dev capability manifest: \(manifestPath)", code: "MISSING_MANIFEST")
+    }
+    do {
+        guard let manifest = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
+            exitError("Invalid dev capability manifest \(manifestPath): expected JSON object", code: "INVALID_MANIFEST")
+        }
+        let capabilities = manifest["capabilities"] as? [[String: Any]] ?? []
+        return (repoRoot, manifestPath, manifest, capabilities)
+    } catch {
+        exitError("Invalid dev capability manifest \(manifestPath): \(error)", code: "INVALID_MANIFEST")
+    }
+}
+
+private func filterDevCapabilities(_ capabilities: [[String: Any]], options: DevCapabilitiesOptions) -> [[String: Any]] {
+    capabilities.filter { capability in
+        if let role = options.role {
+            let roles = capability["roles"] as? [String] ?? []
+            if !roles.isEmpty && !roles.contains(role) {
+                return false
+            }
+        }
+        if let entryPath = options.entryPath {
+            let entryPaths = capability["entry_paths"] as? [String] ?? []
+            if !entryPaths.contains(entryPath) {
+                return false
+            }
+        }
+        return true
+    }
+}
+
+private func compactDevCapability(_ capability: [String: Any]) -> [String: Any] {
+    let adapter = capability["adapter"] as? [String: Any] ?? [:]
+    let mutability = capability["mutability"] as? [String: Any] ?? [:]
+    let execution = capability["execution"] as? [String: Any] ?? [:]
+    return [
+        "id": capability["id"] ?? NSNull(),
+        "label": capability["label"] ?? NSNull(),
+        "summary": capability["summary"] ?? NSNull(),
+        "status": capability["status"] ?? NSNull(),
+        "roles": capability["roles"] ?? [],
+        "entry_paths": capability["entry_paths"] ?? [],
+        "adapter_kind": adapter["kind"] ?? NSNull(),
+        "command": adapter["command"] ?? [],
+        "mutability_class": mutability["class"] ?? NSNull(),
+        "requires_explicit_assignment": mutability["requires_explicit_assignment"] ?? NSNull(),
+        "requires_human_approval": mutability["requires_human_approval"] ?? NSNull(),
+        "requires_body_file": mutability["requires_body_file"] ?? NSNull(),
+        "raw_process": execution["raw_process"] ?? NSNull(),
+        "cwd_policy": execution["cwd_policy"] ?? NSNull(),
+        "timeout_seconds": execution["timeout_seconds"] ?? NSNull(),
+        "audit": execution["audit"] ?? NSNull(),
+    ]
+}
+
+private func loadDevDockProfiles(options: DevDocksOptions) -> (
+    repoRoot: String,
+    dockRoot: String,
+    profiles: [[String: Any]]
+) {
+    let repoRoot = resolveRepoRoot(options.repo)
+    let dockRoot = resolveDockRootPath(options.dockRoot, repoRoot: repoRoot)
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: dockRoot, isDirectory: &isDirectory), isDirectory.boolValue else {
+        exitError("Missing dock root: \(dockRoot)", code: "MISSING_DOCK_ROOT")
+    }
+
+    let entries: [String]
+    do {
+        entries = try FileManager.default.contentsOfDirectory(atPath: dockRoot).sorted()
+    } catch {
+        exitError("Unable to read dock root \(dockRoot): \(error)", code: "DOCK_ROOT_UNREADABLE")
+    }
+
+    var profiles: [[String: Any]] = []
+    for entry in entries {
+        let entryPath = (dockRoot as NSString).appendingPathComponent(entry)
+        var entryIsDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: entryPath, isDirectory: &entryIsDirectory),
+              entryIsDirectory.boolValue else {
+            continue
+        }
+        let profilePath = (entryPath as NSString).appendingPathComponent("dock.json")
+        guard FileManager.default.fileExists(atPath: profilePath) else {
+            continue
+        }
+        profiles.append(loadDevJSONObject(path: profilePath, missingCode: "MISSING_DOCK_PROFILE", invalidCode: "INVALID_DOCK_PROFILE"))
+    }
+
+    return (repoRoot, dockRoot, profiles.sorted { (devString($0["name"]) ?? "") < (devString($1["name"]) ?? "") })
+}
+
+private func resolveDevDockCapabilities(
+    profile: [String: Any],
+    capabilities: [[String: Any]],
+    entryPath: String
+) -> [[String: Any]] {
+    let role = devString(profile["role"])
+    let allowedClasses = Set(devStringArray(profile["allowed_capability_classes"]))
+    let allowedIDs = Set(devStringArray(profile["allowed_capabilities"]))
+    return capabilities.filter { capability in
+        if let status = devString(capability["status"]), status == "deprecated" {
+            return false
+        }
+        guard let capabilityID = devString(capability["id"]) else {
+            return false
+        }
+        if !allowedIDs.isEmpty && !allowedIDs.contains(capabilityID) {
+            return false
+        }
+        let capabilityRoles = devStringArray(capability["roles"])
+        if let role, !capabilityRoles.isEmpty, !capabilityRoles.contains(role) {
+            return false
+        }
+        let capabilityEntryPaths = devStringArray(capability["entry_paths"])
+        if !capabilityEntryPaths.contains(entryPath) {
+            return false
+        }
+        let mutability = capability["mutability"] as? [String: Any] ?? [:]
+        guard let capabilityClass = devString(mutability["class"]),
+              allowedClasses.contains(capabilityClass) else {
+            return false
+        }
+        return true
+    }
+}
+
+private func compactDevDockProfile(_ profile: [String: Any]) -> [String: Any] {
+    return [
+        "name": profile["name"] ?? NSNull(),
+        "role": profile["role"] ?? NSNull(),
+        "harness": profile["harness"] ?? NSNull(),
+        "summary": profile["summary"] ?? NSNull(),
+        "default_entry_path": profile["default_entry_path"] ?? NSNull(),
+        "allowed_entry_paths": profile["allowed_entry_paths"] ?? [],
+        "allowed_capability_classes": profile["allowed_capability_classes"] ?? [],
+        "allowed_capabilities": profile["allowed_capabilities"] ?? [],
+        "requires_explicit_assignment_for": profile["requires_explicit_assignment_for"] ?? [],
+        "requires_goal_prefix": (profile["handoff"] as? [String: Any])?["requires_goal_prefix"] ?? NSNull(),
     ]
 }
 
@@ -582,6 +1387,42 @@ private func resolveManifestPath(_ requested: String?, repoRoot: String) -> Stri
     return (repoRoot as NSString).appendingPathComponent(devWorkflowDefaultManifestRelativePath)
 }
 
+private func resolveCapabilityManifestPath(_ requested: String?, repoRoot: String) -> String {
+    if let requested = requested {
+        let expanded = NSString(string: requested).expandingTildeInPath
+        if expanded.hasPrefix("/") {
+            return NSString(string: expanded).standardizingPath
+        }
+        return NSString(string: (repoRoot as NSString).appendingPathComponent(expanded)).standardizingPath
+    }
+    return (repoRoot as NSString).appendingPathComponent(devCapabilitiesDefaultManifestRelativePath)
+}
+
+private func resolveDockRootPath(_ requested: String?, repoRoot: String) -> String {
+    if let requested = requested {
+        let expanded = NSString(string: requested).expandingTildeInPath
+        if expanded.hasPrefix("/") {
+            return NSString(string: expanded).standardizingPath
+        }
+        return NSString(string: (repoRoot as NSString).appendingPathComponent(expanded)).standardizingPath
+    }
+    return (repoRoot as NSString).appendingPathComponent(devDocksDefaultRootRelativePath)
+}
+
+private func loadDevJSONObject(path: String, missingCode: String, invalidCode: String) -> [String: Any] {
+    guard let data = FileManager.default.contents(atPath: path) else {
+        exitError("Missing JSON file: \(path)", code: missingCode)
+    }
+    do {
+        guard let object = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
+            exitError("Invalid JSON file \(path): expected object", code: invalidCode)
+        }
+        return object
+    } catch {
+        exitError("Invalid JSON file \(path): \(error)", code: invalidCode)
+    }
+}
+
 private func loadDevWorkflowManifest(path: String) -> DevWorkflowManifest {
     switch readDevWorkflowManifest(path: path) {
     case .success(let manifest):
@@ -619,7 +1460,7 @@ private func auditCommandRegistryClaims() -> [DevAuditClaim] {
 
     var claims: [DevAuditClaim] = []
     let forms = Dictionary(uniqueKeysWithValues: dev.forms.map { ($0.id, $0) })
-    let expectedForms = ["dev-classify", "dev-recommend", "dev-build", "dev-audit"]
+    let expectedForms = ["dev-classify", "dev-recommend", "dev-build", "dev-audit", "dev-capabilities", "dev-docks", "dev-gh"]
     let observedForms = dev.forms.map { $0.id }.sorted()
     claims.append(auditClaim(
         id: "dev-help-forms",
@@ -646,6 +1487,21 @@ private func auditCommandRegistryClaims() -> [DevAuditClaim] {
         form: forms["dev-audit"],
         expectedFlags: ["--manifest", "--repo", "--json"],
         defaultManifestRequired: true))
+    claims.append(auditFormFlagClaim(
+        id: "dev-capabilities-help-flags",
+        form: forms["dev-capabilities"],
+        expectedFlags: ["--manifest", "--repo", "--role", "--entry-path", "--json"],
+        defaultManifestRequired: false))
+    claims.append(auditFormFlagClaim(
+        id: "dev-docks-help-flags",
+        form: forms["dev-docks"],
+        expectedFlags: ["--dock-root", "--capabilities-manifest", "--entry-path", "--repo", "--json"],
+        defaultManifestRequired: false))
+    claims.append(auditFormFlagClaim(
+        id: "dev-gh-help-flags",
+        form: forms["dev-gh"],
+        expectedFlags: ["--repo", "--cwd", "--json", "--body-file", "--pr"],
+        defaultManifestRequired: false))
     return claims
 }
 
@@ -800,6 +1656,162 @@ private func printDevAuditText(_ payload: [String: Any]) {
     }
 }
 
+private func printDevCapabilitiesListText(_ payload: [String: Any]) {
+    let count = payload["count"] as? Int ?? 0
+    print("dev capabilities: \(count)")
+    if let manifest = payload["manifest"] as? String {
+        print("Manifest: \(manifest)")
+    }
+    for capability in payload["capabilities"] as? [[String: Any]] ?? [] {
+        let id = capability["id"] as? String ?? "unknown"
+        let label = capability["label"] as? String ?? id
+        let adapter = capability["adapter_kind"] as? String ?? "unknown"
+        let mutability = capability["mutability_class"] as? String ?? "unknown"
+        let raw = capability["raw_process"] as? Bool ?? false
+        print("- \(id) (\(label)): adapter=\(adapter) mutability=\(mutability) raw_process=\(raw)")
+    }
+}
+
+private func printDevCapabilityExplainText(_ payload: [String: Any]) {
+    guard let capability = payload["capability"] as? [String: Any] else {
+        print("dev capability: missing")
+        return
+    }
+    let id = capability["id"] as? String ?? "unknown"
+    let label = capability["label"] as? String ?? id
+    print("\(id) - \(label)")
+    if let summary = capability["summary"] as? String {
+        print(summary)
+    }
+    let adapter = capability["adapter"] as? [String: Any] ?? [:]
+    let mutability = capability["mutability"] as? [String: Any] ?? [:]
+    let execution = capability["execution"] as? [String: Any] ?? [:]
+    print("Adapter: \(adapter["kind"] as? String ?? "unknown")")
+    if let command = adapter["command"] as? [String], !command.isEmpty {
+        print("Command: \(command.joined(separator: " "))")
+    }
+    print("Mutability: \(mutability["class"] as? String ?? "unknown")")
+    print("Raw process: \(execution["raw_process"] as? Bool ?? false)")
+    print("Audit: \(execution["audit"] as? String ?? "unknown")")
+}
+
+private func printDevDocksListText(_ payload: [String: Any]) {
+    let count = payload["count"] as? Int ?? 0
+    print("dev docks: \(count)")
+    if let dockRoot = payload["dock_root"] as? String {
+        print("Dock root: \(dockRoot)")
+    }
+    for dock in payload["docks"] as? [[String: Any]] ?? [] {
+        let name = dock["name"] as? String ?? "unknown"
+        let role = dock["role"] as? String ?? "unknown"
+        let defaultEntryPath = dock["default_entry_path"] as? String ?? "unknown"
+        let classes = (dock["allowed_capability_classes"] as? [String] ?? []).joined(separator: ",")
+        print("- \(name): role=\(role) default_entry_path=\(defaultEntryPath) classes=\(classes)")
+    }
+}
+
+private func printDevDockExplainText(_ payload: [String: Any]) {
+    guard let profile = payload["profile"] as? [String: Any] else {
+        print("dev dock: missing")
+        return
+    }
+    let name = profile["name"] as? String ?? "unknown"
+    let role = profile["role"] as? String ?? "unknown"
+    print("\(name) - \(role)")
+    if let summary = profile["summary"] as? String {
+        print(summary)
+    }
+    print("Default entry path: \(profile["default_entry_path"] as? String ?? "unknown")")
+    print("Allowed entry paths: \((profile["allowed_entry_paths"] as? [String] ?? []).joined(separator: ", "))")
+    print("Allowed classes: \((profile["allowed_capability_classes"] as? [String] ?? []).joined(separator: ", "))")
+}
+
+private func printDevDockCapabilitiesText(_ payload: [String: Any]) {
+    let dock = payload["dock"] as? String ?? "unknown"
+    let activeEntryPath = payload["active_entry_path"] as? String ?? "unknown"
+    let count = payload["count"] as? Int ?? 0
+    print("dev dock capabilities: \(dock) entry_path=\(activeEntryPath) count=\(count)")
+    for capability in payload["capabilities"] as? [[String: Any]] ?? [] {
+        let id = capability["id"] as? String ?? "unknown"
+        let adapter = capability["adapter_kind"] as? String ?? "unknown"
+        let mutability = capability["mutability_class"] as? String ?? "unknown"
+        let raw = capability["raw_process"] as? Bool ?? false
+        print("- \(id): adapter=\(adapter) mutability=\(mutability) raw_process=\(raw)")
+    }
+}
+
+private func printDevGhContextText(_ payload: [String: Any]) {
+    let status = payload["status"] as? String ?? "unknown"
+    print("dev gh context: \(status)")
+    print("Authority: gh CLI")
+    print("Repo root: \(payload["repo_root"] as? String ?? "unknown")")
+    if let repository = payload["repository"] as? String {
+        print("Repository: \(repository)")
+    }
+    if let branch = payload["branch"] as? String {
+        print("Branch: \(branch)")
+    }
+    if let gh = payload["gh"] as? [String: Any] {
+        let available = gh["available"] as? Bool ?? false
+        let authenticated = gh["authenticated"] as? Bool ?? false
+        print("gh: available=\(available) authenticated=\(authenticated)")
+    }
+    if let currentPR = payload["current_pr"] as? [String: Any],
+       let number = currentPR["number"] {
+        print("Current PR: #\(number)")
+    }
+    if let dirty = payload["dirty"] as? [String: Any],
+       let count = dirty["count"] as? Int {
+        print("Dirty files: \(count)")
+    }
+}
+
+private func printDevGhCIText(_ payload: [String: Any]) {
+    let pr = payload["pr"] as? String ?? "unknown"
+    let checks = payload["checks"] as? [[String: Any]] ?? []
+    let failedLogs = payload["failed_logs"] as? [[String: Any]] ?? []
+    print("dev gh ci inspect: PR #\(pr)")
+    print("Checks: \(checks.count)")
+    for check in checks {
+        let name = check["name"] as? String ?? "unknown"
+        let state = check["state"] as? String ?? check["bucket"] as? String ?? "unknown"
+        print("- \(name): \(state)")
+    }
+    if !failedLogs.isEmpty {
+        print("Failed check evidence:")
+        for item in failedLogs {
+            let check = item["check"] as? [String: Any] ?? [:]
+            let name = check["name"] as? String ?? "unknown"
+            let source = item["source"] as? String ?? "unknown"
+            print("- \(name): \(source)")
+            if let stdout = item["stdout"] as? String, !stdout.isEmpty {
+                print(devGhTruncate(stdout.trimmingCharacters(in: .whitespacesAndNewlines), limit: 2000))
+            }
+            if let stderr = item["stderr"] as? String, !stderr.isEmpty {
+                print(devGhTruncate(stderr.trimmingCharacters(in: .whitespacesAndNewlines), limit: 2000))
+            }
+        }
+    }
+}
+
+private func printDevGhReviewCommentsText(_ payload: [String: Any]) {
+    let pr = payload["pr"] as? String ?? "unknown"
+    let count = payload["thread_count"] as? Int ?? 0
+    let unresolved = payload["unresolved_count"] as? Int ?? 0
+    print("dev gh review-comments: PR #\(pr)")
+    print("Threads: \(count), unresolved: \(unresolved)")
+    for thread in payload["threads"] as? [[String: Any]] ?? [] {
+        guard (thread["is_resolved"] as? Bool) == false else { continue }
+        let path = thread["path"] as? String ?? "unknown"
+        let line = thread["line"] ?? thread["start_line"] ?? "?"
+        let comments = thread["comments"] as? [[String: Any]] ?? []
+        let first = comments.first
+        let author = first?["author"] as? String ?? "unknown"
+        let body = devGhOneLine(first?["body"] as? String ?? "", limit: 140)
+        print("- \(path):\(line) @\(author) \(body)")
+    }
+}
+
 private func resolveChangedFiles(options: DevOptions, repoRoot: String) -> (files: [String], base: String?) {
     if !options.files.isEmpty {
         return (options.files, "explicit")
@@ -897,6 +1909,248 @@ private func runGit(_ args: [String], cwd: String) -> (status: Int32, stdout: St
     let stderr = String(data: errData, encoding: .utf8) ?? ""
     let lines = stdout.split(whereSeparator: \.isNewline).map(String.init)
     return (proc.terminationStatus, stdout, stderr, lines)
+}
+
+private func runGh(_ args: [String], cwd: String) -> ProcessOutput {
+    guard let gh = findExecutable("gh") else {
+        return ProcessOutput(exitCode: 127, stdout: "", stderr: "gh CLI not found in PATH\n")
+    }
+    return runProcessCapturingOutput(gh, arguments: args, cwd: cwd)
+}
+
+private func devGhRunAndExit(_ args: [String], cwd: String) -> Never {
+    let result = runGh(args, cwd: cwd)
+    devGhWriteProcessOutput(result)
+    exit(result.exitCode)
+}
+
+private func devGhWriteProcessOutput(_ result: ProcessOutput) {
+    if !result.stdout.isEmpty, let data = result.stdout.data(using: .utf8) {
+        FileHandle.standardOutput.write(data)
+    }
+    if !result.stderr.isEmpty, let data = result.stderr.data(using: .utf8) {
+        FileHandle.standardError.write(data)
+    }
+}
+
+private func devGhEmitCompositeErrorAndExit(command: [String], result: ProcessOutput, json: Bool) -> Never {
+    if json {
+        printDevJSON([
+            "status": "error",
+            "authority": "gh_cli",
+            "command": (["gh"] + command).joined(separator: " "),
+            "exit_code": Int(result.exitCode),
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+        ])
+    } else {
+        devGhWriteProcessOutput(result)
+    }
+    exit(result.exitCode)
+}
+
+private func findExecutable(_ name: String) -> String? {
+    let pathValue = ProcessInfo.processInfo.environment["PATH"] ?? ""
+    for dir in pathValue.split(separator: ":").map(String.init) {
+        let candidate = (dir as NSString).appendingPathComponent(name)
+        if FileManager.default.isExecutableFile(atPath: candidate) {
+            return candidate
+        }
+    }
+    return nil
+}
+
+private func devGhRepositoryFullName(options: DevGhOptions, repoRoot: String) -> String? {
+    if let repo = options.repo, !repo.isEmpty {
+        return repo
+    }
+    let remote = runGit(["remote", "get-url", "origin"], cwd: repoRoot)
+    if remote.status == 0,
+       let value = remote.stdoutLines.first,
+       let parsed = devGhParseGitHubRemote(value) {
+        return parsed
+    }
+    if let info = devGhRepositoryInfo(repoFullName: nil, repoRoot: repoRoot),
+       let nameWithOwner = info["nameWithOwner"] as? String {
+        return nameWithOwner
+    }
+    return nil
+}
+
+private func devGhRepositoryInfo(repoFullName: String?, repoRoot: String) -> [String: Any]? {
+    var args = ["repo", "view"]
+    if let repoFullName, !repoFullName.isEmpty {
+        args.append(repoFullName)
+    }
+    args += ["--json", "nameWithOwner,defaultBranchRef"]
+    let result = runGh(args, cwd: repoRoot)
+    guard result.exitCode == 0 else { return nil }
+    return parseDevGhJSON(result.stdout) as? [String: Any]
+}
+
+private func devGhCurrentPRInfo(repoFullName: String?, repoRoot: String) -> [String: Any]? {
+    var args = ["pr", "view"]
+    devGhAppendRepo(&args, repoFullName: repoFullName)
+    args += ["--json", "number,url,headRefName,baseRefName,state"]
+    let result = runGh(args, cwd: repoRoot)
+    guard result.exitCode == 0 else { return nil }
+    return parseDevGhJSON(result.stdout) as? [String: Any]
+}
+
+private func devGhResolvePRNumber(_ requested: String?, repoFullName: String?, repoRoot: String, json: Bool = false) -> String {
+    if let requested, !requested.isEmpty {
+        return requested
+    }
+    var args = ["pr", "view"]
+    devGhAppendRepo(&args, repoFullName: repoFullName)
+    args += ["--json", "number,url"]
+    let result = runGh(args, cwd: repoRoot)
+    guard result.exitCode == 0 else {
+        devGhEmitCompositeErrorAndExit(command: args, result: result, json: json)
+    }
+    guard let payload = parseDevGhJSON(result.stdout) as? [String: Any],
+          let number = payload["number"] else {
+        exitError("Could not infer current PR number from gh pr view", code: "MISSING_PR")
+    }
+    return "\(number)"
+}
+
+private func devGhAppendRepo(_ args: inout [String], repoFullName: String?) {
+    if let repoFullName, !repoFullName.isEmpty {
+        args += ["--repo", repoFullName]
+    }
+}
+
+private func parseDevGhJSON(_ text: String) -> Any? {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty, let data = trimmed.data(using: .utf8) else {
+        return nil
+    }
+    return try? JSONSerialization.jsonObject(with: data, options: [])
+}
+
+private func devGhParseGitHubRemote(_ remote: String) -> String? {
+    var value = remote.trimmingCharacters(in: .whitespacesAndNewlines)
+    if value.hasSuffix(".git") {
+        value = String(value.dropLast(4))
+    }
+    if value.hasPrefix("git@github.com:") {
+        let tail = String(value.dropFirst("git@github.com:".count))
+        return devGhNormalizeRepoTail(tail)
+    }
+    if let range = value.range(of: "github.com/") {
+        let tail = String(value[range.upperBound...])
+        return devGhNormalizeRepoTail(tail)
+    }
+    return nil
+}
+
+private func devGhNormalizeRepoTail(_ tail: String) -> String? {
+    var clean = tail
+    if let query = clean.firstIndex(of: "?") {
+        clean = String(clean[..<query])
+    }
+    if let fragment = clean.firstIndex(of: "#") {
+        clean = String(clean[..<fragment])
+    }
+    let parts = clean.split(separator: "/").map(String.init)
+    guard parts.count >= 2 else { return nil }
+    return "\(parts[0])/\(parts[1])"
+}
+
+private func devGhSplitRepoFullName(_ value: String) -> (owner: String, name: String)? {
+    let parts = value.split(separator: "/").map(String.init)
+    guard parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty else {
+        return nil
+    }
+    return (parts[0], parts[1])
+}
+
+private func devGhResolveUserPath(_ value: String) -> String {
+    let expanded = NSString(string: value).expandingTildeInPath
+    if expanded.hasPrefix("/") {
+        return NSString(string: expanded).standardizingPath
+    }
+    return NSString(string: (FileManager.default.currentDirectoryPath as NSString).appendingPathComponent(expanded)).standardizingPath
+}
+
+private func devGhNullable(_ value: Any?) -> Any {
+    value ?? NSNull()
+}
+
+private func devString(_ value: Any?) -> String? {
+    value as? String
+}
+
+private func devStringArray(_ value: Any?) -> [String] {
+    value as? [String] ?? []
+}
+
+private func devGhSanitizeAuthStatus(_ value: String) -> String {
+    value
+        .split(whereSeparator: \.isNewline)
+        .map(String.init)
+        .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("- Token") }
+        .joined(separator: "\n")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+private func devGhCheckFailed(_ check: [String: Any]) -> Bool {
+    let state = (check["state"] as? String ?? "").lowercased()
+    let bucket = (check["bucket"] as? String ?? "").lowercased()
+    let failed = ["fail", "failure", "failed", "cancelled", "timed_out", "action_required"]
+    return failed.contains(state) || failed.contains(bucket)
+}
+
+private func devGhActionsRunID(from link: String) -> String? {
+    guard let range = link.range(of: #"/actions/runs/[0-9]+"#, options: .regularExpression) else {
+        return nil
+    }
+    return link[range].split(separator: "/").last.map(String.init)
+}
+
+private func devGhFlattenReviewThreads(_ raw: [String: Any]) -> [[String: Any]] {
+    let data = raw["data"] as? [String: Any] ?? [:]
+    let repository = data["repository"] as? [String: Any] ?? [:]
+    let pullRequest = repository["pullRequest"] as? [String: Any] ?? [:]
+    let reviewThreads = pullRequest["reviewThreads"] as? [String: Any] ?? [:]
+    let nodes = reviewThreads["nodes"] as? [[String: Any]] ?? []
+    return nodes.map { node in
+        let commentsNode = node["comments"] as? [String: Any] ?? [:]
+        let comments = (commentsNode["nodes"] as? [[String: Any]] ?? []).map { comment -> [String: Any] in
+            let author = comment["author"] as? [String: Any] ?? [:]
+            return [
+                "id": devGhNullable(comment["id"]),
+                "url": devGhNullable(comment["url"]),
+                "body": devGhNullable(comment["body"]),
+                "created_at": devGhNullable(comment["createdAt"]),
+                "author": devGhNullable(author["login"]),
+            ]
+        }
+        return [
+            "is_resolved": node["isResolved"] as? Bool ?? false,
+            "is_outdated": node["isOutdated"] as? Bool ?? false,
+            "path": devGhNullable(node["path"]),
+            "line": devGhNullable(node["line"]),
+            "start_line": devGhNullable(node["startLine"]),
+            "comments": comments,
+        ]
+    }
+}
+
+private func devGhOneLine(_ value: String, limit: Int) -> String {
+    let collapsed = value
+        .replacingOccurrences(of: "\n", with: " ")
+        .replacingOccurrences(of: "\t", with: " ")
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    return devGhTruncate(collapsed, limit: limit)
+}
+
+private func devGhTruncate(_ value: String, limit: Int) -> String {
+    if value.count <= limit {
+        return value
+    }
+    return String(value.prefix(max(0, limit - 3))) + "..."
 }
 
 private func splitNul(_ value: String) -> [String] {

--- a/src/shared/command-registry-data.swift
+++ b/src/shared/command-registry-data.swift
@@ -1141,7 +1141,64 @@ func buildCommandRegistry() -> [CommandDescriptor] {
             stdin: nil, constraints: nil,
             execution: execReadOnly(),
             output: outJSONFlag,
-            examples: ["aos dev audit --json"])
+            examples: ["aos dev audit --json"]),
+        InvocationForm(id: "dev-capabilities", usage: "aos dev capabilities <list|explain> [capability-id] [--manifest <path>] [--repo <path>] [--role <role>] [--entry-path <path>] [--json]",
+            args: [
+                pos("action", "Capability discovery action: list or explain"),
+                pos("capability-id", "Capability id for explain", required: false),
+                flag("manifest", "--manifest", "Agent capability manifest path", default: .string("docs/dev/agent-capabilities.json")),
+                flag("repo", "--repo", "Repository root path"),
+                flag("role", "--role", "Filter list output by dock role"),
+                flag("entry-path", "--entry-path", "Filter list output by entry path"),
+                flag("json", "--json", "Emit machine-readable capability metadata", type: .bool)
+            ],
+            stdin: nil, constraints: nil,
+            execution: execReadOnly(),
+            output: outJSONFlag,
+            examples: [
+                "aos dev capabilities list --json",
+                "aos dev capabilities list --role foreman --entry-path aos_developer --json",
+                "aos dev capabilities explain dev.github.issue_comment --json"
+            ]),
+        InvocationForm(id: "dev-docks", usage: "aos dev docks <list|explain|capabilities> [dock] [--dock-root <path>] [--capabilities-manifest <path>] [--entry-path <path>] [--repo <path>] [--json]",
+            args: [
+                pos("action", "Dock profile discovery action: list, explain, or capabilities"),
+                pos("dock", "Dock name for explain or capabilities", required: false),
+                flag("dock-root", "--dock-root", "Dock root path", default: .string(".docks")),
+                flag("capabilities-manifest", "--capabilities-manifest", "Agent capability manifest path", default: .string("docs/dev/agent-capabilities.json")),
+                flag("entry-path", "--entry-path", "Resolve dock capabilities for a non-default entry path"),
+                flag("repo", "--repo", "Repository root path"),
+                flag("json", "--json", "Emit machine-readable dock profile metadata", type: .bool)
+            ],
+            stdin: nil, constraints: nil,
+            execution: execReadOnly(),
+            output: outJSONFlag,
+            examples: [
+                "aos dev docks list --json",
+                "aos dev docks explain foreman --json",
+                "aos dev docks capabilities gdi --json",
+                "aos dev docks capabilities operator --entry-path aos_developer --json"
+            ]),
+        InvocationForm(id: "dev-gh", usage: "aos dev gh <context|issue|pr|ci|review-comments> [--repo owner/name] [--cwd <path>] [--json] [--body-file <path>] [--pr n]",
+            args: [
+                pos("group", "GitHub workflow group: context, issue, pr, ci, or review-comments"),
+                flag("repo", "--repo", "GitHub repository in owner/name form"),
+                flag("cwd", "--cwd", "Local checkout path used for git context and gh execution"),
+                flag("json", "--json", "Emit machine-readable output where the selected operation supports it", type: .bool),
+                flag("body-file", "--body-file", "Markdown file used for issue or PR comment writes"),
+                flag("pr", "--pr", "PR number for CI inspection or review-thread reads"),
+                pos("arg", "Subcommand-specific argument", required: false, variadic: true)
+            ],
+            stdin: nil, constraints: nil,
+            execution: execMutating(),
+            output: outJSONFlag,
+            examples: [
+                "aos dev gh context --json",
+                "aos dev gh issue view 298 --json",
+                "aos dev gh issue comment 298 --body-file /tmp/comment.md",
+                "aos dev gh ci inspect --pr 298 --json",
+                "aos dev gh review-comments --pr 298 --json"
+            ])
     ]))
 
     // ── status ────────────────────────────────────────────

--- a/tests/dev-workflow-router.sh
+++ b/tests/dev-workflow-router.sh
@@ -107,18 +107,295 @@ import os
 
 data = json.loads(os.environ["OUT"])
 forms = {form["id"]: form for form in data["forms"]}
-assert {"dev-classify", "dev-recommend", "dev-build", "dev-audit"} <= set(forms), forms
+assert {"dev-classify", "dev-recommend", "dev-build", "dev-audit", "dev-capabilities", "dev-docks", "dev-gh"} <= set(forms), forms
 tokens = {arg.get("token") for arg in forms["dev-classify"]["args"]}
 assert {"--paths", "--files", "--base", "--manifest", "--repo", "--json"} <= tokens, tokens
 recommend_tokens = {arg.get("token") for arg in forms["dev-recommend"]["args"]}
 assert {"--paths", "--files", "--base", "--manifest", "--repo", "--json"} <= recommend_tokens, recommend_tokens
 audit_tokens = {arg.get("token") for arg in forms["dev-audit"]["args"]}
 assert {"--manifest", "--repo", "--json"} <= audit_tokens, audit_tokens
+capability_tokens = {arg.get("token") for arg in forms["dev-capabilities"]["args"]}
+assert {"--manifest", "--repo", "--role", "--entry-path", "--json"} <= capability_tokens, capability_tokens
+dock_tokens = {arg.get("token") for arg in forms["dev-docks"]["args"]}
+assert {"--dock-root", "--capabilities-manifest", "--entry-path", "--repo", "--json"} <= dock_tokens, dock_tokens
+gh_tokens = {arg.get("token") for arg in forms["dev-gh"]["args"]}
+assert {"--repo", "--cwd", "--json", "--body-file", "--pr"} <= gh_tokens, gh_tokens
 PY
 then
-    pass "dev help exposes classify/recommend/build/audit"
+    pass "dev help exposes classify/recommend/build/audit/capabilities/docks/gh"
 else
     fail "dev help missing workflow router forms"
+fi
+
+if OUT="$(./aos dev capabilities list --role foreman --entry-path aos_developer --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+ids = {item["id"] for item in data["capabilities"]}
+assert data["status"] == "success", data
+assert data["manifest"] == "docs/dev/agent-capabilities.json", data
+assert "dev.github.issue_comment" in ids, ids
+assert "dev.build.aos" in ids, ids
+assert "dev.test.schema_node" in ids, ids
+assert all("adapter_kind" in item for item in data["capabilities"]), data
+PY
+then
+    pass "dev capabilities list discovers canonical manifest"
+else
+    fail "dev capabilities list did not expose expected manifest entries"
+fi
+
+if OUT="$(./aos dev capabilities explain dev.github.issue_comment --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+capability = data["capability"]
+assert capability["id"] == "dev.github.issue_comment", data
+assert capability["adapter"]["kind"] == "aos_cli", data
+assert capability["mutability"]["class"] == "external_write", data
+assert capability["mutability"]["requires_body_file"] is True, data
+assert capability["execution"]["raw_process"] is False, data
+PY
+then
+    pass "dev capabilities explain returns full capability metadata"
+else
+    fail "dev capabilities explain did not return expected capability metadata"
+fi
+
+if ERR="$(./aos dev capabilities explain no.such.capability --json 2>&1 >/dev/null)"; then
+    fail "dev capabilities explain should reject unknown capability ids"
+elif echo "$ERR" | grep -q '"code" : "UNKNOWN_CAPABILITY"'; then
+    pass "dev capabilities explain rejects unknown capability ids"
+else
+    fail "dev capabilities explain unknown id error mismatch: $ERR"
+fi
+
+if OUT="$(./aos dev docks list --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+names = {item["name"] for item in data["docks"]}
+assert data["status"] == "success", data
+assert data["dock_root"] == ".docks", data
+assert {"foreman", "gdi", "operator"} <= names, names
+assert any(item["default_entry_path"] == "aos_developer" for item in data["docks"] if item["name"] == "foreman"), data
+PY
+then
+    pass "dev docks list discovers canonical dock profiles"
+else
+    fail "dev docks list did not expose expected profiles"
+fi
+
+if OUT="$(./aos dev docks capabilities foreman --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+ids = {item["id"] for item in data["capabilities"]}
+assert data["dock"] == "foreman", data
+assert data["active_entry_path"] == "aos_developer", data
+assert "dev.github.issue_comment" in ids, ids
+assert "dev.build.aos" in ids, ids
+PY
+then
+    pass "dev docks capabilities resolves foreman envelope"
+else
+    fail "dev docks capabilities did not resolve foreman envelope"
+fi
+
+if OUT="$(./aos dev docks capabilities gdi --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+ids = {item["id"] for item in data["capabilities"]}
+assert "dev.github.issue_comment" not in ids, ids
+assert "dev.build.aos" in ids, ids
+assert "dev.test.schema_node" in ids, ids
+PY
+then
+    pass "dev docks capabilities keeps GDI out of issue-comment writes"
+else
+    fail "dev docks capabilities allowed unexpected GDI external write"
+fi
+
+if OUT="$(./aos dev docks capabilities operator --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert data["dock"] == "operator", data
+assert data["active_entry_path"] == "agent_harness", data
+assert data["capabilities"] == [], data
+PY
+then
+    pass "dev docks capabilities keeps operator default path narrow"
+else
+    fail "dev docks capabilities operator default path was too broad"
+fi
+
+if OUT="$(./aos dev docks capabilities operator --entry-path aos_developer --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+ids = {item["id"] for item in data["capabilities"]}
+assert "dev.github.context" in ids, ids
+assert "dev.github.ci_inspect" in ids, ids
+assert "dev.github.issue_comment" not in ids, ids
+assert all(item["mutability_class"] == "read_only" for item in data["capabilities"]), data
+PY
+then
+    pass "dev docks capabilities allows operator assigned read-only dev path"
+else
+    fail "dev docks capabilities operator assigned path drifted"
+fi
+
+TMPDIR="$(mktemp -d)"
+OLD_PATH="$PATH"
+export GH_ARGS_LOG="$TMPDIR/gh-args.log"
+trap 'PATH="$OLD_PATH"; rm -rf "$TMPDIR"' EXIT
+cat > "$TMPDIR/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$GH_ARGS_LOG"
+cmd="$*"
+if [[ "$cmd" == "auth status" ]]; then
+    echo "Logged in to github.com"
+    exit 0
+fi
+if [[ "$cmd" == "repo view michaelblum/agent-os --json nameWithOwner,defaultBranchRef" ]]; then
+    echo '{"nameWithOwner":"michaelblum/agent-os","defaultBranchRef":{"name":"main"}}'
+    exit 0
+fi
+if [[ "$cmd" == "pr view --repo michaelblum/agent-os --json number,url,headRefName,baseRefName,state" ]]; then
+    echo '{"number":298,"url":"https://github.com/michaelblum/agent-os/pull/298","headRefName":"codex/example","baseRefName":"main","state":"OPEN"}'
+    exit 0
+fi
+if [[ "$cmd" == issue\ comment\ 298\ --repo\ michaelblum/agent-os\ --body-file\ * ]]; then
+    echo "https://github.com/michaelblum/agent-os/issues/298#issuecomment-test"
+    exit 0
+fi
+if [[ "$cmd" == "pr checks 298 --repo michaelblum/agent-os --json name,state,bucket,link,startedAt,completedAt,workflow" ]]; then
+    echo '[{"name":"unit","state":"failure","bucket":"fail","link":"https://github.com/michaelblum/agent-os/actions/runs/987","workflow":"CI"}]'
+    exit 0
+fi
+if [[ "$cmd" == "run view 987 --repo michaelblum/agent-os --log-failed" ]]; then
+    echo "unit failed log"
+    exit 0
+fi
+if [[ "$1" == "api" && "${2:-}" == "graphql" ]]; then
+    echo '{"data":{"repository":{"pullRequest":{"number":298,"url":"https://github.com/michaelblum/agent-os/pull/298","reviewThreads":{"nodes":[{"isResolved":false,"isOutdated":false,"path":"src/example.swift","line":12,"startLine":null,"comments":{"nodes":[{"id":"c1","url":"https://github.com/comment","body":"Please fix this.","createdAt":"2026-05-13T00:00:00Z","author":{"login":"reviewer"}}]}}]}}}}}'
+    exit 0
+fi
+echo "unexpected fake gh invocation: $cmd" >&2
+exit 64
+SH
+chmod +x "$TMPDIR/gh"
+export PATH="$TMPDIR:$PATH"
+
+if OUT="$(./aos dev gh context --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert data["authority"] == "gh_cli", data
+assert data["tool"] == "gh", data
+assert data["repository"] == "michaelblum/agent-os", data
+assert data["default_branch"] == "main", data
+assert data["current_pr"]["number"] == 298, data
+assert data["gh"]["available"] is True, data
+assert data["gh"]["authenticated"] is True, data
+PY
+then
+    pass "dev gh context uses local gh authority"
+else
+    fail "dev gh context did not report expected local gh state"
+fi
+
+BODY="$TMPDIR/comment.md"
+printf 'accepted state\n' > "$BODY"
+: > "$GH_ARGS_LOG"
+if OUT="$(./aos dev gh issue comment 298 --body-file "$BODY" 2>/dev/null)" &&
+   grep -q "issue comment 298 --repo michaelblum/agent-os --body-file $BODY" "$GH_ARGS_LOG" &&
+   echo "$OUT" | grep -q "issuecomment-test"; then
+    pass "dev gh issue comment shells out to gh with body-file"
+else
+    fail "dev gh issue comment did not shell out through expected gh invocation"
+fi
+
+if OUT="$(./aos dev gh ci inspect --json 2>/dev/null)"; then
+    fail "dev gh ci inspect --json without inferable PR should fail"
+elif OUT="$OUT" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert data["status"] == "error", data
+assert data["authority"] == "gh_cli", data
+assert data["exit_code"] == 64, data
+assert data["command"] == "gh pr view --repo michaelblum/agent-os --json number,url", data
+assert "unexpected fake gh invocation" in data["stderr"], data
+PY
+then
+    pass "dev gh ci inspect --json preserves JSON errors while inferring PR"
+else
+    fail "dev gh ci inspect --json did not emit parseable JSON error"
+fi
+
+if OUT="$(./aos dev gh ci inspect --pr 298 --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert data["status"] == "success", data
+assert data["checks"][0]["name"] == "unit", data
+assert data["failed_logs"][0]["source"] == "github_actions", data
+assert data["failed_logs"][0]["run_id"] == "987", data
+assert "unit failed log" in data["failed_logs"][0]["stdout"], data
+PY
+then
+    pass "dev gh ci inspect captures failed GitHub Actions logs"
+else
+    fail "dev gh ci inspect did not capture failed Actions logs"
+fi
+
+if OUT="$(./aos dev gh review-comments --json 2>/dev/null)"; then
+    fail "dev gh review-comments --json without inferable PR should fail"
+elif OUT="$OUT" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert data["status"] == "error", data
+assert data["authority"] == "gh_cli", data
+assert data["exit_code"] == 64, data
+assert data["command"] == "gh pr view --repo michaelblum/agent-os --json number,url", data
+assert "unexpected fake gh invocation" in data["stderr"], data
+PY
+then
+    pass "dev gh review-comments --json preserves JSON errors while inferring PR"
+else
+    fail "dev gh review-comments --json did not emit parseable JSON error"
+fi
+
+if OUT="$(./aos dev gh review-comments --pr 298 --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert data["status"] == "success", data
+assert data["thread_count"] == 1, data
+assert data["unresolved_count"] == 1, data
+assert data["threads"][0]["comments"][0]["author"] == "reviewer", data
+PY
+then
+    pass "dev gh review-comments reads thread-level review state through gh GraphQL"
+else
+    fail "dev gh review-comments did not return thread-level review state"
 fi
 
 echo

--- a/tests/schemas/aos-agent-capability-manifest-v0.test.mjs
+++ b/tests/schemas/aos-agent-capability-manifest-v0.test.mjs
@@ -1,0 +1,163 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+const schemaPath = path.join(repoRoot, 'shared/schemas/aos-agent-capability-manifest-v0.schema.json');
+const canonicalPath = path.join(repoRoot, 'docs/dev/agent-capabilities.json');
+const fixtureRoot = path.join(repoRoot, 'shared/schemas/fixtures/aos-agent-capability-manifest-v0');
+
+async function jsonFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+    .map((entry) => path.join(dir, entry.name))
+    .sort();
+}
+
+async function loadJson(file) {
+  return JSON.parse(await fs.readFile(file, 'utf8'));
+}
+
+function validate(instancePath) {
+  return spawnSync(
+    'python3',
+    [
+      '-c',
+      `
+import json, sys
+from pathlib import Path
+from jsonschema import Draft202012Validator
+
+schema = json.loads(Path(sys.argv[1]).read_text())
+instance = json.loads(Path(sys.argv[2]).read_text())
+Draft202012Validator.check_schema(schema)
+validator = Draft202012Validator(schema)
+errors = sorted(validator.iter_errors(instance), key=lambda e: list(e.path))
+if errors:
+    for error in errors[:8]:
+        print(error.message)
+    sys.exit(1)
+`,
+      schemaPath,
+      instancePath,
+    ],
+    { encoding: 'utf8' },
+  );
+}
+
+test('valid agent capability manifests match the schema', async () => {
+  const fixtures = await jsonFiles(path.join(fixtureRoot, 'valid'));
+  assert.ok(fixtures.length >= 1, 'expected valid fixtures');
+  for (const fixture of fixtures) {
+    const result = validate(fixture);
+    assert.equal(
+      result.status,
+      0,
+      `${path.relative(repoRoot, fixture)} should validate\n${result.stdout}${result.stderr}`,
+    );
+  }
+});
+
+test('canonical agent capability manifest matches the schema', () => {
+  const result = validate(canonicalPath);
+  assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+});
+
+test('invalid agent capability manifests are rejected by the schema', async () => {
+  const fixtures = await jsonFiles(path.join(fixtureRoot, 'invalid'));
+  assert.ok(fixtures.length >= 1, 'expected invalid fixtures');
+  for (const fixture of fixtures) {
+    const result = validate(fixture);
+    assert.notEqual(result.status, 0, `${path.relative(repoRoot, fixture)} should fail validation`);
+  }
+});
+
+test('node and python adapters cannot avoid raw-process constraints', () => {
+  for (const fixtureName of [
+    'node-adapter-raw-process-false.json',
+    'python-adapter-raw-process-false.json',
+  ]) {
+    const fixture = path.join(fixtureRoot, 'invalid', fixtureName);
+    const result = validate(fixture);
+    assert.notEqual(result.status, 0, `${fixtureName} should fail validation`);
+    assert.match(
+      `${result.stdout}${result.stderr}`,
+      /True was expected/,
+      `${fixtureName} should fail because raw_process must be true`,
+    );
+  }
+});
+
+test('raw process capabilities remain developer/testing scoped', async () => {
+  const fixtures = await jsonFiles(path.join(fixtureRoot, 'valid'));
+  for (const fixture of fixtures) {
+    const manifest = await loadJson(fixture);
+    for (const capability of manifest.capabilities) {
+      if (capability.execution.raw_process !== true) {
+        continue;
+      }
+      assert.ok(
+        capability.entry_paths.every((entryPath) => ['aos_developer', 'testing', 'break_glass'].includes(entryPath)),
+        `${path.relative(repoRoot, fixture)}:${capability.id} raw_process entry paths must stay developer/testing scoped`,
+      );
+      assert.equal(
+        capability.mutability.requires_explicit_assignment,
+        true,
+        `${path.relative(repoRoot, fixture)}:${capability.id} raw_process must require explicit assignment`,
+      );
+      assert.notEqual(
+        capability.execution.audit,
+        'none',
+        `${path.relative(repoRoot, fixture)}:${capability.id} raw_process must be auditable`,
+      );
+      assert.equal(
+        typeof capability.execution.timeout_seconds,
+        'number',
+        `${path.relative(repoRoot, fixture)}:${capability.id} raw_process must have timeout`,
+      );
+    }
+  }
+});
+
+test('typed AOS GitHub capabilities stay non-raw and body-file backed for writes', async () => {
+  const manifest = await loadJson(canonicalPath);
+  const capabilities = new Map(manifest.capabilities.map((capability) => [capability.id, capability]));
+
+  const context = capabilities.get('dev.github.context');
+  assert.equal(context.adapter.kind, 'aos_cli');
+  assert.equal(context.execution.raw_process, false);
+  assert.equal(context.mutability.class, 'read_only');
+
+  const comment = capabilities.get('dev.github.issue_comment');
+  assert.equal(comment.adapter.kind, 'aos_cli');
+  assert.equal(comment.execution.raw_process, false);
+  assert.equal(comment.mutability.class, 'external_write');
+  assert.equal(comment.mutability.requires_body_file, true);
+  assert.equal(comment.failure_policy.bubble_up, true);
+});
+
+test('canonical manifest includes the initial developer capability set', async () => {
+  const manifest = await loadJson(canonicalPath);
+  const capabilities = new Map(manifest.capabilities.map((capability) => [capability.id, capability]));
+
+  for (const id of [
+    'dev.github.context',
+    'dev.github.issue_comment',
+    'dev.github.ci_inspect',
+    'dev.github.review_comments',
+    'dev.build.aos',
+    'dev.test.schema_node',
+  ]) {
+    assert.ok(capabilities.has(id), `canonical manifest should include ${id}`);
+  }
+
+  assert.equal(capabilities.get('dev.build.aos').adapter.kind, 'aos_cli');
+  assert.equal(capabilities.get('dev.build.aos').mutability.class, 'host_write');
+  assert.equal(capabilities.get('dev.test.schema_node').adapter.kind, 'node');
+  assert.equal(capabilities.get('dev.test.schema_node').execution.raw_process, true);
+});

--- a/tests/schemas/aos-dock-profile-v0.test.mjs
+++ b/tests/schemas/aos-dock-profile-v0.test.mjs
@@ -1,0 +1,148 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+const schemaPath = path.join(repoRoot, 'shared/schemas/aos-dock-profile-v0.schema.json');
+const fixtureRoot = path.join(repoRoot, 'shared/schemas/fixtures/aos-dock-profile-v0');
+const capabilityManifestPath = path.join(repoRoot, 'docs/dev/agent-capabilities.json');
+const canonicalDockPaths = [
+  path.join(repoRoot, '.docks/foreman/dock.json'),
+  path.join(repoRoot, '.docks/gdi/dock.json'),
+  path.join(repoRoot, '.docks/operator/dock.json'),
+];
+
+async function jsonFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+    .map((entry) => path.join(dir, entry.name))
+    .sort();
+}
+
+async function loadJson(file) {
+  return JSON.parse(await fs.readFile(file, 'utf8'));
+}
+
+function validate(instancePath) {
+  return spawnSync(
+    'python3',
+    [
+      '-c',
+      `
+import json, sys
+from pathlib import Path
+from jsonschema import Draft202012Validator
+
+schema = json.loads(Path(sys.argv[1]).read_text())
+instance = json.loads(Path(sys.argv[2]).read_text())
+Draft202012Validator.check_schema(schema)
+validator = Draft202012Validator(schema)
+errors = sorted(validator.iter_errors(instance), key=lambda e: list(e.path))
+if errors:
+    for error in errors[:8]:
+        print(error.message)
+    sys.exit(1)
+`,
+      schemaPath,
+      instancePath,
+    ],
+    { encoding: 'utf8' },
+  );
+}
+
+test('valid dock profile fixtures match the schema', async () => {
+  const fixtures = await jsonFiles(path.join(fixtureRoot, 'valid'));
+  assert.ok(fixtures.length >= 1, 'expected valid fixtures');
+  for (const fixture of fixtures) {
+    const result = validate(fixture);
+    assert.equal(
+      result.status,
+      0,
+      `${path.relative(repoRoot, fixture)} should validate\n${result.stdout}${result.stderr}`,
+    );
+  }
+});
+
+test('canonical dock profiles match the schema', () => {
+  for (const dockPath of canonicalDockPaths) {
+    const result = validate(dockPath);
+    assert.equal(
+      result.status,
+      0,
+      `${path.relative(repoRoot, dockPath)} should validate\n${result.stdout}${result.stderr}`,
+    );
+  }
+});
+
+test('invalid dock profile fixtures are rejected by the schema', async () => {
+  const fixtures = await jsonFiles(path.join(fixtureRoot, 'invalid'));
+  assert.ok(fixtures.length >= 1, 'expected invalid fixtures');
+  for (const fixture of fixtures) {
+    const result = validate(fixture);
+    assert.notEqual(result.status, 0, `${path.relative(repoRoot, fixture)} should fail validation`);
+  }
+});
+
+test('canonical dock profiles resolve against the agent capability manifest', async () => {
+  const manifest = await loadJson(capabilityManifestPath);
+  const capabilities = new Map(manifest.capabilities.map((capability) => [capability.id, capability]));
+
+  for (const dockPath of canonicalDockPaths) {
+    const profile = await loadJson(dockPath);
+    const dockName = path.basename(path.dirname(dockPath));
+    assert.equal(profile.name, dockName, `${path.relative(repoRoot, dockPath)} name should match directory`);
+    assert.equal(profile.capability_manifest, 'docs/dev/agent-capabilities.json');
+    assert.ok(
+      profile.allowed_entry_paths.includes(profile.default_entry_path),
+      `${profile.name} default entry path must be allowed`,
+    );
+
+    for (const capabilityID of profile.allowed_capabilities) {
+      const capability = capabilities.get(capabilityID);
+      assert.ok(capability, `${profile.name} references unknown capability ${capabilityID}`);
+
+      const roles = capability.roles ?? [];
+      assert.ok(
+        roles.length === 0 || roles.includes(profile.role),
+        `${profile.name} allows ${capabilityID}, but capability roles are ${roles.join(',')}`,
+      );
+
+      const capabilityClass = capability.mutability.class;
+      assert.ok(
+        profile.allowed_capability_classes.includes(capabilityClass),
+        `${profile.name} allows ${capabilityID}, but not class ${capabilityClass}`,
+      );
+
+      assert.ok(
+        capability.entry_paths.some((entryPath) => profile.allowed_entry_paths.includes(entryPath)),
+        `${profile.name} allows ${capabilityID}, but entry paths do not intersect`,
+      );
+    }
+  }
+});
+
+test('role envelopes preserve the intended coordination boundaries', async () => {
+  const profiles = new Map(
+    await Promise.all(canonicalDockPaths.map(async (dockPath) => {
+      const profile = await loadJson(dockPath);
+      return [profile.name, profile];
+    })),
+  );
+
+  assert.ok(profiles.get('foreman').allowed_capabilities.includes('dev.github.issue_comment'));
+  assert.ok(!profiles.get('gdi').allowed_capabilities.includes('dev.github.issue_comment'));
+  assert.ok(!profiles.get('operator').allowed_capabilities.includes('dev.github.issue_comment'));
+
+  assert.equal(profiles.get('operator').default_entry_path, 'agent_harness');
+  assert.ok(!profiles.get('operator').allowed_capability_classes.includes('external_write'));
+  assert.ok(!profiles.get('operator').allowed_capability_classes.includes('host_write'));
+
+  assert.ok(profiles.get('foreman').allowed_capabilities.includes('dev.test.schema_node'));
+  assert.ok(profiles.get('gdi').allowed_capabilities.includes('dev.test.schema_node'));
+  assert.ok(!profiles.get('operator').allowed_capabilities.includes('dev.test.schema_node'));
+});

--- a/tests/schemas/dev-workflow-rules.test.mjs
+++ b/tests/schemas/dev-workflow-rules.test.mjs
@@ -98,5 +98,15 @@ test('canonical rules preserve the expected V0 routing contracts', async () => {
   );
   assert.ok(rules.get('dev-workflow-manifest')?.patterns?.includes('src/commands/dev.swift'));
   assert.ok(rules.get('dev-workflow-manifest')?.patterns?.includes('src/shared/command-registry-data.swift'));
+  assert.equal(
+    rules.get('agent-capability-manifest')?.commands?.[0]?.command,
+    'node --test tests/schemas/aos-agent-capability-manifest-v0.test.mjs',
+  );
+  assert.ok(rules.get('agent-capability-manifest')?.patterns?.includes('docs/dev/agent-capabilities.json'));
+  assert.equal(
+    rules.get('dock-profiles')?.commands?.[0]?.command,
+    'node --test tests/schemas/aos-dock-profile-v0.test.mjs',
+  );
+  assert.ok(rules.get('dock-profiles')?.patterns?.includes('.docks/*/dock.json'));
   assert.ok(rules.get('app-subtree-local-contract')?.notes?.[0]?.includes('nearest subtree AGENTS.md'));
 });


### PR DESCRIPTION
## Summary

- Add dock profile JSON seeds and shared dock guidance for Foreman, GDI, and Operator.
- Add the agent capability manifest schema, canonical manifest, dock profile schema, fixtures, and tests.
- Extend `./aos dev` with manifest-backed workflow recommendations, capability/dock discovery, and thin GitHub control surfaces.
- Clarify Foreman checkpoint, TCC blocker, and GDI clipboard handoff contracts.

## Stacked Review

Base branch: `codex/docks-session-roots-base`.

This is split out from the broader `codex/docks-session-roots` branch so dock/dev governance can be reviewed separately from gateway cleanup, HTML Workbench docs, and #296 annotation work.

## Verification

- `git diff --check codex/docks-session-roots-base..HEAD`
- `node --test tests/schemas/aos-dock-profile-v0.test.mjs tests/schemas/aos-agent-capability-manifest-v0.test.mjs tests/schemas/dev-workflow-rules.test.mjs`
- `./aos dev build`
- `bash tests/help-contract.sh`
- `bash tests/dev-workflow-router.sh`
- `bash tests/dev-audit.sh`

## Readiness Note

After `./aos dev build`, `./aos ready --repair` reported `diagnosis=daemon_tcc_grant_stale_or_missing` for repo-mode `/Users/Michael/Code/agent-os/aos`. Deterministic checks passed, but live input-tap readiness requires the standard safe macOS permission reset handoff before final live verification.
