### PR TITLE
feat(sigil): extract context menu theme tokens

### DIFF
--- a/apps/sigil/context-menu/styles.css
+++ b/apps/sigil/context-menu/styles.css
@@ -1,18 +1,19 @@
 /* Sigil avatar context menu — Celestial v1 deck-card skin. */
+@import url("../theme/sigil-tokens.css");
 
 .sigil-context-menu-layer {
     position: fixed;
-    inset: 0;
-    z-index: 20;
+    inset: var(--sigil-context-menu-layer-inset);
+    z-index: var(--sigil-context-menu-layer-z);
     pointer-events: auto;
-    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-family: var(--sigil-context-menu-font-family);
 }
 
 .ctx-anchor {
     position: absolute;
     display: none;
-    width: 292px;
-    z-index: 100;
+    width: var(--sigil-context-menu-anchor-width);
+    z-index: var(--sigil-context-menu-anchor-z);
 }
 
 .ctx-anchor.visible {
@@ -21,31 +22,31 @@
 
 .ctx-menu-card {
     position: absolute;
-    top: 0;
-    left: 0;
+    top: var(--sigil-context-menu-space-0);
+    left: var(--sigil-context-menu-space-0);
     display: none;
     flex-direction: column;
-    width: 268px;
-    max-height: 424px;
+    width: var(--sigil-context-menu-card-width);
+    max-height: var(--sigil-context-menu-card-max-height);
     overflow-y: auto;
-    padding: 12px;
-    color: #fff;
-    background: rgba(20, 10, 30, 0.95);
-    border: 1px solid rgba(209, 135, 255, 0.6);
-    border-radius: 8px;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.8);
-    backdrop-filter: blur(12px);
+    padding: var(--sigil-context-menu-card-padding);
+    color: var(--sigil-context-menu-card-color);
+    background: var(--sigil-context-menu-card-bg);
+    border: var(--sigil-context-menu-card-border);
+    border-radius: var(--sigil-context-menu-card-border-radius);
+    box-shadow: var(--sigil-context-menu-card-shadow);
+    backdrop-filter: blur(var(--sigil-context-menu-card-blur));
     transition:
-        transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-        opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-        filter 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+        transform var(--sigil-context-menu-card-transition-duration) var(--sigil-context-menu-card-transition-easing),
+        opacity var(--sigil-context-menu-card-transition-duration) var(--sigil-context-menu-card-transition-easing),
+        filter var(--sigil-context-menu-card-transition-duration) var(--sigil-context-menu-card-transition-easing);
 }
 
 .ctx-menu-card.active {
     position: relative;
     display: flex;
-    z-index: 20;
-    animation: sigilCardForward 0.18s ease-out;
+    z-index: var(--sigil-context-menu-card-z);
+    animation: sigilCardForward var(--sigil-context-menu-card-forward-animation);
 }
 
 .ctx-menu-card.active.returning {
@@ -53,80 +54,80 @@
 }
 
 .ctx-menu-card.ctx-sub {
-    gap: 6px;
+    gap: var(--sigil-context-menu-space-6);
 }
 
 .ctx-menu-card.pushed {
     display: flex;
     overflow-y: hidden;
     cursor: pointer;
-    border-color: rgba(209, 135, 255, 0.35);
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+    border-color: var(--sigil-context-menu-card-pushed-border-color);
+    box-shadow: var(--sigil-context-menu-card-pushed-shadow);
 }
 
 .ctx-menu-card.departing {
     display: flex;
     pointer-events: none;
-    opacity: 1;
-    transform: translateY(0) scale(1);
+    opacity: var(--sigil-context-menu-opacity-visible);
+    transform: translateY(var(--sigil-context-menu-space-0)) scale(var(--sigil-context-menu-scale-full));
 }
 
 .ctx-menu-card.departing-active {
-    opacity: 0;
-    transform: translateY(14px) scale(0.97);
-    filter: blur(1px) brightness(0.84);
+    opacity: var(--sigil-context-menu-opacity-hidden);
+    transform: translateY(var(--sigil-context-menu-card-depart-y)) scale(var(--sigil-context-menu-card-depart-scale));
+    filter: var(--sigil-context-menu-card-depart-filter);
 }
 
 @keyframes sigilCardForward {
     from {
-        opacity: 0.7;
-        transform: translateY(-10px) scale(0.94);
-        filter: brightness(0.72);
+        opacity: var(--sigil-context-menu-card-enter-opacity);
+        transform: translateY(var(--sigil-context-menu-card-enter-y)) scale(var(--sigil-context-menu-card-enter-scale));
+        filter: var(--sigil-context-menu-card-enter-filter);
     }
     to {
-        opacity: 1;
-        transform: translateY(0) scale(1);
-        filter: brightness(1);
+        opacity: var(--sigil-context-menu-opacity-visible);
+        transform: translateY(var(--sigil-context-menu-space-0)) scale(var(--sigil-context-menu-scale-full));
+        filter: brightness(var(--sigil-context-menu-scale-full));
     }
 }
 
 .ctx-tabs {
     display: flex;
-    gap: 4px;
-    padding-bottom: 8px;
-    margin-bottom: 8px;
-    border-bottom: 1px solid rgba(188, 19, 254, 0.4);
+    gap: var(--sigil-context-menu-space-4);
+    padding-bottom: var(--sigil-context-menu-space-8);
+    margin-bottom: var(--sigil-context-menu-space-8);
+    border-bottom: var(--sigil-context-menu-space-1) solid var(--sigil-context-menu-border-color-divider);
 }
 
 .ctx-tab {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 32px;
-    height: 32px;
-    padding: 0;
-    color: rgba(209, 135, 255, 0.7);
-    background: transparent;
-    border: 0;
-    border-radius: 6px;
+    width: var(--sigil-context-menu-space-32);
+    height: var(--sigil-context-menu-space-32);
+    padding: var(--sigil-context-menu-space-0);
+    color: var(--sigil-context-menu-color-accent-muted);
+    background: var(--sigil-context-menu-color-transparent);
+    border: var(--sigil-context-menu-space-0);
+    border-radius: var(--sigil-context-menu-radius-6);
 }
 
 .ctx-tab:hover {
-    color: #d187ff;
-    background: rgba(188, 19, 254, 0.2);
+    color: var(--sigil-context-menu-color-accent);
+    background: var(--sigil-context-menu-surface-hover-bg);
 }
 
 .ctx-tab.active {
-    color: #fff;
-    background: #bc13fe;
+    color: var(--sigil-context-menu-color-primary);
+    background: var(--sigil-context-menu-surface-active-bg);
 }
 
 .ctx-tab svg,
 .ctx-actions svg {
-    width: 18px;
-    height: 18px;
+    width: var(--sigil-context-menu-space-18);
+    height: var(--sigil-context-menu-space-18);
     stroke: currentColor;
-    stroke-width: 1.5;
+    stroke-width: var(--sigil-context-menu-icon-stroke-width);
     stroke-linecap: round;
     stroke-linejoin: round;
     fill: none;
@@ -139,89 +140,89 @@
 .ctx-panel.active {
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: var(--sigil-context-menu-space-6);
 }
 
 .ctx-heading-row {
     display: flex;
-    gap: 8px;
+    gap: var(--sigil-context-menu-space-8);
     align-items: center;
-    padding-bottom: 4px;
-    border-bottom: 1px solid #bc13fe;
+    padding-bottom: var(--sigil-context-menu-space-4);
+    border-bottom: var(--sigil-context-menu-space-1) solid var(--sigil-context-menu-color-accent-strong);
 }
 
 .ctx-menu-card h3 {
-    margin: 0 0 4px;
-    padding-bottom: 4px;
-    color: #fff;
-    font-size: 0.9rem;
-    letter-spacing: 1px;
+    margin: var(--sigil-context-menu-space-0) var(--sigil-context-menu-space-0) var(--sigil-context-menu-space-4);
+    padding-bottom: var(--sigil-context-menu-space-4);
+    color: var(--sigil-context-menu-color-primary);
+    font-size: var(--sigil-context-menu-type-heading-size);
+    letter-spacing: var(--sigil-context-menu-heading-letter-spacing);
     text-transform: uppercase;
-    border-bottom: 1px solid #bc13fe;
+    border-bottom: var(--sigil-context-menu-space-1) solid var(--sigil-context-menu-color-accent-strong);
 }
 
 .ctx-heading-row h3 {
     flex: 1;
-    margin: 0;
-    padding-bottom: 0;
-    border-bottom: 0;
+    margin: var(--sigil-context-menu-space-0);
+    padding-bottom: var(--sigil-context-menu-space-0);
+    border-bottom: var(--sigil-context-menu-space-0);
 }
 
 .ctx-sub-header {
     display: grid;
-    grid-template-columns: 28px minmax(0, 1fr);
-    gap: 8px;
+    grid-template-columns: var(--sigil-context-menu-space-28) minmax(0, 1fr);
+    gap: var(--sigil-context-menu-space-8);
     align-items: center;
-    padding-bottom: 4px;
-    border-bottom: 1px solid #bc13fe;
+    padding-bottom: var(--sigil-context-menu-space-4);
+    border-bottom: var(--sigil-context-menu-space-1) solid var(--sigil-context-menu-color-accent-strong);
 }
 
 .ctx-sub-header h3 {
-    margin: 0;
-    padding-bottom: 0;
-    border-bottom: 0;
+    margin: var(--sigil-context-menu-space-0);
+    padding-bottom: var(--sigil-context-menu-space-0);
+    border-bottom: var(--sigil-context-menu-space-0);
 }
 
 .ctx-back {
     position: relative;
     display: grid;
     place-items: center;
-    width: 26px;
-    height: 24px;
-    padding: 0;
-    color: #d187ff;
-    background: rgba(30, 15, 50, 0.74);
-    border: 1px solid rgba(209, 135, 255, 0.38);
-    border-radius: 4px;
+    width: var(--sigil-context-menu-space-26);
+    height: var(--sigil-context-menu-space-24);
+    padding: var(--sigil-context-menu-space-0);
+    color: var(--sigil-context-menu-color-accent);
+    background: var(--sigil-context-menu-surface-control-bg);
+    border: var(--sigil-context-menu-space-1) solid var(--sigil-context-menu-border-color-control);
+    border-radius: var(--sigil-context-menu-radius-4);
 }
 
 .ctx-back::before {
     content: "";
-    width: 8px;
-    height: 8px;
-    border-top: 2px solid currentColor;
-    border-left: 2px solid currentColor;
-    transform: translateY(2px) rotate(45deg);
+    width: var(--sigil-context-menu-space-8);
+    height: var(--sigil-context-menu-space-8);
+    border-top: var(--sigil-context-menu-space-2) solid currentColor;
+    border-left: var(--sigil-context-menu-space-2) solid currentColor;
+    transform: translateY(var(--sigil-context-menu-space-2)) rotate(45deg);
 }
 
 .ctx-back:hover {
-    color: #fff;
-    background: rgba(188, 19, 254, 0.24);
-    border-color: #bc13fe;
+    color: var(--sigil-context-menu-color-primary);
+    background: var(--sigil-context-menu-surface-hover-bg-medium);
+    border-color: var(--sigil-context-menu-color-accent-strong);
 }
 
 .ctx-segmented {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    width: 124px;
-    padding: 2px;
-    background: rgba(30, 15, 50, 0.85);
-    border: 1px solid rgba(209, 135, 255, 0.35);
-    border-radius: 6px;
+    width: var(--sigil-context-menu-space-124);
+    padding: var(--sigil-context-menu-space-2);
+    background: var(--sigil-context-menu-surface-control-bg-strong);
+    border: var(--sigil-context-menu-space-1) solid var(--sigil-context-menu-border-color-muted);
+    border-radius: var(--sigil-context-menu-radius-6);
 }
 
 .ctx-segmented-wide {
-    width: 100%;
+    width: var(--sigil-context-menu-size-full);
 }
 
 .ctx-segmented-wrap {
@@ -229,31 +230,31 @@
 }
 
 .ctx-segmented button {
-    height: 22px;
-    padding: 0 8px;
-    color: #d187ff;
-    background: transparent;
-    border: 0;
-    border-radius: 4px;
-    font-size: 0.65rem;
+    height: var(--sigil-context-menu-space-22);
+    padding: var(--sigil-context-menu-space-0) var(--sigil-context-menu-space-8);
+    color: var(--sigil-context-menu-color-accent);
+    background: var(--sigil-context-menu-color-transparent);
+    border: var(--sigil-context-menu-space-0);
+    border-radius: var(--sigil-context-menu-radius-4);
+    font-size: var(--sigil-context-menu-type-label-size);
 }
 
 .ctx-segmented-wrap button {
-    height: auto;
-    min-height: 22px;
-    padding: 4px 6px;
+    height: var(--sigil-context-menu-size-auto);
+    min-height: var(--sigil-context-menu-space-22);
+    padding: var(--sigil-context-menu-space-4) var(--sigil-context-menu-space-6);
     white-space: normal;
-    line-height: 1.1;
+    line-height: var(--sigil-context-menu-line-height-tight);
 }
 
 .ctx-segmented button:hover {
-    color: #fff;
-    background: rgba(188, 19, 254, 0.2);
+    color: var(--sigil-context-menu-color-primary);
+    background: var(--sigil-context-menu-surface-hover-bg);
 }
 
 .ctx-segmented button.active {
-    color: #fff;
-    background: #bc13fe;
+    color: var(--sigil-context-menu-color-primary);
+    background: var(--sigil-context-menu-surface-active-bg);
 }
 
 .ctx-shape-scope {
@@ -263,81 +264,81 @@
 .ctx-shape-scope.active {
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: var(--sigil-context-menu-space-6);
 }
 
 .ctx-menu-card label,
 .ctx-field-label {
-    margin-bottom: -4px;
-    color: #d187ff;
-    font-size: 0.65rem;
+    margin-bottom: calc(-1 * var(--sigil-context-menu-space-4));
+    color: var(--sigil-context-menu-color-accent);
+    font-size: var(--sigil-context-menu-type-label-size);
 }
 
 .ctx-menu-card select,
 .ctx-menu-card input[type="color"] {
-    height: 28px;
-    padding: 4px;
+    height: var(--sigil-context-menu-space-28);
+    padding: var(--sigil-context-menu-space-4);
 }
 
 .ctx-menu-card select {
-    color: #fff;
-    background: rgba(30, 15, 50, 0.9);
-    border: 1px solid rgba(209, 135, 255, 0.4);
-    border-radius: 4px;
-    font-size: 0.75rem;
+    color: var(--sigil-context-menu-color-primary);
+    background: var(--sigil-context-menu-surface-control-bg-select);
+    border: var(--sigil-context-menu-space-1) solid var(--sigil-context-menu-border-color-field);
+    border-radius: var(--sigil-context-menu-radius-4);
+    font-size: var(--sigil-context-menu-type-control-size);
 }
 
 .ctx-select-popover {
     display: grid;
-    gap: 2px;
-    max-height: 168px;
-    padding: 4px;
-    margin-top: -4px;
+    gap: var(--sigil-context-menu-space-2);
+    max-height: var(--sigil-context-menu-space-168);
+    padding: var(--sigil-context-menu-space-4);
+    margin-top: calc(-1 * var(--sigil-context-menu-space-4));
     overflow-y: auto;
-    background: rgba(12, 8, 24, 0.96);
-    border: 1px solid rgba(209, 135, 255, 0.42);
-    border-radius: 5px;
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+    background: var(--sigil-context-menu-surface-popover-bg);
+    border: var(--sigil-context-menu-space-1) solid var(--sigil-context-menu-border-color-popover);
+    border-radius: var(--sigil-context-menu-radius-5);
+    box-shadow: var(--sigil-context-menu-shadow-popover-inset);
 }
 
 .ctx-select-popover button {
-    min-height: 24px;
-    padding: 4px 8px;
-    color: #d187ff;
+    min-height: var(--sigil-context-menu-space-24);
+    padding: var(--sigil-context-menu-space-4) var(--sigil-context-menu-space-8);
+    color: var(--sigil-context-menu-color-accent);
     text-align: left;
-    background: transparent;
-    border: 0;
-    border-radius: 4px;
-    font-size: 0.72rem;
+    background: var(--sigil-context-menu-color-transparent);
+    border: var(--sigil-context-menu-space-0);
+    border-radius: var(--sigil-context-menu-radius-4);
+    font-size: var(--sigil-context-menu-type-option-size);
 }
 
 .ctx-select-popover button:hover,
 .ctx-select-popover button.active {
-    color: #fff;
-    background: rgba(188, 19, 254, 0.28);
+    color: var(--sigil-context-menu-color-primary);
+    background: var(--sigil-context-menu-surface-option-active-bg);
 }
 
 .ctx-menu-card input[type="range"] {
-    width: 100%;
-    accent-color: #bc13fe;
+    width: var(--sigil-context-menu-size-full);
+    accent-color: var(--sigil-context-menu-color-accent-strong);
 }
 
 .ctx-range-row {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 44px;
-    gap: 8px;
+    grid-template-columns: minmax(0, 1fr) var(--sigil-context-menu-space-44);
+    gap: var(--sigil-context-menu-space-8);
     align-items: center;
 }
 
 .ctx-value {
-    color: rgba(255, 255, 255, 0.78);
-    font: 0.65rem ui-monospace, SFMono-Regular, Menlo, monospace;
+    color: var(--sigil-context-menu-color-secondary);
+    font: var(--sigil-context-menu-type-value);
     text-align: right;
 }
 
 .ctx-color-row {
     display: flex;
-    gap: 4px;
+    gap: var(--sigil-context-menu-space-4);
 }
 
 .ctx-color-row input {
@@ -345,46 +346,46 @@
 }
 
 .ctx-menu-card input[type="color"] {
-    background: transparent;
-    border: 1px solid rgba(209, 135, 255, 0.4);
-    border-radius: 4px;
+    background: var(--sigil-context-menu-color-transparent);
+    border: var(--sigil-context-menu-space-1) solid var(--sigil-context-menu-border-color-field);
+    border-radius: var(--sigil-context-menu-radius-4);
 }
 
 .ctx-menu-card .checkbox-label {
     display: flex;
     align-items: center;
-    gap: 6px;
-    margin-bottom: 0;
-    color: #d187ff;
-    font-size: 0.75rem;
+    gap: var(--sigil-context-menu-space-6);
+    margin-bottom: var(--sigil-context-menu-space-0);
+    color: var(--sigil-context-menu-color-accent);
+    font-size: var(--sigil-context-menu-type-control-size);
 }
 
 .ctx-menu-card .checkbox-label input[type="checkbox"] {
-    accent-color: #bc13fe;
+    accent-color: var(--sigil-context-menu-color-accent-strong);
 }
 
 .ctx-row {
     display: flex;
     flex-wrap: wrap;
-    gap: 10px;
+    gap: var(--sigil-context-menu-space-10);
     align-items: center;
 }
 
 .ctx-section {
     display: flex;
     flex-direction: column;
-    gap: 6px;
-    padding: 8px;
-    background: rgba(12, 8, 24, 0.42);
-    border: 1px solid rgba(209, 135, 255, 0.24);
-    border-radius: 6px;
+    gap: var(--sigil-context-menu-space-6);
+    padding: var(--sigil-context-menu-space-8);
+    background: var(--sigil-context-menu-surface-section-bg);
+    border: var(--sigil-context-menu-space-1) solid var(--sigil-context-menu-border-color-section);
+    border-radius: var(--sigil-context-menu-radius-6);
 }
 
 .ctx-section-title {
-    color: rgba(255, 255, 255, 0.82);
-    font-size: 0.62rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
+    color: var(--sigil-context-menu-color-section-title);
+    font-size: var(--sigil-context-menu-type-section-title-size);
+    font-weight: var(--sigil-context-menu-type-section-title-weight);
+    letter-spacing: var(--sigil-context-menu-section-title-letter-spacing);
     text-transform: uppercase;
 }
 
@@ -392,78 +393,78 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    width: 100%;
-    padding: 5px 8px;
-    color: #d187ff;
+    width: var(--sigil-context-menu-size-full);
+    padding: var(--sigil-context-menu-space-5) var(--sigil-context-menu-space-8);
+    color: var(--sigil-context-menu-color-accent);
     text-align: left;
-    background: none;
-    border: none;
-    border-radius: 4px;
-    font-size: 0.75rem;
+    background: var(--sigil-context-menu-surface-none);
+    border: var(--sigil-context-menu-border-none);
+    border-radius: var(--sigil-context-menu-radius-4);
+    font-size: var(--sigil-context-menu-type-control-size);
 }
 
 .ctx-trigger:hover {
-    background: rgba(188, 19, 254, 0.15);
+    background: var(--sigil-context-menu-surface-hover-bg-subtle);
 }
 
 .ctx-trigger::after {
     content: "\203A";
-    padding-left: 8px;
+    padding-left: var(--sigil-context-menu-space-8);
     margin-left: auto;
-    font-size: 1rem;
-    line-height: 1;
-    opacity: 0.6;
+    font-size: var(--sigil-context-menu-type-trigger-caret-size);
+    line-height: var(--sigil-context-menu-line-height-solid);
+    opacity: var(--sigil-context-menu-opacity-muted);
 }
 
 .ctx-divider {
-    height: 1px;
-    margin: 4px 0;
-    background: rgba(188, 19, 254, 0.3);
-    border: none;
+    height: var(--sigil-context-menu-space-1);
+    margin: var(--sigil-context-menu-space-4) var(--sigil-context-menu-space-0);
+    background: var(--sigil-context-menu-border-color-hairline);
+    border: var(--sigil-context-menu-border-none);
 }
 
 .ctx-actions {
     display: flex;
-    gap: 6px;
-    padding-top: 6px;
-    margin-top: 2px;
-    border-top: 1px solid rgba(188, 19, 254, 0.25);
+    gap: var(--sigil-context-menu-space-6);
+    padding-top: var(--sigil-context-menu-space-6);
+    margin-top: var(--sigil-context-menu-space-2);
+    border-top: var(--sigil-context-menu-space-1) solid var(--sigil-context-menu-border-color-subtle);
 }
 
 .ctx-actions button {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 28px;
-    height: 28px;
-    color: #d187ff;
-    background: rgba(30, 15, 50, 0.6);
-    border: 1px solid rgba(209, 135, 255, 0.4);
-    border-radius: 4px;
+    width: var(--sigil-context-menu-space-28);
+    height: var(--sigil-context-menu-space-28);
+    color: var(--sigil-context-menu-color-accent);
+    background: var(--sigil-context-menu-surface-control-bg-action);
+    border: var(--sigil-context-menu-space-1) solid var(--sigil-context-menu-border-color-field);
+    border-radius: var(--sigil-context-menu-radius-4);
 }
 
 .ctx-actions button.ctx-action-text {
     flex: 1;
-    width: auto;
-    padding: 0 8px;
-    font-size: 0.68rem;
+    width: var(--sigil-context-menu-size-auto);
+    padding: var(--sigil-context-menu-space-0) var(--sigil-context-menu-space-8);
+    font-size: var(--sigil-context-menu-type-action-text-size);
 }
 
 .ctx-actions button:hover {
-    color: #fff;
-    background: rgba(188, 19, 254, 0.25);
-    border-color: #bc13fe;
+    color: var(--sigil-context-menu-color-primary);
+    background: var(--sigil-context-menu-surface-hover-bg-strong);
+    border-color: var(--sigil-context-menu-color-accent-strong);
 }
 
 .ctx-menu-card::-webkit-scrollbar {
-    width: 5px;
+    width: var(--sigil-context-menu-space-5);
 }
 
 .ctx-menu-card::-webkit-scrollbar-track {
-    background: transparent;
+    background: var(--sigil-context-menu-color-transparent);
 }
 
 .ctx-menu-card::-webkit-scrollbar-thumb {
-    background: rgba(188, 19, 254, 0.4);
-    border-radius: 3px;
+    background: var(--sigil-context-menu-border-color-divider);
+    border-radius: var(--sigil-context-menu-radius-3);
 }

--- a/apps/sigil/theme/sigil-tokens.css
+++ b/apps/sigil/theme/sigil-tokens.css
@@ -1,0 +1,134 @@
+/* Sigil product-level token overrides.
+ *
+ * These --sigil-* tokens preserve Sigil's app-specific visual language while
+ * giving each consumer a fallback path to the shared --aos-* toolkit tokens.
+ */
+
+:root {
+    --sigil-font-ui: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --sigil-font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+    --sigil-type-heading-size: 0.9rem;
+    --sigil-type-label-size: 0.65rem;
+    --sigil-type-control-size: 0.75rem;
+    --sigil-type-option-size: 0.72rem;
+    --sigil-type-value: 0.65rem var(--sigil-context-menu-font-mono);
+    --sigil-type-section-title-size: 0.62rem;
+    --sigil-type-action-text-size: 0.68rem;
+    --sigil-type-trigger-caret-size: 1rem;
+    --sigil-radius-scrollbar: 3px;
+    --sigil-radius-control: 4px;
+    --sigil-radius-popover: 5px;
+    --sigil-radius-group: 6px;
+    --sigil-radius-panel: 8px;
+
+    --sigil-context-menu-layer-inset: 0;
+    --sigil-context-menu-layer-z: 20;
+    --sigil-context-menu-anchor-width: 292px;
+    --sigil-context-menu-anchor-z: 100;
+    --sigil-context-menu-card-z: 20;
+    --sigil-context-menu-card-width: 268px;
+    --sigil-context-menu-card-max-height: 424px;
+    --sigil-context-menu-card-padding: 12px;
+    --sigil-context-menu-card-color: var(--sigil-context-menu-color-primary, var(--aos-window-button-color, #fff));
+    --sigil-context-menu-card-bg: var(--sigil-context-menu-surface-bg, var(--aos-panel-bg, rgba(20, 10, 30, 0.95)));
+    --sigil-context-menu-card-border: 1px solid var(--sigil-context-menu-border-color, var(--aos-panel-border, rgba(209, 135, 255, 0.6)));
+    --sigil-context-menu-card-border-radius: var(--sigil-context-menu-radius-panel, var(--aos-panel-radius, 8px));
+    --sigil-context-menu-card-shadow: var(--sigil-context-menu-shadow-panel, var(--aos-panel-shadow, 0 8px 32px rgba(0, 0, 0, 0.8)));
+    --sigil-context-menu-card-blur: var(--sigil-context-menu-blur-panel, var(--aos-panel-blur, 12px));
+    --sigil-context-menu-card-transition-duration: 0.3s;
+    --sigil-context-menu-card-transition-easing: cubic-bezier(0.4, 0, 0.2, 1);
+    --sigil-context-menu-card-forward-animation: 0.18s ease-out;
+    --sigil-context-menu-card-pushed-border-color: var(--sigil-context-menu-border-color-muted, var(--aos-panel-border-subtle, rgba(209, 135, 255, 0.35)));
+    --sigil-context-menu-card-pushed-shadow: var(--sigil-context-menu-shadow-card-pushed, var(--aos-panel-shadow, 0 4px 20px rgba(0, 0, 0, 0.5)));
+    --sigil-context-menu-card-depart-y: 14px;
+    --sigil-context-menu-card-depart-scale: 0.97;
+    --sigil-context-menu-card-depart-filter: blur(1px) brightness(0.84);
+    --sigil-context-menu-card-enter-opacity: 0.7;
+    --sigil-context-menu-card-enter-y: -10px;
+    --sigil-context-menu-card-enter-scale: 0.94;
+    --sigil-context-menu-card-enter-filter: brightness(0.72);
+    --sigil-context-menu-opacity-hidden: 0;
+    --sigil-context-menu-opacity-visible: 1;
+    --sigil-context-menu-opacity-muted: 0.6;
+    --sigil-context-menu-scale-full: 1;
+    --sigil-context-menu-icon-stroke-width: 1.5;
+    --sigil-context-menu-line-height-solid: 1;
+    --sigil-context-menu-line-height-tight: 1.1;
+    --sigil-context-menu-size-full: 100%;
+    --sigil-context-menu-size-auto: auto;
+
+    --sigil-context-menu-font-family: var(--sigil-font-ui, var(--aos-font-ui, Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif));
+    --sigil-context-menu-font-mono: var(--sigil-font-mono, var(--aos-font-mono, ui-monospace, SFMono-Regular, Menlo, monospace));
+    --sigil-context-menu-type-heading-size: var(--sigil-type-heading-size, var(--aos-type-title-size, 0.9rem));
+    --sigil-context-menu-type-label-size: var(--sigil-type-label-size, var(--aos-type-label-size, 0.65rem));
+    --sigil-context-menu-type-control-size: var(--sigil-type-control-size, var(--aos-type-body-size, 0.75rem));
+    --sigil-context-menu-type-option-size: var(--sigil-type-option-size, var(--aos-type-body-size, 0.72rem));
+    --sigil-context-menu-type-value: var(--sigil-type-value, var(--aos-type-code, 0.65rem var(--sigil-context-menu-font-mono)));
+    --sigil-context-menu-type-section-title-size: var(--sigil-type-section-title-size, var(--aos-type-label-size, 0.62rem));
+    --sigil-context-menu-type-section-title-weight: 700;
+    --sigil-context-menu-type-action-text-size: var(--sigil-type-action-text-size, var(--aos-type-label-size, 0.68rem));
+    --sigil-context-menu-type-trigger-caret-size: var(--sigil-type-trigger-caret-size, var(--aos-type-title-size, 1rem));
+    --sigil-context-menu-heading-letter-spacing: 1px;
+    --sigil-context-menu-section-title-letter-spacing: 0.08em;
+
+    --sigil-context-menu-color-primary: #fff;
+    --sigil-context-menu-color-accent: #d187ff;
+    --sigil-context-menu-color-accent-strong: #bc13fe;
+    --sigil-context-menu-color-accent-muted: rgba(209, 135, 255, 0.7);
+    --sigil-context-menu-color-secondary: rgba(255, 255, 255, 0.78);
+    --sigil-context-menu-color-section-title: rgba(255, 255, 255, 0.82);
+    --sigil-context-menu-color-transparent: transparent;
+    --sigil-context-menu-surface-none: none;
+    --sigil-context-menu-border-none: none;
+    --sigil-context-menu-surface-bg: rgba(20, 10, 30, 0.95);
+    --sigil-context-menu-surface-control-bg: rgba(30, 15, 50, 0.74);
+    --sigil-context-menu-surface-control-bg-strong: rgba(30, 15, 50, 0.85);
+    --sigil-context-menu-surface-control-bg-select: rgba(30, 15, 50, 0.9);
+    --sigil-context-menu-surface-control-bg-action: rgba(30, 15, 50, 0.6);
+    --sigil-context-menu-surface-popover-bg: rgba(12, 8, 24, 0.96);
+    --sigil-context-menu-surface-section-bg: rgba(12, 8, 24, 0.42);
+    --sigil-context-menu-surface-hover-bg: rgba(188, 19, 254, 0.2);
+    --sigil-context-menu-surface-hover-bg-subtle: rgba(188, 19, 254, 0.15);
+    --sigil-context-menu-surface-hover-bg-medium: rgba(188, 19, 254, 0.24);
+    --sigil-context-menu-surface-hover-bg-strong: rgba(188, 19, 254, 0.25);
+    --sigil-context-menu-surface-active-bg: #bc13fe;
+    --sigil-context-menu-surface-option-active-bg: rgba(188, 19, 254, 0.28);
+    --sigil-context-menu-border-color: rgba(209, 135, 255, 0.6);
+    --sigil-context-menu-border-color-muted: rgba(209, 135, 255, 0.35);
+    --sigil-context-menu-border-color-control: rgba(209, 135, 255, 0.38);
+    --sigil-context-menu-border-color-field: rgba(209, 135, 255, 0.4);
+    --sigil-context-menu-border-color-popover: rgba(209, 135, 255, 0.42);
+    --sigil-context-menu-border-color-section: rgba(209, 135, 255, 0.24);
+    --sigil-context-menu-border-color-divider: rgba(188, 19, 254, 0.4);
+    --sigil-context-menu-border-color-subtle: rgba(188, 19, 254, 0.25);
+    --sigil-context-menu-border-color-hairline: rgba(188, 19, 254, 0.3);
+    --sigil-context-menu-shadow-panel: 0 8px 32px rgba(0, 0, 0, 0.8);
+    --sigil-context-menu-shadow-card-pushed: 0 4px 20px rgba(0, 0, 0, 0.5);
+    --sigil-context-menu-shadow-popover-inset: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+    --sigil-context-menu-blur-panel: 12px;
+
+    --sigil-context-menu-space-0: 0;
+    --sigil-context-menu-space-1: 1px;
+    --sigil-context-menu-space-2: 2px;
+    --sigil-context-menu-space-3: 3px;
+    --sigil-context-menu-space-4: 4px;
+    --sigil-context-menu-space-5: 5px;
+    --sigil-context-menu-space-6: 6px;
+    --sigil-context-menu-space-8: 8px;
+    --sigil-context-menu-space-10: 10px;
+    --sigil-context-menu-space-12: 12px;
+    --sigil-context-menu-space-18: 18px;
+    --sigil-context-menu-space-22: 22px;
+    --sigil-context-menu-space-24: 24px;
+    --sigil-context-menu-space-26: 26px;
+    --sigil-context-menu-space-28: 28px;
+    --sigil-context-menu-space-32: 32px;
+    --sigil-context-menu-space-44: 44px;
+    --sigil-context-menu-space-124: 124px;
+    --sigil-context-menu-space-168: 168px;
+    --sigil-context-menu-radius-3: var(--sigil-radius-scrollbar, var(--aos-control-compact-radius, 3px));
+    --sigil-context-menu-radius-4: var(--sigil-radius-control, var(--aos-control-compact-radius, 4px));
+    --sigil-context-menu-radius-5: var(--sigil-radius-popover, var(--aos-control-radius, 5px));
+    --sigil-context-menu-radius-6: var(--sigil-radius-group, var(--aos-control-radius, 6px));
+    --sigil-context-menu-radius-8: var(--sigil-radius-panel, var(--aos-panel-radius, 8px));
+}


### PR DESCRIPTION
Closes #330.

Depends on #329 for the ADR-001 decision doc being present on main; this branch keeps the implementation scope to the Sigil CSS theme extraction.

## Summary

- Adds `apps/sigil/theme/sigil-tokens.css` with Sigil context-menu `--sigil-*` visual override tokens and `--aos-*` fallbacks.
- Replaces the live context menu CSS hard-coded visual treatment with those `--sigil-*` tokens.
- Leaves toolkit `--aos-*` definitions, JS, bridge messages, and manifests untouched.

## Verification

- `node --test tests/toolkit/*.test.mjs`
- `bash tests/help-contract.sh`
- `rg -n "#[0-9a-fA-F]{3,8}|rgba?\(|\\b[0-9]+(?:\\.[0-9]+)?(?:px|rem|em|s)\\b" apps/sigil/context-menu/styles.css || true` returned no matches.
- `rg -n -- "--aos-[A-Za-z0-9_-]+\\s*:" apps/sigil || true` returned no matches.
