### PR TITLE
feat(zag): add adapter horizon

### DIFF
--- a/docs/dev/work-cards/zag-adapter-horizon-review-corrections.md
+++ b/docs/dev/work-cards/zag-adapter-horizon-review-corrections.md
@@ -1,0 +1,157 @@
+# Work Card: zag-adapter-horizon-review-corrections
+
+## Goal
+
+Fix the aggregate review findings on `gdi/zag-adapter-horizon` without
+rewriting the existing per-adapter checkpoint commits.
+
+This is a forward correction card. Add one or more new correction commits after
+`3c00784a3d4bc13492d53a105bf41097a4c42c86`; do not rebase, squash, or edit the
+adapter checkpoint history.
+
+## Review Status
+
+Foreman reviewed the completed Zag adapter horizon at:
+
+```text
+head_sha: 3c00784a3d4bc13492d53a105bf41097a4c42c86
+base_sha: b1514c13d6ca954a95d40c3b53b1c6e0bb05653e
+branch: gdi/zag-adapter-horizon
+```
+
+Deterministic verification:
+
+```bash
+node --test tests/toolkit/zag-adapter-*.test.mjs  # passed, 67/67
+node --test tests/toolkit/*.test.mjs              # passed, 899/899
+export checks for createAosZag<Adapter>           # all function
+```
+
+The branch is not accepted yet because `git diff --check` fails and several
+default bind selectors do not match the AOS data-part contract robustly.
+
+## Findings To Fix
+
+### 1. `git diff --check` fails
+
+Remove trailing whitespace reported by:
+
+```bash
+git diff --check b1514c13d6ca954a95d40c3b53b1c6e0bb05653e..HEAD
+```
+
+Current failures:
+
+```text
+packages/toolkit/adapters/zag/collapsible.js:34: trailing whitespace.
+packages/toolkit/adapters/zag/popover.js:50: trailing whitespace.
+packages/toolkit/adapters/zag/splitter.js:37: trailing whitespace.
+packages/toolkit/adapters/zag/tooltip.js:39: trailing whitespace.
+```
+
+### 2. Repeated-part selectors over-match or miss AOS data attrs
+
+`createZagAdapter.bind()` treats every function binding as a repeated binding
+and uses `selectors[part]` through `bindMany()`
+(`packages/toolkit/adapters/zag/shared.js`). That means broad selectors such as
+`[data-value]`, `[data-index]`, and `[data-id]` are not safe defaults for
+adapter parts.
+
+Concrete review probes:
+
+```text
+tabs: bindTriggers(root) returned 2 when the root contained one trigger and one
+content panel sharing data-value="a".
+
+accordion: bindItems(root) returned 3 when item, item-trigger, and item-content
+all shared data-value="a".
+
+slider: bindThumbs(root) returned 0 for markup with data-aos-slider-thumb.
+
+splitter: bindPanels(root) returned 0 for markup with data-aos-splitter-panel.
+```
+
+Fix the new horizon adapters so default repeated-part selectors use the AOS
+data-part attributes as the primary selector. Preserve existing value/id/index
+derivation inside the binding functions.
+
+At minimum, inspect and correct these selectors:
+
+- `packages/toolkit/adapters/zag/accordion.js`: `item`
+- `packages/toolkit/adapters/zag/tabs.js`: `trigger`
+- `packages/toolkit/adapters/zag/radio-group.js`: `item`
+- `packages/toolkit/adapters/zag/slider.js`: `thumb`
+- `packages/toolkit/adapters/zag/splitter.js`: `panel`
+- `packages/toolkit/adapters/zag/toggle-group.js`: `item`
+- `packages/toolkit/adapters/zag/tags-input.js`: `item`
+
+Do not change the pre-existing select/combobox `[data-value]` behavior in this
+card unless a focused regression proves it is also wrong for those adapters.
+
+### 3. Strengthen bind tests beyond `typeof`
+
+Several new tests currently call `adapter.bind(container)` and assert only that
+the adapter methods exist. Strengthen the tests so they would have caught the
+selector issues above.
+
+Add focused assertions that:
+
+- repeated-part helpers return the expected count for each part;
+- AOS data-part selectors are honored;
+- unrelated sibling parts with the same `data-value` are not bound as the wrong
+  part;
+- at least one concrete Zag-provided role/ARIA/id attribute appears on the
+  intended element after binding.
+
+Minimum scenarios:
+
+- tabs: one trigger and one content panel share `data-value="a"`;
+  `bindTriggers(root)` must return `1`, and `bindContents(root)` must return
+  `1`.
+- accordion: item, trigger, and content share `data-value="a"`;
+  each bind helper must return `1`.
+- slider: a thumb marked with `data-aos-slider-thumb` must be bound and receive
+  slider thumb props.
+- splitter: a panel marked with `data-aos-splitter-panel` must be bound.
+- radio-group, toggle-group, and tags-input should get analogous repeated-part
+  count assertions.
+
+## Boundaries
+
+- Do not adopt these adapters in surfaces.
+- Do not change bridge messages, manifests, or existing surface code.
+- Do not rewrite the prior checkpoint commits.
+- Keep correction commits narrow and reviewable.
+
+## Verification
+
+Run:
+
+```bash
+node --test tests/toolkit/zag-adapter-*.test.mjs
+node --test tests/toolkit/*.test.mjs
+git diff --check b1514c13d6ca954a95d40c3b53b1c6e0bb05653e..HEAD
+git status --short --branch
+```
+
+If the full toolkit suite creates `.playwright-cli/` trace files, remove that
+generated untracked directory before reporting completion.
+
+## Completion Report Format
+
+```text
+## Completion Report
+- profile: agentic_relay
+- horizon: zag-adapter-horizon
+- correction_card: docs/dev/work-cards/zag-adapter-horizon-review-corrections.md
+- branch: gdi/zag-adapter-horizon
+- prior_reviewed_head: 3c00784a3d4bc13492d53a105bf41097a4c42c86
+- new_head_sha: <git rev-parse HEAD>
+- correction_commits: <list sha + subject>
+- files_changed: <n>
+- tests_passed: <n>/<n>
+- diff_check: <passed|failed>
+- conflict_risk: <none|low|medium — list files if low or medium>
+- local_only_state: <none|dirty files/untracked/generated artifacts/runtime blockers, and whether related>
+- relay_action_required: hold_for_foreman_review
+```

--- a/packages/toolkit/adapters/zag/accordion.js
+++ b/packages/toolkit/adapters/zag/accordion.js
@@ -21,7 +21,7 @@ export function createAosZagAccordion(context = {}) {
     }),
     selectors: {
       root: '[data-aos-accordion-root]',
-      item: '[data-value]',
+      item: '[data-aos-accordion-item]',
       itemTrigger: '[data-aos-accordion-item-trigger]',
       itemContent: '[data-aos-accordion-item-content]',
     },

--- a/packages/toolkit/adapters/zag/accordion.js
+++ b/packages/toolkit/adapters/zag/accordion.js
@@ -1,0 +1,60 @@
+import { connect, machine } from '@zag-js/accordion';
+import { createZagAdapter, mergeProps } from './shared.js';
+
+export function createAosZagAccordion(context = {}) {
+  return createZagAdapter({
+    name: 'Accordion',
+    machine,
+    connect,
+    props: (ctx) => ({
+      id: ctx.id,
+      ids: ctx.ids,
+      getRootNode: ctx.getRootNode,
+      value: ctx.value,
+      defaultValue: ctx.defaultValue,
+      multiple: ctx.multiple,
+      collapsible: ctx.collapsible,
+      orientation: ctx.orientation,
+      dir: ctx.dir,
+      onValueChange: ctx.onValueChange,
+      onFocusChange: ctx.onFocusChange,
+    }),
+    selectors: {
+      root: '[data-aos-accordion-root]',
+      item: '[data-value]',
+      itemTrigger: '[data-aos-accordion-item-trigger]',
+      itemContent: '[data-aos-accordion-item-content]',
+    },
+    snapshot: (api, service) => ({
+      api,
+      service: service.service,
+      value: api.value,
+      focusedValue: api.focusedValue,
+      state: service.service.state.get(),
+      send: service.send,
+      getRootProps: (extra = {}) => mergeProps(api.getRootProps(), extra),
+      getItemProps: (props, extra = {}) => mergeProps(api.getItemProps(props), extra),
+      getItemTriggerProps: (props, extra = {}) => mergeProps(api.getItemTriggerProps(props), extra),
+      getItemContentProps: (props, extra = {}) => mergeProps(api.getItemContentProps(props), extra),
+      setValue: api.setValue,
+    }),
+    bindings: {
+      root: { alias: 'Root', getter: 'getRootProps' },
+      item: ({ api, element, extraProps, index }) => {
+        const value = extraProps.value || element?.dataset?.value || element?.dataset?.id || element?.id || `item-${index}`;
+        return { key: value, props: mergeProps(api.getItemProps({ value }), extraProps.extra || {}) };
+      },
+      itemTrigger: ({ api, element, extraProps, index }) => {
+        const value = extraProps.value || element?.dataset?.value || element?.dataset?.id || element?.id || `itemTrigger-${index}`;
+        return { key: value, props: mergeProps(api.getItemTriggerProps({ value }), extraProps.extra || {}) };
+      },
+      itemContent: ({ api, element, extraProps, index }) => {
+        const value = extraProps.value || element?.dataset?.value || element?.dataset?.id || element?.id || `itemContent-${index}`;
+        return { key: value, props: mergeProps(api.getItemContentProps({ value }), extraProps.extra || {}) };
+      },
+    },
+    actions: {
+      setValue: (api, value) => api.setValue(value),
+    },
+  }, context);
+}

--- a/packages/toolkit/adapters/zag/collapsible.js
+++ b/packages/toolkit/adapters/zag/collapsible.js
@@ -1,0 +1,47 @@
+import { connect, machine } from '@zag-js/collapsible';
+import { createZagAdapter, mergeProps } from './shared.js';
+
+export function createAosZagCollapsible(context = {}) {
+  return createZagAdapter({
+    name: 'Collapsible',
+    machine,
+    connect,
+    props: (ctx) => ({
+      id: ctx.id,
+      ids: ctx.ids,
+      getRootNode: ctx.getRootNode,
+      open: ctx.open,
+      defaultOpen: ctx.defaultOpen,
+      disabled: ctx.disabled,
+      onOpenChange: ctx.onOpenChange,
+      onExitComplete: ctx.onExitComplete,
+    }),
+    selectors: {
+      root: '[data-aos-collapsible-root]',
+      trigger: '[data-aos-collapsible-trigger]',
+      content: '[data-aos-collapsible-content]',
+    },
+    snapshot: (api, service) => ({
+      api,
+      service: service.service,
+      open: api.open,
+      state: service.service.state.get(),
+      send: service.send,
+      getRootProps: (extra = {}) => mergeProps(api.getRootProps(), extra),
+      getTriggerProps: (extra = {}) => mergeProps(api.getTriggerProps(), extra),
+      getContentProps: (extra = {}) => mergeProps(api.getContentProps(), extra),
+
+      
+    }),
+    bindings: {
+      root: { alias: 'Root', getter: 'getRootProps' },
+      trigger: { alias: 'Trigger', getter: 'getTriggerProps' },
+      content: { alias: 'Content', getter: 'getContentProps' },
+
+    },
+    actions: {
+      open: (api) => api.setOpen(true),
+      close: (api) => api.setOpen(false),
+    },
+  }, context);
+}

--- a/packages/toolkit/adapters/zag/collapsible.js
+++ b/packages/toolkit/adapters/zag/collapsible.js
@@ -30,14 +30,11 @@ export function createAosZagCollapsible(context = {}) {
       getRootProps: (extra = {}) => mergeProps(api.getRootProps(), extra),
       getTriggerProps: (extra = {}) => mergeProps(api.getTriggerProps(), extra),
       getContentProps: (extra = {}) => mergeProps(api.getContentProps(), extra),
-
-      
     }),
     bindings: {
       root: { alias: 'Root', getter: 'getRootProps' },
       trigger: { alias: 'Trigger', getter: 'getTriggerProps' },
       content: { alias: 'Content', getter: 'getContentProps' },
-
     },
     actions: {
       open: (api) => api.setOpen(true),

--- a/packages/toolkit/adapters/zag/dialog.js
+++ b/packages/toolkit/adapters/zag/dialog.js
@@ -1,0 +1,65 @@
+import { connect, machine } from '@zag-js/dialog';
+import { createZagAdapter, mergeProps } from './shared.js';
+
+export function createAosZagDialog(context = {}) {
+  return createZagAdapter({
+    name: 'Dialog',
+    machine,
+    connect,
+    props: (ctx) => ({
+      id: ctx.id,
+      ids: ctx.ids,
+      getRootNode: ctx.getRootNode,
+      open: ctx.open,
+      defaultOpen: ctx.defaultOpen,
+      modal: ctx.modal,
+      preventScroll: ctx.preventScroll,
+      closeOnEscape: ctx.closeOnEscape,
+      closeOnInteractOutside: ctx.closeOnInteractOutside,
+      initialFocusEl: ctx.initialFocusEl,
+      finalFocusEl: ctx.finalFocusEl,
+      onOpenChange: ctx.onOpenChange,
+      onEscapeKeyDown: ctx.onEscapeKeyDown,
+      onInteractOutside: ctx.onInteractOutside,
+      onPointerDownOutside: ctx.onPointerDownOutside,
+      onFocusOutside: ctx.onFocusOutside,
+    }),
+    selectors: {
+      trigger: '[data-aos-dialog-trigger]',
+      backdrop: '[data-aos-dialog-backdrop]',
+      positioner: '[data-aos-dialog-positioner]',
+      content: '[data-aos-dialog-content]',
+      title: '[data-aos-dialog-title]',
+      description: '[data-aos-dialog-description]',
+      closeTrigger: '[data-aos-dialog-close-trigger]',
+    },
+    snapshot: (api, service) => ({
+      api,
+      service: service.service,
+      open: api.open,
+      state: service.service.state.get(),
+      send: service.send,
+      getTriggerProps: (extra = {}) => mergeProps(api.getTriggerProps(), extra),
+      getBackdropProps: (extra = {}) => mergeProps(api.getBackdropProps(), extra),
+      getPositionerProps: (extra = {}) => mergeProps(api.getPositionerProps(), extra),
+      getContentProps: (extra = {}) => mergeProps(api.getContentProps(), extra),
+      getTitleProps: (extra = {}) => mergeProps(api.getTitleProps(), extra),
+      getDescriptionProps: (extra = {}) => mergeProps(api.getDescriptionProps(), extra),
+      getCloseTriggerProps: (extra = {}) => mergeProps(api.getCloseTriggerProps(), extra),
+      setOpen: api.setOpen,
+    }),
+    bindings: {
+      trigger: { alias: 'Trigger', getter: 'getTriggerProps' },
+      backdrop: { alias: 'Backdrop', getter: 'getBackdropProps' },
+      positioner: { alias: 'Positioner', getter: 'getPositionerProps' },
+      content: { alias: 'Content', getter: 'getContentProps' },
+      title: { alias: 'Title', getter: 'getTitleProps' },
+      description: { alias: 'Description', getter: 'getDescriptionProps' },
+      closeTrigger: { alias: 'CloseTrigger', getter: 'getCloseTriggerProps' },
+    },
+    actions: {
+      open: (api) => api.setOpen(true),
+      close: (api) => api.setOpen(false),
+    },
+  }, context);
+}

--- a/packages/toolkit/adapters/zag/editable.js
+++ b/packages/toolkit/adapters/zag/editable.js
@@ -1,0 +1,68 @@
+import { connect, machine } from '@zag-js/editable';
+import { createZagAdapter, mergeProps } from './shared.js';
+
+export function createAosZagEditable(context = {}) {
+  return createZagAdapter({
+    name: 'Editable',
+    machine,
+    connect,
+    props: (ctx) => ({
+      id: ctx.id,
+      ids: ctx.ids,
+      getRootNode: ctx.getRootNode,
+      value: ctx.value,
+      defaultValue: ctx.defaultValue,
+      placeholder: ctx.placeholder,
+      activationMode: ctx.activationMode,
+      autoResize: ctx.autoResize,
+      disabled: ctx.disabled,
+      readOnly: ctx.readOnly,
+      invalid: ctx.invalid,
+      maxLength: ctx.maxLength,
+      name: ctx.name,
+      form: ctx.form,
+      selectOnFocus: ctx.selectOnFocus,
+      submitMode: ctx.submitMode,
+      translations: ctx.translations,
+      onValueChange: ctx.onValueChange,
+      onValueCommit: ctx.onValueCommit,
+      onValueRevert: ctx.onValueRevert,
+      onEditChange: ctx.onEditChange,
+    }),
+    selectors: {
+      root: '[data-aos-editable-root]',
+      preview: '[data-aos-editable-preview]',
+      input: '[data-aos-editable-input]',
+      editTrigger: '[data-aos-editable-edit-trigger]',
+      submitTrigger: '[data-aos-editable-submit-trigger]',
+      cancelTrigger: '[data-aos-editable-cancel-trigger]',
+    },
+    snapshot: (api, service) => ({
+      api,
+      service: service.service,
+      value: api.value,
+      editing: api.editing,
+      state: service.service.state.get(),
+      send: service.send,
+      getRootProps: (extra = {}) => mergeProps(api.getRootProps(), extra),
+      getPreviewProps: (extra = {}) => mergeProps(api.getPreviewProps(), extra),
+      getInputProps: (extra = {}) => mergeProps(api.getInputProps(), extra),
+      getEditTriggerProps: (extra = {}) => mergeProps(api.getEditTriggerProps(), extra),
+      getSubmitTriggerProps: (extra = {}) => mergeProps(api.getSubmitTriggerProps(), extra),
+      getCancelTriggerProps: (extra = {}) => mergeProps(api.getCancelTriggerProps(), extra),
+      setValue: api.setValue,
+    }),
+    bindings: {
+      root: { alias: 'Root', getter: 'getRootProps' },
+      preview: { alias: 'Preview', getter: 'getPreviewProps' },
+      input: { alias: 'Input', getter: 'getInputProps' },
+      editTrigger: { alias: 'EditTrigger', getter: 'getEditTriggerProps' },
+      submitTrigger: { alias: 'SubmitTrigger', getter: 'getSubmitTriggerProps' },
+      cancelTrigger: { alias: 'CancelTrigger', getter: 'getCancelTriggerProps' },
+
+    },
+    actions: {
+      setValue: (api, value) => api.setValue(value),
+    },
+  }, context);
+}

--- a/packages/toolkit/adapters/zag/index.js
+++ b/packages/toolkit/adapters/zag/index.js
@@ -11,3 +11,18 @@ export {
 export {
   createAosZagCombobox,
 } from './combobox.js';
+
+export { createAosZagDialog } from './dialog.js';
+export { createAosZagTooltip } from './tooltip.js';
+export { createAosZagPopover } from './popover.js';
+export { createAosZagTabs } from './tabs.js';
+export { createAosZagAccordion } from './accordion.js';
+export { createAosZagCollapsible } from './collapsible.js';
+export { createAosZagSplitter } from './splitter.js';
+export { createAosZagSlider } from './slider.js';
+export { createAosZagNumberInput } from './number-input.js';
+export { createAosZagToggleGroup } from './toggle-group.js';
+export { createAosZagRadioGroup } from './radio-group.js';
+export { createAosZagSwitch } from './switch.js';
+export { createAosZagEditable } from './editable.js';
+export { createAosZagTagsInput } from './tags-input.js';

--- a/packages/toolkit/adapters/zag/number-input.js
+++ b/packages/toolkit/adapters/zag/number-input.js
@@ -1,0 +1,68 @@
+import { connect, machine } from '@zag-js/number-input';
+import { createZagAdapter, mergeProps } from './shared.js';
+
+export function createAosZagNumberInput(context = {}) {
+  return createZagAdapter({
+    name: 'NumberInput',
+    machine,
+    connect,
+    props: (ctx) => ({
+      id: ctx.id,
+      ids: ctx.ids,
+      getRootNode: ctx.getRootNode,
+      value: ctx.value,
+      defaultValue: ctx.defaultValue,
+      min: ctx.min,
+      max: ctx.max,
+      step: ctx.step,
+      largeStep: ctx.largeStep,
+      allowMouseWheel: ctx.allowMouseWheel,
+      clampValueOnBlur: ctx.clampValueOnBlur,
+      focusInputOnChange: ctx.focusInputOnChange,
+      formatOptions: ctx.formatOptions,
+      locale: ctx.locale,
+      name: ctx.name,
+      form: ctx.form,
+      disabled: ctx.disabled,
+      readOnly: ctx.readOnly,
+      invalid: ctx.invalid,
+      required: ctx.required,
+      onValueChange: ctx.onValueChange,
+      onFocusChange: ctx.onFocusChange,
+    }),
+    selectors: {
+      root: '[data-aos-number-input-root]',
+      label: '[data-aos-number-input-label]',
+      input: '[data-aos-number-input-input]',
+      incrementTrigger: '[data-aos-number-input-increment-trigger]',
+      decrementTrigger: '[data-aos-number-input-decrement-trigger]',
+    },
+    snapshot: (api, service) => ({
+      api,
+      service: service.service,
+      value: api.value,
+      valueAsNumber: api.valueAsNumber,
+      focused: api.focused,
+      state: service.service.state.get(),
+      send: service.send,
+      getRootProps: (extra = {}) => mergeProps(api.getRootProps(), extra),
+      getLabelProps: (extra = {}) => mergeProps(api.getLabelProps(), extra),
+      getInputProps: (extra = {}) => mergeProps(api.getInputProps(), extra),
+      getIncrementTriggerProps: (extra = {}) => mergeProps(api.getIncrementTriggerProps(), extra),
+      getDecrementTriggerProps: (extra = {}) => mergeProps(api.getDecrementTriggerProps(), extra),
+
+      setValue: api.setValue,
+    }),
+    bindings: {
+      root: { alias: 'Root', getter: 'getRootProps' },
+      label: { alias: 'Label', getter: 'getLabelProps' },
+      input: { alias: 'Input', getter: 'getInputProps' },
+      incrementTrigger: { alias: 'IncrementTrigger', getter: 'getIncrementTriggerProps' },
+      decrementTrigger: { alias: 'DecrementTrigger', getter: 'getDecrementTriggerProps' },
+
+    },
+    actions: {
+      setValue: (api, value) => api.setValue(value),
+    },
+  }, context);
+}

--- a/packages/toolkit/adapters/zag/popover.js
+++ b/packages/toolkit/adapters/zag/popover.js
@@ -1,0 +1,67 @@
+import { connect, machine } from '@zag-js/popover';
+import { createZagAdapter, mergeProps } from './shared.js';
+
+export function createAosZagPopover(context = {}) {
+  return createZagAdapter({
+    name: 'Popover',
+    machine,
+    connect,
+    props: (ctx) => ({
+      id: ctx.id,
+      ids: ctx.ids,
+      getRootNode: ctx.getRootNode,
+      open: ctx.open,
+      defaultOpen: ctx.defaultOpen,
+      modal: ctx.modal,
+      portalled: ctx.portalled,
+      autoFocus: ctx.autoFocus,
+      closeOnEscape: ctx.closeOnEscape,
+      closeOnInteractOutside: ctx.closeOnInteractOutside,
+      positioning: ctx.positioning,
+      onOpenChange: ctx.onOpenChange,
+      onEscapeKeyDown: ctx.onEscapeKeyDown,
+      onInteractOutside: ctx.onInteractOutside,
+      onPointerDownOutside: ctx.onPointerDownOutside,
+      onFocusOutside: ctx.onFocusOutside,
+    }),
+    selectors: {
+      trigger: '[data-aos-popover-trigger]',
+      anchor: '[data-aos-popover-anchor]',
+      positioner: '[data-aos-popover-positioner]',
+      content: '[data-aos-popover-content]',
+      title: '[data-aos-popover-title]',
+      description: '[data-aos-popover-description]',
+      closeTrigger: '[data-aos-popover-close-trigger]',
+    },
+    snapshot: (api, service) => ({
+      api,
+      service: service.service,
+      open: api.open,
+      state: service.service.state.get(),
+      send: service.send,
+      getTriggerProps: (extra = {}) => mergeProps(api.getTriggerProps(), extra),
+      getAnchorProps: (extra = {}) => mergeProps(api.getAnchorProps(), extra),
+      getPositionerProps: (extra = {}) => mergeProps(api.getPositionerProps(), extra),
+      getContentProps: (extra = {}) => mergeProps(api.getContentProps(), extra),
+      getTitleProps: (extra = {}) => mergeProps(api.getTitleProps(), extra),
+      getDescriptionProps: (extra = {}) => mergeProps(api.getDescriptionProps(), extra),
+      getCloseTriggerProps: (extra = {}) => mergeProps(api.getCloseTriggerProps(), extra),
+
+      
+    }),
+    bindings: {
+      trigger: { alias: 'Trigger', getter: 'getTriggerProps' },
+      anchor: { alias: 'Anchor', getter: 'getAnchorProps' },
+      positioner: { alias: 'Positioner', getter: 'getPositionerProps' },
+      content: { alias: 'Content', getter: 'getContentProps' },
+      title: { alias: 'Title', getter: 'getTitleProps' },
+      description: { alias: 'Description', getter: 'getDescriptionProps' },
+      closeTrigger: { alias: 'CloseTrigger', getter: 'getCloseTriggerProps' },
+
+    },
+    actions: {
+      open: (api) => api.setOpen(true),
+      close: (api) => api.setOpen(false),
+    },
+  }, context);
+}

--- a/packages/toolkit/adapters/zag/popover.js
+++ b/packages/toolkit/adapters/zag/popover.js
@@ -46,8 +46,6 @@ export function createAosZagPopover(context = {}) {
       getTitleProps: (extra = {}) => mergeProps(api.getTitleProps(), extra),
       getDescriptionProps: (extra = {}) => mergeProps(api.getDescriptionProps(), extra),
       getCloseTriggerProps: (extra = {}) => mergeProps(api.getCloseTriggerProps(), extra),
-
-      
     }),
     bindings: {
       trigger: { alias: 'Trigger', getter: 'getTriggerProps' },

--- a/packages/toolkit/adapters/zag/radio-group.js
+++ b/packages/toolkit/adapters/zag/radio-group.js
@@ -1,0 +1,66 @@
+import { connect, machine } from '@zag-js/radio-group';
+import { createZagAdapter, mergeProps } from './shared.js';
+
+export function createAosZagRadioGroup(context = {}) {
+  return createZagAdapter({
+    name: 'RadioGroup',
+    machine,
+    connect,
+    props: (ctx) => ({
+      id: ctx.id,
+      ids: ctx.ids,
+      getRootNode: ctx.getRootNode,
+      value: ctx.value,
+      defaultValue: ctx.defaultValue,
+      name: ctx.name,
+      form: ctx.form,
+      orientation: ctx.orientation,
+      dir: ctx.dir,
+      disabled: ctx.disabled,
+      readOnly: ctx.readOnly,
+      invalid: ctx.invalid,
+      required: ctx.required,
+      onValueChange: ctx.onValueChange,
+    }),
+    selectors: {
+      root: '[data-aos-radio-group-root]',
+      label: '[data-aos-radio-group-label]',
+      item: '[data-value]',
+      radio: '[data-aos-radio-group-radio]',
+      radioControl: '[data-aos-radio-group-radio-control]',
+    },
+    snapshot: (api, service) => ({
+      api,
+      service: service.service,
+      value: api.value,
+      state: service.service.state.get(),
+      send: service.send,
+      getRootProps: (extra = {}) => mergeProps(api.getRootProps(), extra),
+      getLabelProps: (extra = {}) => mergeProps(api.getLabelProps(), extra),
+      getItemProps: (props, extra = {}) => mergeProps(api.getItemProps(props), extra),
+      getRadioProps: (props, extra = {}) => mergeProps(api.getItemProps(props), extra),
+      getItemControlProps: (props, extra = {}) => mergeProps(api.getItemControlProps(props), extra),
+      getRadioControlProps: (props, extra = {}) => mergeProps(api.getItemControlProps(props), extra),
+      setValue: api.setValue,
+    }),
+    bindings: {
+      root: { alias: 'Root', getter: 'getRootProps' },
+      label: { alias: 'Label', getter: 'getLabelProps' },
+      item: ({ api, element, extraProps, index }) => {
+        const value = extraProps.value || element?.dataset?.value || element?.dataset?.id || element?.id || `item-${index}`;
+        return { key: value, props: mergeProps(api.getItemProps({ value }), extraProps.extra || {}) };
+      },
+      radio: ({ api, element, extraProps, index }) => {
+        const value = extraProps.value || element?.dataset?.value || element?.dataset?.id || element?.id || `radio-${index}`;
+        return { key: value, props: mergeProps(api.getItemProps({ value }), extraProps.extra || {}) };
+      },
+      radioControl: ({ api, element, extraProps, index }) => {
+        const value = extraProps.value || element?.dataset?.value || element?.dataset?.id || element?.id || `radioControl-${index}`;
+        return { key: value, props: mergeProps(api.getItemControlProps({ value }), extraProps.extra || {}) };
+      },
+    },
+    actions: {
+      setValue: (api, value) => api.setValue(value),
+    },
+  }, context);
+}

--- a/packages/toolkit/adapters/zag/radio-group.js
+++ b/packages/toolkit/adapters/zag/radio-group.js
@@ -25,7 +25,7 @@ export function createAosZagRadioGroup(context = {}) {
     selectors: {
       root: '[data-aos-radio-group-root]',
       label: '[data-aos-radio-group-label]',
-      item: '[data-value]',
+      item: '[data-aos-radio-group-item]',
       radio: '[data-aos-radio-group-radio]',
       radioControl: '[data-aos-radio-group-radio-control]',
     },

--- a/packages/toolkit/adapters/zag/shared.js
+++ b/packages/toolkit/adapters/zag/shared.js
@@ -1,0 +1,177 @@
+import {
+  VanillaMachine,
+  mergeProps,
+  normalizeProps,
+  spreadProps as zagSpreadProps,
+} from './vendor/menu-runtime.mjs';
+
+export function compactProps(props = {}) {
+  return Object.fromEntries(
+    Object.entries(props).filter(([, value]) => value !== undefined)
+  );
+}
+
+export function setDatasetFlag(element, name, enabled) {
+  if (!element?.dataset) return;
+  if (enabled) element.dataset[name] = '';
+  else delete element.dataset[name];
+}
+
+export function valueForElement(element, index = 0) {
+  return element?.dataset?.value
+    || element?.getAttribute?.('data-value')
+    || element?.value
+    || element?.id
+    || `item-${index}`;
+}
+
+export function applyProps(element, props, machineId) {
+  if (!element) return () => {};
+  return zagSpreadProps(element, props, machineId);
+}
+
+function defaultSnapshot(api, service) {
+  return {
+    api,
+    service: service.service,
+    state: service.service.state.get(),
+    send: service.send,
+  };
+}
+
+export function createZagAdapter(config, context = {}) {
+  const {
+    name,
+    machine,
+    connect,
+    props,
+    selectors = {},
+    bindings,
+    snapshot = defaultSnapshot,
+    actions = {},
+    validate,
+  } = config;
+  const { id } = context;
+
+  if (!id) throw new Error(`createAosZag${name} requires an id`);
+  validate?.(context);
+
+  let currentProps = compactProps(props(context));
+  let currentOnStateChange = context.onStateChange;
+  const service = new VanillaMachine(machine, () => currentProps);
+  const cleanups = new Set();
+
+  function api() {
+    return connect(service.service, normalizeProps);
+  }
+
+  function getSnapshot() {
+    return snapshot(api(), service, currentProps);
+  }
+
+  function notify() {
+    currentOnStateChange?.(getSnapshot());
+  }
+
+  service.start();
+  const unsubscribe = service.subscribe(notify);
+
+  function update(nextContext = {}) {
+    currentOnStateChange = nextContext.onStateChange ?? currentOnStateChange;
+    currentProps = compactProps({
+      ...currentProps,
+      ...nextContext,
+      positioning: nextContext.positioning
+        ? {
+            ...(currentProps.positioning || {}),
+            ...nextContext.positioning,
+          }
+        : currentProps.positioning,
+    });
+    delete currentProps.onStateChange;
+    for (const key of Object.keys(selectors)) delete currentProps[key];
+    service.updateProps(() => currentProps);
+    return getSnapshot();
+  }
+
+  function cleanupBindings() {
+    for (const cleanup of cleanups) cleanup();
+    cleanups.clear();
+  }
+
+  function bindPart(part, element, extraProps = {}, index = 0) {
+    const binding = bindings[part];
+    if (!binding) throw new Error(`Unknown Zag ${name} binding: ${part}`);
+    const result = typeof binding === 'function' ? binding({
+      adapter: publicApi,
+      api: api(),
+      currentProps,
+      element,
+      extraProps,
+      id,
+      index,
+    }) : {
+      props: api()[binding.getter](extraProps),
+    };
+    const cleanup = applyProps(element, result.props, `${id}:${part}:${result.key ?? index}`);
+    const wrappedCleanup = () => {
+      result.cleanup?.();
+      cleanup();
+    };
+    cleanups.add(wrappedCleanup);
+    return cleanup;
+  }
+
+  function bindMany(root, part, selector = selectors[part], getProps = null) {
+    const elements = Array.from(root?.querySelectorAll?.(selector) || []);
+    elements.forEach((element, index) => bindPart(part, element, getProps?.(element, index) || {}, index));
+    return elements.length;
+  }
+
+  function bind(root, options = {}) {
+    cleanupBindings();
+    for (const [part, binding] of Object.entries(bindings)) {
+      if (binding.many || typeof binding === 'function') {
+        bindMany(root, part, options[`${part}Selector`] || selectors[part], options[`get${binding.alias || part}Props`] || null);
+        continue;
+      }
+      const element = options[part]
+        || (selectors[part] ? root?.querySelector?.(selectors[part]) : null)
+        || (binding.root ? root : null);
+      bindPart(part, element, options[`${part}Props`] || {});
+    }
+    return getSnapshot();
+  }
+
+  const publicApi = {
+    bind,
+    bindMany,
+    cleanupBindings,
+    connect: getSnapshot,
+    destroy() {
+      cleanupBindings();
+      unsubscribe?.();
+      service.stop();
+    },
+    send: service.send,
+    service: service.service,
+    spreadProps: applyProps,
+    update,
+  };
+
+  for (const [part, binding] of Object.entries(bindings)) {
+    const suffix = binding.alias || part[0].toUpperCase() + part.slice(1);
+    publicApi[`bind${suffix}`] = (element, extraProps = {}, index = 0) => bindPart(part, element, extraProps, index);
+    if (binding.many || typeof binding === 'function') {
+      publicApi[`bind${suffix}s`] = (root, selector = selectors[part], getProps = null) => bindMany(root, part, selector, getProps);
+    }
+  }
+
+  for (const [actionName, action] of Object.entries(actions)) {
+    publicApi[actionName] = (...args) => action(api(), ...args) ?? getSnapshot();
+  }
+
+  return publicApi;
+}
+
+export { mergeProps, normalizeProps };

--- a/packages/toolkit/adapters/zag/slider.js
+++ b/packages/toolkit/adapters/zag/slider.js
@@ -1,0 +1,72 @@
+import { connect, machine } from '@zag-js/slider';
+import { createZagAdapter, mergeProps } from './shared.js';
+
+export function createAosZagSlider(context = {}) {
+  return createZagAdapter({
+    name: 'Slider',
+    machine,
+    connect,
+    props: (ctx) => ({
+      id: ctx.id,
+      ids: ctx.ids,
+      getRootNode: ctx.getRootNode,
+      value: ctx.value,
+      defaultValue: ctx.defaultValue,
+      min: ctx.min,
+      max: ctx.max,
+      step: ctx.step,
+      minStepsBetweenThumbs: ctx.minStepsBetweenThumbs,
+      orientation: ctx.orientation,
+      dir: ctx.dir,
+      disabled: ctx.disabled,
+      readOnly: ctx.readOnly,
+      invalid: ctx.invalid,
+      name: ctx.name,
+      form: ctx.form,
+      getAriaValueText: ctx.getAriaValueText,
+      onValueChange: ctx.onValueChange,
+      onValueChangeEnd: ctx.onValueChangeEnd,
+    }),
+    selectors: {
+      root: '[data-aos-slider-root]',
+      label: '[data-aos-slider-label]',
+      control: '[data-aos-slider-control]',
+      track: '[data-aos-slider-track]',
+      range: '[data-aos-slider-range]',
+      output: '[data-aos-slider-output]',
+      thumb: '[data-index]',
+    },
+    snapshot: (api, service) => ({
+      api,
+      service: service.service,
+      value: api.value,
+      focused: api.focused,
+      state: service.service.state.get(),
+      send: service.send,
+      getRootProps: (extra = {}) => mergeProps(api.getRootProps(), extra),
+      getLabelProps: (extra = {}) => mergeProps(api.getLabelProps(), extra),
+      getControlProps: (extra = {}) => mergeProps(api.getControlProps(), extra),
+      getTrackProps: (extra = {}) => mergeProps(api.getTrackProps(), extra),
+      getRangeProps: (extra = {}) => mergeProps(api.getRangeProps(), extra),
+      getValueTextProps: (extra = {}) => mergeProps(api.getValueTextProps(), extra),
+      getOutputProps: (extra = {}) => mergeProps(api.getValueTextProps(), extra),
+      getThumbProps: (props, extra = {}) => mergeProps(api.getThumbProps(props), extra),
+      setValue: api.setValue,
+    }),
+    bindings: {
+      root: { alias: 'Root', getter: 'getRootProps' },
+      label: { alias: 'Label', getter: 'getLabelProps' },
+      control: { alias: 'Control', getter: 'getControlProps' },
+      track: { alias: 'Track', getter: 'getTrackProps' },
+      range: { alias: 'Range', getter: 'getRangeProps' },
+      output: { alias: 'Output', getter: 'getValueTextProps' },
+      thumb: ({ api, element, extraProps, index }) => {
+        const value = extraProps.value || element?.dataset?.value || element?.dataset?.id || element?.id || `thumb-${index}`;
+        return { key: value, props: mergeProps(api.getThumbProps({ index }), extraProps.extra || {}) };
+      },
+    },
+    actions: {
+      setValue: (api, value) => api.setValue(value),
+    },
+  }, context);
+}

--- a/packages/toolkit/adapters/zag/slider.js
+++ b/packages/toolkit/adapters/zag/slider.js
@@ -34,7 +34,7 @@ export function createAosZagSlider(context = {}) {
       track: '[data-aos-slider-track]',
       range: '[data-aos-slider-range]',
       output: '[data-aos-slider-output]',
-      thumb: '[data-index]',
+      thumb: '[data-aos-slider-thumb]',
     },
     snapshot: (api, service) => ({
       api,

--- a/packages/toolkit/adapters/zag/splitter.js
+++ b/packages/toolkit/adapters/zag/splitter.js
@@ -1,0 +1,54 @@
+import { connect, machine } from '@zag-js/splitter';
+import { createZagAdapter, mergeProps } from './shared.js';
+
+export function createAosZagSplitter(context = {}) {
+  return createZagAdapter({
+    name: 'Splitter',
+    machine,
+    connect,
+    props: (ctx) => ({
+      id: ctx.id,
+      ids: ctx.ids,
+      getRootNode: ctx.getRootNode,
+      panels: ctx.panels,
+      orientation: ctx.orientation,
+      dir: ctx.dir,
+      size: ctx.size,
+      defaultSize: ctx.defaultSize,
+      onSizeChange: ctx.onSizeChange,
+      onSizeChangeEnd: ctx.onSizeChangeEnd,
+    }),
+    selectors: {
+      root: '[data-aos-splitter-root]',
+      panel: '[data-id]',
+      resizeTrigger: '[data-aos-splitter-resize-trigger]',
+    },
+    snapshot: (api, service) => ({
+      api,
+      service: service.service,
+      panels: api.panels,
+      state: service.service.state.get(),
+      send: service.send,
+      getRootProps: (extra = {}) => mergeProps(api.getRootProps(), extra),
+      getPanelProps: (props, extra = {}) => mergeProps(api.getPanelProps(props), extra),
+      getResizeTriggerProps: (props, extra = {}) => mergeProps(api.getResizeTriggerProps(props), extra),
+      getSizes: api.getSizes,
+      setSizes: api.setSizes,
+      
+    }),
+    bindings: {
+      root: { alias: 'Root', getter: 'getRootProps' },
+      panel: ({ api, element, extraProps, index }) => {
+        const value = extraProps.value || element?.dataset?.value || element?.dataset?.id || element?.id || `panel-${index}`;
+        return { key: value, props: mergeProps(api.getPanelProps({ id: value }), extraProps.extra || {}) };
+      },
+      resizeTrigger: ({ api, element, extraProps, index }) => {
+        const value = extraProps.value || element?.dataset?.value || element?.dataset?.id || element?.id || 'a:b';
+        return { key: value, props: mergeProps(api.getResizeTriggerProps({ id: value }), extraProps.extra || {}) };
+      },
+    },
+    actions: {
+
+    },
+  }, context);
+}

--- a/packages/toolkit/adapters/zag/splitter.js
+++ b/packages/toolkit/adapters/zag/splitter.js
@@ -20,7 +20,7 @@ export function createAosZagSplitter(context = {}) {
     }),
     selectors: {
       root: '[data-aos-splitter-root]',
-      panel: '[data-id]',
+      panel: '[data-aos-splitter-panel]',
       resizeTrigger: '[data-aos-splitter-resize-trigger]',
     },
     snapshot: (api, service) => ({
@@ -34,7 +34,6 @@ export function createAosZagSplitter(context = {}) {
       getResizeTriggerProps: (props, extra = {}) => mergeProps(api.getResizeTriggerProps(props), extra),
       getSizes: api.getSizes,
       setSizes: api.setSizes,
-      
     }),
     bindings: {
       root: { alias: 'Root', getter: 'getRootProps' },

--- a/packages/toolkit/adapters/zag/switch.js
+++ b/packages/toolkit/adapters/zag/switch.js
@@ -1,0 +1,57 @@
+import { connect, machine } from '@zag-js/switch';
+import { createZagAdapter, mergeProps } from './shared.js';
+
+export function createAosZagSwitch(context = {}) {
+  return createZagAdapter({
+    name: 'Switch',
+    machine,
+    connect,
+    props: (ctx) => ({
+      id: ctx.id,
+      ids: ctx.ids,
+      getRootNode: ctx.getRootNode,
+      checked: ctx.checked,
+      defaultChecked: ctx.defaultChecked,
+      name: ctx.name,
+      form: ctx.form,
+      value: ctx.value,
+      disabled: ctx.disabled,
+      readOnly: ctx.readOnly,
+      invalid: ctx.invalid,
+      required: ctx.required,
+      onCheckedChange: ctx.onCheckedChange,
+    }),
+    selectors: {
+      root: '[data-aos-switch-root]',
+      label: '[data-aos-switch-label]',
+      control: '[data-aos-switch-control]',
+      thumb: '[data-aos-switch-thumb]',
+      hiddenInput: '[data-aos-switch-hidden-input]',
+    },
+    snapshot: (api, service) => ({
+      api,
+      service: service.service,
+      checked: api.checked,
+      focused: api.focused,
+      state: service.service.state.get(),
+      send: service.send,
+      getRootProps: (extra = {}) => mergeProps(api.getRootProps(), extra),
+      getLabelProps: (extra = {}) => mergeProps(api.getLabelProps(), extra),
+      getControlProps: (extra = {}) => mergeProps(api.getControlProps(), extra),
+      getThumbProps: (extra = {}) => mergeProps(api.getThumbProps(), extra),
+      getHiddenInputProps: (extra = {}) => mergeProps(api.getHiddenInputProps(), extra),
+      setChecked: api.setChecked,
+    }),
+    bindings: {
+      root: { alias: 'Root', getter: 'getRootProps' },
+      label: { alias: 'Label', getter: 'getLabelProps' },
+      control: { alias: 'Control', getter: 'getControlProps' },
+      thumb: { alias: 'Thumb', getter: 'getThumbProps' },
+      hiddenInput: { alias: 'HiddenInput', getter: 'getHiddenInputProps' },
+
+    },
+    actions: {
+      setChecked: (api, checked) => api.setChecked(checked),
+    },
+  }, context);
+}

--- a/packages/toolkit/adapters/zag/tabs.js
+++ b/packages/toolkit/adapters/zag/tabs.js
@@ -1,0 +1,60 @@
+import { connect, machine } from '@zag-js/tabs';
+import { createZagAdapter, mergeProps } from './shared.js';
+
+export function createAosZagTabs(context = {}) {
+  return createZagAdapter({
+    name: 'Tabs',
+    machine,
+    connect,
+    props: (ctx) => ({
+      id: ctx.id,
+      ids: ctx.ids,
+      getRootNode: ctx.getRootNode,
+      value: ctx.value,
+      defaultValue: ctx.defaultValue,
+      activationMode: ctx.activationMode,
+      loopFocus: ctx.loopFocus,
+      orientation: ctx.orientation,
+      dir: ctx.dir,
+      composite: ctx.composite,
+      deselectable: ctx.deselectable,
+      navigate: ctx.navigate,
+      onValueChange: ctx.onValueChange,
+      onFocusChange: ctx.onFocusChange,
+    }),
+    selectors: {
+      root: '[data-aos-tabs-root]',
+      list: '[data-aos-tabs-list]',
+      trigger: '[data-value]',
+      content: '[data-aos-tabs-content]',
+    },
+    snapshot: (api, service) => ({
+      api,
+      service: service.service,
+      value: api.value,
+      focusedValue: api.focusedValue,
+      state: service.service.state.get(),
+      send: service.send,
+      getRootProps: (extra = {}) => mergeProps(api.getRootProps(), extra),
+      getListProps: (extra = {}) => mergeProps(api.getListProps(), extra),
+      getTriggerProps: (props, extra = {}) => mergeProps(api.getTriggerProps(props), extra),
+      getContentProps: (props, extra = {}) => mergeProps(api.getContentProps(props), extra),
+      setValue: api.setValue,
+    }),
+    bindings: {
+      root: { alias: 'Root', getter: 'getRootProps' },
+      list: { alias: 'List', getter: 'getListProps' },
+      trigger: ({ api, element, extraProps, index }) => {
+        const value = extraProps.value || element?.dataset?.value || element?.dataset?.id || element?.id || `trigger-${index}`;
+        return { key: value, props: mergeProps(api.getTriggerProps({ value }), extraProps.extra || {}) };
+      },
+      content: ({ api, element, extraProps, index }) => {
+        const value = extraProps.value || element?.dataset?.value || element?.dataset?.id || element?.id || `content-${index}`;
+        return { key: value, props: mergeProps(api.getContentProps({ value }), extraProps.extra || {}) };
+      },
+    },
+    actions: {
+      setValue: (api, value) => api.setValue(value),
+    },
+  }, context);
+}

--- a/packages/toolkit/adapters/zag/tabs.js
+++ b/packages/toolkit/adapters/zag/tabs.js
@@ -25,7 +25,7 @@ export function createAosZagTabs(context = {}) {
     selectors: {
       root: '[data-aos-tabs-root]',
       list: '[data-aos-tabs-list]',
-      trigger: '[data-value]',
+      trigger: '[data-aos-tabs-trigger]',
       content: '[data-aos-tabs-content]',
     },
     snapshot: (api, service) => ({

--- a/packages/toolkit/adapters/zag/tags-input.js
+++ b/packages/toolkit/adapters/zag/tags-input.js
@@ -1,0 +1,71 @@
+import { connect, machine } from '@zag-js/tags-input';
+import { createZagAdapter, mergeProps } from './shared.js';
+
+export function createAosZagTagsInput(context = {}) {
+  return createZagAdapter({
+    name: 'TagsInput',
+    machine,
+    connect,
+    props: (ctx) => ({
+      id: ctx.id,
+      ids: ctx.ids,
+      getRootNode: ctx.getRootNode,
+      value: ctx.value,
+      defaultValue: ctx.defaultValue,
+      inputValue: ctx.inputValue,
+      defaultInputValue: ctx.defaultInputValue,
+      name: ctx.name,
+      form: ctx.form,
+      disabled: ctx.disabled,
+      readOnly: ctx.readOnly,
+      invalid: ctx.invalid,
+      required: ctx.required,
+      max: ctx.max,
+      maxLength: ctx.maxLength,
+      delimiter: ctx.delimiter,
+      addOnPaste: ctx.addOnPaste,
+      allowEditTag: ctx.allowEditTag,
+      blurBehavior: ctx.blurBehavior,
+      editable: ctx.editable,
+      translations: ctx.translations,
+      validate: ctx.validate,
+      onValueChange: ctx.onValueChange,
+      onInputValueChange: ctx.onInputValueChange,
+      onValueInvalid: ctx.onValueInvalid,
+      onHighlightChange: ctx.onHighlightChange,
+    }),
+    selectors: {
+      root: '[data-aos-tags-input-root]',
+      label: '[data-aos-tags-input-label]',
+      control: '[data-aos-tags-input-control]',
+      input: '[data-aos-tags-input-input]',
+      item: '[data-value]',
+    },
+    snapshot: (api, service) => ({
+      api,
+      service: service.service,
+      value: api.value,
+      state: service.service.state.get(),
+      send: service.send,
+      getRootProps: (extra = {}) => mergeProps(api.getRootProps(), extra),
+      getLabelProps: (extra = {}) => mergeProps(api.getLabelProps(), extra),
+      getControlProps: (extra = {}) => mergeProps(api.getControlProps(), extra),
+      getInputProps: (extra = {}) => mergeProps(api.getInputProps(), extra),      getItemProps: (props, extra = {}) => mergeProps(api.getItemProps(props), extra),
+      setValue: api.setValue, setInputValue: api.setInputValue,
+    }),
+    bindings: {
+      root: { alias: 'Root', getter: 'getRootProps' },
+      label: { alias: 'Label', getter: 'getLabelProps' },
+      control: { alias: 'Control', getter: 'getControlProps' },
+      input: { alias: 'Input', getter: 'getInputProps' },
+      item: ({ api, element, extraProps, index }) => {
+        const value = extraProps.value || element?.dataset?.value || element?.dataset?.id || element?.id || `item-${index}`;
+        return { key: value, props: mergeProps(api.getItemProps({ index, value }), extraProps.extra || {}) };
+      },
+    },
+    actions: {
+      setValue: (api, value) => api.setValue(value),
+      setInputValue: (api, value) => api.setInputValue(value),
+    },
+  }, context);
+}

--- a/packages/toolkit/adapters/zag/tags-input.js
+++ b/packages/toolkit/adapters/zag/tags-input.js
@@ -39,7 +39,7 @@ export function createAosZagTagsInput(context = {}) {
       label: '[data-aos-tags-input-label]',
       control: '[data-aos-tags-input-control]',
       input: '[data-aos-tags-input-input]',
-      item: '[data-value]',
+      item: '[data-aos-tags-input-item]',
     },
     snapshot: (api, service) => ({
       api,
@@ -50,8 +50,10 @@ export function createAosZagTagsInput(context = {}) {
       getRootProps: (extra = {}) => mergeProps(api.getRootProps(), extra),
       getLabelProps: (extra = {}) => mergeProps(api.getLabelProps(), extra),
       getControlProps: (extra = {}) => mergeProps(api.getControlProps(), extra),
-      getInputProps: (extra = {}) => mergeProps(api.getInputProps(), extra),      getItemProps: (props, extra = {}) => mergeProps(api.getItemProps(props), extra),
-      setValue: api.setValue, setInputValue: api.setInputValue,
+      getInputProps: (extra = {}) => mergeProps(api.getInputProps(), extra),
+      getItemProps: (props, extra = {}) => mergeProps(api.getItemProps(props), extra),
+      setValue: api.setValue,
+      setInputValue: api.setInputValue,
     }),
     bindings: {
       root: { alias: 'Root', getter: 'getRootProps' },

--- a/packages/toolkit/adapters/zag/toggle-group.js
+++ b/packages/toolkit/adapters/zag/toggle-group.js
@@ -1,0 +1,47 @@
+import { connect, machine } from '@zag-js/toggle-group';
+import { createZagAdapter, mergeProps } from './shared.js';
+
+export function createAosZagToggleGroup(context = {}) {
+  return createZagAdapter({
+    name: 'ToggleGroup',
+    machine,
+    connect,
+    props: (ctx) => ({
+      id: ctx.id,
+      ids: ctx.ids,
+      getRootNode: ctx.getRootNode,
+      value: ctx.value,
+      defaultValue: ctx.defaultValue,
+      multiple: ctx.multiple,
+      orientation: ctx.orientation,
+      dir: ctx.dir,
+      loopFocus: ctx.loopFocus,
+      disabled: ctx.disabled,
+      rovingFocus: ctx.rovingFocus,
+      onValueChange: ctx.onValueChange,
+    }),
+    selectors: {
+      root: '[data-aos-toggle-group-root]',
+      item: '[data-value]',
+    },
+    snapshot: (api, service) => ({
+      api,
+      service: service.service,
+      value: api.value,
+      state: service.service.state.get(),
+      send: service.send,
+      getRootProps: (extra = {}) => mergeProps(api.getRootProps(), extra),      getItemProps: (props, extra = {}) => mergeProps(api.getItemProps(props), extra),
+      setValue: api.setValue,
+    }),
+    bindings: {
+      root: { alias: 'Root', getter: 'getRootProps' },
+      item: ({ api, element, extraProps, index }) => {
+        const value = extraProps.value || element?.dataset?.value || element?.dataset?.id || element?.id || `item-${index}`;
+        return { key: value, props: mergeProps(api.getItemProps({ value }), extraProps.extra || {}) };
+      },
+    },
+    actions: {
+      setValue: (api, value) => api.setValue(value),
+    },
+  }, context);
+}

--- a/packages/toolkit/adapters/zag/toggle-group.js
+++ b/packages/toolkit/adapters/zag/toggle-group.js
@@ -22,7 +22,7 @@ export function createAosZagToggleGroup(context = {}) {
     }),
     selectors: {
       root: '[data-aos-toggle-group-root]',
-      item: '[data-value]',
+      item: '[data-aos-toggle-group-item]',
     },
     snapshot: (api, service) => ({
       api,
@@ -30,7 +30,8 @@ export function createAosZagToggleGroup(context = {}) {
       value: api.value,
       state: service.service.state.get(),
       send: service.send,
-      getRootProps: (extra = {}) => mergeProps(api.getRootProps(), extra),      getItemProps: (props, extra = {}) => mergeProps(api.getItemProps(props), extra),
+      getRootProps: (extra = {}) => mergeProps(api.getRootProps(), extra),
+      getItemProps: (props, extra = {}) => mergeProps(api.getItemProps(props), extra),
       setValue: api.setValue,
     }),
     bindings: {

--- a/packages/toolkit/adapters/zag/tooltip.js
+++ b/packages/toolkit/adapters/zag/tooltip.js
@@ -35,14 +35,11 @@ export function createAosZagTooltip(context = {}) {
       getTriggerProps: (extra = {}) => mergeProps(api.getTriggerProps(), extra),
       getPositionerProps: (extra = {}) => mergeProps(api.getPositionerProps(), extra),
       getContentProps: (extra = {}) => mergeProps(api.getContentProps(), extra),
-
-      
     }),
     bindings: {
       trigger: { alias: 'Trigger', getter: 'getTriggerProps' },
       positioner: { alias: 'Positioner', getter: 'getPositionerProps' },
       content: { alias: 'Content', getter: 'getContentProps' },
-
     },
     actions: {
       open: (api) => api.setOpen(true),

--- a/packages/toolkit/adapters/zag/tooltip.js
+++ b/packages/toolkit/adapters/zag/tooltip.js
@@ -1,0 +1,52 @@
+import { connect, machine } from '@zag-js/tooltip';
+import { createZagAdapter, mergeProps } from './shared.js';
+
+export function createAosZagTooltip(context = {}) {
+  return createZagAdapter({
+    name: 'Tooltip',
+    machine,
+    connect,
+    props: (ctx) => ({
+      id: ctx.id,
+      ids: ctx.ids,
+      getRootNode: ctx.getRootNode,
+      open: ctx.open,
+      defaultOpen: ctx.defaultOpen,
+      openDelay: ctx.openDelay,
+      closeDelay: ctx.closeDelay,
+      closeOnPointerDown: ctx.closeOnPointerDown,
+      closeOnEscape: ctx.closeOnEscape,
+      interactive: ctx.interactive,
+      disabled: ctx.disabled,
+      positioning: ctx.positioning,
+      onOpenChange: ctx.onOpenChange,
+    }),
+    selectors: {
+      trigger: '[data-aos-tooltip-trigger]',
+      positioner: '[data-aos-tooltip-positioner]',
+      content: '[data-aos-tooltip-content]',
+    },
+    snapshot: (api, service) => ({
+      api,
+      service: service.service,
+      open: api.open,
+      state: service.service.state.get(),
+      send: service.send,
+      getTriggerProps: (extra = {}) => mergeProps(api.getTriggerProps(), extra),
+      getPositionerProps: (extra = {}) => mergeProps(api.getPositionerProps(), extra),
+      getContentProps: (extra = {}) => mergeProps(api.getContentProps(), extra),
+
+      
+    }),
+    bindings: {
+      trigger: { alias: 'Trigger', getter: 'getTriggerProps' },
+      positioner: { alias: 'Positioner', getter: 'getPositionerProps' },
+      content: { alias: 'Content', getter: 'getContentProps' },
+
+    },
+    actions: {
+      open: (api) => api.setOpen(true),
+      close: (api) => api.setOpen(false),
+    },
+  }, context);
+}

--- a/packages/toolkit/package-lock.json
+++ b/packages/toolkit/package-lock.json
@@ -8,9 +8,23 @@
       "name": "@agent-os/toolkit",
       "version": "0.1.0",
       "dependencies": {
+        "@zag-js/accordion": "^1.40.0",
+        "@zag-js/collapsible": "^1.40.0",
         "@zag-js/combobox": "^1.40.0",
+        "@zag-js/dialog": "^1.40.0",
+        "@zag-js/editable": "^1.40.0",
         "@zag-js/menu": "^1.40.0",
+        "@zag-js/number-input": "^1.40.0",
+        "@zag-js/popover": "^1.40.0",
+        "@zag-js/radio-group": "^1.40.0",
         "@zag-js/select": "^1.40.0",
+        "@zag-js/slider": "^1.40.0",
+        "@zag-js/splitter": "^1.40.0",
+        "@zag-js/switch": "^1.40.0",
+        "@zag-js/tabs": "^1.40.0",
+        "@zag-js/tags-input": "^1.40.0",
+        "@zag-js/toggle-group": "^1.40.0",
+        "@zag-js/tooltip": "^1.40.0",
         "@zag-js/vanilla": "^1.40.0"
       }
     },
@@ -39,11 +53,73 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.5.tgz",
+      "integrity": "sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@zag-js/accordion": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/accordion/-/accordion-1.40.0.tgz",
+      "integrity": "sha512-YDdyvZJ6fr92RZazyXQq+juT3ZA0ubjDISptb5YPgMoTPdnjKNiICPpMeCeVj1ncYRDkHXrOdChS/5CtuX/K6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
     "node_modules/@zag-js/anatomy": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@zag-js/anatomy/-/anatomy-1.40.0.tgz",
       "integrity": "sha512-oiB4uAaV//L38JluLVPtOHO3xvqambrfrXVOoq4kmNrBv1LLlCmFvrXA2HOR9lakn4ExK27XSUrKhUN7YlKjfQ==",
       "license": "MIT"
+    },
+    "node_modules/@zag-js/aria-hidden": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/aria-hidden/-/aria-hidden-1.40.0.tgz",
+      "integrity": "sha512-lNWujEIlfGKwMQIcgfXuOZSsJD2avrgPsQHrXNVF9mkXygjLFcIRKz2pEexTSCqFh/HuUZJ6rG4pM/hJ/BiVCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/auto-resize": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/auto-resize/-/auto-resize-1.40.0.tgz",
+      "integrity": "sha512-eZC+AGKUip7UMu41/ApeT1wCIgn2fmo63FJeGAdMMD8E9M8M7QLsfISMIoieNNGBAYWhSyqELQ3jPgkUf6xReA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/collapsible": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/collapsible/-/collapsible-1.40.0.tgz",
+      "integrity": "sha512-xDLY4j9D3gdoTirkwzMaCtelfCjnMhBzPyY6c/mh4oPvD3RB6dr3V3kI80i3yxHaUUeDCIUm/XAxK0InPsRBug==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
     },
     "node_modules/@zag-js/collection": {
       "version": "1.40.0",
@@ -82,6 +158,23 @@
         "@zag-js/utils": "1.40.0"
       }
     },
+    "node_modules/@zag-js/dialog": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/dialog/-/dialog-1.40.0.tgz",
+      "integrity": "sha512-1FHxR7/Kuu+9K2dxH7dKlSckCZ26n5ec79qWr0aMSSs2DF+ypQf5GUlaS6z2UqroZvIoJCvABVMm9OMko/qxlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/aria-hidden": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dismissable": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/focus-trap": "1.40.0",
+        "@zag-js/remove-scroll": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
     "node_modules/@zag-js/dismissable": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@zag-js/dismissable/-/dismissable-1.40.0.tgz",
@@ -100,6 +193,29 @@
       "license": "MIT",
       "dependencies": {
         "@zag-js/types": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/editable": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/editable/-/editable-1.40.0.tgz",
+      "integrity": "sha512-X23wOg42BPvFWfJQi3yd8HiL8xtisrpL5ouFEzba56SQIxWZHDRpeWoqXqyLODq2/z2+SsZ0wV3laRD3ZH0C2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/interact-outside": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/focus-trap": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/focus-trap/-/focus-trap-1.40.0.tgz",
+      "integrity": "sha512-Q6W+DU7pix5rtRwoDnYzTYMkUV2kMWrFV0/EdNN3spFSvnUSkDWRmcNpzf+56AuCNeqsAZxaLJpsHLZkcT2xrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.40.0"
       }
     },
     "node_modules/@zag-js/focus-visible": {
@@ -144,6 +260,38 @@
         "@zag-js/utils": "1.40.0"
       }
     },
+    "node_modules/@zag-js/number-input": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/number-input/-/number-input-1.40.0.tgz",
+      "integrity": "sha512-WffdeqSOpsKmgPzBkNZl9nAolQPlyl9dIabaPguGgXdYtZW/OGCGj8jCYqyEu4VL3kDPPVVQRWEqC/XzwzVCRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@internationalized/number": "3.6.5",
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/popover": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/popover/-/popover-1.40.0.tgz",
+      "integrity": "sha512-bjvOep1YNlsvIYGh/rPsFCHjH2cCt2aKsVLyRvzTT1jhGZJvBdQKQBJjSuG5Nh4y1PUqtrrz69ZMWRrJGQ3rNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/aria-hidden": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dismissable": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/focus-trap": "1.40.0",
+        "@zag-js/popper": "1.40.0",
+        "@zag-js/remove-scroll": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
     "node_modules/@zag-js/popper": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@zag-js/popper/-/popper-1.40.0.tgz",
@@ -155,11 +303,34 @@
         "@zag-js/utils": "1.40.0"
       }
     },
+    "node_modules/@zag-js/radio-group": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/radio-group/-/radio-group-1.40.0.tgz",
+      "integrity": "sha512-sFJCdyOKzQC9hylSP19R71yv44by/C78D9EHfsxQJtvOgDv9E+h13NNX4n9wWyubC20xftlxkja8sNT5NfJKUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/focus-visible": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
     "node_modules/@zag-js/rect-utils": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@zag-js/rect-utils/-/rect-utils-1.40.0.tgz",
       "integrity": "sha512-ikgLuE4rLlACm4mGLp6Ga8sJA44uFwohA1nVmb95sQ+VIyx2naf91CEF7SMrZVEwFKHaHpxdKVQSZLRjJqO/dw==",
       "license": "MIT"
+    },
+    "node_modules/@zag-js/remove-scroll": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/remove-scroll/-/remove-scroll-1.40.0.tgz",
+      "integrity": "sha512-f6EgODnJMRtkbgdJCgyllND8jui+RtPrCZy6JYhhOg7KQ+bFfV36KzWQMty38ZdOyrh23UUO7MJ3WGcFXPvk3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/dom-query": "1.40.0"
+      }
     },
     "node_modules/@zag-js/select": {
       "version": "1.40.0",
@@ -178,6 +349,32 @@
         "@zag-js/utils": "1.40.0"
       }
     },
+    "node_modules/@zag-js/slider": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/slider/-/slider-1.40.0.tgz",
+      "integrity": "sha512-xZGycm+ghGFG3kTYq8g0t1Av1moxg45WiFz5E3bRgP7YU9beSTaFZI8h6f65NiC5P3YuwA0RoYxA46GH22qoZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/splitter": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/splitter/-/splitter-1.40.0.tgz",
+      "integrity": "sha512-64KNKwlIjyUIjp7i/whDCpREiSFrNI/cF7MpBJvBGRPUWq8NpNxMGKWD+vBCV+JC61QF9xg/NgNoigFycS9sYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
     "node_modules/@zag-js/store": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@zag-js/store/-/store-1.40.0.tgz",
@@ -185,6 +382,77 @@
       "license": "MIT",
       "dependencies": {
         "proxy-compare": "3.0.1"
+      }
+    },
+    "node_modules/@zag-js/switch": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/switch/-/switch-1.40.0.tgz",
+      "integrity": "sha512-hUH3AF79ndSFZxt7Plw7mVZV0QlM0kFqKwrAGBEOE77P3rKpOsMJ3wWgMb3w6nwlxGQsbwmMgAFvYUslLpM4Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/focus-visible": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/tabs": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/tabs/-/tabs-1.40.0.tgz",
+      "integrity": "sha512-xqfPC2nQ6Bn4nqy1L+1CVcQcg/Z7K2q753OvsX2C8Wtu+7tF//HyMbOpF6fGikqlLkUzCkvjkqDjdOXcfWN9ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/tags-input": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/tags-input/-/tags-input-1.40.0.tgz",
+      "integrity": "sha512-3cB7nPlUvzZNZwQw5AaTuxwcRn1n2qkDCjLEb2NEwtmI+YxHbK3k1MtXjTccjcYjU8cAkv+jaeyZPs6KFKQcHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/auto-resize": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/interact-outside": "1.40.0",
+        "@zag-js/live-region": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/toggle-group": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/toggle-group/-/toggle-group-1.40.0.tgz",
+      "integrity": "sha512-+JKcnfEbdQnr5p7uRvYLdivhUsM6iio71UC10tK74nXYRnYm0/Uvxg3oQzvbNTq9WdcU/DIh3gZVZ2Vex9nBnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
+      }
+    },
+    "node_modules/@zag-js/tooltip": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@zag-js/tooltip/-/tooltip-1.40.0.tgz",
+      "integrity": "sha512-pyrvit+nB8dIwVNTGBRlHPsh7yMJGAxxM1zfY7HOTJqF+n6+6xYTQ4gQ/Ocy1Q7I5kO88+m16naEh0qLFiTZww==",
+      "license": "MIT",
+      "dependencies": {
+        "@zag-js/anatomy": "1.40.0",
+        "@zag-js/core": "1.40.0",
+        "@zag-js/dom-query": "1.40.0",
+        "@zag-js/focus-visible": "1.40.0",
+        "@zag-js/popper": "1.40.0",
+        "@zag-js/types": "1.40.0",
+        "@zag-js/utils": "1.40.0"
       }
     },
     "node_modules/@zag-js/types": {
@@ -225,6 +493,12 @@
       "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
       "integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==",
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     }
   }
 }

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -4,9 +4,23 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "@zag-js/accordion": "^1.40.0",
+    "@zag-js/collapsible": "^1.40.0",
     "@zag-js/combobox": "^1.40.0",
+    "@zag-js/dialog": "^1.40.0",
+    "@zag-js/editable": "^1.40.0",
     "@zag-js/menu": "^1.40.0",
+    "@zag-js/number-input": "^1.40.0",
+    "@zag-js/popover": "^1.40.0",
+    "@zag-js/radio-group": "^1.40.0",
     "@zag-js/select": "^1.40.0",
+    "@zag-js/slider": "^1.40.0",
+    "@zag-js/splitter": "^1.40.0",
+    "@zag-js/switch": "^1.40.0",
+    "@zag-js/tabs": "^1.40.0",
+    "@zag-js/tags-input": "^1.40.0",
+    "@zag-js/toggle-group": "^1.40.0",
+    "@zag-js/tooltip": "^1.40.0",
     "@zag-js/vanilla": "^1.40.0"
   }
 }

--- a/tests/toolkit/zag-adapter-accordion.test.mjs
+++ b/tests/toolkit/zag-adapter-accordion.test.mjs
@@ -1,0 +1,67 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAosZagAccordion } from '../../packages/toolkit/adapters/zag/accordion.js';
+import { createDocument, patchSpreadSupport } from './zag-adapter-test-utils.mjs';
+
+function createAdapter(extra = {}) {
+  const document = createDocument();
+  const adapter = createAosZagAccordion({
+    id: 'test-accordion',
+    getRootNode: () => document,
+    ...extra,
+  });
+  return { adapter, document };
+}
+
+test('createAosZagAccordion exposes expected Zag accordion helpers', () => {
+  const { adapter } = createAdapter({defaultValue: ['a']});
+  const snapshot = adapter.connect();
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof snapshot.getRootProps, 'function');
+  assert.equal(typeof snapshot.getItemProps, 'function');
+  assert.equal(typeof snapshot.getItemTriggerProps, 'function');
+  assert.equal(typeof snapshot.getItemContentProps, 'function');
+  adapter.destroy();
+});
+
+test('bind wires minimum accordion parts', () => {
+  const { adapter, document } = createAdapter({defaultValue: ['a']});
+  const container = patchSpreadSupport(document.createElement('div'));
+  const elRoot = patchSpreadSupport(document.createElement('div'));
+  elRoot.dataset.aosAccordionRoot = '';
+  container.appendChild(elRoot);
+  const elItem = patchSpreadSupport(document.createElement('div'));
+  elItem.dataset.aosAccordionItem = '';
+  elItem.dataset.value = 'a';
+  container.appendChild(elItem);
+  const elItemTrigger = patchSpreadSupport(document.createElement('div'));
+  elItemTrigger.dataset.aosAccordionItemTrigger = '';
+  elItemTrigger.dataset.value = 'a';
+  container.appendChild(elItemTrigger);
+  const elItemContent = patchSpreadSupport(document.createElement('div'));
+  elItemContent.dataset.aosAccordionItemContent = '';
+  elItemContent.dataset.value = 'a';
+  container.appendChild(elItemContent);
+  document.body.appendChild(container);
+
+  const snapshot = adapter.bind(container);
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof adapter.bindRoot, 'function');
+  assert.equal(typeof adapter.bindItem, 'function');
+  assert.equal(typeof adapter.bindItemTrigger, 'function');
+  assert.equal(typeof adapter.bindItemContent, 'function');
+  adapter.destroy();
+});
+
+test('programmatic helpers update accordion state through Zag API', () => {
+  const { adapter } = createAdapter({defaultValue: ['a']});
+  adapter.setValue(['b']);
+  assert.equal(typeof adapter.connect().api, 'object');
+  adapter.destroy();
+});
+
+test('constructor validates required id', () => {
+  assert.throws(() => createAosZagAccordion({}), /requires an id/);
+});

--- a/tests/toolkit/zag-adapter-accordion.test.mjs
+++ b/tests/toolkit/zag-adapter-accordion.test.mjs
@@ -45,6 +45,13 @@ test('bind wires minimum accordion parts', () => {
   container.appendChild(elItemContent);
   document.body.appendChild(container);
 
+  assert.equal(adapter.bindItems(container), 1);
+  assert.equal(adapter.bindItemTriggers(container), 1);
+  assert.equal(adapter.bindItemContents(container), 1);
+  assert.equal(elItem.getAttribute('data-part'), 'item');
+  assert.equal(elItemTrigger.getAttribute('aria-controls'), elItemContent.getAttribute('id'));
+  assert.equal(elItemContent.getAttribute('role'), 'region');
+
   const snapshot = adapter.bind(container);
 
   assert.equal(typeof snapshot.api, 'object');

--- a/tests/toolkit/zag-adapter-collapsible.test.mjs
+++ b/tests/toolkit/zag-adapter-collapsible.test.mjs
@@ -1,0 +1,61 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAosZagCollapsible } from '../../packages/toolkit/adapters/zag/collapsible.js';
+import { createDocument, patchSpreadSupport } from './zag-adapter-test-utils.mjs';
+
+function createAdapter(extra = {}) {
+  const document = createDocument();
+  const adapter = createAosZagCollapsible({
+    id: 'test-collapsible',
+    getRootNode: () => document,
+    ...extra,
+  });
+  return { adapter, document };
+}
+
+test('createAosZagCollapsible exposes expected Zag collapsible helpers', () => {
+  const { adapter } = createAdapter({});
+  const snapshot = adapter.connect();
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof snapshot.getRootProps, 'function');
+  assert.equal(typeof snapshot.getTriggerProps, 'function');
+  assert.equal(typeof snapshot.getContentProps, 'function');
+  adapter.destroy();
+});
+
+test('bind wires minimum collapsible parts', () => {
+  const { adapter, document } = createAdapter({});
+  const container = patchSpreadSupport(document.createElement('div'));
+  const elRoot = patchSpreadSupport(document.createElement('div'));
+  elRoot.dataset.aosCollapsibleRoot = '';
+  container.appendChild(elRoot);
+  const elTrigger = patchSpreadSupport(document.createElement('div'));
+  elTrigger.dataset.aosCollapsibleTrigger = '';
+  elTrigger.dataset.value = 'a';
+  container.appendChild(elTrigger);
+  const elContent = patchSpreadSupport(document.createElement('div'));
+  elContent.dataset.aosCollapsibleContent = '';
+  elContent.dataset.value = 'a';
+  container.appendChild(elContent);
+  document.body.appendChild(container);
+
+  const snapshot = adapter.bind(container);
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof adapter.bindRoot, 'function');
+  assert.equal(typeof adapter.bindTrigger, 'function');
+  assert.equal(typeof adapter.bindContent, 'function');
+  adapter.destroy();
+});
+
+test('programmatic helpers update collapsible state through Zag API', () => {
+  const { adapter } = createAdapter({});
+  assert.equal(typeof adapter.open, 'function');
+  assert.equal(typeof adapter.close, 'function');
+  adapter.destroy();
+});
+
+test('constructor validates required id', () => {
+  assert.throws(() => createAosZagCollapsible({}), /requires an id/);
+});

--- a/tests/toolkit/zag-adapter-dialog.test.mjs
+++ b/tests/toolkit/zag-adapter-dialog.test.mjs
@@ -1,0 +1,81 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAosZagDialog } from '../../packages/toolkit/adapters/zag/dialog.js';
+import { createDocument, patchSpreadSupport } from './zag-adapter-test-utils.mjs';
+
+function createAdapter(extra = {}) {
+  const document = createDocument();
+  const adapter = createAosZagDialog({
+    id: 'test-dialog',
+    getRootNode: () => document,
+    ...extra,
+  });
+  return { adapter, document };
+}
+
+test('createAosZagDialog exposes expected Zag dialog helpers', () => {
+  const { adapter } = createAdapter({});
+  const snapshot = adapter.connect();
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof snapshot.getTriggerProps, 'function');
+  assert.equal(typeof snapshot.getBackdropProps, 'function');
+  assert.equal(typeof snapshot.getPositionerProps, 'function');
+  assert.equal(typeof snapshot.getContentProps, 'function');
+  assert.equal(typeof snapshot.getTitleProps, 'function');
+  assert.equal(typeof snapshot.getDescriptionProps, 'function');
+  assert.equal(typeof snapshot.getCloseTriggerProps, 'function');
+  adapter.destroy();
+});
+
+test('bind wires minimum dialog parts', () => {
+  const { adapter, document } = createAdapter({});
+  const container = patchSpreadSupport(document.createElement('div'));
+  const elTrigger = patchSpreadSupport(document.createElement('div'));
+  elTrigger.dataset.aosDialogTrigger = '';
+  elTrigger.dataset.value = 'a';
+  container.appendChild(elTrigger);
+  const elBackdrop = patchSpreadSupport(document.createElement('div'));
+  elBackdrop.dataset.aosDialogBackdrop = '';
+  container.appendChild(elBackdrop);
+  const elPositioner = patchSpreadSupport(document.createElement('div'));
+  elPositioner.dataset.aosDialogPositioner = '';
+  container.appendChild(elPositioner);
+  const elContent = patchSpreadSupport(document.createElement('div'));
+  elContent.dataset.aosDialogContent = '';
+  elContent.dataset.value = 'a';
+  container.appendChild(elContent);
+  const elTitle = patchSpreadSupport(document.createElement('div'));
+  elTitle.dataset.aosDialogTitle = '';
+  container.appendChild(elTitle);
+  const elDescription = patchSpreadSupport(document.createElement('div'));
+  elDescription.dataset.aosDialogDescription = '';
+  container.appendChild(elDescription);
+  const elCloseTrigger = patchSpreadSupport(document.createElement('div'));
+  elCloseTrigger.dataset.aosDialogCloseTrigger = '';
+  container.appendChild(elCloseTrigger);
+  document.body.appendChild(container);
+
+  const snapshot = adapter.bind(container);
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof adapter.bindTrigger, 'function');
+  assert.equal(typeof adapter.bindBackdrop, 'function');
+  assert.equal(typeof adapter.bindPositioner, 'function');
+  assert.equal(typeof adapter.bindContent, 'function');
+  assert.equal(typeof adapter.bindTitle, 'function');
+  assert.equal(typeof adapter.bindDescription, 'function');
+  assert.equal(typeof adapter.bindCloseTrigger, 'function');
+  adapter.destroy();
+});
+
+test('programmatic helpers update dialog state through Zag API', () => {
+  const { adapter } = createAdapter({});
+  assert.equal(typeof adapter.open, 'function');
+  assert.equal(typeof adapter.close, 'function');
+  adapter.destroy();
+});
+
+test('constructor validates required id', () => {
+  assert.throws(() => createAosZagDialog({}), /requires an id/);
+});

--- a/tests/toolkit/zag-adapter-editable.test.mjs
+++ b/tests/toolkit/zag-adapter-editable.test.mjs
@@ -1,0 +1,74 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAosZagEditable } from '../../packages/toolkit/adapters/zag/editable.js';
+import { createDocument, patchSpreadSupport } from './zag-adapter-test-utils.mjs';
+
+function createAdapter(extra = {}) {
+  const document = createDocument();
+  const adapter = createAosZagEditable({
+    id: 'test-editable',
+    getRootNode: () => document,
+    ...extra,
+  });
+  return { adapter, document };
+}
+
+test('createAosZagEditable exposes expected Zag editable helpers', () => {
+  const { adapter } = createAdapter({defaultValue: 'draft'});
+  const snapshot = adapter.connect();
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof snapshot.getRootProps, 'function');
+  assert.equal(typeof snapshot.getPreviewProps, 'function');
+  assert.equal(typeof snapshot.getInputProps, 'function');
+  assert.equal(typeof snapshot.getEditTriggerProps, 'function');
+  assert.equal(typeof snapshot.getSubmitTriggerProps, 'function');
+  assert.equal(typeof snapshot.getCancelTriggerProps, 'function');
+  adapter.destroy();
+});
+
+test('bind wires minimum editable parts', () => {
+  const { adapter, document } = createAdapter({defaultValue: 'draft'});
+  const container = patchSpreadSupport(document.createElement('div'));
+  const elRoot = patchSpreadSupport(document.createElement('div'));
+  elRoot.dataset.aosEditableRoot = '';
+  container.appendChild(elRoot);
+  const elPreview = patchSpreadSupport(document.createElement('div'));
+  elPreview.dataset.aosEditablePreview = '';
+  container.appendChild(elPreview);
+  const elInput = patchSpreadSupport(document.createElement('input'));
+  elInput.dataset.aosEditableInput = '';
+  container.appendChild(elInput);
+  const elEditTrigger = patchSpreadSupport(document.createElement('div'));
+  elEditTrigger.dataset.aosEditableEditTrigger = '';
+  container.appendChild(elEditTrigger);
+  const elSubmitTrigger = patchSpreadSupport(document.createElement('div'));
+  elSubmitTrigger.dataset.aosEditableSubmitTrigger = '';
+  container.appendChild(elSubmitTrigger);
+  const elCancelTrigger = patchSpreadSupport(document.createElement('div'));
+  elCancelTrigger.dataset.aosEditableCancelTrigger = '';
+  container.appendChild(elCancelTrigger);
+  document.body.appendChild(container);
+
+  const snapshot = adapter.bind(container);
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof adapter.bindRoot, 'function');
+  assert.equal(typeof adapter.bindPreview, 'function');
+  assert.equal(typeof adapter.bindInput, 'function');
+  assert.equal(typeof adapter.bindEditTrigger, 'function');
+  assert.equal(typeof adapter.bindSubmitTrigger, 'function');
+  assert.equal(typeof adapter.bindCancelTrigger, 'function');
+  adapter.destroy();
+});
+
+test('programmatic helpers update editable state through Zag API', () => {
+  const { adapter } = createAdapter({defaultValue: 'draft'});
+  adapter.setValue('next');
+  assert.equal(typeof adapter.connect().api, 'object');
+  adapter.destroy();
+});
+
+test('constructor validates required id', () => {
+  assert.throws(() => createAosZagEditable({}), /requires an id/);
+});

--- a/tests/toolkit/zag-adapter-number-input.test.mjs
+++ b/tests/toolkit/zag-adapter-number-input.test.mjs
@@ -1,0 +1,69 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAosZagNumberInput } from '../../packages/toolkit/adapters/zag/number-input.js';
+import { createDocument, patchSpreadSupport } from './zag-adapter-test-utils.mjs';
+
+function createAdapter(extra = {}) {
+  const document = createDocument();
+  const adapter = createAosZagNumberInput({
+    id: 'test-number-input',
+    getRootNode: () => document,
+    ...extra,
+  });
+  return { adapter, document };
+}
+
+test('createAosZagNumberInput exposes expected Zag number-input helpers', () => {
+  const { adapter } = createAdapter({defaultValue: '2'});
+  const snapshot = adapter.connect();
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof snapshot.getRootProps, 'function');
+  assert.equal(typeof snapshot.getLabelProps, 'function');
+  assert.equal(typeof snapshot.getInputProps, 'function');
+  assert.equal(typeof snapshot.getIncrementTriggerProps, 'function');
+  assert.equal(typeof snapshot.getDecrementTriggerProps, 'function');
+  adapter.destroy();
+});
+
+test('bind wires minimum number-input parts', () => {
+  const { adapter, document } = createAdapter({defaultValue: '2'});
+  const container = patchSpreadSupport(document.createElement('div'));
+  const elRoot = patchSpreadSupport(document.createElement('div'));
+  elRoot.dataset.aosNumberInputRoot = '';
+  container.appendChild(elRoot);
+  const elLabel = patchSpreadSupport(document.createElement('div'));
+  elLabel.dataset.aosNumberInputLabel = '';
+  container.appendChild(elLabel);
+  const elInput = patchSpreadSupport(document.createElement('input'));
+  elInput.dataset.aosNumberInputInput = '';
+  container.appendChild(elInput);
+  const elIncrementTrigger = patchSpreadSupport(document.createElement('div'));
+  elIncrementTrigger.dataset.aosNumberInputIncrementTrigger = '';
+  container.appendChild(elIncrementTrigger);
+  const elDecrementTrigger = patchSpreadSupport(document.createElement('div'));
+  elDecrementTrigger.dataset.aosNumberInputDecrementTrigger = '';
+  container.appendChild(elDecrementTrigger);
+  document.body.appendChild(container);
+
+  const snapshot = adapter.bind(container);
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof adapter.bindRoot, 'function');
+  assert.equal(typeof adapter.bindLabel, 'function');
+  assert.equal(typeof adapter.bindInput, 'function');
+  assert.equal(typeof adapter.bindIncrementTrigger, 'function');
+  assert.equal(typeof adapter.bindDecrementTrigger, 'function');
+  adapter.destroy();
+});
+
+test('programmatic helpers update number-input state through Zag API', () => {
+  const { adapter } = createAdapter({defaultValue: '2'});
+  adapter.setValue('4');
+  assert.equal(typeof adapter.connect().api, 'object');
+  adapter.destroy();
+});
+
+test('constructor validates required id', () => {
+  assert.throws(() => createAosZagNumberInput({}), /requires an id/);
+});

--- a/tests/toolkit/zag-adapter-popover.test.mjs
+++ b/tests/toolkit/zag-adapter-popover.test.mjs
@@ -1,0 +1,81 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAosZagPopover } from '../../packages/toolkit/adapters/zag/popover.js';
+import { createDocument, patchSpreadSupport } from './zag-adapter-test-utils.mjs';
+
+function createAdapter(extra = {}) {
+  const document = createDocument();
+  const adapter = createAosZagPopover({
+    id: 'test-popover',
+    getRootNode: () => document,
+    ...extra,
+  });
+  return { adapter, document };
+}
+
+test('createAosZagPopover exposes expected Zag popover helpers', () => {
+  const { adapter } = createAdapter({});
+  const snapshot = adapter.connect();
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof snapshot.getTriggerProps, 'function');
+  assert.equal(typeof snapshot.getAnchorProps, 'function');
+  assert.equal(typeof snapshot.getPositionerProps, 'function');
+  assert.equal(typeof snapshot.getContentProps, 'function');
+  assert.equal(typeof snapshot.getTitleProps, 'function');
+  assert.equal(typeof snapshot.getDescriptionProps, 'function');
+  assert.equal(typeof snapshot.getCloseTriggerProps, 'function');
+  adapter.destroy();
+});
+
+test('bind wires minimum popover parts', () => {
+  const { adapter, document } = createAdapter({});
+  const container = patchSpreadSupport(document.createElement('div'));
+  const elTrigger = patchSpreadSupport(document.createElement('div'));
+  elTrigger.dataset.aosPopoverTrigger = '';
+  elTrigger.dataset.value = 'a';
+  container.appendChild(elTrigger);
+  const elAnchor = patchSpreadSupport(document.createElement('div'));
+  elAnchor.dataset.aosPopoverAnchor = '';
+  container.appendChild(elAnchor);
+  const elPositioner = patchSpreadSupport(document.createElement('div'));
+  elPositioner.dataset.aosPopoverPositioner = '';
+  container.appendChild(elPositioner);
+  const elContent = patchSpreadSupport(document.createElement('div'));
+  elContent.dataset.aosPopoverContent = '';
+  elContent.dataset.value = 'a';
+  container.appendChild(elContent);
+  const elTitle = patchSpreadSupport(document.createElement('div'));
+  elTitle.dataset.aosPopoverTitle = '';
+  container.appendChild(elTitle);
+  const elDescription = patchSpreadSupport(document.createElement('div'));
+  elDescription.dataset.aosPopoverDescription = '';
+  container.appendChild(elDescription);
+  const elCloseTrigger = patchSpreadSupport(document.createElement('div'));
+  elCloseTrigger.dataset.aosPopoverCloseTrigger = '';
+  container.appendChild(elCloseTrigger);
+  document.body.appendChild(container);
+
+  const snapshot = adapter.bind(container);
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof adapter.bindTrigger, 'function');
+  assert.equal(typeof adapter.bindAnchor, 'function');
+  assert.equal(typeof adapter.bindPositioner, 'function');
+  assert.equal(typeof adapter.bindContent, 'function');
+  assert.equal(typeof adapter.bindTitle, 'function');
+  assert.equal(typeof adapter.bindDescription, 'function');
+  assert.equal(typeof adapter.bindCloseTrigger, 'function');
+  adapter.destroy();
+});
+
+test('programmatic helpers update popover state through Zag API', () => {
+  const { adapter } = createAdapter({});
+  assert.equal(typeof adapter.open, 'function');
+  assert.equal(typeof adapter.close, 'function');
+  adapter.destroy();
+});
+
+test('constructor validates required id', () => {
+  assert.throws(() => createAosZagPopover({}), /requires an id/);
+});

--- a/tests/toolkit/zag-adapter-radio-group.test.mjs
+++ b/tests/toolkit/zag-adapter-radio-group.test.mjs
@@ -1,0 +1,72 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAosZagRadioGroup } from '../../packages/toolkit/adapters/zag/radio-group.js';
+import { createDocument, patchSpreadSupport } from './zag-adapter-test-utils.mjs';
+
+function createAdapter(extra = {}) {
+  const document = createDocument();
+  const adapter = createAosZagRadioGroup({
+    id: 'test-radio-group',
+    getRootNode: () => document,
+    ...extra,
+  });
+  return { adapter, document };
+}
+
+test('createAosZagRadioGroup exposes expected Zag radio-group helpers', () => {
+  const { adapter } = createAdapter({defaultValue: 'a'});
+  const snapshot = adapter.connect();
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof snapshot.getRootProps, 'function');
+  assert.equal(typeof snapshot.getLabelProps, 'function');
+  assert.equal(typeof snapshot.getItemProps, 'function');
+  assert.equal(typeof snapshot.getRadioProps, 'function');
+  assert.equal(typeof snapshot.getRadioControlProps, 'function');
+  adapter.destroy();
+});
+
+test('bind wires minimum radio-group parts', () => {
+  const { adapter, document } = createAdapter({defaultValue: 'a'});
+  const container = patchSpreadSupport(document.createElement('div'));
+  const elRoot = patchSpreadSupport(document.createElement('div'));
+  elRoot.dataset.aosRadioGroupRoot = '';
+  container.appendChild(elRoot);
+  const elLabel = patchSpreadSupport(document.createElement('div'));
+  elLabel.dataset.aosRadioGroupLabel = '';
+  container.appendChild(elLabel);
+  const elItem = patchSpreadSupport(document.createElement('div'));
+  elItem.dataset.aosRadioGroupItem = '';
+  elItem.dataset.value = 'a';
+  container.appendChild(elItem);
+  const elRadio = patchSpreadSupport(document.createElement('div'));
+  elRadio.dataset.aosRadioGroupRadio = '';
+  elRadio.dataset.value = 'a';
+  container.appendChild(elRadio);
+  const elRadioControl = patchSpreadSupport(document.createElement('div'));
+  elRadioControl.dataset.aosRadioGroupRadioControl = '';
+  elRadioControl.dataset.value = 'a';
+  container.appendChild(elRadioControl);
+  document.body.appendChild(container);
+
+  const snapshot = adapter.bind(container);
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof adapter.bindRoot, 'function');
+  assert.equal(typeof adapter.bindLabel, 'function');
+  assert.equal(typeof adapter.bindItem, 'function');
+  assert.equal(typeof adapter.bindRadio, 'function');
+  assert.equal(typeof adapter.bindRadioControl, 'function');
+  adapter.destroy();
+});
+
+test('programmatic helpers update radio-group state through Zag API', () => {
+  const { adapter } = createAdapter({defaultValue: 'a'});
+  adapter.setValue('b');
+  assert.equal(typeof adapter.connect().api, 'object');
+  adapter.destroy();
+});
+
+test('constructor validates required id', () => {
+  assert.throws(() => createAosZagRadioGroup({}), /requires an id/);
+});

--- a/tests/toolkit/zag-adapter-radio-group.test.mjs
+++ b/tests/toolkit/zag-adapter-radio-group.test.mjs
@@ -49,6 +49,13 @@ test('bind wires minimum radio-group parts', () => {
   container.appendChild(elRadioControl);
   document.body.appendChild(container);
 
+  assert.equal(adapter.bindItems(container), 1);
+  assert.equal(adapter.bindRadios(container), 1);
+  assert.equal(adapter.bindRadioControls(container), 1);
+  assert.equal(elItem.getAttribute('data-part'), 'item');
+  assert.equal(elRadio.getAttribute('data-part'), 'item');
+  assert.equal(elRadioControl.getAttribute('data-part'), 'item-control');
+
   const snapshot = adapter.bind(container);
 
   assert.equal(typeof snapshot.api, 'object');

--- a/tests/toolkit/zag-adapter-slider.test.mjs
+++ b/tests/toolkit/zag-adapter-slider.test.mjs
@@ -1,0 +1,80 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAosZagSlider } from '../../packages/toolkit/adapters/zag/slider.js';
+import { createDocument, patchSpreadSupport } from './zag-adapter-test-utils.mjs';
+
+function createAdapter(extra = {}) {
+  const document = createDocument();
+  const adapter = createAosZagSlider({
+    id: 'test-slider',
+    getRootNode: () => document,
+    ...extra,
+  });
+  return { adapter, document };
+}
+
+test('createAosZagSlider exposes expected Zag slider helpers', () => {
+  const { adapter } = createAdapter({defaultValue: [25]});
+  const snapshot = adapter.connect();
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof snapshot.getRootProps, 'function');
+  assert.equal(typeof snapshot.getLabelProps, 'function');
+  assert.equal(typeof snapshot.getControlProps, 'function');
+  assert.equal(typeof snapshot.getTrackProps, 'function');
+  assert.equal(typeof snapshot.getRangeProps, 'function');
+  assert.equal(typeof snapshot.getThumbProps, 'function');
+  assert.equal(typeof snapshot.getOutputProps, 'function');
+  adapter.destroy();
+});
+
+test('bind wires minimum slider parts', () => {
+  const { adapter, document } = createAdapter({defaultValue: [25]});
+  const container = patchSpreadSupport(document.createElement('div'));
+  const elRoot = patchSpreadSupport(document.createElement('div'));
+  elRoot.dataset.aosSliderRoot = '';
+  container.appendChild(elRoot);
+  const elLabel = patchSpreadSupport(document.createElement('div'));
+  elLabel.dataset.aosSliderLabel = '';
+  container.appendChild(elLabel);
+  const elControl = patchSpreadSupport(document.createElement('div'));
+  elControl.dataset.aosSliderControl = '';
+  container.appendChild(elControl);
+  const elTrack = patchSpreadSupport(document.createElement('div'));
+  elTrack.dataset.aosSliderTrack = '';
+  container.appendChild(elTrack);
+  const elRange = patchSpreadSupport(document.createElement('div'));
+  elRange.dataset.aosSliderRange = '';
+  container.appendChild(elRange);
+  const elThumb = patchSpreadSupport(document.createElement('div'));
+  elThumb.dataset.aosSliderThumb = '';
+  elThumb.dataset.value = 'a';
+  container.appendChild(elThumb);
+  const elOutput = patchSpreadSupport(document.createElement('div'));
+  elOutput.dataset.aosSliderOutput = '';
+  container.appendChild(elOutput);
+  document.body.appendChild(container);
+
+  const snapshot = adapter.bind(container);
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof adapter.bindRoot, 'function');
+  assert.equal(typeof adapter.bindLabel, 'function');
+  assert.equal(typeof adapter.bindControl, 'function');
+  assert.equal(typeof adapter.bindTrack, 'function');
+  assert.equal(typeof adapter.bindRange, 'function');
+  assert.equal(typeof adapter.bindThumb, 'function');
+  assert.equal(typeof adapter.bindOutput, 'function');
+  adapter.destroy();
+});
+
+test('programmatic helpers update slider state through Zag API', () => {
+  const { adapter } = createAdapter({defaultValue: [25]});
+  adapter.setValue([40]);
+  assert.equal(typeof adapter.connect().api, 'object');
+  adapter.destroy();
+});
+
+test('constructor validates required id', () => {
+  assert.throws(() => createAosZagSlider({}), /requires an id/);
+});

--- a/tests/toolkit/zag-adapter-slider.test.mjs
+++ b/tests/toolkit/zag-adapter-slider.test.mjs
@@ -50,10 +50,18 @@ test('bind wires minimum slider parts', () => {
   elThumb.dataset.aosSliderThumb = '';
   elThumb.dataset.value = 'a';
   container.appendChild(elThumb);
+  const elIndexOnly = patchSpreadSupport(document.createElement('div'));
+  elIndexOnly.dataset.index = '0';
+  container.appendChild(elIndexOnly);
   const elOutput = patchSpreadSupport(document.createElement('div'));
   elOutput.dataset.aosSliderOutput = '';
   container.appendChild(elOutput);
   document.body.appendChild(container);
+
+  assert.equal(adapter.bindThumbs(container), 1);
+  assert.equal(elThumb.getAttribute('role'), 'slider');
+  assert.equal(elThumb.getAttribute('aria-valuenow'), '25');
+  assert.equal(elIndexOnly.getAttribute('role'), null);
 
   const snapshot = adapter.bind(container);
 

--- a/tests/toolkit/zag-adapter-splitter.test.mjs
+++ b/tests/toolkit/zag-adapter-splitter.test.mjs
@@ -34,11 +34,19 @@ test('bind wires minimum splitter parts', () => {
   elPanel.dataset.aosSplitterPanel = '';
   elPanel.dataset.value = 'a';
   container.appendChild(elPanel);
+  const elIdOnly = patchSpreadSupport(document.createElement('div'));
+  elIdOnly.dataset.id = 'a';
+  container.appendChild(elIdOnly);
   const elResizeTrigger = patchSpreadSupport(document.createElement('div'));
   elResizeTrigger.dataset.aosSplitterResizeTrigger = '';
   elResizeTrigger.dataset.value = 'a:b';
   container.appendChild(elResizeTrigger);
   document.body.appendChild(container);
+
+  assert.equal(adapter.bindPanels(container), 1);
+  assert.equal(elPanel.getAttribute('data-part'), 'panel');
+  assert.equal(elPanel.getAttribute('data-id'), 'a');
+  assert.equal(elIdOnly.getAttribute('data-part'), null);
 
   const snapshot = adapter.bind(container);
 

--- a/tests/toolkit/zag-adapter-splitter.test.mjs
+++ b/tests/toolkit/zag-adapter-splitter.test.mjs
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAosZagSplitter } from '../../packages/toolkit/adapters/zag/splitter.js';
+import { createDocument, patchSpreadSupport } from './zag-adapter-test-utils.mjs';
+
+function createAdapter(extra = {}) {
+  const document = createDocument();
+  const adapter = createAosZagSplitter({
+    id: 'test-splitter',
+    getRootNode: () => document,
+    ...extra,
+  });
+  return { adapter, document };
+}
+
+test('createAosZagSplitter exposes expected Zag splitter helpers', () => {
+  const { adapter } = createAdapter({panels: [{ id: 'a', size: 50 }, { id: 'b', size: 50 }]});
+  const snapshot = adapter.connect();
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof snapshot.getRootProps, 'function');
+  assert.equal(typeof snapshot.getPanelProps, 'function');
+  assert.equal(typeof snapshot.getResizeTriggerProps, 'function');
+  adapter.destroy();
+});
+
+test('bind wires minimum splitter parts', () => {
+  const { adapter, document } = createAdapter({panels: [{ id: 'a', size: 50 }, { id: 'b', size: 50 }]});
+  const container = patchSpreadSupport(document.createElement('div'));
+  const elRoot = patchSpreadSupport(document.createElement('div'));
+  elRoot.dataset.aosSplitterRoot = '';
+  container.appendChild(elRoot);
+  const elPanel = patchSpreadSupport(document.createElement('div'));
+  elPanel.dataset.aosSplitterPanel = '';
+  elPanel.dataset.value = 'a';
+  container.appendChild(elPanel);
+  const elResizeTrigger = patchSpreadSupport(document.createElement('div'));
+  elResizeTrigger.dataset.aosSplitterResizeTrigger = '';
+  elResizeTrigger.dataset.value = 'a:b';
+  container.appendChild(elResizeTrigger);
+  document.body.appendChild(container);
+
+  const snapshot = adapter.bind(container);
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof adapter.bindRoot, 'function');
+  assert.equal(typeof adapter.bindPanel, 'function');
+  assert.equal(typeof adapter.bindResizeTrigger, 'function');
+  adapter.destroy();
+});
+
+test('programmatic helpers update splitter state through Zag API', () => {
+  const { adapter } = createAdapter({panels: [{ id: 'a', size: 50 }, { id: 'b', size: 50 }]});
+  assert.equal(typeof adapter.connect().api, 'object');
+  adapter.destroy();
+});
+
+test('constructor validates required id', () => {
+  assert.throws(() => createAosZagSplitter({}), /requires an id/);
+});

--- a/tests/toolkit/zag-adapter-switch.test.mjs
+++ b/tests/toolkit/zag-adapter-switch.test.mjs
@@ -1,0 +1,70 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAosZagSwitch } from '../../packages/toolkit/adapters/zag/switch.js';
+import { createDocument, patchSpreadSupport } from './zag-adapter-test-utils.mjs';
+
+function createAdapter(extra = {}) {
+  const document = createDocument();
+  const adapter = createAosZagSwitch({
+    id: 'test-switch',
+    getRootNode: () => document,
+    ...extra,
+  });
+  return { adapter, document };
+}
+
+test('createAosZagSwitch exposes expected Zag switch helpers', () => {
+  const { adapter } = createAdapter({defaultChecked: false});
+  const snapshot = adapter.connect();
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof snapshot.getRootProps, 'function');
+  assert.equal(typeof snapshot.getLabelProps, 'function');
+  assert.equal(typeof snapshot.getControlProps, 'function');
+  assert.equal(typeof snapshot.getThumbProps, 'function');
+  assert.equal(typeof snapshot.getHiddenInputProps, 'function');
+  adapter.destroy();
+});
+
+test('bind wires minimum switch parts', () => {
+  const { adapter, document } = createAdapter({defaultChecked: false});
+  const container = patchSpreadSupport(document.createElement('div'));
+  const elRoot = patchSpreadSupport(document.createElement('div'));
+  elRoot.dataset.aosSwitchRoot = '';
+  container.appendChild(elRoot);
+  const elLabel = patchSpreadSupport(document.createElement('div'));
+  elLabel.dataset.aosSwitchLabel = '';
+  container.appendChild(elLabel);
+  const elControl = patchSpreadSupport(document.createElement('div'));
+  elControl.dataset.aosSwitchControl = '';
+  container.appendChild(elControl);
+  const elThumb = patchSpreadSupport(document.createElement('div'));
+  elThumb.dataset.aosSwitchThumb = '';
+  elThumb.dataset.value = 'a';
+  container.appendChild(elThumb);
+  const elHiddenInput = patchSpreadSupport(document.createElement('input'));
+  elHiddenInput.dataset.aosSwitchHiddenInput = '';
+  container.appendChild(elHiddenInput);
+  document.body.appendChild(container);
+
+  const snapshot = adapter.bind(container);
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof adapter.bindRoot, 'function');
+  assert.equal(typeof adapter.bindLabel, 'function');
+  assert.equal(typeof adapter.bindControl, 'function');
+  assert.equal(typeof adapter.bindThumb, 'function');
+  assert.equal(typeof adapter.bindHiddenInput, 'function');
+  adapter.destroy();
+});
+
+test('programmatic helpers update switch state through Zag API', () => {
+  const { adapter } = createAdapter({defaultChecked: false});
+  adapter.setChecked(true);
+  assert.equal(typeof adapter.connect().api, 'object');
+  adapter.destroy();
+});
+
+test('constructor validates required id', () => {
+  assert.throws(() => createAosZagSwitch({}), /requires an id/);
+});

--- a/tests/toolkit/zag-adapter-tabs.test.mjs
+++ b/tests/toolkit/zag-adapter-tabs.test.mjs
@@ -1,0 +1,66 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAosZagTabs } from '../../packages/toolkit/adapters/zag/tabs.js';
+import { createDocument, patchSpreadSupport } from './zag-adapter-test-utils.mjs';
+
+function createAdapter(extra = {}) {
+  const document = createDocument();
+  const adapter = createAosZagTabs({
+    id: 'test-tabs',
+    getRootNode: () => document,
+    ...extra,
+  });
+  return { adapter, document };
+}
+
+test('createAosZagTabs exposes expected Zag tabs helpers', () => {
+  const { adapter } = createAdapter({defaultValue: 'a'});
+  const snapshot = adapter.connect();
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof snapshot.getRootProps, 'function');
+  assert.equal(typeof snapshot.getListProps, 'function');
+  assert.equal(typeof snapshot.getTriggerProps, 'function');
+  assert.equal(typeof snapshot.getContentProps, 'function');
+  adapter.destroy();
+});
+
+test('bind wires minimum tabs parts', () => {
+  const { adapter, document } = createAdapter({defaultValue: 'a'});
+  const container = patchSpreadSupport(document.createElement('div'));
+  const elRoot = patchSpreadSupport(document.createElement('div'));
+  elRoot.dataset.aosTabsRoot = '';
+  container.appendChild(elRoot);
+  const elList = patchSpreadSupport(document.createElement('div'));
+  elList.dataset.aosTabsList = '';
+  container.appendChild(elList);
+  const elTrigger = patchSpreadSupport(document.createElement('div'));
+  elTrigger.dataset.aosTabsTrigger = '';
+  elTrigger.dataset.value = 'a';
+  container.appendChild(elTrigger);
+  const elContent = patchSpreadSupport(document.createElement('div'));
+  elContent.dataset.aosTabsContent = '';
+  elContent.dataset.value = 'a';
+  container.appendChild(elContent);
+  document.body.appendChild(container);
+
+  const snapshot = adapter.bind(container);
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof adapter.bindRoot, 'function');
+  assert.equal(typeof adapter.bindList, 'function');
+  assert.equal(typeof adapter.bindTrigger, 'function');
+  assert.equal(typeof adapter.bindContent, 'function');
+  adapter.destroy();
+});
+
+test('programmatic helpers update tabs state through Zag API', () => {
+  const { adapter } = createAdapter({defaultValue: 'a'});
+  adapter.setValue('b');
+  assert.equal(typeof adapter.connect().api, 'object');
+  adapter.destroy();
+});
+
+test('constructor validates required id', () => {
+  assert.throws(() => createAosZagTabs({}), /requires an id/);
+});

--- a/tests/toolkit/zag-adapter-tabs.test.mjs
+++ b/tests/toolkit/zag-adapter-tabs.test.mjs
@@ -44,6 +44,12 @@ test('bind wires minimum tabs parts', () => {
   container.appendChild(elContent);
   document.body.appendChild(container);
 
+  assert.equal(adapter.bindTriggers(container), 1);
+  assert.equal(adapter.bindContents(container), 1);
+  assert.equal(elTrigger.getAttribute('role'), 'tab');
+  assert.equal(elContent.getAttribute('role'), 'tabpanel');
+  assert.equal(elTrigger.getAttribute('aria-controls'), elContent.getAttribute('id'));
+
   const snapshot = adapter.bind(container);
 
   assert.equal(typeof snapshot.api, 'object');

--- a/tests/toolkit/zag-adapter-tags-input.test.mjs
+++ b/tests/toolkit/zag-adapter-tags-input.test.mjs
@@ -45,7 +45,15 @@ test('bind wires minimum tags-input parts', () => {
   elItem.dataset.aosTagsInputItem = '';
   elItem.dataset.value = 'a';
   container.appendChild(elItem);
+  const elValueOnly = patchSpreadSupport(document.createElement('div'));
+  elValueOnly.dataset.value = 'a';
+  container.appendChild(elValueOnly);
   document.body.appendChild(container);
+
+  assert.equal(adapter.bindItems(container), 1);
+  assert.equal(elItem.getAttribute('data-part'), 'item');
+  assert.equal(elItem.getAttribute('data-value'), 'a');
+  assert.equal(elValueOnly.getAttribute('data-part'), null);
 
   const snapshot = adapter.bind(container);
 

--- a/tests/toolkit/zag-adapter-tags-input.test.mjs
+++ b/tests/toolkit/zag-adapter-tags-input.test.mjs
@@ -1,0 +1,72 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAosZagTagsInput } from '../../packages/toolkit/adapters/zag/tags-input.js';
+import { createDocument, patchSpreadSupport } from './zag-adapter-test-utils.mjs';
+
+function createAdapter(extra = {}) {
+  const document = createDocument();
+  const adapter = createAosZagTagsInput({
+    id: 'test-tags-input',
+    getRootNode: () => document,
+    ...extra,
+  });
+  return { adapter, document };
+}
+
+test('createAosZagTagsInput exposes expected Zag tags-input helpers', () => {
+  const { adapter } = createAdapter({defaultValue: ['a']});
+  const snapshot = adapter.connect();
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof snapshot.getRootProps, 'function');
+  assert.equal(typeof snapshot.getLabelProps, 'function');
+  assert.equal(typeof snapshot.getControlProps, 'function');
+  assert.equal(typeof snapshot.getInputProps, 'function');
+  assert.equal(typeof snapshot.getItemProps, 'function');
+  adapter.destroy();
+});
+
+test('bind wires minimum tags-input parts', () => {
+  const { adapter, document } = createAdapter({defaultValue: ['a']});
+  const container = patchSpreadSupport(document.createElement('div'));
+  const elRoot = patchSpreadSupport(document.createElement('div'));
+  elRoot.dataset.aosTagsInputRoot = '';
+  container.appendChild(elRoot);
+  const elLabel = patchSpreadSupport(document.createElement('div'));
+  elLabel.dataset.aosTagsInputLabel = '';
+  container.appendChild(elLabel);
+  const elControl = patchSpreadSupport(document.createElement('div'));
+  elControl.dataset.aosTagsInputControl = '';
+  container.appendChild(elControl);
+  const elInput = patchSpreadSupport(document.createElement('input'));
+  elInput.dataset.aosTagsInputInput = '';
+  container.appendChild(elInput);
+  const elItem = patchSpreadSupport(document.createElement('div'));
+  elItem.dataset.aosTagsInputItem = '';
+  elItem.dataset.value = 'a';
+  container.appendChild(elItem);
+  document.body.appendChild(container);
+
+  const snapshot = adapter.bind(container);
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof adapter.bindRoot, 'function');
+  assert.equal(typeof adapter.bindLabel, 'function');
+  assert.equal(typeof adapter.bindControl, 'function');
+  assert.equal(typeof adapter.bindInput, 'function');
+  assert.equal(typeof adapter.bindItem, 'function');
+  adapter.destroy();
+});
+
+test('programmatic helpers update tags-input state through Zag API', () => {
+  const { adapter } = createAdapter({defaultValue: ['a']});
+  adapter.setValue(['b']);
+  assert.equal(typeof adapter.connect().api, 'object');
+  adapter.setInputValue('new');
+  assert.equal(typeof adapter.connect().api, 'object');
+  adapter.destroy();
+});
+
+test('constructor validates required id', () => {
+  assert.throws(() => createAosZagTagsInput({}), /requires an id/);
+});

--- a/tests/toolkit/zag-adapter-test-utils.mjs
+++ b/tests/toolkit/zag-adapter-test-utils.mjs
@@ -1,0 +1,88 @@
+import { FakeElement, createFakeDocument } from './dom-fixture.mjs';
+
+globalThis.requestAnimationFrame ??= (callback) => {
+  callback();
+  return 0;
+};
+globalThis.cancelAnimationFrame ??= () => {};
+
+export async function flushMachine() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+export function patchSpreadSupport(element) {
+  element.getRootNode ??= function getRootNode() {
+    return this.ownerDocument;
+  };
+  element.scrollTo ??= () => {};
+  element.focus ??= () => {};
+  element.blur ??= () => {};
+  element.style.setProperty ??= function setProperty(name, value) {
+    this[name] = value;
+  };
+  element.style.removeProperty ??= function removeProperty(name) {
+    delete this[name];
+  };
+  element.removeAttribute ??= function removeAttribute(name) {
+    this.attributes.delete(name);
+    if (name.startsWith('data-')) {
+      const key = name.slice(5).replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+      delete this.dataset[key];
+    }
+  };
+  element.hasAttribute ??= function hasAttribute(name) {
+    return this.attributes.has(name);
+  };
+  element.toggleAttribute ??= function toggleAttribute(name, enabled) {
+    if (enabled) this.setAttribute(name, '');
+    else this.removeAttribute(name);
+  };
+  for (const child of element.children || []) patchSpreadSupport(child);
+  return element;
+}
+
+export function createDocument() {
+  const document = createFakeDocument();
+  document.defaultView.requestAnimationFrame = globalThis.requestAnimationFrame;
+  document.defaultView.cancelAnimationFrame = globalThis.cancelAnimationFrame;
+  document.defaultView.document = document;
+  document.defaultView.HTMLElement = FakeElement;
+  document.defaultView.Element = FakeElement;
+  document.defaultView.Node = FakeElement;
+  document.defaultView.HTMLInputElement = FakeElement;
+  document.defaultView.HTMLTextAreaElement = FakeElement;
+  document.defaultView.KeyboardEvent = class KeyboardEvent {};
+  document.defaultView.MutationObserver = class MutationObserver {
+    observe() {}
+    disconnect() {}
+  };
+  document.defaultView.addEventListener ??= document.addEventListener;
+  document.defaultView.removeEventListener ??= document.removeEventListener;
+  document.defaultView.getComputedStyle ??= () => ({
+    getPropertyValue: () => '',
+    overflow: 'visible',
+    overflowX: 'visible',
+    overflowY: 'visible',
+    position: 'static',
+  });
+  const findById = (node, id) => {
+    if (node.id === id) return node;
+    for (const child of node.children || []) {
+      const match = findById(child, id);
+      if (match) return match;
+    }
+    return null;
+  };
+  document.getElementById = (id) => {
+    if (document.body.id === id) return document.body;
+    return findById(document.body, id);
+  };
+  document.querySelectorAll = (selector) => document.body.querySelectorAll(selector);
+  document.querySelector = (selector) => document.body.querySelector(selector);
+  patchSpreadSupport(document.body);
+  globalThis.document = document;
+  globalThis.window = document.defaultView;
+  globalThis.CSS ??= { escape: (value) => String(value) };
+  return document;
+}

--- a/tests/toolkit/zag-adapter-toggle-group.test.mjs
+++ b/tests/toolkit/zag-adapter-toggle-group.test.mjs
@@ -1,0 +1,55 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAosZagToggleGroup } from '../../packages/toolkit/adapters/zag/toggle-group.js';
+import { createDocument, patchSpreadSupport } from './zag-adapter-test-utils.mjs';
+
+function createAdapter(extra = {}) {
+  const document = createDocument();
+  const adapter = createAosZagToggleGroup({
+    id: 'test-toggle-group',
+    getRootNode: () => document,
+    ...extra,
+  });
+  return { adapter, document };
+}
+
+test('createAosZagToggleGroup exposes expected Zag toggle-group helpers', () => {
+  const { adapter } = createAdapter({defaultValue: ['a']});
+  const snapshot = adapter.connect();
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof snapshot.getRootProps, 'function');
+  assert.equal(typeof snapshot.getItemProps, 'function');
+  adapter.destroy();
+});
+
+test('bind wires minimum toggle-group parts', () => {
+  const { adapter, document } = createAdapter({defaultValue: ['a']});
+  const container = patchSpreadSupport(document.createElement('div'));
+  const elRoot = patchSpreadSupport(document.createElement('div'));
+  elRoot.dataset.aosToggleGroupRoot = '';
+  container.appendChild(elRoot);
+  const elItem = patchSpreadSupport(document.createElement('div'));
+  elItem.dataset.aosToggleGroupItem = '';
+  elItem.dataset.value = 'a';
+  container.appendChild(elItem);
+  document.body.appendChild(container);
+
+  const snapshot = adapter.bind(container);
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof adapter.bindRoot, 'function');
+  assert.equal(typeof adapter.bindItem, 'function');
+  adapter.destroy();
+});
+
+test('programmatic helpers update toggle-group state through Zag API', () => {
+  const { adapter } = createAdapter({defaultValue: ['a']});
+  adapter.setValue(['b']);
+  assert.equal(typeof adapter.connect().api, 'object');
+  adapter.destroy();
+});
+
+test('constructor validates required id', () => {
+  assert.throws(() => createAosZagToggleGroup({}), /requires an id/);
+});

--- a/tests/toolkit/zag-adapter-toggle-group.test.mjs
+++ b/tests/toolkit/zag-adapter-toggle-group.test.mjs
@@ -33,7 +33,15 @@ test('bind wires minimum toggle-group parts', () => {
   elItem.dataset.aosToggleGroupItem = '';
   elItem.dataset.value = 'a';
   container.appendChild(elItem);
+  const elValueOnly = patchSpreadSupport(document.createElement('div'));
+  elValueOnly.dataset.value = 'a';
+  container.appendChild(elValueOnly);
   document.body.appendChild(container);
+
+  assert.equal(adapter.bindItems(container), 1);
+  assert.equal(elItem.getAttribute('data-part'), 'item');
+  assert.equal(elItem.getAttribute('aria-checked'), 'true');
+  assert.equal(elValueOnly.getAttribute('data-part'), null);
 
   const snapshot = adapter.bind(container);
 

--- a/tests/toolkit/zag-adapter-tooltip.test.mjs
+++ b/tests/toolkit/zag-adapter-tooltip.test.mjs
@@ -1,0 +1,61 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAosZagTooltip } from '../../packages/toolkit/adapters/zag/tooltip.js';
+import { createDocument, patchSpreadSupport } from './zag-adapter-test-utils.mjs';
+
+function createAdapter(extra = {}) {
+  const document = createDocument();
+  const adapter = createAosZagTooltip({
+    id: 'test-tooltip',
+    getRootNode: () => document,
+    ...extra,
+  });
+  return { adapter, document };
+}
+
+test('createAosZagTooltip exposes expected Zag tooltip helpers', () => {
+  const { adapter } = createAdapter({});
+  const snapshot = adapter.connect();
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof snapshot.getTriggerProps, 'function');
+  assert.equal(typeof snapshot.getPositionerProps, 'function');
+  assert.equal(typeof snapshot.getContentProps, 'function');
+  adapter.destroy();
+});
+
+test('bind wires minimum tooltip parts', () => {
+  const { adapter, document } = createAdapter({});
+  const container = patchSpreadSupport(document.createElement('div'));
+  const elTrigger = patchSpreadSupport(document.createElement('div'));
+  elTrigger.dataset.aosTooltipTrigger = '';
+  elTrigger.dataset.value = 'a';
+  container.appendChild(elTrigger);
+  const elPositioner = patchSpreadSupport(document.createElement('div'));
+  elPositioner.dataset.aosTooltipPositioner = '';
+  container.appendChild(elPositioner);
+  const elContent = patchSpreadSupport(document.createElement('div'));
+  elContent.dataset.aosTooltipContent = '';
+  elContent.dataset.value = 'a';
+  container.appendChild(elContent);
+  document.body.appendChild(container);
+
+  const snapshot = adapter.bind(container);
+
+  assert.equal(typeof snapshot.api, 'object');
+  assert.equal(typeof adapter.bindTrigger, 'function');
+  assert.equal(typeof adapter.bindPositioner, 'function');
+  assert.equal(typeof adapter.bindContent, 'function');
+  adapter.destroy();
+});
+
+test('programmatic helpers update tooltip state through Zag API', () => {
+  const { adapter } = createAdapter({});
+  assert.equal(typeof adapter.open, 'function');
+  assert.equal(typeof adapter.close, 'function');
+  adapter.destroy();
+});
+
+test('constructor validates required id', () => {
+  assert.throws(() => createAosZagTooltip({}), /requires an id/);
+});


### PR DESCRIPTION
## Summary

Adds the full Zag adapter horizon for toolkit primitives on one review branch, with one reversible checkpoint commit per adapter and one aggregate correction commit after Foreman review.

Adapters added:

- dialog
- tooltip
- popover
- tabs
- accordion
- collapsible
- splitter
- slider
- number-input
- toggle-group
- radio-group
- switch
- editable
- tags-input

The branch also adds a shared adapter harness and focused fake-DOM tests for the adapter contracts. The correction commit tightens repeated-part selectors so default binding uses AOS data-part attributes instead of broad `[data-value]`/`[data-id]` selectors.

## Verification

Foreman reran:

```bash
node --test tests/toolkit/zag-adapter-*.test.mjs
node --test tests/toolkit/*.test.mjs
git diff --check b1514c13d6ca954a95d40c3b53b1c6e0bb05653e..HEAD
```

Results:

- focused Zag adapter tests: 67/67 passed
- full toolkit suite: 899/899 passed
- diff check: passed
- selector probes for tabs, accordion, slider, and splitter returned expected counts

## Issues

Closes #341
Closes #342
Closes #343
Closes #344
Closes #345
Closes #346
Closes #347
Closes #348
Closes #349
Closes #350
Closes #351
Closes #352
Closes #353
Closes #354
