### PR TITLE
feat(toolkit): add shared textarea control

### DIFF
--- a/docs/api/toolkit/controls.md
+++ b/docs/api/toolkit/controls.md
@@ -14,8 +14,10 @@ import {
   createCheckboxGroup,
   createSelect,
   createTextField,
+  createTextarea,
   createTimerBar,
   createToggle,
+  renderTextareaHtml,
   wireNumberFieldControls,
 } from 'aos://toolkit/controls/index.js'
 ```
@@ -32,6 +34,7 @@ control.
 | `createButtonGroup({ options, value, onChange })` | exclusive choice button row using `.aos-segmented` | `getValue`, `setValue`, `on('change')`, `destroy` |
 | `createToggle({ label, checked, onChange })` | boolean switch backed by an accessible hidden checkbox | `getValue`, `setValue`, `on('change')`, `destroy` |
 | `createTextField({ value, placeholder, label, maxLength, validate, onChange, onCommit })` | single-line text input with inline error state | `getValue`, `setValue`, `setError`, `on('change')`, `on('commit')`, `destroy` |
+| `createTextarea({ value, placeholder, rows, maxLength, spellcheck, readOnly, onChange, onCommit })` | native multi-line text area using shared textarea styling | `getValue`, `setValue`, `setReadOnly`, `on('change')`, `on('commit')`, `destroy` |
 | `createCheckboxGroup({ options, value, onChange })` | multi-choice checkbox column with select-all when there are at least three options | `getValue`, `setValue`, `on('change')`, `destroy` |
 | `createSelect({ options, value, label, onChange })` | native single-value select | `getValue`, `setValue`, `on('change')`, `destroy` |
 | `createTimerBar({ totalMs, direction, display, flashThresholdMs, flashIntervalMs, onExpire })` | cosmetic count-down/count-up timer with digital or pie display | `start`, `pause`, `resume`, `reset`, `getRemainingMs`, `destroy` |
@@ -42,11 +45,15 @@ stepping and returns `{ dispose() }`.
 
 ## Styling
 
+`renderTextareaHtml(config)` is the string-rendering companion for surfaces that
+render HTML templates before wiring controls; it accepts the same static
+textarea attributes and escapes values before placing them in markup.
+
 Stock visual classes live in `packages/toolkit/controls/defaults.css`. Consumers
 may use the classes directly or override the shared `--aos-control-*` tokens by
 cascade. V0 controls use `.aos-button`, `.aos-segmented`, `.aos-toggle-switch`,
-`.aos-text-input`, `.aos-checkbox`, `.aos-select`, `.aos-timer-bar`, and
-`.aos-field-error`.
+`.aos-text-input`, `.aos-textarea`, `.aos-checkbox`, `.aos-select`,
+`.aos-timer-bar`, and `.aos-field-error`.
 
 ## Form Harness
 

--- a/packages/toolkit/components/markdown-workbench/index.js
+++ b/packages/toolkit/components/markdown-workbench/index.js
@@ -1,4 +1,5 @@
 import { renderMarkdown } from '../../markdown/render.js';
+import { createTextarea } from '../../controls/textarea.js';
 import { buildAnnotationProjectionResult } from '../../workbench/annotation-projection.js';
 import {
   createMarkdownOpenRequestFromWikiSelection,
@@ -678,9 +679,7 @@ export default function MarkdownWorkbench(options = {}) {
             <button type="button" class="aos-window-button aos-window-close markdown-workbench-close-content" data-action="close-content" aria-label="Close content view" title="Close content view" data-aos-ref="markdown-workbench:content-close" data-aos-action="close_content" data-aos-surface="markdown-workbench" data-semantic-target-id="content-close">x</button>
           </header>
           <div class="markdown-workbench-document-body">
-            <section class="markdown-workbench-source" aria-label="Markdown source">
-              <textarea spellcheck="true" aria-label="Markdown source editor" data-aos-ref="markdown-workbench:source-editor" data-aos-action="edit_markdown" data-aos-surface="markdown-workbench" data-semantic-target-id="source-editor"></textarea>
-            </section>
+            <section class="markdown-workbench-source" aria-label="Markdown source"></section>
             <section class="markdown-workbench-preview-pane" aria-label="Rendered Markdown preview" data-aos-ref="markdown-workbench:preview-pane" data-aos-surface="markdown-workbench" data-semantic-target-id="preview-pane">
               <div class="aos-markdown-preview markdown-workbench-preview" data-aos-ref="markdown-workbench:preview" data-aos-surface="markdown-workbench" data-semantic-target-id="preview"></div>
             </section>
@@ -702,8 +701,20 @@ export default function MarkdownWorkbench(options = {}) {
         </section>
       </main>
     `;
+    const editorControl = createTextarea({
+      document,
+      spellcheck: true,
+      ariaLabel: 'Markdown source editor',
+      dataset: {
+        aosRef: 'markdown-workbench:source-editor',
+        aosAction: 'edit_markdown',
+        aosSurface: 'markdown-workbench',
+        semanticTargetId: 'source-editor',
+      },
+    });
+    root.querySelector('.markdown-workbench-source')?.appendChild(editorControl.el);
     dom.path = root.querySelector('[data-role="path"]');
-    dom.editor = root.querySelector('textarea');
+    dom.editor = editorControl.el;
     dom.sourcePane = root.querySelector('.markdown-workbench-source');
     dom.previewPane = root.querySelector('.markdown-workbench-preview-pane');
     dom.preview = root.querySelector('.markdown-workbench-preview');

--- a/packages/toolkit/components/test-console/model.js
+++ b/packages/toolkit/components/test-console/model.js
@@ -1,3 +1,4 @@
+import { renderTextareaHtml } from '../../controls/textarea.js';
 import {
   TEST_CONSOLE_SURFACE,
   TEST_CONSOLE_URL,
@@ -503,7 +504,12 @@ export function renderTestConsoleHtml(snapshot = {}) {
           </div>
           <p>${escapeHtml(snapshot.human_request?.prompt || 'Record a supervised-run response for this step.')}</p>
           <label for="test-console-note">Note</label>
-          <textarea id="test-console-note" rows="3" placeholder="Optional supervisor note">${escapeHtml(snapshot.note || '')}</textarea>
+          ${renderTextareaHtml({
+            id: 'test-console-note',
+            rows: 3,
+            placeholder: 'Optional supervisor note',
+            value: snapshot.note || '',
+          })}
           <div class="test-console-actions">
             <button type="button" data-action="confirm" ${loaded ? '' : 'disabled'}>Confirm</button>
             <button type="button" data-action="fail" ${loaded ? '' : 'disabled'}>Fail</button>

--- a/packages/toolkit/components/work-record-workbench/index.js
+++ b/packages/toolkit/components/work-record-workbench/index.js
@@ -1,4 +1,5 @@
 import { esc } from '../../runtime/bridge.js';
+import { createTextarea } from '../../controls/textarea.js';
 import {
   applyWorkRecordPatchResult,
   buildWorkRecordPatchRequest,
@@ -19,6 +20,10 @@ function el(tag, className, textContent) {
   if (className) node.className = className;
   if (textContent !== undefined) node.textContent = textContent;
   return node;
+}
+
+function textareaEl(config = {}) {
+  return createTextarea({ document, ...config }).el;
 }
 
 function text(value, fallback = '') {
@@ -284,22 +289,18 @@ export default function WorkRecordWorkbench(options = {}) {
         <section class="work-record-intent" aria-label="Work record intent">
           <label>
             <span>Intent</span>
-            <textarea data-role="intent-nl" spellcheck="true" aria-label="Natural language intent"></textarea>
           </label>
           <div class="work-record-intent-grid">
             <label>
               <span>Purpose</span>
-              <textarea data-role="intent-purpose" spellcheck="true" aria-label="Intent purpose"></textarea>
             </label>
             <label>
               <span>Acceptance</span>
-              <textarea data-role="intent-acceptance" spellcheck="true" aria-label="Acceptance condition"></textarea>
             </label>
           </div>
         </section>
         <section class="work-record-json" aria-label="Execution map JSON">
           <div class="work-record-section-title">Execution Map JSON</div>
-          <textarea data-role="execution-map" spellcheck="false" aria-label="Execution map JSON editor"></textarea>
         </section>
         <aside class="work-record-inspector" aria-label="Work record health and evidence">
           <section>
@@ -337,6 +338,28 @@ export default function WorkRecordWorkbench(options = {}) {
         </aside>
       </main>
     `;
+
+    const intentLabels = root.querySelectorAll('.work-record-intent label');
+    intentLabels[0]?.appendChild(textareaEl({
+      spellcheck: true,
+      ariaLabel: 'Natural language intent',
+      dataset: { role: 'intent-nl' },
+    }));
+    intentLabels[1]?.appendChild(textareaEl({
+      spellcheck: true,
+      ariaLabel: 'Intent purpose',
+      dataset: { role: 'intent-purpose' },
+    }));
+    intentLabels[2]?.appendChild(textareaEl({
+      spellcheck: true,
+      ariaLabel: 'Acceptance condition',
+      dataset: { role: 'intent-acceptance' },
+    }));
+    root.querySelector('.work-record-json')?.appendChild(textareaEl({
+      spellcheck: false,
+      ariaLabel: 'Execution map JSON editor',
+      dataset: { role: 'execution-map' },
+    }));
 
     dom.recordId = root.querySelector('[data-role="record-id"]');
     dom.recordType = root.querySelector('[data-role="record-type"]');

--- a/packages/toolkit/controls/index.js
+++ b/packages/toolkit/controls/index.js
@@ -4,6 +4,7 @@ export { createToggle } from './toggle.js';
 export { createTextField } from './text-field.js';
 export { createCheckboxGroup } from './checkbox-group.js';
 export { createSelect } from './select.js';
+export { createTextarea, renderTextareaHtml } from './textarea.js';
 export { createTimerBar } from './timer-bar.js';
 export {
   handleNumberFieldKeydown,

--- a/packages/toolkit/controls/textarea.js
+++ b/packages/toolkit/controls/textarea.js
@@ -1,0 +1,111 @@
+import { createEventHub, dispatchDomEvent, ownerDocument } from './_events.js';
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function appendClassNames(el, className) {
+  for (const name of String(className || '').split(/\s+/).filter(Boolean)) {
+    el.classList.add(name);
+  }
+}
+
+function applyTextareaConfig(el, config = {}) {
+  el.classList.add('aos-textarea');
+  appendClassNames(el, config.className);
+  if (config.id) el.id = String(config.id);
+  if (config.name) el.name = String(config.name);
+  if (config.placeholder) el.placeholder = String(config.placeholder);
+  if (config.ariaLabel) el.setAttribute('aria-label', String(config.ariaLabel));
+  if (config.rows !== undefined) el.rows = Number(config.rows);
+  if (config.maxLength !== undefined) el.maxLength = Number(config.maxLength);
+  if (config.spellcheck !== undefined) el.spellcheck = !!config.spellcheck;
+  if (config.readOnly !== undefined) el.readOnly = !!config.readOnly;
+  for (const [name, value] of Object.entries(config.attributes || {})) {
+    if (value === undefined || value === null || value === false) continue;
+    el.setAttribute(name, value === true ? '' : String(value));
+  }
+  for (const [name, value] of Object.entries(config.dataset || {})) {
+    if (value === undefined || value === null) continue;
+    el.dataset[name] = String(value);
+  }
+}
+
+function textareaAttributeParts(config = {}) {
+  const parts = ['class="aos-textarea'];
+  const extraClass = String(config.className || '').trim();
+  parts[0] += extraClass ? ` ${escapeHtml(extraClass)}"` : '"';
+  if (config.id) parts.push(`id="${escapeHtml(config.id)}"`);
+  if (config.name) parts.push(`name="${escapeHtml(config.name)}"`);
+  if (config.placeholder) parts.push(`placeholder="${escapeHtml(config.placeholder)}"`);
+  if (config.ariaLabel) parts.push(`aria-label="${escapeHtml(config.ariaLabel)}"`);
+  if (config.rows !== undefined) parts.push(`rows="${escapeHtml(Number(config.rows))}"`);
+  if (config.maxLength !== undefined) parts.push(`maxlength="${escapeHtml(Number(config.maxLength))}"`);
+  if (config.spellcheck !== undefined) parts.push(`spellcheck="${config.spellcheck ? 'true' : 'false'}"`);
+  if (config.readOnly) parts.push('readonly');
+  for (const [name, value] of Object.entries(config.attributes || {})) {
+    if (value === undefined || value === null || value === false) continue;
+    parts.push(value === true ? escapeHtml(name) : `${escapeHtml(name)}="${escapeHtml(value)}"`);
+  }
+  for (const [name, value] of Object.entries(config.dataset || {})) {
+    if (value === undefined || value === null) continue;
+    const attrName = `data-${String(name).replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)}`;
+    parts.push(`${escapeHtml(attrName)}="${escapeHtml(value)}"`);
+  }
+  return parts;
+}
+
+export function renderTextareaHtml(config = {}) {
+  return `<textarea ${textareaAttributeParts(config).join(' ')}>${escapeHtml(config.value ?? '')}</textarea>`;
+}
+
+export function createTextarea(config = {}) {
+  const doc = ownerDocument(config);
+  const hub = createEventHub();
+  const el = doc.createElement('textarea');
+
+  applyTextareaConfig(el, config);
+  el.value = config.value ?? '';
+
+  const emitChange = () => {
+    config.onChange?.(el.value);
+    hub.emit('change', el.value);
+    dispatchDomEvent(el, 'change', { value: el.value });
+  };
+
+  const emitCommit = () => {
+    config.onCommit?.(el.value);
+    hub.emit('commit', el.value);
+    dispatchDomEvent(el, 'commit', { value: el.value });
+  };
+
+  el.addEventListener('input', emitChange);
+  el.addEventListener('blur', emitCommit);
+
+  return {
+    el,
+    getValue() {
+      return el.value;
+    },
+    setValue(value, options = {}) {
+      el.value = value ?? '';
+      if (options.emit) emitChange();
+    },
+    setReadOnly(readOnly = true) {
+      el.readOnly = !!readOnly;
+    },
+    on(type, callback) {
+      return type === 'change' || type === 'commit' ? hub.on(type, callback) : () => {};
+    },
+    destroy() {
+      el.removeEventListener('input', emitChange);
+      el.removeEventListener('blur', emitCommit);
+      hub.clear();
+    },
+  };
+}

--- a/tests/toolkit/controls-textarea.test.mjs
+++ b/tests/toolkit/controls-textarea.test.mjs
@@ -1,0 +1,67 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createTextarea, renderTextareaHtml } from '../../packages/toolkit/controls/textarea.js';
+import { FakeEvent, createFakeDocument } from './dom-fixture.mjs';
+
+test('createTextarea returns shape and updates value', () => {
+  const document = createFakeDocument();
+  const field = createTextarea({
+    document,
+    value: 'start',
+    placeholder: 'Notes',
+    rows: 4,
+    spellcheck: false,
+    ariaLabel: 'Notes field',
+  });
+
+  assert.equal(typeof field.getValue, 'function');
+  assert.equal(typeof field.setValue, 'function');
+  assert.equal(typeof field.setReadOnly, 'function');
+  assert.equal(typeof field.on, 'function');
+  assert.equal(typeof field.destroy, 'function');
+  assert.equal(field.el.tagName, 'TEXTAREA');
+  assert.equal(field.el.classList.contains('aos-textarea'), true);
+  assert.equal(field.el.getAttribute('aria-label'), 'Notes field');
+  assert.equal(field.getValue(), 'start');
+  field.setValue('next');
+  assert.equal(field.getValue(), 'next');
+});
+
+test('textarea emits change on input and commit on blur', () => {
+  const document = createFakeDocument();
+  const changes = [];
+  const commits = [];
+  const field = createTextarea({
+    document,
+    value: 'x',
+    onChange: (value) => changes.push(value),
+    onCommit: (value) => commits.push(value),
+  });
+  field.on('change', (value) => changes.push(`hub:${value}`));
+  field.on('commit', (value) => commits.push(`hub:${value}`));
+
+  field.el.value = 'typed';
+  field.el.dispatchEvent(new FakeEvent('input', { bubbles: true }));
+  field.el.dispatchEvent(new FakeEvent('blur'));
+
+  assert.deepEqual(changes, ['typed', 'hub:typed']);
+  assert.deepEqual(commits, ['typed', 'hub:typed']);
+});
+
+test('renderTextareaHtml escapes attributes and value', () => {
+  const html = renderTextareaHtml({
+    id: 'note',
+    value: '<hello>',
+    placeholder: '"note"',
+    rows: 3,
+    dataset: { aosRef: 'surface:note' },
+  });
+
+  assert.match(html, /^<textarea /);
+  assert.match(html, /class="aos-textarea"/);
+  assert.match(html, /id="note"/);
+  assert.match(html, /placeholder="&quot;note&quot;"/);
+  assert.match(html, /rows="3"/);
+  assert.match(html, /data-aos-ref="surface:note"/);
+  assert.match(html, />&lt;hello&gt;<\/textarea>$/);
+});

--- a/tests/toolkit/markdown-workbench-layout.test.mjs
+++ b/tests/toolkit/markdown-workbench-layout.test.mjs
@@ -156,7 +156,9 @@ test('markdown source editor leaves native undo and redo key chords alone', asyn
   const js = await repoText('packages/toolkit/components/markdown-workbench/index.js');
   const keydownBody = js.match(/function handleEditorKeydown\(event\) \{[\s\S]*?\n  \}/)?.[0] || '';
 
-  assert.match(js, /<textarea spellcheck="true" aria-label="Markdown source editor"[^>]*><\/textarea>/);
+  assert.match(js, /import \{ createTextarea \} from '..\/..\/controls\/textarea\.js'/);
+  assert.match(js, /createTextarea\(\{[\s\S]*ariaLabel: 'Markdown source editor'/);
+  assert.match(js, /semanticTargetId: 'source-editor'/);
   assert.match(keydownBody, /key === 's'/);
   assert.match(keydownBody, /event\.key !== 'Tab'/);
   assert.doesNotMatch(keydownBody, /key === 'z'/);

--- a/tests/toolkit/toolkit-api-docs-contract.test.mjs
+++ b/tests/toolkit/toolkit-api-docs-contract.test.mjs
@@ -66,6 +66,7 @@ test('toolkit scoped API files exist and own expected stable terms', async () =>
   assert.match(docs['docs/api/toolkit/controls.md'], /createButton/);
   assert.match(docs['docs/api/toolkit/controls.md'], /createButtonGroup/);
   assert.match(docs['docs/api/toolkit/controls.md'], /createTextField/);
+  assert.match(docs['docs/api/toolkit/controls.md'], /createTextarea/);
   assert.match(docs['docs/api/toolkit/controls.md'], /createTimerBar/);
   assert.match(docs['docs/api/toolkit/controls.md'], /wireNumberFieldControls/);
 

--- a/tests/toolkit/wiki-subject-browser.test.mjs
+++ b/tests/toolkit/wiki-subject-browser.test.mjs
@@ -748,7 +748,8 @@ test('wiki subject browser exposes named shell manifest and semantic launch refs
   assert.match(markdownJs, /data-aos-ref="markdown-workbench:wiki-graph"/);
   assert.match(markdownJs, /data-aos-ref="markdown-workbench:content-pane"/);
   assert.match(markdownJs, /data-aos-ref="markdown-workbench:content-close"/);
-  assert.match(markdownJs, /data-aos-ref="markdown-workbench:source-editor"/);
+  assert.match(markdownJs, /createTextarea\(\{/);
+  assert.match(markdownJs, /aosRef: 'markdown-workbench:source-editor'/);
   assert.match(markdownJs, /type\.startsWith\('wiki-kb\/'\)/);
 });
 


### PR DESCRIPTION
## Summary

Closes the shared `<textarea>` gap identified in the toolkit surface audit.

## Changes

- Added `createTextarea` and `renderTextareaHtml` to `packages/toolkit/controls/textarea.js`
- Exported both from `packages/toolkit/controls/index.js`
- Refactored `markdown-workbench`, `work-record-workbench`, and `test-console` to consume the shared textarea layer
- Updated toolkit controls API docs (`docs/api/toolkit/controls.md`)
- Added `tests/toolkit/controls-textarea.test.mjs` (67 lines)

## Verification

- `node --test tests/toolkit/*.test.mjs`: **820/820** ✅
- `bash tests/help-contract.sh`: **passed** ✅
- Focused affected tests passed before full suite run

## Stats

10 files changed, 243 insertions(+), 13 deletions(-)

---

_Branch: `gdi/shared-textarea-export` — HEAD: `eacb698`_
_Work card: `docs/dev/work-cards/shared-textarea-export.md`_