### PR TITLE
Consolidate user-signal service policy helpers

### DIFF
--- a/docs/api/toolkit/workbench.md
+++ b/docs/api/toolkit/workbench.md
@@ -259,6 +259,14 @@ stamps target elements with `data-aos-ref`, `data-aos-surface`,
 `data-semantic-target-id`, source path, and source line metadata, and emits a
 metadata payload next to the HTML.
 
+Generated workbench expressions follow the repo-wide generated-artifact
+lifecycle policy in
+[`docs/design/generated-artifact-lifecycle-policy.md`](../../design/generated-artifact-lifecycle-policy.md).
+New producers must define the canonical source, generated output locator,
+source hash/provenance, human-facing target map, cleanup/archive policy,
+privacy/redaction policy, and the structured sidecar/result that survives if
+the projection is deleted.
+
 Canonical metadata schema:
 [`shared/schemas/aos-html-workbench-expression-v0.schema.json`](../../../shared/schemas/aos-html-workbench-expression-v0.schema.json)
 

--- a/docs/design/2026-05-17-platform-debt-map.md
+++ b/docs/design/2026-05-17-platform-debt-map.md
@@ -1,0 +1,84 @@
+# Platform Debt Map, 2026-05-17
+
+Status: Foreman coordination map.
+
+This note captures the platform debt exposed by the May 11-17 workstream and
+routes the next two bounded work cards. It is not a new product plan and should
+not reopen completed V0 trackers without fresh evidence.
+
+## Current Trajectory
+
+The repo is converging on AOS as a platform substrate rather than a collection
+of app demos. The live direction is:
+
+- daemon/kernel owns native primitives and generic contracts;
+- toolkit owns reusable surface, workbench, control, and session policy;
+- apps such as Sigil own product expression and domain behavior;
+- docs, schemas, work records, and runtime wiki projections keep agent work
+  recoverable across sessions.
+
+Recent work closed several large slices:
+
+- Surface Stack V0 made DesktopWorld stage layers, input regions, panel
+  windowing, and Sigil second-client behavior concrete enough to stop broad
+  surface churn.
+- Toolkit control work added shared HTML/control helpers and a broad Zag adapter
+  horizon.
+- Sigil radial and 3D work moved more behavior toward data/config and object
+  graph contracts while keeping product rendering in Sigil.
+- Repo-doc wiki projection made canonical Git docs queryable in the runtime
+  wiki without moving source of truth out of Git.
+- User-signal work added durable gate records, deferred continuations, local UI
+  submit, and guided signal sessions.
+
+The next useful work is not another broad feature. It is two debt-reduction
+slices that make the new platform surface easier to keep correct.
+
+## Routed Debt Slices
+
+| Priority | Debt | Why Now | Routed Card |
+| --- | --- | --- | --- |
+| 1 | User-signal service consolidation | Gate records, continuations, UI submit, and guided sessions landed quickly. The behavior is covered, but terminal state, redaction, runtime-store, idempotency, and adapter-boundary logic now deserve a single audit/refactor pass before more receptors or annotation flows build on them. | `docs/design/work-cards/user-signal-service-consolidation-v0.md` |
+| 2 | Generated artifact lifecycle policy | HTML workbench expressions, artifact bundles, wiki projections, evidence captures, screenshots, and runtime records now have strong local contracts but weaker shared disposal/archive rules. Without a lifecycle policy, useful projections can become repo or state-root clutter. | `docs/design/work-cards/generated-artifact-lifecycle-policy-v0.md` |
+
+These slices are ordered. Run the user-signal consolidation first because it may
+clarify which runtime records and resume artifacts need lifecycle vocabulary.
+Then run the artifact lifecycle policy with the consolidation findings in hand.
+
+## Important Non-Routed Debt
+
+These remain salient but are not the next two slices:
+
+- **Display-first Annotation Mode:** #295 remains the highest product/platform
+  thread, but it should consume user-signal and artifact-lifecycle cleanup
+  rather than racing ahead of it.
+- **Sigil shared 3D editor path:** `docs/design/aos-3d-object-graph-platform-contract.md`
+  identifies a real future toolkit subject/editor opportunity. Do not start a
+  generic editor until the current radial/avatar object graph consumers show a
+  second concrete reuse point.
+- **Transitional surface fallbacks:** the WebView minimized-chip fallback and
+  parts of `avatar-main` remain transitional. Retire only with confidence
+  evidence, telemetry, or a fresh regression proving the fallback is now debt
+  rather than resilience.
+- **Test harness organization:** #162 remains valid. The serial live-canvas
+  contract and test primitive/molecule guidance reduced risk, but broader file
+  organization should wait for a cleaner routing window.
+- **Evidence workflow blocks:** #293 remains a useful abstraction gate. Do not
+  extract neutral evidence schemas until the Employer Brand pilot stabilizes or
+  a second workflow repeats the same block pattern.
+
+## Guardrails
+
+- Do not move toolkit policy into the daemon while paying down debt.
+- Do not reopen closed V0 epics just to hold cleanup work.
+- Do not create broad migration cards from this note. Each routed slice should
+  leave one accepted state or one exact follow-up.
+- Do not delete or relocate generated artifacts as part of the lifecycle-policy
+  slice unless the work card explicitly narrows to a safe fixture-only change.
+
+## Current Runtime Note
+
+During this Foreman routing pass, `./aos ready` reported the repo daemon
+reachable but the input tap unavailable. These routed cards are deterministic
+docs/refactor slices; live checks should report the readiness blocker rather
+than trying to force unrelated permission repair.

--- a/docs/design/generated-artifact-lifecycle-policy.md
+++ b/docs/design/generated-artifact-lifecycle-policy.md
@@ -1,0 +1,125 @@
+# Generated Artifact Lifecycle Policy
+
+**Status:** V0 policy
+**Owner layers:** daemon primitives, toolkit workbench policy, app/domain producers
+**Related:** #300, #293, #306, #359 through #362
+
+## Purpose
+
+AOS uses generated artifacts to make work inspectable: HTML workbench
+expressions, runtime wiki projections, artifact bundles, screenshots, evidence
+captures, user-signal records, and test proof payloads. These artifacts are
+useful only when their source of truth, storage location, cleanup path, and
+surviving result are explicit.
+
+This policy keeps generated output from becoming a second canonical source. A
+generated projection may be rich, visual, or human-facing, but it must link back
+to the canonical source or durable runtime record that owns the truth.
+
+## Current Producers
+
+HTML Workbench Expressions are generated projections of durable Markdown or
+structured source. Their canonical source is Markdown or JSON, the HTML path is
+the review surface, and the metadata sidecar carries source hashes, generated
+HTML paths, semantic targets, source maps, security policy, and export/resume
+behavior. They belong in Git only as checked-in fixtures or intentionally
+reviewed examples.
+
+Artifact Bundle Subjects describe archived or collected bundle members with
+provenance, validation, exports, and linked work-record evidence. The bundle
+descriptor is the subject; individual artifacts may be generated projections,
+evidence artifacts, or archived bundle members depending on their origin.
+
+Runtime wiki repo-doc projections are generated projections from canonical Git
+docs into runtime wiki state. The manifest in `docs/wiki/repo-docs-projection-v0.json`
+is source-controlled, but projected wiki pages live under runtime state and
+carry generated/projection metadata plus source hashes and backlinks.
+
+User-signal gate records, deferred continuations, resume events, and guided
+user-signal session records are runtime records, not generated projections.
+They are written under the active runtime mode, honor `AOS_STATE_ROOT`, redact
+sensitive human-authored payloads by default, and preserve provider boundaries
+by writing adapter hints/events rather than auto-running resume backends.
+
+Work-record captures and evidence adapters produce evidence artifacts plus
+structured work-record evidence. The structured evidence/result survives; bulky
+captures may be bundled, archived, or deleted according to the workflow policy.
+
+Employer Brand evidence fixtures and proof artifacts are checked-in test
+fixtures or domain pilot artifacts. They remain domain-owned until #293's
+neutral evidence workflow extraction gate is met.
+
+Live AOS screenshots, visual smoke captures, and local proof payloads are
+evidence artifacts or disposable scratch unless a work card explicitly archives
+them in an artifact bundle or fixture directory.
+
+Test output artifacts belong in isolated temp roots or repo fixture directories
+only when the test contract needs stable checked-in proof. Runtime-state tests
+must avoid canonical `~/.config/aos/{mode}` unless they are explicitly live
+daemon tests with documented cleanup.
+
+## Lifecycle Classes
+
+| Class | Owner layer | Source of truth | Storage locations | Git? | Cleanup or archive trigger | Surviving result | Privacy and provenance |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Canonical source | App, docs, schema, or workflow owner | The editable source file or record | Repo docs, schemas, source packages, or durable domain stores | Yes when repo-owned | Normal source review | The source itself | No generated-only facts; normal repo privacy rules |
+| Generated projection | Producing toolkit/daemon/app policy | Canonical source plus producer metadata | Runtime state, build output, temp dirs, or checked-in fixtures | Only as fixtures/examples | Delete when stale, regenerate from source, or archive into bundle | Metadata sidecar/result with source hash and backlinks | Must identify producer, source path/hash, output path, and security policy |
+| Runtime record | Daemon or toolkit runtime policy | The runtime record | `$AOS_STATE_ROOT/{repo|installed}` or `~/.config/aos/{repo|installed}` | No, except fixtures | Retain by runtime policy; never silently migrate/delete in implementation slices | JSON/JSONL record and readback surface | Redact human-authored payloads by default; record runtime mode and provenance |
+| Evidence artifact | Test, verifier, work-record, or domain workflow | Structured evidence/result plus capture metadata | Temp roots, evidence folders, artifact bundles, selected fixtures | Only when intentionally fixture/proof | Archive when needed for review; delete disposable captures after verification | Work-record evidence, manifest row, acceptance report, or failure record | Must separate runtime failure from subject failure and cite capture provenance |
+| Archived bundle member | Artifact bundle owner | Bundle descriptor and provenance | Artifact bundle folder or controlled archive | Yes only for reviewed bundles/fixtures | When a generated/evidence artifact must remain inspectable after the run | Bundle descriptor with validation and exports | Must preserve provenance, validation state, and source/work-record links |
+| Disposable scratch | Current task or test harness | None beyond the active run | Temp dirs, ignored local state, isolated `AOS_STATE_ROOT` | No | Delete at end of run or leave only when reported as local-only state | None, or a concise terminal command result | Do not store private/human payloads; do not rely on scratch as completion evidence |
+| Test fixture | Test owner | The fixture contract | `tests/`, `shared/schemas/fixtures/`, or `docs/design/fixtures/` | Yes | Update only with test/schema contract changes | Passing deterministic test and fixture content | Must be synthetic or approved; include stable provenance when relevant |
+| Stale generated output | Producing policy owner | Canonical source, not the stale file | Any generated location | No new commits unless proving stale handling | Delete, regenerate, or mark stale when source hash/provenance no longer matches | Stale marker, regenerated output, or deleted projection with sidecar retained | Must not be treated as truth; source hash mismatch is the blocker |
+
+## Producer Requirements
+
+Every new generated-artifact producer must define these fields or explain why a
+field is not applicable before it ships:
+
+| Requirement | Contract |
+| --- | --- |
+| Producer id | Stable producer name plus schema/version when applicable. |
+| Source expression | Canonical source path, subject id, runtime record id, or bundle member id. |
+| Output locator | Generated output path, runtime state path, or bundle entry. |
+| Source hash/provenance | Deterministic hash for file sources or equivalent provenance for runtime records. |
+| Human-facing target map | Semantic targets, source map, selectors, or equivalent when humans inspect or annotate the artifact. |
+| Cleanup/archive policy | Whether output is disposable, regenerated, archived as a bundle member, or checked in as a fixture. |
+| Privacy/redaction policy | Default handling for prompt bodies, answer payloads, comments, screenshots, and other human-authored or sensitive data. |
+| Surviving structured result | The JSON sidecar, work-record evidence, manifest row, resume event, or other durable result that remains if the projection is deleted. |
+
+## User-Signal Consolidation Finding
+
+The current user-signal pieces intentionally stay split by responsibility. The
+blocking gate service owns caller-facing request/receptor/timeout behavior.
+Durable gate records own JSONL audit records. Deferred continuations and resume
+events own pause/resume state and idempotent submit. The trusted local UI submit
+bridge calls the same continuation submit path from a canvas without shelling
+out. Guided user-signal sessions are toolkit runtime records for guidance,
+capture intent, optional gate links, and daemon-owned input authority. Provider
+adapter fields remain hints/events only; AOS core does not auto-run Codex,
+Claude, or any other resume backend.
+
+The consolidation point is small service policy, not a new lifecycle daemon:
+runtime-mode path selection, isolated `AOS_STATE_ROOT` handling, public source
+projection, redaction defaults, and JSON atomic write mechanics are shared.
+Terminal states remain local to each service because `answered`, `dismissed`,
+`timeout`, `submitted`, `captured`, `cancelled`, `expired`, and `error` mean
+different things at different layers.
+
+## Operating Rules
+
+Do not commit generated projections merely because they were useful during a
+session. Commit them only as fixtures, docs examples, or archived bundle members
+with provenance.
+
+Do not delete or migrate existing runtime records as part of a policy or docs
+slice. Cleanup commands must be explicit work with their own verification.
+
+Do not treat screenshots or HTML as canonical source. Link them to source,
+record, or work-record evidence that can survive deletion.
+
+Do not expand HTML Workbench Expression kinds without defining lifecycle,
+security, source map, surviving sidecar, and cleanup/archive behavior.
+
+Use isolated state roots for tests and smokes that write runtime records. Report
+any local-only generated artifacts left behind in the completion report.

--- a/docs/design/html-workbench-expression-adoption-audit-2026-05-13.md
+++ b/docs/design/html-workbench-expression-adoption-audit-2026-05-13.md
@@ -114,6 +114,12 @@ explicit as the source-vs-projection rule. Without a lifecycle rule, the system
 can regress into artifact sprawl: useful visual outputs with unclear ownership,
 cleanup, archival, or surviving structured result.
 
+The V0 lifecycle answer is now `docs/design/generated-artifact-lifecycle-policy.md`.
+Future HTML Workbench Expression kinds should treat that note as the minimum
+producer contract for source hashes, output locators, cleanup/archive policy,
+privacy/redaction policy, and the structured result that survives if generated
+HTML is deleted.
+
 The fifth tension is Design Operator history. Issue #140 remains open as a
 design-operator context tracker, but its comments already warn that older
 `docs/superpowers` path guidance is stale and that artifact/workspace ideas now
@@ -161,3 +167,7 @@ lifecycle decision for generated projection artifacts:
 4. Define cleanup expectations for one-off generated HTML and report outputs.
 5. Add the lifecycle rule to the relevant toolkit workbench docs before adding
    more artifact kinds.
+
+The initial decision is captured in
+`docs/design/generated-artifact-lifecycle-policy.md`; remaining work should
+apply it to new producers rather than inventing ad hoc artifact rules.

--- a/docs/design/work-cards/generated-artifact-lifecycle-policy-v0.md
+++ b/docs/design/work-cards/generated-artifact-lifecycle-policy-v0.md
@@ -1,0 +1,269 @@
+# Generated Artifact Lifecycle Policy V0
+
+## Tracker
+
+- Platform debt map: `docs/design/2026-05-17-platform-debt-map.md`
+- HTML Workbench Expression epic: #300
+- Neutral evidence workflow tracker: #293
+- Related completed work:
+  - #301 HTML Workbench Expression V0 for Markdown work-cards
+  - #306 Project canonical repo docs into the runtime wiki
+  - #359 through #362 user-signal durable records and guided sessions
+- Design notes:
+  - `docs/design/html-workbench-expression-adoption-audit-2026-05-13.md`
+  - `docs/design/evidence-workflow-block-abstraction-tracker.md`
+  - `docs/design/user-signal-surface.md`
+
+## Fresh Context Contract
+
+GDI starts from a fresh context window. Do not assume branch, worktree, daemon,
+wiki state, artifact paths, issue state, local runtime records, or prior
+implementation state. Read and rediscover before editing. Work in
+`/Users/Michael/Code/agent-os`, not in `.docks/`.
+
+## Goal
+
+Define the first repo-wide generated-artifact lifecycle policy so AOS can keep
+rich projections and evidence useful without accumulating unclear state-root or
+repo clutter.
+
+The policy should explain how generated HTML workbench expressions, runtime wiki
+projections, artifact bundle members, screenshots, evidence captures,
+user-signal records, and test proof payloads are classified, cleaned up,
+archived, and linked back to canonical source.
+
+This is a policy and contract slice first. Do not delete or migrate existing
+artifacts unless a tiny fixture-only correction is obviously safe and directly
+proves the policy.
+
+## Dependency
+
+Run after `docs/design/work-cards/user-signal-service-consolidation-v0.md` has
+reported completion or an exact blocker. Use its findings about gate records,
+continuations, resume events, and guided-session records when classifying
+runtime records versus generated projections.
+
+## Read First
+
+- `AGENTS.md`
+- `docs/design/2026-05-17-platform-debt-map.md`
+- `docs/design/html-workbench-expression-adoption-audit-2026-05-13.md`
+- `docs/design/evidence-workflow-block-abstraction-tracker.md`
+- `docs/design/user-signal-surface.md`
+- `docs/recipes/layered-subject-expressions.md`
+- `docs/recipes/gdi-work-card-authoring.md`
+- `docs/api/aos.md`
+- `docs/api/toolkit/workbench.md`
+- `docs/wiki/repo-docs-projection-v0.json`
+- `shared/schemas/aos-html-workbench-expression-v0.md`
+- `shared/schemas/aos-html-workbench-expression-v0.schema.json`
+- `packages/toolkit/workbench/html-workbench-expression.js`
+- `src/commands/wiki-project-docs.swift`
+- `packages/toolkit/workbench/artifact-bundle-subject.js`
+- `packages/toolkit/workbench/work-record-capture.js`
+
+## Rediscover State
+
+Run from the repo root:
+
+```bash
+git status --short --branch
+git worktree list
+./aos ready
+./aos dev recommend --json
+./aos dev gh issue view 300 --json
+./aos dev gh issue view 293 --json
+./aos dev gh issue view 306 --json
+```
+
+If `./aos ready` is blocked, report the exact blocker. This slice should be
+verifiable deterministically unless GDI chooses to add a small runtime wiki
+smoke with isolated `AOS_STATE_ROOT`.
+
+## Existing Code And Artifacts To Inspect
+
+- `packages/toolkit/workbench/html-workbench-expression.js` - generated HTML
+  expression metadata, source hashes, sidecars, and output paths.
+- `packages/toolkit/components/html-workbench-expression/` - consumer surface
+  expectations for generated HTML expressions.
+- `scripts/aos-html-workbench-expression.mjs` - command/script behavior for
+  producing generated expressions.
+- `src/commands/wiki-project-docs.swift` and
+  `docs/wiki/repo-docs-projection-v0.json` - generated runtime wiki projection
+  behavior and manifest metadata.
+- `packages/toolkit/workbench/artifact-bundle-subject.js` - artifact bundle
+  subject classification and provenance expectations.
+- `packages/toolkit/workbench/work-record-capture.js` and related work-record
+  modules - evidence and capture payload shape.
+- `packages/toolkit/workbench/employer-brand-*` - current pilot artifacts that
+  should inform policy without forcing a neutral abstraction.
+- `docs/design/fixtures/aos-artifacts/` - checked-in proof fixtures and
+  evidence bundles.
+- `tests/README.md` - generated test artifact and cleanup expectations.
+
+## Required Behavior
+
+### 1. Inventory Current Artifact Producers
+
+Create a concise inventory of current generated-artifact producers and classify
+each by lifecycle type. Include at least:
+
+- HTML Workbench Expressions;
+- Artifact Bundle Subjects;
+- runtime wiki repo-doc projections;
+- user-signal gate records, continuations, resume events, and guided-session
+  records;
+- work-record captures and evidence adapters;
+- Employer Brand evidence fixtures and proof artifacts;
+- live AOS screenshots or visual smoke payloads;
+- test output artifacts under temp roots or repo fixtures.
+
+### 2. Define Lifecycle Classes
+
+Add or update a design note with a small vocabulary. Suggested classes:
+
+- canonical source;
+- generated projection;
+- runtime record;
+- evidence artifact;
+- archived bundle member;
+- disposable scratch;
+- test fixture;
+- stale generated output.
+
+For each class, define:
+
+- owner layer;
+- source of truth;
+- allowed storage locations;
+- whether it belongs in Git, runtime state, temp dirs, or artifact bundles;
+- cleanup or archive trigger;
+- surviving structured result;
+- privacy/redaction expectations;
+- source hash or provenance requirement.
+
+### 3. Define Producer Requirements
+
+For new generated-artifact producers, define the minimum metadata before they
+ship:
+
+- producer id and schema/version when applicable;
+- source expression and canonical source path or subject;
+- generated output path or runtime state path;
+- source hash/provenance;
+- semantic targets or source map when the artifact is human-facing;
+- cleanup/archive policy;
+- privacy/redaction policy;
+- durable sidecar/result that survives if the projection is deleted.
+
+### 4. Reconcile Current Docs
+
+Update the smallest durable docs needed so future agents stop treating generated
+HTML, wiki projections, screenshots, and evidence payloads as ad hoc output.
+
+Likely updates:
+
+- `docs/design/html-workbench-expression-adoption-audit-2026-05-13.md`
+- a new focused lifecycle note under `docs/design/`
+- `docs/recipes/layered-subject-expressions.md`
+- `docs/api/toolkit/workbench.md` if the workbench expression contract needs a
+  concise lifecycle pointer.
+
+### 5. Optional Tiny Guardrail
+
+If a low-risk deterministic guardrail is obvious, add it. Examples:
+
+- a schema/docs test that confirms HTML Workbench Expression metadata includes
+  source hash, output path, security policy, and cleanup/archive fields already
+  present in the contract;
+- a manifest validation assertion that repo-doc projections identify themselves
+  as generated projections;
+- a docs-contract test that checks the lifecycle note is referenced from the
+  HTML workbench expression docs.
+
+Skip code changes if they would turn the policy slice into a migration.
+
+## Scope
+
+Likely ownership:
+
+- docs/design policy note;
+- docs/api or recipe pointer updates;
+- optional schema/docs tests if they directly enforce existing metadata;
+- no runtime behavior changes unless a tiny existing metadata omission blocks
+  the policy from being true.
+
+## Hard Boundaries / Non-Goals
+
+- Do not delete, move, or bulk-regenerate existing artifacts.
+- Do not extract #293 neutral evidence schemas in this slice.
+- Do not implement a workflow engine, report renderer, or export system.
+- Do not make HTML canonical source.
+- Do not move Git docs into the runtime wiki.
+- Do not ingest private personal/operator material.
+- Do not add broad cleanup commands.
+- Do not require live visual verification.
+- Do not broaden into Display-first Annotation Mode implementation.
+
+## Suggested Implementation Areas
+
+Treat these as starting points, not mandates:
+
+- Add `docs/design/generated-artifact-lifecycle-policy.md`.
+- Update `docs/design/html-workbench-expression-adoption-audit-2026-05-13.md`
+  to point at the policy as the answer to the lifecycle tension.
+- Update `docs/recipes/layered-subject-expressions.md` with a short lifecycle
+  checklist.
+- Update `docs/api/toolkit/workbench.md` only if it needs a concise pointer for
+  HTML Workbench Expression consumers.
+- Add focused tests only when the policy can be enforced without broad runtime
+  changes.
+
+## Verification
+
+Start with the router:
+
+```bash
+./aos dev recommend --json --files \
+  docs/design/generated-artifact-lifecycle-policy.md \
+  docs/design/html-workbench-expression-adoption-audit-2026-05-13.md \
+  docs/recipes/layered-subject-expressions.md \
+  docs/api/toolkit/workbench.md
+```
+
+Run deterministic checks selected by actual changes. Expected baseline
+candidates:
+
+```bash
+node --test tests/toolkit/html-workbench-expression.test.mjs
+node --test tests/schemas/aos-html-workbench-expression-v0.test.mjs
+bash tests/wiki-project-docs.sh
+bash tests/help-contract.sh
+bash tests/dev-workflow-router.sh
+bash tests/dev-audit.sh
+git diff --check
+```
+
+If the slice remains docs-only, run at least:
+
+```bash
+bash tests/dev-workflow-router.sh
+bash tests/dev-audit.sh
+git diff --check
+```
+
+Report `./aos ready` state, but skip live AOS verification unless GDI adds a
+specific runtime wiki or workbench smoke and readiness is green.
+
+## Completion Report
+
+Report:
+
+- changed files;
+- lifecycle classes defined;
+- current artifact producers inventoried;
+- any metadata or docs-contract guardrail added;
+- exact tests run and results;
+- live readiness state or blocker;
+- one remaining follow-up, if any, such as a later cleanup command, lifecycle
+  metadata schema patch, or #293 extraction gate update.

--- a/docs/design/work-cards/user-signal-service-consolidation-v0.md
+++ b/docs/design/work-cards/user-signal-service-consolidation-v0.md
@@ -1,0 +1,256 @@
+# User Signal Service Consolidation V0
+
+## Tracker
+
+- Platform debt map: `docs/design/2026-05-17-platform-debt-map.md`
+- Design note: `docs/design/user-signal-surface.md`
+- Related closed issues:
+  - #359 Persist user signal gate decisions as durable records
+  - #360 Add deferred user signal continuations for turn-ending HITL
+  - #361 Add deferred user signal UI submit bridge
+  - #362 Add Guided User Signal Session V0
+- Adjacent open epics:
+  - #141 Human Intent Sensing and Steerable Collection Sessions
+  - #149 Supervised runs and HITL test console
+  - #295 Display-first Annotation Mode and Sigil reticle
+
+## Fresh Context Contract
+
+GDI starts from a fresh context window. Do not assume branch, worktree, daemon,
+issue, runtime state, local gate records, continuation records, resume events,
+guided-session records, or prior implementation state. Read and rediscover
+before editing. Work in `/Users/Michael/Code/agent-os`, not in `.docks/`.
+
+## Goal
+
+Pay down the consolidation debt created by the fast user-signal sequence:
+durable gate records, deferred continuations, local UI submit, and guided user
+signal sessions should share the same small service conventions for terminal
+state, idempotency, redaction, runtime-mode storage, and provider-adapter
+boundaries.
+
+This is a cleanup/refactor slice. It should not add a new receptor, promote the
+gate lifecycle into the daemon, or auto-run any provider resume backend.
+
+## Read First
+
+- `AGENTS.md`
+- `packages/daemon/AGENTS.md`
+- `packages/toolkit/AGENTS.md`
+- `packages/toolkit/runtime/AGENTS.md`
+- `docs/design/2026-05-17-platform-debt-map.md`
+- `docs/design/user-signal-surface.md`
+- `docs/design/work-cards/user-signal-durable-gate-records-v0.md`
+- `docs/design/work-cards/deferred-user-signal-continuations-v0.md`
+- `docs/design/work-cards/deferred-user-signal-ui-submit-bridge-v0.md`
+- `docs/design/work-cards/guided-user-signal-session-v0.md`
+- `docs/api/aos.md`
+- `docs/api/toolkit/runtime.md`
+- `docs/api/toolkit/components.md`
+- `docs/api/toolkit/workbench.md`
+- `shared/schemas/aos.gate.record.v1.json`
+- `shared/schemas/aos.gate.continuation.v1.json`
+- `shared/schemas/aos.gate.resume-event.v1.json`
+- `shared/schemas/aos.guided-user-signal.session.v1.json`
+
+## Rediscover State
+
+Run from the repo root:
+
+```bash
+git status --short --branch
+git worktree list
+./aos ready
+./aos dev recommend --json
+./aos dev gh issue view 359 --json
+./aos dev gh issue view 360 --json
+./aos dev gh issue view 361 --json
+./aos dev gh issue view 362 --json
+```
+
+If `./aos ready` is blocked by macOS TCC or input tap state, report the exact
+blocker and continue deterministic tests only. Do not run permission repair
+unless Foreman or the human explicitly routes runtime repair work.
+
+Use isolated runtime state for any command that writes records:
+
+```bash
+AOS_STATE_ROOT="$(mktemp -d -t aos-user-signal-consolidation)" AOS_RUNTIME_MODE=repo ...
+```
+
+Do not mutate canonical `~/.config/aos/repo` state in tests.
+
+## Existing Code To Inspect
+
+- `packages/daemon/gate/index.js` - CLI-owned gate service and terminal record
+  write path.
+- `packages/daemon/gate/records.js` - durable gate record store and redaction
+  policy.
+- `packages/daemon/gate/continuations.js` - continuation store, idempotent
+  submit, resume event formation, and adapter hint boundary.
+- `packages/daemon/gate/LocalCanvasReceptor.js` - blocking receptor and
+  `window.__gateResult` polling path that must remain distinct from durable UI
+  submit.
+- `packages/cli/verbs/gate-ask.js`, `gate-defer.js`, `gate-submit.js`,
+  `gate-continuations.js`, and `gate-records.js` - public CLI surfaces.
+- `packages/toolkit/runtime/gate.js` - toolkit helper for `gate.submit`.
+- `packages/toolkit/components/decision-gate/index.js` and `deferred.html` -
+  terminal-state UI behavior and deferred submit path.
+- `packages/toolkit/workbench/guided-user-signal-session.js` - guided-session
+  record normalization/store behavior.
+- `src/daemon/unified.swift` - daemon bridge dispatch for `gate.submit` and
+  related input/canvas boundaries.
+- Current tests under `tests/daemon/`, `tests/toolkit/`, `tests/gateway/`, and
+  `tests/schemas/` that mention gate, continuation, resume, or guided signal.
+
+## Required Behavior
+
+### 1. Inventory The Service Boundary
+
+Write a short implementation note in the completion report, or in a small docs
+update if useful, classifying current user-signal pieces as:
+
+- blocking gate service;
+- durable gate records;
+- deferred continuation and resume event store;
+- trusted local UI submit bridge;
+- guided user signal session record;
+- provider adapter hints only.
+
+Call out duplicated helpers, policy drift, and intentionally separate code.
+
+### 2. Consolidate Shared Runtime Store Mechanics
+
+If inspection finds duplicated state-root/runtime-mode/path/id-validation logic,
+extract the smallest shared helper at the existing ownership layer. Prefer
+`packages/daemon/gate/` or a nearby shared gate/user-signal module over broad
+new abstractions.
+
+The helper must preserve:
+
+- `AOS_STATE_ROOT` isolation;
+- repo/installed runtime mode isolation;
+- continuation id validation before filesystem access;
+- deterministic resume event id semantics;
+- existing JSON/JSONL file compatibility.
+
+Do not migrate storage format in this slice.
+
+### 3. Consolidate Terminal State And Idempotency Policy
+
+Audit the terminal-state paths for:
+
+- answered, dismissed, timeout, cancelled, submitted, captured, error;
+- async submit pending behavior;
+- duplicate submit idempotency;
+- no-answer outcomes versus infrastructure errors.
+
+If a shared helper makes behavior clearer, add it. If the existing separation is
+correct, add focused comments/docs/tests instead of forcing an abstraction.
+
+### 4. Consolidate Redaction Policy
+
+Audit prompt-body, answer-payload, free-text answer, and annotation-comment
+redaction across records, continuations, resume events, DecisionGate UI submit,
+and guided sessions.
+
+Expected default: redact sensitive human-authored payloads unless the request or
+command explicitly opts into storage.
+
+If possible, make this policy flow through one shared helper or one documented
+normalizer. Add regressions where the most likely drift would occur.
+
+### 5. Preserve Provider Boundaries
+
+Codex exec or any other resume backend remains an adapter hint/event boundary.
+AOS core must not auto-run provider commands in this slice. `auto_resume=false`
+remains the V0 behavior even if metadata contains an entrypoint.
+
+## Scope
+
+Likely ownership:
+
+- Node daemon/gate modules;
+- toolkit runtime/component helpers for the existing bridge;
+- guided-session normalizer/store if it shares redaction or state-root policy;
+- schema/API/docs updates only where the public contract changes or a current
+  design note needs correction;
+- deterministic tests.
+
+Swift changes are allowed only for a narrow bridge-contract bug found during the
+audit. If Swift changes are needed, use `./aos dev build` for verification.
+
+## Hard Boundaries / Non-Goals
+
+- Do not promote `./aos gate ask` into a long-running daemon-owned lifecycle.
+- Do not add `./aos gate queue` or a new receptor.
+- Do not add network submit, remote relay, Slack, or gateway-owned state.
+- Do not auto-run `codex exec`, Claude, or any provider resume backend.
+- Do not change storage from JSON/JSONL to SQLite.
+- Do not delete existing runtime records or canonical user state.
+- Do not broaden into Display-first Annotation Mode implementation.
+- Do not start the generated-artifact lifecycle policy card in the same diff.
+
+## Suggested Implementation Areas
+
+Treat these as starting points, not mandates:
+
+- `packages/daemon/gate/` for shared state/redaction/idempotency helpers.
+- `packages/toolkit/workbench/guided-user-signal-session.js` for guided-session
+  alignment with gate redaction/state policy.
+- `packages/toolkit/components/decision-gate/index.js` for any remaining
+  terminal-state race tests.
+- `tests/daemon/gate-continuations.test.mjs`,
+  `tests/daemon/gate-records.test.mjs`, `tests/toolkit/decision-gate.test.mjs`,
+  `tests/toolkit/guided-user-signal-session.test.mjs`, and schema tests for
+  regressions.
+
+## Verification
+
+Start with the router:
+
+```bash
+./aos dev recommend --json --files \
+  packages/daemon/gate/index.js \
+  packages/daemon/gate/records.js \
+  packages/daemon/gate/continuations.js \
+  packages/toolkit/workbench/guided-user-signal-session.js \
+  packages/toolkit/components/decision-gate/index.js
+```
+
+Run focused deterministic tests selected by the actual changed files. Expected
+baseline candidates:
+
+```bash
+node --test tests/daemon/gate-continuations.test.mjs tests/daemon/gate-records.test.mjs tests/daemon/gate-service.test.mjs tests/daemon/gate-receptor.test.mjs
+node --test tests/toolkit/decision-gate.test.mjs tests/toolkit/runtime-gate.test.mjs tests/toolkit/guided-user-signal-session.test.mjs
+node --test tests/gateway/user-signal-surface.test.mjs
+node --test tests/schemas/aos-gate-continuation.test.mjs tests/schemas/aos-guided-user-signal-session.test.mjs tests/schemas/*.test.mjs
+bash tests/help-contract.sh
+bash tests/dev-workflow-router.sh
+bash tests/dev-audit.sh
+git diff --check
+```
+
+If Swift changes are made, also run:
+
+```bash
+./aos dev build
+```
+
+If `./aos ready` passes after the deterministic work, run one bounded isolated
+defer/submit/readback smoke with a temporary `AOS_STATE_ROOT`. If readiness is
+blocked, report the exact blocker and skip live smoke.
+
+## Completion Report
+
+Report:
+
+- changed files;
+- whether shared helpers were added, or why existing separation was retained;
+- terminal-state/idempotency behavior checked;
+- redaction behavior checked;
+- exact tests run and results;
+- live smoke result or readiness blocker;
+- any remaining follow-up, especially whether daemon-owned gate lifecycle is now
+  clearer as a future slice or still premature.

--- a/docs/recipes/layered-subject-expressions.md
+++ b/docs/recipes/layered-subject-expressions.md
@@ -46,6 +46,10 @@ or verification logic.
 6. Identify health, validation, or verifier status.
 7. Reuse toolkit/workbench primitives for chrome, panes, controls, patching,
    and persistence instead of duplicating private panel logic.
+8. Classify generated outputs with
+   `docs/design/generated-artifact-lifecycle-policy.md`: name the lifecycle
+   class, storage location, cleanup/archive trigger, privacy policy, source
+   hash/provenance, and surviving structured result before adding a producer.
 
 ## Source Notes
 

--- a/packages/daemon/gate/continuations.js
+++ b/packages/daemon/gate/continuations.js
@@ -1,10 +1,16 @@
 import { randomUUID } from 'node:crypto';
-import { mkdir, readFile, readdir, rename, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
-import { homedir, userInfo } from 'node:os';
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { userInfo } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { normalizeGateRequest } from './index.js';
 import { createGateRecord, shouldStoreGateResponse } from './records.js';
+import {
+  publicUserSignalSource,
+  runtimeStatePath,
+  writeJsonAtomic,
+  writeJsonExclusive,
+} from '../../../shared/user-signal/service-policy.mjs';
 
 export const GATE_CONTINUATION_SCHEMA_VERSION = 'aos.gate.continuation.v1';
 export const GATE_RESUME_EVENT_SCHEMA_VERSION = 'aos.gate.resume-event.v1';
@@ -16,25 +22,16 @@ const TERMINAL_STATES = new Set(['submitted', 'cancelled', 'expired']);
 const CONTINUATION_ID_RE = /^gate-cont-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 const RESUME_EVENT_ID_RE = /^gate-resume-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
-function runtimeMode(env = process.env) {
-  const mode = String(env.AOS_RUNTIME_MODE || '').toLowerCase();
-  return mode === 'installed' ? 'installed' : 'repo';
-}
-
-function stateRoot(env = process.env) {
-  return env.AOS_STATE_ROOT || join(homedir(), '.config', 'aos');
-}
-
 function isObject(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 export function gateContinuationDir({ env = process.env, root = null } = {}) {
-  return join(root || stateRoot(env), runtimeMode(env), 'gate', 'continuations');
+  return runtimeStatePath(['gate', 'continuations'], { env, root });
 }
 
 export function gateResumeEventDir({ env = process.env, root = null } = {}) {
-  return join(root || stateRoot(env), runtimeMode(env), 'gate', 'resume-events');
+  return runtimeStatePath(['gate', 'resume-events'], { env, root });
 }
 
 export function gateContinuationPath(id, options = {}) {
@@ -45,18 +42,6 @@ export function gateContinuationPath(id, options = {}) {
 export function gateResumeEventPath(id, options = {}) {
   assertResumeEventId(id);
   return join(gateResumeEventDir(options), `${id}.json`);
-}
-
-async function writeJsonAtomic(path, value) {
-  await mkdir(dirname(path), { recursive: true });
-  const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
-  await writeFile(tmp, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
-  await rename(tmp, path);
-}
-
-async function writeJsonExclusive(path, value) {
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, { encoding: 'utf8', flag: 'wx' });
 }
 
 function assertContinuationId(id) {
@@ -74,15 +59,6 @@ function assertResumeEventId(id) {
 function resumeEventIdFor(continuationId) {
   assertContinuationId(continuationId);
   return `gate-resume-${continuationId.slice('gate-cont-'.length)}`;
-}
-
-function publicSource(source) {
-  if (!isObject(source)) return {};
-  const output = {};
-  for (const key of ['surface', 'session_id', 'agent']) {
-    if (source[key] !== undefined) output[key] = source[key];
-  }
-  return output;
 }
 
 function gitValue(args, { cwd }) {
@@ -185,7 +161,7 @@ export class GateContinuationStore {
       gate_id: normalized.id,
       request_schema_version: normalized.schema_version,
       prompt_title: normalized.prompt?.title ?? null,
-      source: publicSource(normalized.source),
+      source: publicUserSignalSource(normalized.source),
       session: defaultSessionMetadata({ sessionId, harness, dock, cwd, env: this.env }),
       lifecycle: {
         state: 'pending',

--- a/packages/daemon/gate/records.js
+++ b/packages/daemon/gate/records.js
@@ -1,26 +1,14 @@
 import { appendFile, mkdir, readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import { homedir } from 'node:os';
+import {
+  publicUserSignalSource,
+  runtimeStatePath,
+} from '../../../shared/user-signal/service-policy.mjs';
 
 export const GATE_RECORD_SCHEMA_VERSION = 'aos.gate.record.v1';
 
-function runtimeMode(env = process.env) {
-  const mode = String(env.AOS_RUNTIME_MODE || '').toLowerCase();
-  return mode === 'installed' ? 'installed' : 'repo';
-}
-
 export function gateRecordPath({ env = process.env, stateRoot = null } = {}) {
-  const root = stateRoot || env.AOS_STATE_ROOT || join(homedir(), '.config', 'aos');
-  return join(root, runtimeMode(env), 'gate', 'records.jsonl');
-}
-
-function publicSource(source) {
-  if (!source || typeof source !== 'object' || Array.isArray(source)) return {};
-  const output = {};
-  for (const key of ['surface', 'session_id', 'agent']) {
-    if (source[key] !== undefined) output[key] = source[key];
-  }
-  return output;
+  return runtimeStatePath(['gate', 'records.jsonl'], { env, root: stateRoot });
 }
 
 function statusFor(resolution, value) {
@@ -59,7 +47,7 @@ export function createGateRecord({
     gate_id: request.id,
     request_schema_version: request.schema_version,
     prompt_title: request.prompt?.title ?? null,
-    source: publicSource(request.source),
+    source: publicUserSignalSource(request.source),
     receptor: receptorName ?? null,
     ui_variant: request.ui?.variant ?? null,
     field_kinds: Array.isArray(request.fields) ? request.fields.map((field) => field.kind) : [],

--- a/packages/toolkit/workbench/guided-user-signal-session.js
+++ b/packages/toolkit/workbench/guided-user-signal-session.js
@@ -1,8 +1,14 @@
 import { randomUUID } from 'node:crypto';
-import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
-import { homedir } from 'node:os';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { normalizeAnnotationAnchor } from './annotation-session.js';
+import {
+  normalizeUserSignalRedaction,
+  runtimeMode,
+  stateRoot,
+  runtimeStatePath,
+  writeJsonAtomic,
+} from '../../../shared/user-signal/service-policy.mjs';
 
 export const GUIDED_USER_SIGNAL_SESSION_SCHEMA_VERSION = 'aos.guided-user-signal.session.v1';
 export const GUIDED_USER_SIGNAL_STORE_READBACK_SCHEMA_VERSION = 'aos.guided-user-signal.sessions.readback.v1';
@@ -39,15 +45,6 @@ function isoNow(now = Date.now()) {
   if (typeof now === 'string') return now;
   const date = now instanceof Date ? now : new Date(now);
   return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
-}
-
-function runtimeMode(env = process.env) {
-  const mode = String(env.AOS_RUNTIME_MODE || '').toLowerCase();
-  return mode === 'installed' ? 'installed' : 'repo';
-}
-
-function stateRoot(env = process.env) {
-  return env.AOS_STATE_ROOT || join(homedir(), '.config', 'aos');
 }
 
 function normalizeRect(rect = null) {
@@ -168,27 +165,20 @@ function normalizeLinks(links = {}) {
 }
 
 function normalizeRedaction(redaction = {}) {
-  const input = object(redaction);
-  return {
-    prompt_bodies: input.prompt_bodies === 'store' ? 'store' : 'redact',
-    free_text_answers: input.free_text_answers === 'store' ? 'store' : 'redact',
-    answer_payloads: input.answer_payloads === 'store' ? 'store' : 'redact',
-  };
+  return normalizeUserSignalRedaction(redaction);
 }
 
 function storageFor(sessionId, { env = process.env, root = null } = {}) {
   const mode = runtimeMode(env);
-  const base = root || stateRoot(env);
   return {
     runtime_mode: mode,
-    state_root: base,
-    session_path: join(base, mode, 'guided-user-signal', 'sessions', `${sessionId}.json`),
+    state_root: root || stateRoot(env),
+    session_path: runtimeStatePath(['guided-user-signal', 'sessions', `${sessionId}.json`], { env, root }),
   };
 }
 
 export function guidedUserSignalSessionDir({ env = process.env, root = null } = {}) {
-  const mode = runtimeMode(env);
-  return join(root || stateRoot(env), mode, 'guided-user-signal', 'sessions');
+  return runtimeStatePath(['guided-user-signal', 'sessions'], { env, root });
 }
 
 export function assertGuidedUserSignalSessionId(id) {
@@ -283,13 +273,6 @@ export function buildGuidedUserSignalShellPlan(session = {}, options = {}) {
       ? { submit_helper: 'submitGateContinuation', continuation_id: record.linked_artifacts.continuation_id }
       : null,
   };
-}
-
-async function writeJsonAtomic(path, value) {
-  await mkdir(dirname(path), { recursive: true });
-  const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
-  await writeFile(tmp, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
-  await rename(tmp, path);
 }
 
 export class GuidedUserSignalSessionStore {

--- a/shared/user-signal/service-policy.mjs
+++ b/shared/user-signal/service-policy.mjs
@@ -1,0 +1,52 @@
+import { mkdir, rename, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+
+export const USER_SIGNAL_DEFAULT_REDACTION = Object.freeze({
+  prompt_bodies: 'redact',
+  free_text_answers: 'redact',
+  answer_payloads: 'redact',
+});
+
+export function runtimeMode(env = process.env) {
+  const mode = String(env.AOS_RUNTIME_MODE || '').toLowerCase();
+  return mode === 'installed' ? 'installed' : 'repo';
+}
+
+export function stateRoot(env = process.env) {
+  return env.AOS_STATE_ROOT || join(homedir(), '.config', 'aos');
+}
+
+export function runtimeStatePath(segments = [], { env = process.env, root = null } = {}) {
+  return join(root || stateRoot(env), runtimeMode(env), ...segments);
+}
+
+export function publicUserSignalSource(source) {
+  if (!source || typeof source !== 'object' || Array.isArray(source)) return {};
+  const output = {};
+  for (const key of ['surface', 'session_id', 'agent']) {
+    if (source[key] !== undefined) output[key] = source[key];
+  }
+  return output;
+}
+
+export function normalizeUserSignalRedaction(redaction = {}) {
+  const input = redaction && typeof redaction === 'object' && !Array.isArray(redaction) ? redaction : {};
+  return {
+    prompt_bodies: input.prompt_bodies === 'store' ? 'store' : USER_SIGNAL_DEFAULT_REDACTION.prompt_bodies,
+    free_text_answers: input.free_text_answers === 'store' ? 'store' : USER_SIGNAL_DEFAULT_REDACTION.free_text_answers,
+    answer_payloads: input.answer_payloads === 'store' ? 'store' : USER_SIGNAL_DEFAULT_REDACTION.answer_payloads,
+  };
+}
+
+export async function writeJsonAtomic(path, value) {
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tmp, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+  await rename(tmp, path);
+}
+
+export async function writeJsonExclusive(path, value) {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, { encoding: 'utf8', flag: 'wx' });
+}

--- a/tests/toolkit/toolkit-api-docs-contract.test.mjs
+++ b/tests/toolkit/toolkit-api-docs-contract.test.mjs
@@ -112,6 +112,30 @@ test('surface interaction decision tree remains discoverable from toolkit API do
   }
 });
 
+test('generated artifact lifecycle policy is discoverable from workbench docs', async () => {
+  const policyPath = 'docs/design/generated-artifact-lifecycle-policy.md';
+  const [workbench, audit, recipe, policy] = await Promise.all([
+    text('docs/api/toolkit/workbench.md'),
+    text('docs/design/html-workbench-expression-adoption-audit-2026-05-13.md'),
+    text('docs/recipes/layered-subject-expressions.md'),
+    text(policyPath),
+  ]);
+
+  assert.match(workbench, escaped(policyPath));
+  assert.match(audit, escaped(policyPath));
+  assert.match(recipe, escaped(policyPath));
+  for (const phrase of [
+    'HTML Workbench Expressions',
+    'Runtime wiki repo-doc projections',
+    'User-signal gate records',
+    'Producer Requirements',
+    'source hash/provenance',
+    'Surviving structured result',
+  ]) {
+    assert.match(policy, escaped(phrase));
+  }
+});
+
 test('canvas_object.marks documents fixed minimap and DesktopWorld-projected sizes', async () => {
   const doc = await text('docs/api/toolkit/components.md');
   const compact = doc.replace(/\s+/g, ' ');


### PR DESCRIPTION
## Summary

- Consolidates shared user-signal service policy helpers for runtime-mode state paths, `AOS_STATE_ROOT` handling, public source projection, default redaction policy, and JSON writes.
- Updates gate continuation, gate record, and guided user-signal session stores to use the shared policy while keeping terminal-state and idempotency behavior local to each service.
- Adds a generated-artifact lifecycle policy, links it from workbench and layered-subject docs, and adds a docs-contract regression.
- Records the platform-debt map and routed work cards that led to this slice.

## Verification

- `node --test tests/daemon/gate-continuations.test.mjs tests/daemon/gate-records.test.mjs tests/daemon/gate-service.test.mjs tests/daemon/gate-receptor.test.mjs tests/toolkit/guided-user-signal-session.test.mjs tests/toolkit/decision-gate.test.mjs tests/toolkit/runtime-gate.test.mjs tests/gateway/user-signal-surface.test.mjs tests/schemas/aos-gate-continuation.test.mjs tests/schemas/aos-guided-user-signal-session.test.mjs` passed 60/60.
- `node --test tests/toolkit/toolkit-api-docs-contract.test.mjs tests/toolkit/html-workbench-expression.test.mjs tests/schemas/aos-html-workbench-expression-v0.test.mjs` passed 18/18.
- `node --test tests/schemas/*.test.mjs` passed 70/70.
- `bash tests/help-contract.sh` passed.
- `bash tests/dev-workflow-router.sh` passed.
- `bash tests/dev-audit.sh` passed.
- `git diff --check main...HEAD` passed.
- `./aos ready` returned `ready=true mode=repo daemon=reachable tap=active` before publication.

## Notes

Refs #293, #295, #300, #306, #359, #360, #361, and #362.
