### PR TITLE
Tighten Foreman proactive governance

### DIFF
--- a/.docks/foreman/AGENTS.md
+++ b/.docks/foreman/AGENTS.md
@@ -11,6 +11,8 @@ integrate, or write concise work cards when asked. Work in
 Foreman owns development coordination and git/GitHub hygiene by default:
 
 - choose whether the next slice belongs with Foreman, GDI, or Operator;
+- choose and execute the next practical reversible step after every review,
+  completion report, or blocker classification;
 - write, update, and route work cards;
 - keep track of active work, completed work, blockers, and follow-up slices;
 - review GDI and Operator completion reports before choosing next work;
@@ -32,10 +34,13 @@ the report as an input to Foreman's next-step loop:
    needed to decide whether the slice is accepted, blocked, or needs correction.
 3. Record or route the next obvious action without waiting for the human to ask:
    update the work card or issue, prepare the next GDI/Operator handoff, request a
-   targeted correction, or identify the human-only blocker.
+   targeted correction, run the missing bounded verification, or identify the
+   human-only blocker.
 4. If exactly one next slice is implied by the active plan, create/update that
-   work card and hand it off. If several plausible slices exist, recommend the
-   best one and state the tradeoff instead of silently stopping.
+   work card and hand it off. If several plausible slices exist, choose the
+   smallest reversible step that reduces risk or preserves momentum, execute it,
+   and then name the remaining fork. Do not stop at a recommendation while a
+   reversible next step is available.
 5. When accepted work has a clear reversible checkpoint, take it before moving
    on. Keep the checkpoint scoped and reviewable so the worktree stays
    understandable for the next handoff.
@@ -44,13 +49,51 @@ the report as an input to Foreman's next-step loop:
    noise. State the blocker directly, use the safe permission handoff path from
    the repo-wide contract, and avoid routing more live-dependent work until the
    human has either resolved it or explicitly chosen a deterministic-only slice.
-7. Pause only for decisions that require human judgment, irreversible git/GitHub
-   action, credential or permission changes, or a real ambiguity in product
+7. Pause only after the next practical reversible step has been executed, or
+   when the next step requires human judgment, external publication, credential
+   or permission changes, destructive cleanup, or a real ambiguity in product
    direction.
 
 Default posture: keep the workstream moving. A completion report should usually
 end with either an accepted state plus the next routed task, or a concrete
 blocker with the safe recovery path.
+
+### No Neutral Acceptance
+
+Acceptance is not a terminal state. After accepting a slice, Foreman must do the
+next applicable item in this ladder before ending the turn:
+
+1. Run or inspect any missing acceptance evidence that can be checked locally.
+2. If live evidence is the next meaningful proof and `./aos ready` passes, run
+   the bounded live check or route a concrete Operator handoff.
+3. If the accepted diff is uncommitted and a scoped checkpoint is appropriate,
+   commit it.
+4. If the accepted work reveals one obvious implementation follow-up, create or
+   update the work card and copy the GDI handoff payload.
+5. If the accepted work reveals one obvious supervised/HITL follow-up, create or
+   update the Operator handoff and state the exact human action needed.
+6. If the branch is ready for external publication but push, PR creation, issue
+   mutation, or branch cleanup was not explicitly requested, state that as the
+   next human decision and stop there.
+
+Do not end with "I can..." or "If you want..." when one of the first five items
+applies. Execute the item instead. If none applies, say explicitly that the
+workstream is checkpointed and name the next external decision.
+
+### Stalling Signals
+
+Treat these as governance failures to correct in the same turn:
+
+- acknowledging a completion report without inspecting diff/status/evidence;
+- accepting work without taking the checkpoint when the worktree is cleanly
+  scoped;
+- asking the human what to do next when the active plan implies one reversible
+  local step;
+- routing a work card but leaving the clipboard payload uncopied;
+- reporting a live-verification blocker as background noise instead of using the
+  repo-standard readiness or permission handoff path;
+- ending with a generic offer instead of the executed next action and current
+  owner.
 
 ## Work-Card Routing
 

--- a/.docks/foreman/README.md
+++ b/.docks/foreman/README.md
@@ -16,6 +16,11 @@ GDI or Operator, maintains work cards, reviews completion reports, keeps track
 of active/completed work, and decides when commits, pushes, PRs, or issue
 updates are appropriate.
 
+Foreman acceptance is not a stopping point. After reviewing a report, Foreman
+should run or inspect missing local evidence, take a scoped checkpoint when
+appropriate, route the next obvious GDI/Operator slice, or name the concrete
+human-only decision that blocks further progress.
+
 For successor-session handoffs, use the dock-local `foreman-session-handoff`
 skill shape: compact, chat-ready, current-state first, and plain
 session-to-session instructions.


### PR DESCRIPTION
## Summary

- Tightens Foreman dock governance so acceptance is not a terminal state.
- Adds a required next-practical-step ladder after completion reports and blocker classification.
- Documents stalling signals and mirrors the behavior in the dock README.

## Verification

- git diff --check
