### PR TITLE
feat(gateway): add user_signal_surface MCP tool

### DIFF
--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -14,6 +14,8 @@ import { ScriptRegistry } from './scripts.js';
 import { startSDKSocket } from './sdk-socket.js';
 import { acquirePidLock, PeerAliveError, type PidLock } from './singleton.js';
 import { registerExecutionTools } from './tools/execution.js';
+// @ts-expect-error JS adapter lives outside src so MCP hosts can exercise it directly.
+import { userSignalSurface, userSignalSurfaceTool } from '../tools/user-signal-surface.js';
 
 const scriptPath = fileURLToPath(import.meta.url);
 const mode = detectMode(scriptPath);
@@ -66,7 +68,10 @@ router.register(engine);
 const registry = new ScriptRegistry(paths.scriptsDir);
 
 const execTools = registerExecutionTools(router, registry, paths.socketPath);
-const allHandlers: Record<string, (args: any) => any> = { ...execTools };
+const allHandlers: Record<string, (args: any) => any> = {
+  ...execTools,
+  user_signal_surface: userSignalSurface,
+};
 
 const TOOL_DEFS = [
   { name: 'run_os_script', description: 'Execute a TS/JS script against the aos SDK. Runs off-stage.',
@@ -87,6 +92,7 @@ const TOOL_DEFS = [
     } } },
   { name: 'discover_capabilities', description: 'Returns SDK namespaces and method signatures.',
     inputSchema: { type: 'object' as const, properties: { namespace: { type: 'string' } } } },
+  userSignalSurfaceTool,
 ];
 
 const server = new Server({ name: 'aos-gateway', version: '0.1.0' }, { capabilities: { tools: {} } });
@@ -100,7 +106,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const result = await handler(args ?? {});
     return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
   } catch (err: any) {
-    return { content: [{ type: 'text', text: JSON.stringify({ error: err.message }) }] };
+    return { isError: true, content: [{ type: 'text', text: JSON.stringify({ error: err.message }) }] };
   }
 });
 

--- a/packages/gateway/tools/user-signal-surface.js
+++ b/packages/gateway/tools/user-signal-surface.js
@@ -1,0 +1,137 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const TOOL_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(TOOL_DIR, '..', '..', '..');
+const DEFAULT_TIMEOUT_MS = 20000;
+const PROCESS_GRACE_MS = 1000;
+
+export const userSignalSurfaceTool = {
+  name: 'user_signal_surface',
+  description:
+    'Request a bounded structured human decision via a transient AOS surface. ' +
+    'Returns the resolved value or null.',
+  inputSchema: {
+    type: 'object',
+    additionalProperties: true,
+    properties: {
+      schema_version: { const: 'aos.gate.request.v1' },
+      id: { type: 'string' },
+      prompt: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          body: { type: ['string', 'null'] },
+        },
+        required: ['title'],
+      },
+      response_schema: { type: 'object' },
+      fields: { $ref: '#/$defs/fields' },
+      ui: {
+        type: 'object',
+        additionalProperties: true,
+        properties: {
+          variant: {
+            type: ['string', 'null'],
+            enum: ['yes_no_with_escape', 'approve_deny', 'single_choice', 'multi_choice', 'freetext', null],
+          },
+          fields: { $ref: '#/$defs/fields' },
+          timer: { type: 'object', additionalProperties: true },
+        },
+      },
+      timeout_ms: { type: 'number', minimum: 0 },
+      source: {
+        type: 'object',
+        additionalProperties: true,
+        properties: {
+          surface: { type: 'string' },
+          session_id: { type: ['string', 'null'] },
+          agent: { type: ['string', 'null'] },
+        },
+      },
+    },
+    required: ['prompt'],
+    $defs: {
+      fields: {
+        type: 'array',
+        items: {
+          type: 'object',
+          additionalProperties: true,
+          required: ['id', 'kind'],
+          properties: {
+            id: { type: 'string', minLength: 1 },
+            kind: {
+              type: 'string',
+              enum: ['boolean', 'exclusive_choice', 'multi_choice', 'text', 'number'],
+            },
+            label: { type: 'string' },
+            style: { type: 'string' },
+            placeholder: { type: 'string' },
+            options: { type: 'array', items: { type: 'object' } },
+            visible_when: { type: 'object' },
+          },
+        },
+      },
+    },
+  },
+};
+
+export async function userSignalSurface(args = {}, options = {}) {
+  const request = normalizeRequest(args);
+  const requestDir = await mkdtemp(join(tmpdir(), 'aos-gate-request-'));
+  const requestPath = join(requestDir, 'request.json');
+  const execFileFn = options.execFile ?? execFile;
+  const timeout = options.timeoutMs ?? request.timeout_ms + PROCESS_GRACE_MS;
+  const cwd = options.cwd ?? REPO_ROOT;
+  const command = options.command ?? './aos';
+
+  try {
+    await writeFile(requestPath, `${JSON.stringify(request)}\n`, 'utf8');
+    const stdout = await execAosGateAsk(execFileFn, command, requestPath, { cwd, timeout });
+    return parseGateStdout(stdout);
+  } finally {
+    await rm(requestDir, { recursive: true, force: true });
+  }
+}
+
+function normalizeRequest(args) {
+  const request = { ...args };
+  request.schema_version = request.schema_version ?? 'aos.gate.request.v1';
+  request.timeout_ms = Number.isFinite(request.timeout_ms) ? request.timeout_ms : DEFAULT_TIMEOUT_MS;
+  request.source = {
+    surface: 'aos-gateway-mcp',
+    ...(request.source ?? {}),
+  };
+  return request;
+}
+
+function execAosGateAsk(execFileFn, command, requestPath, options) {
+  return new Promise((resolve, reject) => {
+    execFileFn(
+      command,
+      ['gate', 'ask', '--request', requestPath],
+      options,
+      (error, stdout, stderr) => {
+        if (error) {
+          const message = stderr?.trim() || error.message || 'aos gate ask failed';
+          reject(new Error(message));
+          return;
+        }
+        resolve(stdout);
+      },
+    );
+  });
+}
+
+function parseGateStdout(stdout) {
+  const text = String(stdout ?? '').trim();
+  if (!text) throw new Error('aos gate ask returned empty stdout');
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(`aos gate ask returned malformed JSON: ${error.message}`);
+  }
+}

--- a/tests/gateway/user-signal-surface.test.mjs
+++ b/tests/gateway/user-signal-surface.test.mjs
@@ -1,0 +1,75 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { userSignalSurface } from '../../packages/gateway/tools/user-signal-surface.js';
+
+function execMock(callback) {
+  const calls = [];
+  const fn = (command, args, options, done) => {
+    calls.push({ command, args, options });
+    callback({ command, args, options, done });
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+test('user_signal_surface resolves parsed stdout from aos gate ask', async () => {
+  const execFile = execMock(({ command, args, options, done }) => {
+    assert.equal(command, './aos');
+    assert.deepEqual(args.slice(0, 3), ['gate', 'ask', '--request']);
+    assert.equal(options.cwd.endsWith('/agent-os'), true);
+    const request = JSON.parse(readFileSync(args[3], 'utf8'));
+    assert.equal(request.schema_version, 'aos.gate.request.v1');
+    assert.deepEqual(request.prompt, { title: 'Proceed?' });
+    assert.deepEqual(request.fields, [{ id: 'decision', kind: 'exclusive_choice' }]);
+    assert.equal(request.source.surface, 'aos-gateway-mcp');
+    done(null, '{"decision":"approve"}\n', '');
+  });
+
+  const result = await userSignalSurface({
+    prompt: { title: 'Proceed?' },
+    fields: [{ id: 'decision', kind: 'exclusive_choice' }],
+    timeout_ms: 1234,
+  }, { execFile });
+
+  assert.deepEqual(result, { decision: 'approve' });
+  assert.equal(execFile.calls[0].options.timeout, 2234);
+});
+
+test('user_signal_surface rejects on non-zero aos gate ask exit', async () => {
+  const execFile = execMock(({ done }) => {
+    const error = new Error('Command failed');
+    error.code = 1;
+    done(error, '', 'human rejected');
+  });
+
+  await assert.rejects(
+    () => userSignalSurface({ prompt: { title: 'Proceed?' } }, { execFile }),
+    /human rejected/,
+  );
+});
+
+test('user_signal_surface rejects on subprocess timeout', async () => {
+  const execFile = execMock(({ done }) => {
+    const error = new Error('Command timed out');
+    error.killed = true;
+    error.signal = 'SIGTERM';
+    done(error, '', '');
+  });
+
+  await assert.rejects(
+    () => userSignalSurface({ prompt: { title: 'Proceed?' }, timeout_ms: 5 }, { execFile }),
+    /Command timed out/,
+  );
+});
+
+test('user_signal_surface rejects malformed stdout', async () => {
+  const execFile = execMock(({ done }) => {
+    done(null, 'not-json\n', '');
+  });
+
+  await assert.rejects(
+    () => userSignalSurface({ prompt: { title: 'Proceed?' } }, { execFile }),
+    /malformed JSON/,
+  );
+});


### PR DESCRIPTION
Relay merge via agentic_relay profile.

Deliverables:
- `packages/gateway/tools/user-signal-surface.js`
- `packages/gateway/src/index.ts` (tool registration)
- `tests/gateway/user-signal-surface.test.mjs` (4/4)

Verification: 4/4 gateway, 10/10 daemon, 817/817 toolkit, gateway build green.
HEAD SHA: d7b24514b4109225c2c67b72cd4714f63ff80672