### PR TITLE
feat(gate): add daemon gate receptor

### DIFF
--- a/packages/cli/verbs/gate-ask.js
+++ b/packages/cli/verbs/gate-ask.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+import { createGateService, normalizeGateRequest } from '../../daemon/gate/index.js';
+
+function usage() {
+  return `Usage:
+  aos gate ask "Prompt title"
+  aos gate ask --preset approve_deny --title "Run test?" --timeout 30
+  aos gate ask --request gate-request.json
+  aos gate ask --json '{"prompt":{"title":"Continue?"},"ui":{"variant":"yes_no_with_escape"}}'
+
+Writes a JSON value or null to stdout.`;
+}
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => { data += chunk; });
+    process.stdin.on('error', reject);
+    process.stdin.on('end', () => resolve(data));
+  });
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    title: null,
+    message: null,
+    preset: null,
+    timeoutSeconds: null,
+    requestFile: null,
+    json: null,
+  };
+  const positional = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--help' || arg === '-h') {
+      parsed.help = true;
+    } else if (arg === '--request') {
+      parsed.requestFile = argv[++index];
+    } else if (arg === '--json') {
+      parsed.json = argv[++index];
+    } else if (arg === '--preset') {
+      parsed.preset = argv[++index];
+    } else if (arg === '--title') {
+      parsed.title = argv[++index];
+    } else if (arg === '--message' || arg === '--body') {
+      parsed.message = argv[++index];
+    } else if (arg === '--timeout') {
+      parsed.timeoutSeconds = Number(argv[++index]);
+    } else if (arg.startsWith('--')) {
+      throw new Error(`unknown option: ${arg}`);
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  if (!parsed.title && positional.length) parsed.title = positional.join(' ');
+  return parsed;
+}
+
+async function requestFromArgs(args) {
+  if (args.requestFile) return JSON.parse(await readFile(args.requestFile, 'utf8'));
+  if (args.json) return JSON.parse(args.json);
+
+  if (!args.title && !process.stdin.isTTY) {
+    const stdin = (await readStdin()).trim();
+    if (stdin) return JSON.parse(stdin);
+  }
+
+  if (!args.title) throw new Error('prompt title is required');
+  return {
+    schema_version: 'aos.gate.request.v1',
+    prompt: { title: args.title, body: args.message ?? null },
+    ui: { variant: args.preset || 'yes_no_with_escape' },
+    timeout_ms: Number.isFinite(args.timeoutSeconds) ? args.timeoutSeconds * 1000 : 20000,
+    source: { surface: 'aos-cli' },
+  };
+}
+
+export async function runGateAsk(argv = process.argv.slice(2), {
+  stdout = process.stdout,
+  stderr = process.stderr,
+  service = createGateService(),
+} = {}) {
+  try {
+    const args = parseArgs(argv);
+    if (args.help) {
+      stdout.write(`${usage()}\n`);
+      return 0;
+    }
+
+    const request = normalizeGateRequest(await requestFromArgs(args));
+    const result = await service.ask(request);
+    stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  } catch (error) {
+    stderr.write(`aos gate ask: ${error.message}\n`);
+    return 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exitCode = await runGateAsk();
+}

--- a/packages/daemon/gate/GateReceptor.js
+++ b/packages/daemon/gate/GateReceptor.js
@@ -1,0 +1,41 @@
+const SUPPORTED_FIELD_KINDS = new Set([
+  'boolean',
+  'exclusive_choice',
+  'multi_choice',
+  'text',
+  'number',
+]);
+
+export class GateReceptor {
+  constructor({ onResolve = null, onReject = null } = {}) {
+    this.onResolve = onResolve;
+    this.onReject = onReject;
+  }
+
+  async receive(gateRequest) {
+    return this.present(gateRequest);
+  }
+
+  async present(_gateRequest) {
+    throw new Error(`${this.constructor.name}.present() must be implemented`);
+  }
+
+  async dismiss(_handle) {
+  }
+
+  supports(kind) {
+    return SUPPORTED_FIELD_KINDS.has(kind);
+  }
+
+  resolve(id, values) {
+    if (!id) throw new Error('GateReceptor.resolve requires an id');
+    this.onResolve?.(id, values);
+  }
+
+  reject(id, reason) {
+    if (!id) throw new Error('GateReceptor.reject requires an id');
+    this.onReject?.(id, reason);
+  }
+}
+
+export { SUPPORTED_FIELD_KINDS };

--- a/packages/daemon/gate/LocalCanvasReceptor.js
+++ b/packages/daemon/gate/LocalCanvasReceptor.js
@@ -1,0 +1,105 @@
+import { spawn } from 'node:child_process';
+import { GateReceptor } from './GateReceptor.js';
+
+const DEFAULT_POLL_MS = 400;
+
+function requestParam(request) {
+  return Buffer.from(JSON.stringify(request), 'utf8').toString('base64');
+}
+
+function defaultCanvasClient({ aosPath = './aos' } = {}) {
+  const run = (args) => new Promise((resolve, reject) => {
+    const child = spawn(aosPath, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) resolve(stdout.trim());
+      else reject(new Error(stderr.trim() || `${aosPath} ${args.join(' ')} exited ${code}`));
+    });
+  });
+
+  return {
+    async createCanvas(request) {
+      const url = `aos://toolkit/components/decision-gate/index.html?requestB64=${encodeURIComponent(requestParam(request))}`;
+      await run(['show', 'create', '--id', request.id, '--url', url, '--interactive', '--focus']);
+      return request.id;
+    },
+    async evalCanvas(canvasId, expression) {
+      return run(['show', 'eval', '--id', String(canvasId), '--js', expression]);
+    },
+    async removeCanvas(canvasId) {
+      await run(['show', 'remove', '--id', String(canvasId)]);
+    },
+  };
+}
+
+function parseGateResult(raw) {
+  if (raw === undefined || raw === null || raw === '') return undefined;
+  const text = String(raw).trim();
+  if (!text || text === 'undefined') return undefined;
+  const parsed = JSON.parse(text);
+  if (parsed && typeof parsed === 'object' && 'result' in parsed) return parseGateResult(parsed.result);
+  return typeof parsed === 'string' ? JSON.parse(parsed) : parsed;
+}
+
+export class LocalCanvasReceptor extends GateReceptor {
+  constructor({
+    canvasClient = defaultCanvasClient(),
+    pollMs = DEFAULT_POLL_MS,
+    setIntervalFn = setInterval,
+    clearIntervalFn = clearInterval,
+    ...callbacks
+  } = {}) {
+    super(callbacks);
+    this.canvasClient = canvasClient;
+    this.pollMs = pollMs;
+    this.setIntervalFn = setIntervalFn;
+    this.clearIntervalFn = clearIntervalFn;
+  }
+
+  async present(gateRequest) {
+    const canvasId = await this.canvasClient.createCanvas(gateRequest);
+    const handle = { id: gateRequest.id, canvasId, poller: null, closed: false };
+    const expression = 'window.__gateResult';
+
+    const poll = async () => {
+      if (handle.closed) return;
+      try {
+        const raw = await this.canvasClient.evalCanvas(canvasId, expression);
+        const value = parseGateResult(raw);
+        if (value !== undefined) {
+          handle.closed = true;
+          this.clearIntervalFn(handle.poller);
+          handle.poller = null;
+          this.resolve(gateRequest.id, value);
+        }
+      } catch (error) {
+        handle.closed = true;
+        this.clearIntervalFn(handle.poller);
+        handle.poller = null;
+        this.reject(gateRequest.id, error);
+      }
+    };
+
+    handle.poller = this.setIntervalFn(poll, this.pollMs);
+    poll();
+    return handle;
+  }
+
+  async dismiss(handle) {
+    if (!handle) return;
+    handle.closed = true;
+    if (handle.poller) {
+      this.clearIntervalFn(handle.poller);
+      handle.poller = null;
+    }
+    if (handle.canvasId !== undefined && handle.canvasId !== null) {
+      await this.canvasClient.removeCanvas(handle.canvasId);
+    }
+  }
+}
+
+export { defaultCanvasClient, parseGateResult };

--- a/packages/daemon/gate/index.js
+++ b/packages/daemon/gate/index.js
@@ -1,0 +1,202 @@
+import { randomUUID } from 'node:crypto';
+import { LocalCanvasReceptor } from './LocalCanvasReceptor.js';
+
+const MIN_TIMEOUT_MS = 5000;
+const MAX_TIMEOUT_MS = 120000;
+const PRESETS = new Set([
+  'yes_no_with_escape',
+  'approve_deny',
+  'single_choice',
+  'multi_choice',
+  'freetext',
+]);
+const FIELD_KINDS = new Set(['boolean', 'exclusive_choice', 'multi_choice', 'text', 'number']);
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function clampTimeout(timeoutMs) {
+  const numeric = Number(timeoutMs);
+  if (!Number.isFinite(numeric)) return 20000;
+  return Math.min(MAX_TIMEOUT_MS, Math.max(MIN_TIMEOUT_MS, numeric));
+}
+
+function presetFields(variant, request = {}) {
+  const choices = Array.isArray(request.choices)
+    ? request.choices
+    : Array.isArray(request.ui?.options)
+      ? request.ui.options
+      : [];
+
+  if (variant === 'yes_no_with_escape') {
+    return [
+      { id: 'decision', kind: 'exclusive_choice', style: 'buttons', options: [
+        { value: 'yes', label: 'Yes' },
+        { value: 'no', label: 'No' },
+        { value: 'other', label: 'Something else' },
+      ] },
+      { id: 'other_text', kind: 'text', placeholder: 'Something else...', visible_when: { field: 'decision', equals: 'other' } },
+    ];
+  }
+  if (variant === 'approve_deny') {
+    return [
+      { id: 'decision', kind: 'exclusive_choice', style: 'buttons', options: [
+        { value: 'approve', label: 'Approve' },
+        { value: 'deny', label: 'Deny', danger: true },
+      ] },
+      { id: 'other_text', kind: 'text', placeholder: 'Reason...', visible_when: { field: 'decision', equals: 'deny' } },
+    ];
+  }
+  if (variant === 'single_choice') return [{ id: 'decision', kind: 'exclusive_choice', style: 'buttons', options: choices }];
+  if (variant === 'multi_choice') return [{ id: 'decisions', kind: 'multi_choice', options: choices }];
+  return [{ id: 'text', kind: 'text', placeholder: 'Your response...' }];
+}
+
+function validateFields(fields, { path = 'fields' } = {}) {
+  if (!Array.isArray(fields) || fields.length === 0) throw new Error(`${path} must be a non-empty array`);
+  for (const [index, field] of fields.entries()) {
+    if (!isObject(field)) throw new Error(`${path}[${index}] must be an object`);
+    if (typeof field.id !== 'string' || field.id.length === 0) throw new Error(`${path}[${index}].id is required`);
+    if (!FIELD_KINDS.has(field.kind)) throw new Error(`${path}[${index}].kind is unsupported`);
+    if ((field.kind === 'exclusive_choice' || field.kind === 'multi_choice') && (!Array.isArray(field.options) || field.options.length === 0)) {
+      throw new Error(`${path}[${index}].options must be non-empty`);
+    }
+  }
+}
+
+export function normalizeGateRequest(input, { source = { surface: 'aos-cli' } } = {}) {
+  if (!isObject(input)) throw new Error('gate request must be an object');
+  const prompt = isObject(input.prompt) ? input.prompt : null;
+  if (!prompt || typeof prompt.title !== 'string' || prompt.title.length === 0) {
+    throw new Error('prompt.title is required');
+  }
+
+  const ui = isObject(input.ui) ? { ...input.ui } : {};
+  const variant = ui.variant ?? (Array.isArray(input.fields) ? null : 'freetext');
+  if (variant !== null && variant !== undefined && !PRESETS.has(variant)) throw new Error(`unsupported ui.variant: ${variant}`);
+
+  const fields = Array.isArray(input.fields)
+    ? input.fields
+    : Array.isArray(ui.fields)
+      ? ui.fields
+      : presetFields(variant || 'freetext', input);
+  validateFields(fields);
+
+  return {
+    ...input,
+    schema_version: 'aos.gate.request.v1',
+    id: typeof input.id === 'string' && input.id.length > 0 ? input.id : `gate-${randomUUID()}`,
+    prompt: {
+      title: prompt.title,
+      body: prompt.body ?? null,
+    },
+    fields,
+    ui: {
+      ...ui,
+      variant,
+      fields,
+    },
+    timeout_ms: clampTimeout(input.timeout_ms),
+    source: isObject(input.source) ? input.source : source,
+  };
+}
+
+export function validateGateRequest(input) {
+  normalizeGateRequest(input);
+  return true;
+}
+
+export function createGateService({
+  receptor = null,
+  receptorFactory = null,
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
+  logger = null,
+} = {}) {
+  const pending = new Map();
+
+  function log(event, payload) {
+    logger?.({ event, ...payload });
+  }
+
+  async function settle(id, resolution, value, rejectError = null) {
+    const entry = pending.get(id);
+    if (!entry) return;
+    pending.delete(id);
+    clearTimeoutFn(entry.timer);
+    try {
+      await entry.receptor.dismiss(entry.handle);
+    } finally {
+      log('gate.resolved', { gate_id: id, resolution, elapsed_ms: Date.now() - entry.startedAt });
+      if (rejectError) entry.reject(rejectError);
+      else entry.resolve(value);
+    }
+  }
+
+  const callbacks = {
+    onResolve(id, values) {
+      settle(id, values === null ? 'dismiss' : 'user', values);
+    },
+    onReject(id, reason) {
+      settle(id, 'error', null, reason instanceof Error ? reason : new Error(String(reason || 'gate rejected')));
+    },
+  };
+
+  async function ask(gateRequest) {
+    const request = normalizeGateRequest(gateRequest);
+    const selectedReceptor = receptor || (receptorFactory ? receptorFactory(callbacks) : new LocalCanvasReceptor(callbacks));
+    for (const field of request.fields) {
+      if (!selectedReceptor.supports(field.kind)) throw new Error(`no receptor support for field kind: ${field.kind}`);
+    }
+
+    log('gate.requested', {
+      gate_id: request.id,
+      variant: request.ui?.variant ?? null,
+      timeout_ms: request.timeout_ms,
+    });
+
+    return new Promise((resolve, reject) => {
+      const entry = {
+        request,
+        receptor: selectedReceptor,
+        handle: null,
+        resolve,
+        reject,
+        startedAt: Date.now(),
+        timer: setTimeoutFn(() => {
+          settle(request.id, 'timeout', null);
+        }, request.timeout_ms),
+      };
+      pending.set(request.id, entry);
+
+      selectedReceptor.receive(request)
+        .then((handle) => {
+          if (!pending.has(request.id)) {
+            selectedReceptor.dismiss(handle);
+            return;
+          }
+          entry.handle = handle;
+          log('gate.presented', { gate_id: request.id, receptor: selectedReceptor.constructor.name });
+        })
+        .catch((error) => {
+          settle(request.id, 'error', null, error);
+        });
+    });
+  }
+
+  return {
+    pending,
+    ask,
+    resolve(id, values) {
+      return settle(id, values === null ? 'dismiss' : 'user', values);
+    },
+    reject(id, reason) {
+      return settle(id, 'error', null, reason instanceof Error ? reason : new Error(String(reason || 'gate rejected')));
+    },
+  };
+}
+
+export const gateService = createGateService();
+export { GateReceptor } from './GateReceptor.js';
+export { LocalCanvasReceptor } from './LocalCanvasReceptor.js';

--- a/shared/schemas/aos.gate.request.v1.json
+++ b/shared/schemas/aos.gate.request.v1.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agent-os.local/schemas/aos.gate.request.v1.json",
+  "title": "AOS Gate Request",
+  "description": "Envelope for bounded structured human-input gate requests.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["schema_version", "prompt", "timeout_ms"],
+  "properties": {
+    "schema_version": {
+      "const": "aos.gate.request.v1"
+    },
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "prompt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "body": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "response_schema": {
+      "type": "object"
+    },
+    "fields": {
+      "$ref": "#/$defs/fields"
+    },
+    "ui": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "variant": {
+          "type": ["string", "null"],
+          "enum": [
+            "yes_no_with_escape",
+            "approve_deny",
+            "single_choice",
+            "multi_choice",
+            "freetext",
+            null
+          ]
+        },
+        "fields": {
+          "$ref": "#/$defs/fields"
+        },
+        "timer": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "visible": { "type": "boolean" },
+            "display": { "type": "string", "enum": ["digital", "pie"] },
+            "direction": { "type": "string", "enum": ["countDown", "countUp"] },
+            "flash_threshold_ms": { "type": "number", "minimum": 0 },
+            "flash_interval_ms": { "type": "number", "minimum": 0 }
+          }
+        }
+      }
+    },
+    "timeout_ms": {
+      "type": "number",
+      "minimum": 0
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "surface": { "type": "string" },
+        "session_id": { "type": ["string", "null"] },
+        "agent": { "type": ["string", "null"] }
+      }
+    }
+  },
+  "$defs": {
+    "fields": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["id", "kind"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "kind": {
+            "type": "string",
+            "enum": ["boolean", "exclusive_choice", "multi_choice", "text", "number"]
+          },
+          "label": {
+            "type": "string"
+          },
+          "style": {
+            "type": "string"
+          },
+          "placeholder": {
+            "type": "string"
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true,
+              "required": ["value", "label"],
+              "properties": {
+                "value": {
+                  "type": ["string", "number", "boolean"]
+                },
+                "label": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "danger": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "visible_when": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["field", "equals"],
+            "properties": {
+              "field": {
+                "type": "string",
+                "minLength": 1
+              },
+              "equals": {}
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/commands/gate.swift
+++ b/src/commands/gate.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+func gateCommand(args: [String]) {
+    if args.contains("--help") || args.contains("-h") || args.isEmpty {
+        printCommandHelp(["gate"], json: args.contains("--json"))
+        exit(0)
+    }
+
+    let subcommand = args[0]
+    let subArgs = Array(args.dropFirst())
+    switch subcommand {
+    case "ask":
+        runGateAsk(args: subArgs)
+    default:
+        exitError("Unknown gate subcommand: \(subcommand)", code: "UNKNOWN_SUBCOMMAND")
+    }
+}
+
+private func runGateAsk(args: [String]) {
+    let verb = aosRepoPath("packages/cli/verbs/gate-ask.js")
+    guard FileManager.default.fileExists(atPath: verb) else {
+        exitError("gate ask verb not found at \(verb)", code: "GATE_VERB_MISSING")
+    }
+
+    let task = Process()
+    task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    task.arguments = ["node", verb] + args
+    task.standardInput = FileHandle.standardInput
+    task.standardOutput = FileHandle.standardOutput
+    task.standardError = FileHandle.standardError
+
+    do {
+        try task.run()
+    } catch {
+        exitError("failed to spawn gate ask verb: \(error.localizedDescription)", code: "SPAWN_FAILED")
+    }
+    task.waitUntilExit()
+    exit(task.terminationStatus)
+}

--- a/src/main.swift
+++ b/src/main.swift
@@ -32,6 +32,8 @@ struct AOS {
             handleTell(args: Array(args.dropFirst()))
         case "listen":
             handleListen(args: Array(args.dropFirst()))
+        case "gate":
+            gateCommand(args: Array(args.dropFirst()))
         case "voice":
             voiceCommand(args: Array(args.dropFirst()))
         case "config":

--- a/src/shared/command-registry-data.swift
+++ b/src/shared/command-registry-data.swift
@@ -713,6 +713,36 @@ func buildCommandRegistry() -> [CommandDescriptor] {
             ])
     ]))
 
+    // ── gate ──────────────────────────────────────────────
+    reg.append(CommandDescriptor(path: ["gate"], summary: "Request a bounded structured human decision", forms: [
+        InvocationForm(id: "gate-ask", usage: "aos gate ask [prompt] [--preset name] [--title text] [--timeout seconds] [--json request] [--request file]",
+            args: [
+                pos("prompt", "Prompt title", required: false, variadic: true),
+                flag("preset", "--preset", "Gate preset",
+                     type: .enumeration([
+                        EnumValue(value: "yes_no_with_escape", summary: "Yes / No with escape text"),
+                        EnumValue(value: "approve_deny", summary: "Approve / Deny"),
+                        EnumValue(value: "single_choice", summary: "Choose one option"),
+                        EnumValue(value: "multi_choice", summary: "Choose many options"),
+                        EnumValue(value: "freetext", summary: "Free text response")
+                     ])),
+                flag("title", "--title", "Prompt title"),
+                flag("message", "--message", "Prompt body"),
+                flag("timeout", "--timeout", "Timeout in seconds", type: .float),
+                flag("json", "--json", "Inline aos.gate.request.v1 JSON"),
+                flag("request", "--request", "Path to aos.gate.request.v1 JSON file")
+            ],
+            stdin: StdinDescriptor(supported: true, usedWhen: "no prompt, --json, or --request", contentType: "aos.gate.request.v1 JSON"),
+            constraints: ConstraintSet(requires: nil, conflicts: [["json", "request"]], oneOf: nil, implies: nil),
+            execution: execInteractive(daemon: true),
+            output: outJSON,
+            examples: [
+                "aos gate ask \"Continue?\"",
+                "aos gate ask --preset approve_deny --title \"Run disruptive test?\" --timeout 30",
+                "aos gate ask --request gate-request.json"
+            ])
+    ]))
+
     // ── tell ──────────────────────────────────────────────
     reg.append(CommandDescriptor(path: ["tell"], summary: "Communication — send to human, channel, or session", forms: [
         InvocationForm(id: "tell-message", usage: "aos tell <audience>|--session-id <id> [--json <payload>] [--from <name>] [--from-session-id <id>] [--purpose <name>] [<text> | stdin]",

--- a/tests/daemon/gate-receptor.test.mjs
+++ b/tests/daemon/gate-receptor.test.mjs
@@ -1,0 +1,124 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { GateReceptor } from '../../packages/daemon/gate/GateReceptor.js';
+import { LocalCanvasReceptor, parseGateResult } from '../../packages/daemon/gate/LocalCanvasReceptor.js';
+
+function request(overrides = {}) {
+  return {
+    schema_version: 'aos.gate.request.v1',
+    id: 'gate-test',
+    prompt: { title: 'Continue?', body: null },
+    fields: [{ id: 'decision', kind: 'boolean' }],
+    timeout_ms: 20000,
+    source: { surface: 'test' },
+    ...overrides,
+  };
+}
+
+test('GateReceptor exposes receive, resolve, reject, and support checks', async () => {
+  const events = [];
+  class TestReceptor extends GateReceptor {
+    async present(gateRequest) {
+      return { id: gateRequest.id };
+    }
+  }
+  const receptor = new TestReceptor({
+    onResolve: (id, values) => events.push(['resolve', id, values]),
+    onReject: (id, reason) => events.push(['reject', id, reason]),
+  });
+
+  assert.deepEqual(await receptor.receive(request()), { id: 'gate-test' });
+  assert.equal(receptor.supports('text'), true);
+  assert.equal(receptor.supports('point3d'), false);
+
+  receptor.resolve('gate-test', { decision: true });
+  receptor.reject('gate-test', 'cancel');
+
+  assert.deepEqual(events, [
+    ['resolve', 'gate-test', { decision: true }],
+    ['reject', 'gate-test', 'cancel'],
+  ]);
+});
+
+test('base GateReceptor requires concrete presentation', async () => {
+  const receptor = new GateReceptor();
+  await assert.rejects(() => receptor.receive(request()), /present\(\) must be implemented/);
+});
+
+test('LocalCanvasReceptor creates canvas, polls result, resolves, and dismisses', async () => {
+  const calls = [];
+  const events = [];
+  const intervals = [];
+  const receptor = new LocalCanvasReceptor({
+    canvasClient: {
+      async createCanvas(gateRequest) {
+        calls.push(['create', gateRequest.id]);
+        return 'canvas-1';
+      },
+      async evalCanvas(canvasId) {
+        calls.push(['eval', canvasId]);
+        return JSON.stringify({ decision: 'yes' });
+      },
+      async removeCanvas(canvasId) {
+        calls.push(['remove', canvasId]);
+      },
+    },
+    setIntervalFn(callback) {
+      intervals.push(callback);
+      return 'poller-1';
+    },
+    clearIntervalFn(id) {
+      calls.push(['clear', id]);
+    },
+    onResolve: (id, values) => events.push(['resolve', id, values]),
+    onReject: (id, reason) => events.push(['reject', id, reason]),
+  });
+
+  const handle = await receptor.receive(request());
+  await new Promise((resolve) => setImmediate(resolve));
+  await receptor.dismiss(handle);
+
+  assert.equal(handle.canvasId, 'canvas-1');
+  assert.deepEqual(events, [['resolve', 'gate-test', { decision: 'yes' }]]);
+  assert.deepEqual(calls, [
+    ['create', 'gate-test'],
+    ['eval', 'canvas-1'],
+    ['clear', 'poller-1'],
+    ['remove', 'canvas-1'],
+  ]);
+  assert.equal(intervals.length, 1);
+});
+
+test('LocalCanvasReceptor rejects when canvas polling fails', async () => {
+  const events = [];
+  const receptor = new LocalCanvasReceptor({
+    canvasClient: {
+      async createCanvas() {
+        return 'canvas-1';
+      },
+      async evalCanvas() {
+        throw new Error('canvas closed');
+      },
+      async removeCanvas() {},
+    },
+    setIntervalFn() {
+      return 'poller-1';
+    },
+    clearIntervalFn() {},
+    onResolve: (id, values) => events.push(['resolve', id, values]),
+    onReject: (id, reason) => events.push(['reject', id, reason.message]),
+  });
+
+  await receptor.receive(request());
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(events, [['reject', 'gate-test', 'canvas closed']]);
+});
+
+test('parseGateResult handles canvas string protocol', () => {
+  assert.equal(parseGateResult(undefined), undefined);
+  assert.equal(parseGateResult('undefined'), undefined);
+  assert.equal(parseGateResult('null'), null);
+  assert.deepEqual(parseGateResult('{"decision":"yes"}'), { decision: 'yes' });
+  assert.deepEqual(parseGateResult(JSON.stringify(JSON.stringify({ decision: 'yes' }))), { decision: 'yes' });
+});

--- a/tests/daemon/gate-service.test.mjs
+++ b/tests/daemon/gate-service.test.mjs
@@ -1,0 +1,152 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { GateReceptor } from '../../packages/daemon/gate/GateReceptor.js';
+import { createGateService, normalizeGateRequest } from '../../packages/daemon/gate/index.js';
+
+function request(id, overrides = {}) {
+  return {
+    schema_version: 'aos.gate.request.v1',
+    id,
+    prompt: { title: `Gate ${id}`, body: null },
+    fields: [{ id: 'decision', kind: 'boolean' }],
+    timeout_ms: 20000,
+    source: { surface: 'test' },
+    ...overrides,
+  };
+}
+
+class ManualReceptor extends GateReceptor {
+  constructor(callbacks) {
+    super(callbacks);
+    this.handles = [];
+    this.dismissed = [];
+  }
+
+  async present(gateRequest) {
+    const handle = { id: gateRequest.id };
+    this.handles.push(handle);
+    return handle;
+  }
+
+  async dismiss(handle) {
+    this.dismissed.push(handle?.id);
+  }
+}
+
+function timeoutHarness() {
+  const timers = [];
+  return {
+    timers,
+    setTimeoutFn(callback, ms) {
+      const timer = { callback, ms, cleared: false };
+      timers.push(timer);
+      return timer;
+    },
+    clearTimeoutFn(timer) {
+      if (timer) timer.cleared = true;
+    },
+  };
+}
+
+test('normalizeGateRequest assigns id, source, fields, and clamps timeout', () => {
+  const normalized = normalizeGateRequest({
+    prompt: { title: 'Continue?' },
+    ui: { variant: 'yes_no_with_escape' },
+    timeout_ms: 1,
+  });
+
+  assert.equal(normalized.schema_version, 'aos.gate.request.v1');
+  assert.match(normalized.id, /^gate-/);
+  assert.equal(normalized.timeout_ms, 5000);
+  assert.equal(normalized.source.surface, 'aos-cli');
+  assert.equal(normalized.fields.length, 2);
+  assert.equal(normalized.ui.fields, normalized.fields);
+});
+
+test('ask resolves with user values and cleans up pending gate', async () => {
+  const harness = timeoutHarness();
+  let receptor;
+  const service = createGateService({
+    receptorFactory(callbacks) {
+      receptor = new ManualReceptor(callbacks);
+      return receptor;
+    },
+    ...harness,
+  });
+
+  const promise = service.ask(request('gate-a'));
+  await new Promise((resolve) => setImmediate(resolve));
+  receptor.resolve('gate-a', { decision: true });
+
+  assert.deepEqual(await promise, { decision: true });
+  assert.equal(service.pending.size, 0);
+  assert.deepEqual(receptor.dismissed, ['gate-a']);
+  assert.equal(harness.timers[0].cleared, true);
+});
+
+test('ask resolves null on daemon-authoritative timeout', async () => {
+  const harness = timeoutHarness();
+  let receptor;
+  const service = createGateService({
+    receptorFactory(callbacks) {
+      receptor = new ManualReceptor(callbacks);
+      return receptor;
+    },
+    ...harness,
+  });
+
+  const promise = service.ask(request('gate-timeout', { timeout_ms: 9000 }));
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(harness.timers[0].ms, 9000);
+  harness.timers[0].callback();
+
+  assert.equal(await promise, null);
+  assert.equal(service.pending.size, 0);
+  assert.deepEqual(receptor.dismissed, ['gate-timeout']);
+});
+
+test('ask handles concurrent gates independently', async () => {
+  const harness = timeoutHarness();
+  const receptors = [];
+  const service = createGateService({
+    receptorFactory(callbacks) {
+      const receptor = new ManualReceptor(callbacks);
+      receptors.push(receptor);
+      return receptor;
+    },
+    ...harness,
+  });
+
+  const first = service.ask(request('gate-1'));
+  const second = service.ask(request('gate-2'));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  receptors[1].resolve('gate-2', { decision: false });
+  assert.deepEqual(await second, { decision: false });
+  assert.equal(service.pending.has('gate-1'), true);
+  assert.equal(service.pending.has('gate-2'), false);
+
+  receptors[0].resolve('gate-1', { decision: true });
+  assert.deepEqual(await first, { decision: true });
+  assert.equal(service.pending.size, 0);
+});
+
+test('ask rejects when receptor reports an error', async () => {
+  const harness = timeoutHarness();
+  let receptor;
+  const service = createGateService({
+    receptorFactory(callbacks) {
+      receptor = new ManualReceptor(callbacks);
+      return receptor;
+    },
+    ...harness,
+  });
+
+  const promise = service.ask(request('gate-error'));
+  await new Promise((resolve) => setImmediate(resolve));
+  receptor.reject('gate-error', new Error('surface failed'));
+
+  await assert.rejects(() => promise, /surface failed/);
+  assert.equal(service.pending.size, 0);
+  assert.deepEqual(receptor.dismissed, ['gate-error']);
+});


### PR DESCRIPTION
Relay merge via agentic_relay profile.

Deliverables:
- `shared/schemas/aos.gate.request.v1.json`
- `packages/daemon/gate/GateReceptor.js`
- `packages/daemon/gate/LocalCanvasReceptor.js`
- `packages/daemon/gate/index.js`
- `packages/cli/verbs/gate-ask.js`
- `src/commands/gate.swift` + registry wiring
- `tests/daemon/gate-receptor.test.mjs` (5/5)
- `tests/daemon/gate-service.test.mjs` (5/5)

Verification: 10/10 daemon, 817/817 toolkit, build green, `./aos gate ask --help` passing.

Known baseline issues (pre-existing, not introduced by this branch):
- `tests/schemas/dev-workflow-profiles.test.mjs` expects `hybrid_trunk`, active profile is `agentic_relay`
- `./aos ready` reports `human_required` pending Accessibility/Input Monitoring regrant

HEAD SHA: 6a6fc334af97272ce33a02969b45f5639e56c553