### PR TITLE
refactor(toolkit): retrofit shared controls

### DIFF
--- a/packages/toolkit/components/surface-inspector/index.html
+++ b/packages/toolkit/components/surface-inspector/index.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <link rel="stylesheet" href="../_base/theme.css">
 <link rel="stylesheet" href="../../panel/defaults.css">
+<link rel="stylesheet" href="../../controls/defaults.css">
 <link rel="stylesheet" href="./styles.css">
 </head>
 <body>

--- a/packages/toolkit/components/surface-inspector/index.js
+++ b/packages/toolkit/components/surface-inspector/index.js
@@ -14,6 +14,7 @@ import { canvasLifecycleCanvasID, mergeCanvasLifecycleCanvas } from '../../runti
 import { normalizeCanvasInputMessage } from '../../runtime/input-events.js'
 import { createFixedSidebarPane } from '../../panel/layouts/split-pane.js'
 import { cloneFrame, resizeFrameFromTopLeft } from '../../panel/placement.js'
+import { renderButtonHtml, renderTextFieldHtml } from '../../controls/index.js'
 import { subscribe, unsubscribe } from '../../runtime/subscribe.js'
 import {
   nativeToDesktopWorldPoint,
@@ -336,9 +337,38 @@ function renderCanvasActionButtons(canvasId, options = {}) {
   const statsIds = options.statsIds || new Set()
   const tintClass = tintedIds.has(canvasId) ? 'btn tint-btn active' : 'btn tint-btn'
   const statsClass = statsIds.has(canvasId) ? 'btn stats-btn active' : 'btn stats-btn'
-  return `<button class="${statsClass}" data-id="${escapeHTML(canvasId)}" ${canvasActionAttrs(canvasId, 'stats', { pressed: statsIds.has(canvasId) })}>stats</button>`
-    + `<button class="${tintClass}" data-id="${escapeHTML(canvasId)}" ${canvasActionAttrs(canvasId, 'tint', { pressed: tintedIds.has(canvasId) })}>tint</button>`
-    + `<button class="btn remove-btn" data-id="${escapeHTML(canvasId)}" ${canvasActionAttrs(canvasId, 'remove')}>\u2715</button>`
+  return renderButtonHtml({
+    label: 'stats',
+    className: statsClass,
+    includeBaseClass: false,
+    classFirst: true,
+    dataset: { id: canvasId },
+    rawAttributes: canvasActionAttrs(canvasId, 'stats', { pressed: statsIds.has(canvasId) }),
+  })
+    + renderButtonHtml({
+      label: 'tint',
+      className: tintClass,
+      includeBaseClass: false,
+      classFirst: true,
+      dataset: { id: canvasId },
+      rawAttributes: canvasActionAttrs(canvasId, 'tint', { pressed: tintedIds.has(canvasId) }),
+    })
+    + renderButtonHtml({
+      label: '\u2715',
+      className: 'btn remove-btn',
+      includeBaseClass: false,
+      classFirst: true,
+      dataset: { id: canvasId },
+      rawAttributes: canvasActionAttrs(canvasId, 'remove'),
+    })
+}
+
+function renderInspectorButton(config = {}) {
+  return renderButtonHtml({
+    includeBaseClass: false,
+    classFirst: true,
+    ...config,
+  })
 }
 
 export function renderCursorToggleRowHTML(options = {}) {
@@ -350,11 +380,18 @@ export function renderCursorToggleRowHTML(options = {}) {
     + `<span class="cursor-toggle-label">minimap cursor</span>`
     + `<span class="cursor-toggle-state">${enabled ? 'live' : 'hidden'}</span>`
     + `<span class="canvas-flags">`
-    + `<button class="${toggleClass}" data-enabled="${enabled ? '1' : '0'}" ${inspectorControlAttrs('minimap-cursor', {
-      name: 'Minimap cursor',
-      action: 'toggle_minimap_cursor',
-      pressed: enabled,
-    })}>${toggleLabel}</button>`
+    + renderButtonHtml({
+      label: toggleLabel,
+      className: toggleClass,
+      includeBaseClass: false,
+      classFirst: true,
+      dataset: { enabled: enabled ? '1' : '0' },
+      rawAttributes: inspectorControlAttrs('minimap-cursor', {
+        name: 'Minimap cursor',
+        action: 'toggle_minimap_cursor',
+        pressed: enabled,
+      }),
+    })
     + `</span>`
     + `</div>`
 }
@@ -368,11 +405,18 @@ export function renderMouseEventsToggleRowHTML(options = {}) {
     + `<span class="cursor-toggle-label">mouse events</span>`
     + `<span class="cursor-toggle-state">${enabled ? 'live' : 'hidden'}</span>`
     + `<span class="canvas-flags">`
-    + `<button class="${toggleClass}" data-enabled="${enabled ? '1' : '0'}" ${inspectorControlAttrs('mouse-events', {
-      name: 'Mouse events',
-      action: 'toggle_mouse_events',
-      pressed: enabled,
-    })}>${toggleLabel}</button>`
+    + renderButtonHtml({
+      label: toggleLabel,
+      className: toggleClass,
+      includeBaseClass: false,
+      classFirst: true,
+      dataset: { enabled: enabled ? '1' : '0' },
+      rawAttributes: inspectorControlAttrs('mouse-events', {
+        name: 'Mouse events',
+        action: 'toggle_mouse_events',
+        pressed: enabled,
+      }),
+    })
     + `</span>`
     + `</div>`
 }
@@ -386,11 +430,19 @@ export function renderAnnotationModeToggleRowHTML(options = {}) {
     + `<span class="cursor-toggle-label">annotation mode</span>`
     + `<span class="cursor-toggle-state">${enabled ? 'active' : 'off'}</span>`
     + `<span class="canvas-flags">`
-    + `<button class="${toggleClass}" data-enabled="${enabled ? '1' : '0'}" title="${escapeHTML(label)}" ${inspectorControlAttrs('annotation-mode', {
-      name: label,
-      action: 'toggle_annotation_mode',
-      pressed: enabled,
-    })}>${enabled ? 'on' : 'off'}</button>`
+    + renderButtonHtml({
+      label: enabled ? 'on' : 'off',
+      className: toggleClass,
+      includeBaseClass: false,
+      classFirst: true,
+      title: label,
+      dataset: { enabled: enabled ? '1' : '0' },
+      rawAttributes: inspectorControlAttrs('annotation-mode', {
+        name: label,
+        action: 'toggle_annotation_mode',
+        pressed: enabled,
+      }),
+    })
     + `</span>`
     + `</div>`
 }
@@ -588,13 +640,17 @@ export function buildAnnotationNativeHitRegions({ nativeWindowCandidate = null, 
 export function renderCanvasListToggleButton(options = {}) {
   const collapsed = options.collapsed !== false
   const label = collapsed ? 'Show canvas list' : 'Hide canvas list'
-  return `<button class="canvas-list-toggle" type="button" ${inspectorControlAttrs('canvas-list-toggle', {
-    name: label,
-    action: 'toggle_canvas_list',
-    expanded: !collapsed,
-  })} title="${escapeHTML(label)}">`
-    + `<span class="canvas-list-caret ${collapsed ? '' : 'open'}" aria-hidden="true"></span>`
-    + `</button>`
+  return renderButtonHtml({
+    className: 'canvas-list-toggle',
+    includeBaseClass: false,
+    classFirst: true,
+    title: label,
+    rawAttributes: inspectorControlAttrs('canvas-list-toggle', {
+      name: label,
+      action: 'toggle_canvas_list',
+      expanded: !collapsed,
+    }),
+  }).replace('</button>', `<span class="canvas-list-caret ${collapsed ? '' : 'open'}" aria-hidden="true"></span></button>`)
 }
 
 function renderSurfaceSegmentRow(segment, depth) {
@@ -1876,12 +1932,30 @@ export default function CanvasInspector() {
   function renderAnnotationEditor() {
     if (!annotationState.editor) return ''
     const isEdit = annotationState.editor.mode === 'edit'
-    const value = escapeHTML(annotationState.editor.text || '')
+    const value = annotationState.editor.text || ''
     return `<div class="annotation-editor" role="dialog" aria-label="${isEdit ? 'Edit annotation comment' : 'Add annotation comment'}">`
-      + `<input class="annotation-editor-input" placeholder="Leave a comment" value="${value}" ${inspectorControlAttrs('annotation-comment-input', { name: 'Leave a comment', action: 'edit_comment_text' })}>`
+      + renderTextFieldHtml({
+        className: 'annotation-editor-input',
+        placeholder: 'Leave a comment',
+        value,
+        rawAttributes: inspectorControlAttrs('annotation-comment-input', { name: 'Leave a comment', action: 'edit_comment_text' }),
+      })
       + `<div class="annotation-editor-actions">`
-      + `<button class="btn annotation-editor-cancel" ${inspectorControlAttrs('annotation-editor-cancel', { name: 'Cancel comment edit', action: 'cancel_comment' })}>Cancel</button>`
-      + `<button class="btn annotation-editor-save ${value.trim() ? '' : 'disabled'}" ${value.trim() ? '' : 'disabled'} ${inspectorControlAttrs('annotation-editor-save', { name: isEdit ? 'Update comment' : 'Add Comment', action: isEdit ? 'update_comment' : 'add_comment' })}>${isEdit ? 'Update' : 'Add Comment'}</button>`
+      + renderButtonHtml({
+        label: 'Cancel',
+        className: 'btn annotation-editor-cancel',
+        includeBaseClass: false,
+        classFirst: true,
+        rawAttributes: inspectorControlAttrs('annotation-editor-cancel', { name: 'Cancel comment edit', action: 'cancel_comment' }),
+      })
+      + renderButtonHtml({
+        label: isEdit ? 'Update' : 'Add Comment',
+        className: `btn annotation-editor-save ${value.trim() ? '' : 'disabled'}`,
+        includeBaseClass: false,
+        classFirst: true,
+        disabled: !value.trim(),
+        rawAttributes: inspectorControlAttrs('annotation-editor-save', { name: isEdit ? 'Update comment' : 'Add Comment', action: isEdit ? 'update_comment' : 'add_comment' }),
+      })
       + `</div></div>`
   }
 
@@ -1891,8 +1965,20 @@ export default function CanvasInspector() {
     return `<div class="annotation-confirm" role="alertdialog" aria-label="Confirm destructive annotation clear">`
       + `<div class="annotation-confirm-message">${esc(confirmation.message || 'Annotations will be lost.')}</div>`
       + `<div class="annotation-confirm-actions">`
-      + `<button class="btn annotation-confirm-cancel" ${inspectorControlAttrs('annotation-clear-cancel', { name: 'Cancel annotation clear', action: 'cancel_destructive_clear' })}>Cancel</button>`
-      + `<button class="btn annotation-confirm-ok" ${inspectorControlAttrs('annotation-clear-confirm', { name: 'Confirm annotation clear', action: 'confirm_destructive_clear' })}>Confirm</button>`
+      + renderButtonHtml({
+        label: 'Cancel',
+        className: 'btn annotation-confirm-cancel',
+        includeBaseClass: false,
+        classFirst: true,
+        rawAttributes: inspectorControlAttrs('annotation-clear-cancel', { name: 'Cancel annotation clear', action: 'cancel_destructive_clear' }),
+      })
+      + renderButtonHtml({
+        label: 'Confirm',
+        className: 'btn annotation-confirm-ok',
+        includeBaseClass: false,
+        classFirst: true,
+        rawAttributes: inspectorControlAttrs('annotation-clear-confirm', { name: 'Confirm annotation clear', action: 'confirm_destructive_clear' }),
+      })
       + `</div></div>`
   }
 
@@ -2111,13 +2197,32 @@ export default function CanvasInspector() {
     const canBack = stack.length > 0
     const rootActive = stack.length === 0
     const crumbs = [
-      `<button class="annotation-scope-crumb ${rootActive ? 'active' : ''}" data-pin-id="" ${inspectorControlAttrs('annotation-scope-root', { name: 'Annotation scope main', action: 'select_annotation_scope_root' })}>main</button>`,
-      ...stack.map((frame, index) => `<button class="annotation-scope-crumb ${index === stack.length - 1 ? 'active' : ''}" data-pin-id="${esc(frame.pin_id)}" ${inspectorControlAttrs(`annotation-scope-${frame.pin_id}`, { name: `Annotation scope ${frame.subject_id}`, action: 'select_annotation_scope' })}>${esc(frame.subject_id)}</button>`),
+      renderInspectorButton({
+        label: 'main',
+        className: `annotation-scope-crumb ${rootActive ? 'active' : ''}`,
+        dataset: { pinId: '' },
+        rawAttributes: inspectorControlAttrs('annotation-scope-root', { name: 'Annotation scope main', action: 'select_annotation_scope_root' }),
+      }),
+      ...stack.map((frame, index) => renderInspectorButton({
+        label: frame.subject_id,
+        className: `annotation-scope-crumb ${index === stack.length - 1 ? 'active' : ''}`,
+        dataset: { pinId: frame.pin_id },
+        rawAttributes: inspectorControlAttrs(`annotation-scope-${frame.pin_id}`, { name: `Annotation scope ${frame.subject_id}`, action: 'select_annotation_scope' }),
+      })),
     ].join('<span class="annotation-scope-separator">/</span>')
     return `<div class="tree-row annotation-scope-row" style="${indentStyle(depth)}">`
-      + `<button class="btn annotation-scope-back" ${canBack ? '' : 'disabled'} ${inspectorControlAttrs('annotation-scope-back', { name: 'Back annotation scope', action: 'back_annotation_scope' })}>Back</button>`
+      + renderInspectorButton({
+        label: 'Back',
+        className: 'btn annotation-scope-back',
+        disabled: !canBack,
+        rawAttributes: inspectorControlAttrs('annotation-scope-back', { name: 'Back annotation scope', action: 'back_annotation_scope' }),
+      })
       + `<span class="annotation-scope-crumbs">${crumbs}</span>`
-      + `<button class="btn annotation-clear-anchors" ${inspectorControlAttrs('annotation-clear-anchors', { name: 'Clear anchors', action: 'clear_anchors' })}>Clear anchors</button>`
+      + renderInspectorButton({
+        label: 'Clear anchors',
+        className: 'btn annotation-clear-anchors',
+        rawAttributes: inspectorControlAttrs('annotation-clear-anchors', { name: 'Clear anchors', action: 'clear_anchors' }),
+      })
       + `</div>`
   }
 
@@ -2196,10 +2301,21 @@ export default function CanvasInspector() {
     if (row.type === 'comment') {
       return `<div class="tree-row annotation-row comment ${row.active ? 'active' : ''} state-${esc(stateLabel)}" data-comment-id="${esc(row.comment.id)}" style="${indentStyle(depth)}" title="${esc(blocker || row.comment.text)}">`
         + `<span class="annotation-comment-dot"></span>`
-        + `<button class="annotation-comment-text" data-comment-id="${esc(row.comment.id)}" data-pin-id="${esc(row.comment.pin_id)}" ${inspectorControlAttrs(`annotation-comment-${row.comment.id}`, { name: `Edit comment ${row.comment.id}`, action: 'edit_comment' })}>${esc(row.comment.text)}</button>`
+        + renderInspectorButton({
+          label: row.comment.text,
+          className: 'annotation-comment-text',
+          dataset: { commentId: row.comment.id, pinId: row.comment.pin_id },
+          rawAttributes: inspectorControlAttrs(`annotation-comment-${row.comment.id}`, { name: `Edit comment ${row.comment.id}`, action: 'edit_comment' }),
+        })
         + `<span class="annotation-projection-state">${esc(stateLabel)}</span>`
         + (blocker ? `<span class="annotation-blocker">${esc(blocker)}</span>` : '')
-        + `<button class="btn annotation-comment-delete" data-comment-id="${esc(row.comment.id)}" title="Delete comment" ${inspectorControlAttrs(`annotation-delete-${row.comment.id}`, { name: `Delete comment ${row.comment.id}`, action: 'delete_comment' })}>del</button>`
+        + renderInspectorButton({
+          label: 'del',
+          className: 'btn annotation-comment-delete',
+          title: 'Delete comment',
+          dataset: { commentId: row.comment.id },
+          rawAttributes: inspectorControlAttrs(`annotation-delete-${row.comment.id}`, { name: `Delete comment ${row.comment.id}`, action: 'delete_comment' }),
+        })
         + `</div>`
     }
     const expanded = row.pin.expanded === true
@@ -2207,14 +2323,42 @@ export default function CanvasInspector() {
     const label = address.compact
     return `<div class="tree-row annotation-row pin ${row.active ? 'active' : ''} state-${esc(stateLabel)}" data-pin-id="${esc(row.pin.id)}" style="${indentStyle(depth)}" title="${esc(address.full)}">`
       + `<span class="annotation-pin-dot"></span>`
-      + `<button class="annotation-pin-label" data-pin-id="${esc(row.pin.id)}" ${inspectorControlAttrs(`annotation-pin-${row.pin.id}`, { name: `Frame address ${address.full}`, action: 'select_frame_anchor' })}>${esc(label)}</button>`
+      + renderInspectorButton({
+        label,
+        className: 'annotation-pin-label',
+        dataset: { pinId: row.pin.id },
+        rawAttributes: inspectorControlAttrs(`annotation-pin-${row.pin.id}`, { name: `Frame address ${address.full}`, action: 'select_frame_anchor' }),
+      })
       + `<span class="annotation-projection-state">${esc(stateLabel)}</span>`
       + `<span class="annotation-reveal-capability">${row.can_reveal ? 'revealable' : 'no reveal'}</span>`
       + (blocker ? `<span class="annotation-blocker">${esc(blocker)}</span>` : '')
-      + (row.can_reveal ? `<button class="btn annotation-pin-reveal" data-pin-id="${esc(row.pin.id)}" ${inspectorControlAttrs(`annotation-reveal-${row.pin.id}`, { name: `Reveal Target ${label}`, action: 'reveal_target' })}>Reveal</button>` : '')
-      + `<button class="btn annotation-pin-expand" data-pin-id="${esc(row.pin.id)}" title="Expand frame address" ${inspectorControlAttrs(`annotation-expand-${row.pin.id}`, { name: `Expand frame address ${label}`, action: 'expand_frame_address' })}>${expanded ? 'less' : 'more'}</button>`
-      + `<button class="btn annotation-pin-copy" data-pin-id="${esc(row.pin.id)}" title="Copy full frame address" ${inspectorControlAttrs(`annotation-copy-${row.pin.id}`, { name: `Copy full frame address ${label}`, action: 'copy_full_frame_address' })}>copy</button>`
-      + `<button class="btn annotation-pin-remove" data-pin-id="${esc(row.pin.id)}" title="Remove frame anchor" ${inspectorControlAttrs(`annotation-remove-${row.pin.id}`, { name: `Remove frame anchor ${label}`, action: 'remove_frame_anchor' })}>remove</button>`
+      + (row.can_reveal ? renderInspectorButton({
+        label: 'Reveal',
+        className: 'btn annotation-pin-reveal',
+        dataset: { pinId: row.pin.id },
+        rawAttributes: inspectorControlAttrs(`annotation-reveal-${row.pin.id}`, { name: `Reveal Target ${label}`, action: 'reveal_target' }),
+      }) : '')
+      + renderInspectorButton({
+        label: expanded ? 'less' : 'more',
+        className: 'btn annotation-pin-expand',
+        title: 'Expand frame address',
+        dataset: { pinId: row.pin.id },
+        rawAttributes: inspectorControlAttrs(`annotation-expand-${row.pin.id}`, { name: `Expand frame address ${label}`, action: 'expand_frame_address' }),
+      })
+      + renderInspectorButton({
+        label: 'copy',
+        className: 'btn annotation-pin-copy',
+        title: 'Copy full frame address',
+        dataset: { pinId: row.pin.id },
+        rawAttributes: inspectorControlAttrs(`annotation-copy-${row.pin.id}`, { name: `Copy full frame address ${label}`, action: 'copy_full_frame_address' }),
+      })
+      + renderInspectorButton({
+        label: 'remove',
+        className: 'btn annotation-pin-remove',
+        title: 'Remove frame anchor',
+        dataset: { pinId: row.pin.id },
+        rawAttributes: inspectorControlAttrs(`annotation-remove-${row.pin.id}`, { name: `Remove frame anchor ${label}`, action: 'remove_frame_anchor' }),
+      })
       + (expanded ? `<span class="annotation-full-path">${esc(address.full)}</span>` : '')
       + `</div>`
   }

--- a/packages/toolkit/components/wiki-kb/index.html
+++ b/packages/toolkit/components/wiki-kb/index.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <link rel="stylesheet" href="../_base/theme.css">
 <link rel="stylesheet" href="../../panel/defaults.css">
+<link rel="stylesheet" href="../../controls/defaults.css">
 <link rel="stylesheet" href="./styles.css">
 </head>
 <body>

--- a/packages/toolkit/components/wiki-kb/index.js
+++ b/packages/toolkit/components/wiki-kb/index.js
@@ -19,6 +19,7 @@ import {
   createWikiSubjectSelectionPayload,
   WIKI_SUBJECT_SELECTION_TYPE,
 } from '../../workbench/wiki-subject-opening.js'
+import { createButton, createButtonGroup, createSelect } from '../../controls/index.js'
 
 const VIEW_DEFS = [
   { id: 'graph', label: 'Graph', factory: GraphView },
@@ -57,6 +58,12 @@ function buildRelatedNodes(state, nodeId) {
     }
   }
   return [...related.values()]
+}
+
+function addClassNames(el, className = '') {
+  for (const name of String(className || '').split(/\s+/).filter(Boolean)) {
+    el.classList.add(name)
+  }
 }
 
 export default function WikiKB(options = {}) {
@@ -147,9 +154,9 @@ export default function WikiKB(options = {}) {
 
     const fragment = document.createDocumentFragment()
     for (const relatedNode of related) {
-      const button = document.createElement('button')
-      button.type = 'button'
-      button.className = 'wiki-kb-related-link'
+      const control = createButton({ label: '' })
+      const button = control.el
+      addClassNames(button, 'wiki-kb-related-link')
       button.dataset.nodeId = relatedNode.id
       applyWikiKBSemanticTarget(button, {
         id: `related-${relatedNode.id}`,
@@ -395,26 +402,14 @@ export default function WikiKB(options = {}) {
             <div class="wiki-kb-compact-chrome" aria-label="Wiki graph view controls">
               <label class="wiki-kb-view-menu" title="Select graph view">
                 <span>View</span>
-                <select class="wiki-kb-view-select" aria-label="Wiki graph view">
-                  ${viewDefs.map((view) => `<option value="${view.id}">${view.label}</option>`).join('')}
-                </select>
+                <span data-role="wiki-kb-view-select"></span>
               </label>
               <span class="wiki-kb-status" role="status" aria-live="polite"></span>
             </div>
           ` : `<span class="wiki-kb-status wiki-kb-floating-status" role="status" aria-live="polite"></span>`}
         ` : `
           <div class="wiki-kb-tab-strip" role="tablist" aria-label="Wiki KB Views">
-            ${viewDefs.map((view, index) => `
-              <button
-                type="button"
-                id="wiki-kb-tab-${view.id}"
-                class="wiki-kb-view-tab${index === 0 ? ' active' : ''}"
-                data-view="${view.id}"
-                role="tab"
-                aria-selected="${index === 0 ? 'true' : 'false'}"
-                aria-controls="wiki-kb-panel-${view.id}"
-              >${view.label}</button>
-            `).join('')}
+            <span data-role="wiki-kb-view-tabs"></span>
             <div class="wiki-kb-tab-spacer"></div>
             <span class="wiki-kb-status" role="status" aria-live="polite"></span>
           </div>
@@ -425,13 +420,10 @@ export default function WikiKB(options = {}) {
             <div class="wiki-kb-sidebar-header">
               <span class="wiki-kb-sidebar-type" data-type="">unknown</span>
               <span class="wiki-kb-sidebar-name">No selection</span>
-              <button type="button" class="wiki-kb-sidebar-close" aria-label="Close details">x</button>
+              <span data-role="wiki-kb-sidebar-close"></span>
             </div>
             <div class="wiki-kb-sidebar-toggle">
-              <div class="wiki-kb-toggle-group">
-                <button type="button" class="wiki-kb-toggle-button active" data-mode="markdown" aria-pressed="true">Markdown</button>
-                <button type="button" class="wiki-kb-toggle-button" data-mode="raw" aria-pressed="false">Raw</button>
-              </div>
+              <span data-role="wiki-kb-sidebar-toggle"></span>
             </div>
             <div class="wiki-kb-sidebar-description"></div>
             <div class="wiki-kb-sidebar-tags"></div>
@@ -447,7 +439,36 @@ export default function WikiKB(options = {}) {
 
     contentEl = rootEl.querySelector('.wiki-kb-content')
     dom.statusEl = rootEl.querySelector('.wiki-kb-status')
-    dom.viewSelectEl = rootEl.querySelector('.wiki-kb-view-select')
+    const viewSelectSlot = rootEl.querySelector('[data-role="wiki-kb-view-select"]')
+    if (viewSelectSlot) {
+      const viewSelect = createSelect({
+        value: activeViewId,
+        options: viewDefs.map((view) => ({ value: view.id, label: view.label })),
+      })
+      dom.viewSelectEl = viewSelect.el.querySelector('select')
+      addClassNames(dom.viewSelectEl, 'wiki-kb-view-select')
+      dom.viewSelectEl.setAttribute('aria-label', 'Wiki graph view')
+      viewSelectSlot.replaceWith(viewSelect.el)
+    } else {
+      dom.viewSelectEl = null
+    }
+    const viewTabsSlot = rootEl.querySelector('[data-role="wiki-kb-view-tabs"]')
+    if (viewTabsSlot) {
+      const viewTabs = createButtonGroup({
+        value: activeViewId,
+        options: viewDefs.map((view) => ({ value: view.id, label: view.label })),
+      })
+      for (const [index, button] of [...viewTabs.el.querySelectorAll('button')].entries()) {
+        const view = viewDefs[index]
+        button.id = `wiki-kb-tab-${view.id}`
+        addClassNames(button, `wiki-kb-view-tab${index === 0 ? ' active' : ''}`)
+        button.dataset.view = view.id
+        button.setAttribute('role', 'tab')
+        button.setAttribute('aria-selected', index === 0 ? 'true' : 'false')
+        button.setAttribute('aria-controls', `wiki-kb-panel-${view.id}`)
+      }
+      viewTabsSlot.replaceWith(viewTabs.el)
+    }
     dom.sidebarEl = rootEl.querySelector('.wiki-kb-sidebar')
     dom.sidebarTypeEl = rootEl.querySelector('.wiki-kb-sidebar-type')
     dom.sidebarNameEl = rootEl.querySelector('.wiki-kb-sidebar-name')
@@ -456,6 +477,26 @@ export default function WikiKB(options = {}) {
     dom.sidebarBodyEl = rootEl.querySelector('.wiki-kb-sidebar-body')
     dom.relatedSectionEl = rootEl.querySelector('.wiki-kb-sidebar-related')
     dom.relatedListEl = rootEl.querySelector('.wiki-kb-related-list')
+
+    const sidebarCloseSlot = rootEl.querySelector('[data-role="wiki-kb-sidebar-close"]')
+    const closeControl = createButton({ label: 'x' })
+    addClassNames(closeControl.el, 'wiki-kb-sidebar-close')
+    closeControl.el.setAttribute('aria-label', 'Close details')
+    sidebarCloseSlot?.replaceWith(closeControl.el)
+    const sidebarToggleSlot = rootEl.querySelector('[data-role="wiki-kb-sidebar-toggle"]')
+    const sidebarToggle = createButtonGroup({
+      value: 'markdown',
+      options: [
+        { value: 'markdown', label: 'Markdown' },
+        { value: 'raw', label: 'Raw' },
+      ],
+    })
+    addClassNames(sidebarToggle.el, 'wiki-kb-toggle-group')
+    for (const button of sidebarToggle.el.querySelectorAll('button')) {
+      addClassNames(button, 'wiki-kb-toggle-button')
+      button.dataset.mode = button.dataset.value
+    }
+    sidebarToggleSlot?.replaceWith(sidebarToggle.el)
 
     applyWikiKBSemanticTarget(rootEl.querySelector('.wiki-kb-sidebar-close'), {
       id: 'sidebar-close',

--- a/packages/toolkit/components/wiki-kb/views/graph.js
+++ b/packages/toolkit/components/wiki-kb/views/graph.js
@@ -17,6 +17,7 @@ import {
   wikiKBAosRef,
 } from '../semantics.js'
 import { createFixedSidebarPane } from '../../../panel/layouts/split-pane.js'
+import { createButton, createButtonGroup, createTextField, createToggle } from '../../../controls/index.js'
 
 const COLORS = {
   edge: 'rgba(100, 100, 160, 0.35)',
@@ -265,6 +266,24 @@ export default function GraphView({ onSelectNode }) {
     })
   }
 
+  function addClassNames(el, className = '') {
+    for (const name of String(className || '').split(/\s+/).filter(Boolean)) {
+      el.classList.add(name)
+    }
+  }
+
+  function replaceButton(selector, { label, className = '', dataset = {} } = {}) {
+    const existing = rootEl.querySelector(selector)
+    if (!existing) return null
+    const control = createButton({ label })
+    addClassNames(control.el, className || existing.className)
+    for (const [key, value] of Object.entries(dataset)) {
+      if (value !== undefined && value !== null) control.el.dataset[key] = String(value)
+    }
+    existing.replaceWith(control.el)
+    return control.el
+  }
+
   function collectFocusNodes() {
     const selected = selectedNode()
     if (!selected) return []
@@ -421,13 +440,12 @@ export default function GraphView({ onSelectNode }) {
 
     const fragment = document.createDocumentFragment()
     for (const type of filteredGraph.availableTypes) {
-      const button = document.createElement('button')
-      button.type = 'button'
-      button.className = 'wiki-kb-filter'
+      const control = createButton({ label: type })
+      const button = control.el
+      addClassNames(button, 'wiki-kb-filter')
       button.dataset.kind = 'type'
       button.dataset.value = type
       button.dataset.type = type
-      button.textContent = type
       const isActive = activeTypes.has(type)
       button.classList.toggle('active', isActive)
       applyGraphSemanticTarget(button, `type-filter-${type}`, {
@@ -448,12 +466,11 @@ export default function GraphView({ onSelectNode }) {
 
     const fragment = document.createDocumentFragment()
     for (const entry of filteredGraph.availableTags) {
-      const button = document.createElement('button')
-      button.type = 'button'
-      button.className = 'wiki-kb-tag-filter'
+      const control = createButton({ label: `${entry.value} (${entry.count})` })
+      const button = control.el
+      addClassNames(button, 'wiki-kb-tag-filter')
       button.dataset.kind = 'tag'
       button.dataset.value = entry.value
-      button.textContent = `${entry.value} (${entry.count})`
       const isActive = activeTags.has(entry.value)
       button.classList.toggle('active', isActive)
       applyGraphSemanticTarget(button, `tag-filter-${entry.value}`, {
@@ -1149,6 +1166,110 @@ export default function GraphView({ onSelectNode }) {
           <div class="wiki-kb-hint">drag nodes · scroll to zoom · click to inspect</div>
         </div>
       `
+
+      const searchInput = rootEl.querySelector('.wiki-kb-search')
+      if (searchInput) {
+        const searchControl = createTextField({
+          placeholder: 'Search nodes, tags, or descriptions',
+        })
+        const sharedInput = searchControl.el.querySelector('input')
+        sharedInput.id = 'wiki-kb-search-input'
+        addClassNames(sharedInput, 'wiki-kb-search')
+        sharedInput.autocomplete = 'off'
+        sharedInput.spellcheck = false
+        searchInput.replaceWith(searchControl.el)
+      }
+
+      const scopeGroup = rootEl.querySelector('.wiki-kb-controls-section-scope .wiki-kb-segmented')
+      if (scopeGroup) {
+        const control = createButtonGroup({
+          value: mode,
+          options: [
+            { value: 'global', label: 'Global' },
+            { value: 'local', label: 'Local' },
+          ],
+        })
+        addClassNames(control.el, 'wiki-kb-segmented')
+        for (const button of control.el.querySelectorAll('button')) {
+          addClassNames(button, 'wiki-kb-scope-button')
+          button.dataset.mode = button.dataset.value
+        }
+        scopeGroup.replaceWith(control.el)
+      }
+
+      const labelGroup = rootEl.querySelector('.wiki-kb-controls-section-labels .wiki-kb-segmented')
+      if (labelGroup) {
+        const control = createButtonGroup({
+          value: labelMode,
+          options: [
+            { value: 'all', label: 'All' },
+            { value: 'selection', label: 'Selection' },
+            { value: 'hover', label: 'Hover' },
+          ],
+        })
+        addClassNames(control.el, 'wiki-kb-segmented')
+        for (const button of control.el.querySelectorAll('button')) {
+          addClassNames(button, 'wiki-kb-mini-action')
+          button.dataset.labelMode = button.dataset.value
+        }
+        labelGroup.replaceWith(control.el)
+      }
+
+      replaceButton('[data-action="types-all"]', {
+        label: 'All',
+        className: 'wiki-kb-mini-action',
+        dataset: { action: 'types-all' },
+      })
+      replaceButton('[data-action="tags-clear"]', {
+        label: 'Clear',
+        className: 'wiki-kb-mini-action',
+        dataset: { action: 'tags-clear' },
+      })
+      replaceButton('[data-action="set-path-start"]', {
+        label: 'Set Path Start',
+        className: 'wiki-kb-mini-action',
+        dataset: { action: 'set-path-start' },
+      })
+      replaceButton('[data-action="clear-path"]', {
+        label: 'Clear Path',
+        className: 'wiki-kb-mini-action',
+        dataset: { action: 'clear-path' },
+      })
+      replaceButton('[data-action="focus-selection"]', {
+        label: 'Focus Selection',
+        className: 'wiki-kb-action-button',
+        dataset: { action: 'focus-selection' },
+      })
+      replaceButton('[data-action="fit"]', {
+        label: 'Fit Graph',
+        className: 'wiki-kb-action-button',
+        dataset: { action: 'fit' },
+      })
+      replaceButton('[data-action="reset-view"]', {
+        label: 'Reset View',
+        className: 'wiki-kb-action-button',
+        dataset: { action: 'reset-view' },
+      })
+      replaceButton('[data-action="reset-filters"]', {
+        label: 'Reset Filters',
+        className: 'wiki-kb-action-button',
+        dataset: { action: 'reset-filters' },
+      })
+
+      for (const { selector, label, className } of [
+        { selector: '.wiki-kb-check-row-neighbors', label: 'Highlight neighbors', className: 'wiki-kb-check-row wiki-kb-check-row-neighbors' },
+        { selector: '.wiki-kb-check-row-isolated', label: 'Show isolated nodes', className: 'wiki-kb-check-row wiki-kb-check-row-isolated' },
+        { selector: '.wiki-kb-check-row-freeze', label: 'Freeze layout', className: 'wiki-kb-check-row wiki-kb-check-row-freeze' },
+      ]) {
+        const existing = rootEl.querySelector(selector)
+        if (!existing) continue
+        const input = existing.querySelector('input')
+        const control = createToggle({ label, checked: input?.checked })
+        addClassNames(control.el, className)
+        const sharedInput = control.el.querySelector('input')
+        if (input?.className) addClassNames(sharedInput, input.className)
+        existing.replaceWith(control.el)
+      }
 
       canvas = rootEl.querySelector('canvas')
       ctx = canvas.getContext('2d')

--- a/packages/toolkit/components/wiki-subject-browser/index.html
+++ b/packages/toolkit/components/wiki-subject-browser/index.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <link rel="stylesheet" href="../_base/theme.css">
 <link rel="stylesheet" href="../../panel/defaults.css">
+<link rel="stylesheet" href="../../controls/defaults.css">
 <link rel="stylesheet" href="../../workbench/defaults.css">
 <link rel="stylesheet" href="../wiki-kb/styles.css">
 <link rel="stylesheet" href="../markdown-workbench/styles.css">

--- a/packages/toolkit/components/wiki-subject-browser/index.js
+++ b/packages/toolkit/components/wiki-subject-browser/index.js
@@ -9,6 +9,7 @@ import {
   WIKI_SUBJECT_SELECTION_TYPE,
 } from '../../workbench/wiki-subject-opening.js';
 import MarkdownWorkbench from '../markdown-workbench/index.js';
+import { createButton, createSelect, createTextField } from '../../controls/index.js';
 import {
   SUBJECT_BROWSER_INDEX_FILTER_KEYS,
   applySubjectIndexFilter,
@@ -179,6 +180,30 @@ function subjectFilterName(filterKey = '') {
   if (filterKey === 'capability') return 'Capability';
   if (filterKey === 'health') return 'Health';
   return 'Filter';
+}
+
+function addClassNames(el, className = '') {
+  for (const name of String(className || '').split(/\s+/).filter(Boolean)) {
+    el.classList.add(name);
+  }
+}
+
+function createSharedButton({
+  label = '',
+  className = '',
+  disabled = false,
+  dataset = {},
+  semantic = null,
+  onClick = null,
+} = {}) {
+  const control = createButton({ label, disabled });
+  addClassNames(control.el, className);
+  for (const [key, value] of Object.entries(dataset)) {
+    if (value !== undefined && value !== null) control.el.dataset[key] = String(value);
+  }
+  if (semantic) applyWikiSubjectBrowserSemanticTarget(control.el, semantic);
+  if (onClick) control.el.addEventListener('click', onClick);
+  return control.el;
 }
 
 export default function WikiSubjectBrowser(options = {}) {
@@ -492,20 +517,19 @@ export default function WikiSubjectBrowser(options = {}) {
         const refs = entry.affordances?.reference_count || 0;
         meta.textContent = `${contracts} contracts · ${refs} refs`;
 
-        const button = document.createElement('button');
-        button.type = 'button';
-        button.disabled = entry.affordances?.openable !== true;
-        button.dataset.subjectOpen = entry.id;
-        applyWikiSubjectBrowserSemanticTarget(button, {
-          id: `subject-catalog-open-${entry.key}`,
-          name: `Open ${entry.label}`,
-          role: 'AXButton',
-          action: 'open_subject',
-          enabled: !button.disabled,
-          aosRef: catalogEntryRef(entry, 'open'),
-        });
-        button.textContent = 'Open';
-        button.addEventListener('click', () => {
+        const button = createSharedButton({
+          label: 'Open',
+          disabled: entry.affordances?.openable !== true,
+          dataset: { subjectOpen: entry.id },
+          semantic: {
+            id: `subject-catalog-open-${entry.key}`,
+            name: `Open ${entry.label}`,
+            role: 'AXButton',
+            action: 'open_subject',
+            enabled: entry.affordances?.openable === true,
+            aosRef: catalogEntryRef(entry, 'open'),
+          },
+          onClick: () => {
           openCatalogEntry(entry.id).catch((error) => {
             const result = {
               type: SUBJECT_OPEN_RESULT_TYPE,
@@ -517,6 +541,7 @@ export default function WikiSubjectBrowser(options = {}) {
             applySubjectOpenResult(state, result);
             syncSnapshot();
           });
+          },
         });
 
         item.append(title, meta, button);
@@ -574,36 +599,36 @@ export default function WikiSubjectBrowser(options = {}) {
           const actions = document.createElement('div');
           actions.className = 'wiki-subject-browser-subject-actions';
 
-          const inspectButton = document.createElement('button');
-          inspectButton.type = 'button';
-          inspectButton.dataset.subjectIndexInspect = entry.key;
-          applyWikiSubjectBrowserSemanticTarget(inspectButton, {
-            id: `subject-index-inspect-${entry.key}`,
-            name: `Inspect ${entry.label}`,
-            role: 'AXButton',
-            action: 'inspect_subject',
-            current: focused ? 'true' : null,
-            aosRef: entry.inspect_ref,
-          });
-          inspectButton.textContent = 'Inspect';
-          inspectButton.addEventListener('click', () => {
+          const inspectButton = createSharedButton({
+            label: 'Inspect',
+            dataset: { subjectIndexInspect: entry.key },
+            semantic: {
+              id: `subject-index-inspect-${entry.key}`,
+              name: `Inspect ${entry.label}`,
+              role: 'AXButton',
+              action: 'inspect_subject',
+              current: focused ? 'true' : null,
+              aosRef: entry.inspect_ref,
+            },
+            onClick: () => {
             inspectSubjectIndexEntry(entry);
+            },
           });
 
-          const openButton = document.createElement('button');
-          openButton.type = 'button';
-          openButton.disabled = !indexEntryCanOpen(entry);
-          openButton.dataset.subjectIndexOpen = entry.key;
-          applyWikiSubjectBrowserSemanticTarget(openButton, {
-            id: `subject-index-open-${entry.key}`,
-            name: `Open ${entry.label}`,
-            role: 'AXButton',
-            action: 'open_subject',
-            enabled: !openButton.disabled,
-            aosRef: entry.open_ref,
-          });
-          openButton.textContent = 'Open';
-          openButton.addEventListener('click', () => {
+          const canOpen = indexEntryCanOpen(entry);
+          const openButton = createSharedButton({
+            label: 'Open',
+            disabled: !canOpen,
+            dataset: { subjectIndexOpen: entry.key },
+            semantic: {
+              id: `subject-index-open-${entry.key}`,
+              name: `Open ${entry.label}`,
+              role: 'AXButton',
+              action: 'open_subject',
+              enabled: canOpen,
+              aosRef: entry.open_ref,
+            },
+            onClick: () => {
             openSubjectIndexEntry(entry.key).catch((error) => {
               const result = {
                 type: SUBJECT_OPEN_RESULT_TYPE,
@@ -616,6 +641,7 @@ export default function WikiSubjectBrowser(options = {}) {
               applySubjectOpenResult(state, result);
               syncSnapshot();
             });
+            },
           });
 
           actions.append(inspectButton, openButton);
@@ -689,19 +715,19 @@ export default function WikiSubjectBrowser(options = {}) {
 
     const controls = document.createElement('div');
     controls.className = 'wiki-subject-browser-details-actions';
-    const clear = document.createElement('button');
-    clear.type = 'button';
-    applyWikiSubjectBrowserSemanticTarget(clear, {
-      id: 'subject-details-clear',
-      name: 'Clear focused Subject details',
-      role: 'AXButton',
-      action: 'clear_subject_focus',
-      aosRef: details.clear_ref,
-    });
-    clear.textContent = 'Clear';
-    clear.addEventListener('click', () => {
+    const clear = createSharedButton({
+      label: 'Clear',
+      semantic: {
+        id: 'subject-details-clear',
+        name: 'Clear focused Subject details',
+        role: 'AXButton',
+        action: 'clear_subject_focus',
+        aosRef: details.clear_ref,
+      },
+      onClick: () => {
       clearSubjectIndexFocus(state);
       syncSnapshot();
+      },
     });
     controls.appendChild(clear);
     subject.appendChild(controls);
@@ -748,19 +774,19 @@ export default function WikiSubjectBrowser(options = {}) {
       meta.className = 'wiki-subject-browser-details-meta';
       meta.textContent = relatedSubjectMetaText(target);
 
-      const openButton = document.createElement('button');
-      openButton.type = 'button';
-      openButton.disabled = !relatedSubjectCanOpen(target);
-      applyWikiSubjectBrowserSemanticTarget(openButton, {
-        id: `subject-details-related-open-${target.key || reference.id}`,
-        name: target.resolved ? `Open ${target.label}` : `Unresolved ${target.label}`,
-        role: 'AXButton',
-        action: 'open_subject',
-        enabled: !openButton.disabled,
-        aosRef: target.open_ref || wikiSubjectBrowserAosRef('subject-details', 'related', 'unresolved', target.key || reference.id),
-      });
-      openButton.textContent = target.resolved ? 'Open' : 'Unresolved';
-      openButton.addEventListener('click', () => {
+      const canOpen = relatedSubjectCanOpen(target);
+      const openButton = createSharedButton({
+        label: target.resolved ? 'Open' : 'Unresolved',
+        disabled: !canOpen,
+        semantic: {
+          id: `subject-details-related-open-${target.key || reference.id}`,
+          name: target.resolved ? `Open ${target.label}` : `Unresolved ${target.label}`,
+          role: 'AXButton',
+          action: 'open_subject',
+          enabled: canOpen,
+          aosRef: target.open_ref || wikiSubjectBrowserAosRef('subject-details', 'related', 'unresolved', target.key || reference.id),
+        },
+        onClick: () => {
         openRelatedSubject(target).catch((error) => {
           const result = {
             type: SUBJECT_OPEN_RESULT_TYPE,
@@ -772,6 +798,7 @@ export default function WikiSubjectBrowser(options = {}) {
           applySubjectOpenResult(state, result);
           syncSnapshot();
         });
+        },
       });
 
       item.append(title, meta, openButton);
@@ -855,17 +882,17 @@ export default function WikiSubjectBrowser(options = {}) {
 
     const latest = trail[trail.length - 1]?.entry_handle || '';
     for (const entry of [...trail].reverse()) {
-      const button = document.createElement('button');
-      button.type = 'button';
-      button.className = 'wiki-subject-browser-trail-entry';
-      button.dataset.entryHandle = entry.entry_handle;
-      applyWikiSubjectBrowserSemanticTarget(button, {
-        id: `navigation-trail-open-${entry.key}`,
-        name: `Open ${entry.label}`,
-        role: 'AXButton',
-        action: 'open_subject',
-        current: entry.entry_handle === latest ? 'page' : null,
-        aosRef: entry.open_ref,
+      const button = createSharedButton({
+        className: 'wiki-subject-browser-trail-entry',
+        dataset: { entryHandle: entry.entry_handle },
+        semantic: {
+          id: `navigation-trail-open-${entry.key}`,
+          name: `Open ${entry.label}`,
+          role: 'AXButton',
+          action: 'open_subject',
+          current: entry.entry_handle === latest ? 'page' : null,
+          aosRef: entry.open_ref,
+        },
       });
       const label = document.createElement('span');
       label.textContent = entry.label;
@@ -1031,6 +1058,16 @@ export default function WikiSubjectBrowser(options = {}) {
       subjectIndexStatusEl = subjectIndexEl.querySelector('[data-role="subject-index-status"]');
       subjectIndexSummaryEl = subjectIndexEl.querySelector('[data-role="subject-index-summary"]');
       subjectSearchEl = subjectIndexEl.querySelector('[data-role="subject-search"]');
+      if (subjectSearchEl) {
+        const searchControl = createTextField();
+        const searchInput = searchControl.el.querySelector('input');
+        searchInput.type = 'search';
+        searchInput.autocomplete = 'off';
+        searchInput.spellcheck = false;
+        searchInput.dataset.role = 'subject-search';
+        subjectSearchEl.replaceWith(searchControl.el);
+        subjectSearchEl = searchInput;
+      }
       subjectFiltersEl = subjectIndexEl.querySelector('[data-role="subject-filters"]');
       subjectListStatusEl = subjectIndexEl.querySelector('[data-role="subject-list-status"]');
       subjectListEl = subjectIndexEl.querySelector('[data-role="subject-list"]');
@@ -1061,20 +1098,30 @@ export default function WikiSubjectBrowser(options = {}) {
       for (const filterKey of SUBJECT_BROWSER_INDEX_FILTER_KEYS) {
         const role = filterKey.replaceAll('_', '-');
         const select = subjectIndexEl.querySelector(`[data-role="subject-filter-${role}"]`);
-        subjectFilterEls.set(filterKey, select);
-        applyWikiSubjectBrowserSemanticTarget(select, {
+        const selectControl = createSelect();
+        const sharedSelect = selectControl.el.querySelector('select');
+        sharedSelect.dataset.role = `subject-filter-${role}`;
+        select?.replaceWith(selectControl.el);
+        subjectFilterEls.set(filterKey, sharedSelect);
+        applyWikiSubjectBrowserSemanticTarget(sharedSelect, {
           id: `subject-filter-${role}`,
           name: `${subjectFilterName(filterKey)} filter`,
           role: 'AXPopUpButton',
           action: 'filter_subjects',
           aosRef: wikiSubjectBrowserAosRef('subject-filter', role),
         });
-        select?.addEventListener('change', () => {
-          applySubjectIndexFilter(state, filterKey, select.value);
+        sharedSelect?.addEventListener('change', () => {
+          applySubjectIndexFilter(state, filterKey, sharedSelect.value);
           syncSnapshot();
         });
       }
       subjectFiltersResetEl = subjectIndexEl.querySelector('[data-role="subject-filters-reset"]');
+      if (subjectFiltersResetEl) {
+        const resetControl = createButton({ label: 'Reset' });
+        resetControl.el.dataset.role = 'subject-filters-reset';
+        subjectFiltersResetEl.replaceWith(resetControl.el);
+        subjectFiltersResetEl = resetControl.el;
+      }
       applyWikiSubjectBrowserSemanticTarget(subjectFiltersResetEl, {
         id: 'subject-filters-reset',
         name: 'Reset Subject index filters',

--- a/packages/toolkit/controls/button.js
+++ b/packages/toolkit/controls/button.js
@@ -4,7 +4,7 @@ import { attributeParts, escapeHtml } from './_html.js';
 const VARIANTS = new Set(['primary', 'secondary', 'danger', 'ghost']);
 
 function buttonClassName(config = {}) {
-  const classes = ['aos-button'];
+  const classes = config.includeBaseClass === false ? [] : ['aos-button'];
   const variant = config.variant || 'secondary';
   if (variant && variant !== 'secondary' && VARIANTS.has(variant)) classes.push(variant);
   for (const name of String(config.className || '').split(/\s+/).filter(Boolean)) classes.push(name);
@@ -16,6 +16,7 @@ export function renderButtonHtml(config = {}) {
     `class="${escapeHtml(buttonClassName(config))}"`,
     `type="${escapeHtml(config.type || 'button')}"`,
   ];
+  if (config.classFirst) parts.reverse();
   if (config.id) parts.push(`id="${escapeHtml(config.id)}"`);
   if (config.title) parts.push(`title="${escapeHtml(config.title)}"`);
   if (config.ariaLabel) parts.push(`aria-label="${escapeHtml(config.ariaLabel)}"`);
@@ -24,6 +25,7 @@ export function renderButtonHtml(config = {}) {
     parts.push('disabled');
     parts.push('aria-disabled="true"');
   }
+  if (config.pressed !== undefined) parts.push(`aria-pressed="${config.pressed ? 'true' : 'false'}"`);
   parts.push(...attributeParts(config));
   return `<button ${parts.join(' ')}>${escapeHtml(config.label ?? '')}</button>`;
 }

--- a/packages/toolkit/controls/index.js
+++ b/packages/toolkit/controls/index.js
@@ -1,7 +1,7 @@
 export { createButton, renderButtonHtml } from './button.js';
 export { createButtonGroup } from './button-group.js';
 export { createToggle, renderToggleHtml } from './toggle.js';
-export { createTextField } from './text-field.js';
+export { createTextField, renderTextFieldHtml } from './text-field.js';
 export { createCheckboxGroup } from './checkbox-group.js';
 export { createSelect, renderSelectHtml } from './select.js';
 export { createTextarea, renderTextareaHtml } from './textarea.js';

--- a/packages/toolkit/controls/text-field.js
+++ b/packages/toolkit/controls/text-field.js
@@ -1,5 +1,41 @@
 import { createEventHub, dispatchDomEvent, ownerDocument } from './_events.js';
 
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function renderTextFieldHtml(config = {}) {
+  const classNames = ['aos-text-input'];
+  if (config.className) classNames.push(...String(config.className).split(/\s+/).filter(Boolean));
+  const parts = [
+    `type="${escapeHtml(config.type || 'text')}"`,
+    `class="${escapeHtml(classNames.join(' '))}"`,
+  ];
+  if (config.id) parts.push(`id="${escapeHtml(config.id)}"`);
+  if (config.name) parts.push(`name="${escapeHtml(config.name)}"`);
+  if (config.value !== undefined) parts.push(`value="${escapeHtml(config.value)}"`);
+  if (config.placeholder) parts.push(`placeholder="${escapeHtml(config.placeholder)}"`);
+  if (config.ariaLabel) parts.push(`aria-label="${escapeHtml(config.ariaLabel)}"`);
+  if (config.maxLength !== undefined) parts.push(`maxlength="${escapeHtml(Number(config.maxLength))}"`);
+  if (config.spellcheck !== undefined) parts.push(`spellcheck="${config.spellcheck ? 'true' : 'false'}"`);
+  for (const [name, value] of Object.entries(config.attributes || {})) {
+    if (value === undefined || value === null || value === false) continue;
+    parts.push(value === true ? escapeHtml(name) : `${escapeHtml(name)}="${escapeHtml(value)}"`);
+  }
+  if (config.rawAttributes) parts.push(String(config.rawAttributes));
+  for (const [name, value] of Object.entries(config.dataset || {})) {
+    if (value === undefined || value === null) continue;
+    const attrName = `data-${String(name).replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)}`;
+    parts.push(`${escapeHtml(attrName)}="${escapeHtml(value)}"`);
+  }
+  return `<input ${parts.join(' ')}>`;
+}
+
 export function createTextField(config = {}) {
   const doc = ownerDocument(config);
   const hub = createEventHub();

--- a/tests/toolkit/controls-button.test.mjs
+++ b/tests/toolkit/controls-button.test.mjs
@@ -41,6 +41,7 @@ test('renderButtonHtml escapes labels and supports raw attributes', () => {
     variant: 'primary',
     className: 'wide',
     disabled: true,
+    pressed: true,
     dataset: { action: 'runNow' },
     attributes: { title: 'ignored?', 'aria-controls': 'panel-1' },
     rawAttributes: ['data-safe-fragment="ok"'],
@@ -51,6 +52,7 @@ test('renderButtonHtml escapes labels and supports raw attributes', () => {
   assert.match(html, /type="button"/);
   assert.match(html, /disabled/);
   assert.match(html, /aria-disabled="true"/);
+  assert.match(html, /aria-pressed="true"/);
   assert.match(html, /data-action="runNow"/);
   assert.match(html, /aria-controls="panel-1"/);
   assert.match(html, /data-safe-fragment="ok"/);

--- a/tests/toolkit/controls-text-field.test.mjs
+++ b/tests/toolkit/controls-text-field.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { createTextField } from '../../packages/toolkit/controls/text-field.js';
+import { createTextField, renderTextFieldHtml } from '../../packages/toolkit/controls/text-field.js';
 import { FakeEvent, createFakeDocument } from './dom-fixture.mjs';
 
 test('createTextField returns shape and updates value', () => {
@@ -41,4 +41,25 @@ test('text field commits on Enter and blur', () => {
   input.dispatchEvent(new FakeEvent('blur'));
 
   assert.deepEqual(commits, ['x', 'x']);
+});
+
+test('renderTextFieldHtml escapes attributes and value', () => {
+  const html = renderTextFieldHtml({
+    type: 'search',
+    className: 'query-input',
+    value: '<term>',
+    placeholder: 'Find "subject"',
+    spellcheck: false,
+    dataset: { role: 'subject-search' },
+    attributes: { autocomplete: 'off' },
+  });
+
+  assert.match(html, /^<input /);
+  assert.match(html, /type="search"/);
+  assert.match(html, /class="aos-text-input query-input"/);
+  assert.match(html, /value="&lt;term&gt;"/);
+  assert.match(html, /placeholder="Find &quot;subject&quot;"/);
+  assert.match(html, /spellcheck="false"/);
+  assert.match(html, /data-role="subject-search"/);
+  assert.match(html, /autocomplete="off"/);
 });

--- a/tests/toolkit/surface-inspector.test.mjs
+++ b/tests/toolkit/surface-inspector.test.mjs
@@ -621,7 +621,8 @@ test('Surface Inspector exposes Annotation Mode controls and snapshot state', ()
   assert.doesNotMatch(source, /makeButton/);
   assert.doesNotMatch(source, /background:rgba\(244,197,66,0\.08\)/);
   assert.doesNotMatch(source, /hover target buttons/);
-  assert.match(source, /placeholder="Leave a comment"/);
+  assert.match(source, /renderTextFieldHtml/);
+  assert.match(source, /placeholder: 'Leave a comment'/);
   assert.match(source, /emit\('canvas_inspector\.annotation_state'/);
   assert.match(source, /surface_inspector_suspended/);
   assert.match(styles, /\.minimap-annotation-frame/);
@@ -700,8 +701,10 @@ test('annotation scope breadcrumbs remain actionable buttons for root and ancest
   const scopeBlock = source.slice(scopeStart, supportStart);
   const bindBlock = source.slice(bindStart, bindEnd);
 
-  assert.match(scopeBlock, /<button class="annotation-scope-crumb \$\{rootActive \? 'active' : ''\}" data-pin-id=""/);
-  assert.match(scopeBlock, /data-pin-id="\$\{esc\(frame\.pin_id\)\}"/);
+  assert.match(scopeBlock, /renderInspectorButton/);
+  assert.match(scopeBlock, /className: `annotation-scope-crumb \$\{rootActive \? 'active' : ''\}`/);
+  assert.match(scopeBlock, /dataset: \{ pinId: '' \}/);
+  assert.match(scopeBlock, /dataset: \{ pinId: frame\.pin_id \}/);
   assert.match(scopeBlock, /inspectorControlAttrs\('annotation-scope-root'/);
   assert.match(scopeBlock, /action: 'select_annotation_scope_root'/);
   assert.match(scopeBlock, /action: 'select_annotation_scope'/);


### PR DESCRIPTION
Closes work card `docs/dev/work-cards/retrofit-shared-controls.md`.

## Summary

Retrofits the three highest-value toolkit components to consume the shared control layer instead of hand-rolling inline controls. Retrofit only — no behavioral changes.

## Components Retrofitted

- **`surface-inspector`** — primary inspection surface (post canvas-inspector rename, PR #318)
- **`wiki-kb`** — inline controls replaced with shared layer; graph view updated
- **`wiki-subject-browser`** — inline controls replaced with shared layer

## Shared Control Layer Changes

- Added `packages/toolkit/controls/button.js` — HTML render helper for string-rendered surfaces
- Added `packages/toolkit/controls/text-field.js` — HTML render helper for string-rendered surfaces
- Exported both from `packages/toolkit/controls/index.js`

## Verification

- `node --test tests/toolkit/*.test.mjs` → **822/822** ✅
- `bash tests/help-contract.sh` → **passed** ✅
- `bash tests/wiki-kb-smoke.sh` → **passed** ✅
- `bash tests/surface-inspector-snapshot.sh` → **passed** ✅
- Working tree clean; no unrelated dirty state

## Stats

13 files changed, 641 insertions(+), 160 deletions(-)

## References

- Surface audit: `docs/dev/reports/toolkit-surface-audit.md`
- Reference implementation: `packages/toolkit/controls/textarea.js` (PR #322)
- Active workflow profile: `agentic_relay`
