### PR TITLE
Document HTML Workbench expression adoption direction

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -34,7 +34,9 @@ Use `./aos dev classify --json` and `./aos dev recommend --json` to route repo
 changes through the manifest-backed developer workflow before choosing a build,
 test, canvas reload, or readiness loop. Use `./aos dev build`
 instead of raw `bash build.sh` unless `./aos` is missing or the build surface is
-itself under repair.
+itself under repair. Use `./aos dev gh` for GitHub operations from repo
+sessions; it shells out to the authenticated local `gh` CLI and does not fall
+back to connector-backed GitHub tools.
 
 ## Contract
 
@@ -142,13 +144,42 @@ Typical consumer loop:
 ./aos dev classify --json
 ./aos dev recommend --json
 ./aos dev recommend --paths src/main.swift,packages/toolkit/runtime/canvas.js --json
+./aos dev capabilities list --json
+./aos dev capabilities explain dev.github.issue_comment --json
+./aos dev docks list --json
+./aos dev docks capabilities foreman --json
 ./aos dev build
+./aos dev gh context --json
+./aos dev gh issue comment 298 --body-file /tmp/comment.md
+./aos dev gh ci inspect --pr 298 --json
+./aos dev gh review-comments --pr 298 --json
 ```
 
 `classify` reports changed files, matched rules, classes, actions, and whether
 the set is hot-swappable or TCC-sensitive. `recommend` adds ordered commands
 and verification steps. The rules live in `docs/dev/workflow-rules.json` and
 are validated by `shared/schemas/dev-workflow-rules.schema.json`.
+
+`capabilities` is read-only discovery over
+`docs/dev/agent-capabilities.json`. It lists or explains typed agent
+capabilities, including whether a capability uses a typed AOS surface or an
+explicit raw-process adapter. It does not execute capabilities or grant
+permissions.
+
+`docks` is read-only discovery over `.docks/*/dock.json`. It lists or explains
+dock profiles and can resolve a dock's profile against
+`docs/dev/agent-capabilities.json` for the active entry path. This keeps dock
+identity, entry-path defaults, and allowed capability classes explicit without
+turning the profile into a rigid executor.
+
+`dev gh` is the repo GitHub control surface. It deliberately uses the real
+`gh` executable from `PATH`, the user's existing `gh` authentication, and the
+local git checkout to infer `owner/repo` unless `--repo owner/name` is supplied.
+Direct operations such as `issue view`, `issue comment`, `pr view`, `pr checks`,
+and `pr comment` forward to `gh` and preserve its exit behavior. The composite
+helpers cover repo-specific repeated loops: `ci inspect` reads PR checks and
+fetches failed GitHub Actions logs when the check links to an Actions run, while
+`review-comments` uses `gh api graphql` to read review-thread resolution state.
 
 ### 2. Create a Persistent Canvas
 

--- a/docs/api/toolkit/workbench.md
+++ b/docs/api/toolkit/workbench.md
@@ -103,6 +103,37 @@ Subject descriptors are included in lock-in/save handoff payloads so agents,
 apps, and future workbench shells can reason about different editors using one
 vocabulary.
 
+### Annotation Session V0
+
+`packages/toolkit/workbench/annotation-session.js` provides the neutral
+display-first in-memory Annotation Mode session model. It is shared toolkit
+state for future display overlays, Surface Inspector support views, and Sigil
+reticle entry; it is not a persistent annotation database.
+
+Sessions use schema `aos_annotation_session` version `0.1.0` and carry
+`active`, `entry_source`, `root`, `committed_scope_stack`,
+`preview_scope_stack`, `hover_candidate`, `anchors`, `snapshot_count`, and
+`updated_at`. Subject addresses are authoritative. Projection records are copied
+only as current evidence, so absent or stale subjects use `absent` or `stale`
+anchor status rather than preserving old overlay rectangles as truth.
+
+Frames are represented as anchors whose `comment_text` is an empty string.
+Adding comment text updates the anchor at the same subject address or creates a
+new anchor with text. Hover candidates update preview state only, while
+committing preview creates or updates anchors for the selected scope chain.
+Clearing or exiting resets live session state and preserves `snapshot_count`;
+snapshots remain explicit point-in-time artifacts.
+
+The display-first opacity helper is:
+
+```js
+import { opacityForDepth } from '../workbench/annotation-session.js'
+```
+
+`opacityForDepth(index, count, floor = 0.75)` returns `1` for the current or
+only frame, `0.75` for the outer/root frame when ancestry exists, and evenly
+interpolates intermediate frames between those values.
+
 ### HTML Workbench Expression V0
 
 `packages/toolkit/workbench/html-workbench-expression.js` builds the V0 rich

--- a/docs/design/html-workbench-expression-adoption-audit-2026-05-13.md
+++ b/docs/design/html-workbench-expression-adoption-audit-2026-05-13.md
@@ -1,0 +1,163 @@
+# HTML Workbench Expression Adoption Audit
+
+**Date:** 2026-05-13
+**Status:** durable design audit
+**Related issues:** #300, #301, #263, #293, #295, #141, #129, #140, #302
+
+## Source Signal
+
+A transcript about "HTML as the new Markdown" argued that agents should use
+HTML for richer human-facing outputs: side-by-side exploration, PR explainers,
+research reports, custom one-off editors, diagrams, sliders, visual hierarchy,
+and other surfaces that keep humans in the loop. The useful signal is not that
+HTML should replace Markdown. The useful signal is that agent-generated work
+often needs an inspectable surface rather than another long text document.
+
+The transcript also carries cautions: HTML costs more tokens, can be noisy in
+version control, can decay from novelty into new clutter, can look polished
+while remaining shallow, can fail on mobile, and can hallucinate or mishandle
+images. It is strongest as a projection and interaction layer, not as canonical
+source.
+
+## Adoption Finding
+
+Agent OS has already absorbed the strong version of the signal under the
+Layered Subject Expression and HTML Workbench Expression patterns.
+
+The current AOS stance is:
+
+- Markdown remains the durable source expression for prose, work-cards, recipes,
+  and docs.
+- JSON remains the canonical machine-readable expression for schemas, bundles,
+  manifests, evidence, and audit data.
+- HTML becomes a rich workbench expression for human review, annotation,
+  semantic targets, Mermaid diagrams, checkpoint interaction, and structured
+  intent alignment.
+
+This is better than the raw "just ask for HTML" pattern. It keeps simple source
+diffs and machine contracts stable while using HTML where a browser layout tree,
+DOM selectors, `data-aos-ref`, scroll/reveal behavior, and Surface Inspector
+integration are actually useful.
+
+## Current Repo Evidence
+
+HTML Workbench Expression V0 exists as a concrete slice:
+
+- `shared/schemas/aos-html-workbench-expression-v0.md`
+- `shared/schemas/aos-html-workbench-expression-v0.schema.json`
+- `packages/toolkit/workbench/html-workbench-expression.js`
+- `packages/toolkit/components/html-workbench-expression/`
+- `scripts/aos-html-workbench-expression.mjs`
+- `docs/api/toolkit/workbench.md`
+- `docs/design/work-cards/aos-html-workbench-expression-v0.md`
+- `tests/toolkit/html-workbench-expression.test.mjs`
+- `tests/schemas/aos-html-workbench-expression-v0.test.mjs`
+
+The V0 implementation supports Markdown-authored work-cards and human alignment
+packs. It emits deterministic metadata, source hashes, generated HTML paths,
+source maps, semantic targets, Mermaid preservation records, capability flags,
+security policy, and resume/export behavior. It deliberately does not mutate
+source Markdown automatically.
+
+Artifact Bundle Subject V0 is also already integrated, not merely proposed.
+Issue #263 is closed as complete, with a read-only artifact-bundle subject,
+fixture, canonical subject helper, artifact bundle workbench, catalog/browser
+opening path, docs, tests, and live AOS verification evidence. The artifact
+bundle workbench covers gallery, preview, source, exports, provenance,
+validation, and linked work-record evidence.
+
+## Reinforced Design Rule
+
+Use format pluralism by layer:
+
+- Use Markdown when the main job is durable text that humans and agents can edit
+  line by line.
+- Use JSON or another structured format when the main job is correctness,
+  validation, or machine exchange.
+- Use HTML Workbench Expressions when the main job is comprehension,
+  annotation, reveal, comparison, review, or checkpointed human steering.
+- Use Artifact Bundle Subjects when the main job is inspecting a collection of
+  generated or collected artifacts with provenance, validation, exports, and
+  related work records.
+- Use application-native UI only when the interaction is recurring enough to
+  deserve product-quality controls and persistence.
+
+The durable primitive is not a file extension. It is the loop: ingest real
+context, render a human-legible surface, let the human steer, then export a
+precise machine-legible result.
+
+## Contradictions And Divergent Patterns
+
+The main contradiction is stale documentation, not implementation. The Open
+Design cross-reference still describes artifact bundles as a proposed narrow
+path and says the note has no runtime implementation. That was true when it was
+written, but issue #263 later integrated Artifact Bundle Subject V0. Future
+agents should treat that note as historical analysis plus adaptation rationale,
+not current implementation status.
+
+The second tension is issue lifecycle. Issue #301 says V0 is covered in PR #307
+and should close after merge if review finds no missing acceptance item. As of
+this audit, PR #307 is still open and draft, so #301 should remain open even
+though the local worktree contains the implementation.
+
+The third tension is scope naming. Issue #300 calls HTML the "default rich
+workbench expression for human-facing artifacts," while implementation stays
+narrow to `work_card` and `human_alignment_pack`. That is healthy if future
+work expands through explicit artifact kinds and tests. It becomes risky if
+agents read #300 as permission to generate arbitrary HTML reports without
+source maps, semantic targets, sidecars, or cleanup policy.
+
+The fourth tension is artifact lifecycle. AOS has strong source/projection
+contracts, but the default disposal/archive policy for one-off generated HTML,
+reports, screenshots, PDFs, prototypes, and validation outputs is still not as
+explicit as the source-vs-projection rule. Without a lifecycle rule, the system
+can regress into artifact sprawl: useful visual outputs with unclear ownership,
+cleanup, archival, or surviving structured result.
+
+The fifth tension is Design Operator history. Issue #140 remains open as a
+design-operator context tracker, but its comments already warn that older
+`docs/superpowers` path guidance is stale and that artifact/workspace ideas now
+route through AOS workbench subjects and #263. Do not implement from the old
+path wording without checking current design docs.
+
+## GitHub Issue Audit
+
+- #300 is the correct parent epic for HTML Workbench Expressions. Its principle
+  is aligned with current repo state and should stay open as the broader
+  workstream.
+- #301 is the concrete V0 implementation tracker. It should close only after PR
+  #307 lands and review confirms no missing acceptance item.
+- #263 is closed and should be treated as completed adoption of Artifact Bundle
+  Subject V0, not future speculation.
+- #293 remains a valid abstraction gate for neutral evidence workflow blocks.
+  HTML expressions can become rich review projections for evidence workflow
+  artifacts, but extraction should still wait for stabilized cross-domain
+  reuse.
+- #295, #297, #298, and #299 are adjacent annotation/projection issues. HTML
+  expressions should reduce synthetic Markdown geometry when these issues touch
+  human-review surfaces, but should not force generic annotation behavior into
+  the HTML expression contract itself.
+- #141 remains the broader human-intent / steerable-collection context. HTML
+  expressions are checkpointable review/control surfaces within that direction,
+  not a replacement for collection/session workflow semantics.
+- #129 remains relevant for control-surface molecules. The durable connection is
+  generated controls over structured state, not arbitrary custom UI.
+- #140 is historical context for design workflows. Current implementation
+  should route through workbench subjects, artifact bundles, and explicit
+  licensing/IP boundaries.
+- #302 is the broader lore-consistency tracker. This audit reinforces its
+  warning: keep daemon/toolkit/app boundaries loud and avoid turning projection
+  surfaces into new product-specific platform forks.
+
+## Recommended Next Work
+
+Do not broaden HTML Workbench Expression immediately. First add a narrow
+lifecycle decision for generated projection artifacts:
+
+1. Define where disposable generated expressions live.
+2. Define when generated expressions are archived as artifact-bundle members.
+3. Define what structured sidecar/result must survive when an expression is
+   discarded.
+4. Define cleanup expectations for one-off generated HTML and report outputs.
+5. Add the lifecycle rule to the relevant toolkit workbench docs before adding
+   more artifact kinds.

--- a/docs/design/open-design-workbench-cross-reference.md
+++ b/docs/design/open-design-workbench-cross-reference.md
@@ -1,7 +1,26 @@
 # Open Design Workbench Cross-Reference
 
-Status: Research note and adaptation proposal. No runtime implementation.
+Status: Research note and adaptation proposal. Artifact Bundle Subject V0 has
+since landed; see the 2026-05-13 status update below before treating the
+proposed narrow path as current work.
 Tracking issue: #263.
+
+## 2026-05-13 Status Update
+
+Issue #263 is closed as integrated. The repo now has a read-only Artifact
+Bundle Subject V0 with fixture, canonical subject helper, artifact bundle
+workbench, catalog/browser opening path, docs, tests, and live AOS verification
+evidence. The analysis in this note remains useful as adaptation rationale, but
+the "Proposed Narrow Path" section is historical. Future work should build from
+the live `aos.artifact_bundle` subject and
+`aos://toolkit/components/artifact-bundle-workbench/index.html`, not restart the
+proposal.
+
+The 2026-05-13 HTML Workbench Expression audit also reinforces the boundary:
+Markdown and JSON remain durable source/contract layers, HTML and artifact
+bundle workbenches are projection/review layers, and generated artifacts need
+explicit lifecycle, cleanup, archive, export, and provenance policy before the
+pattern broadens.
 
 Source studied:
 

--- a/shared/schemas/aos-html-workbench-expression-v0.md
+++ b/shared/schemas/aos-html-workbench-expression-v0.md
@@ -20,3 +20,17 @@ or inline event handler execution is not supported.
 Resume/export records must not mutate source Markdown automatically. They may
 emit annotation sidecars, decision sidecars, proposed Markdown patches, or
 no-op approval records for a later step to apply.
+
+## Design Positioning
+
+The contract is Agent OS's disciplined adoption of the "HTML as richer agent
+output" pattern. HTML is not the source of truth and not a blanket replacement
+for Markdown. It is an addressable projection layer used when human review,
+annotation, reveal, comparison, or checkpoint interaction needs real DOM
+geometry and stable semantic targets.
+
+Keep new artifact kinds narrow and evidence-backed. Before expanding beyond
+`work_card` and `human_alignment_pack`, define the source expression, generated
+HTML expression, surviving structured sidecar/result, security policy, and
+cleanup/archive behavior. See
+`docs/design/html-workbench-expression-adoption-audit-2026-05-13.md`.


### PR DESCRIPTION
## Summary

- Document the HTML Workbench expression adoption direction across AOS and toolkit API docs.
- Add the adoption audit note for generated HTML expression surfaces.
- Cross-reference the Open Design Workbench direction and clarify the schema contract.

## Stacked Review

Base branch: `codex/docks-session-roots-base`.

This is split out from the broader `codex/docks-session-roots` branch so the HTML Workbench adoption note can be reviewed separately from dock/dev governance, gateway cleanup, and #296 annotation work.

## Verification

- `git diff --check codex/docks-session-roots-base..HEAD`
- `node --test tests/schemas/aos-html-workbench-expression-v0.test.mjs tests/toolkit/html-workbench-expression.test.mjs`
