### PR TITLE
Fix browser evidence capture session collisions

### DIFF
--- a/packages/toolkit/workbench/browser-evidence-capture.js
+++ b/packages/toolkit/workbench/browser-evidence-capture.js
@@ -21,6 +21,8 @@ const CAPTURE_STATUSES = new Set([
   'capture_failed',
 ]);
 
+let captureSessionCounter = 0;
+
 function text(value, fallback = '') {
   const normalized = String(value ?? '').replace(/\s+/g, ' ').trim();
   return normalized || fallback;
@@ -225,6 +227,16 @@ function runPlaywright(playwrightCli, args, { timeout = 30_000 } = {}) {
     };
   }
   return result;
+}
+
+function createPlaywrightSessionName(sessionPrefix) {
+  captureSessionCounter = (captureSessionCounter + 1) % Number.MAX_SAFE_INTEGER;
+  const prefix = slug(sessionPrefix, 'capture').slice(0, 8);
+  const pid = process.pid.toString(36);
+  const counter = captureSessionCounter.toString(36);
+  const timestamp = Date.now().toString(36);
+  // playwright-cli derives short socket names from the leading session text.
+  return `${prefix}-${pid}-${counter}-${timestamp}`;
 }
 
 function parseRunCodeResult(stdout) {
@@ -541,7 +553,7 @@ export function captureBrowserEvidenceRequest(requestInput, {
     };
   }
 
-  const session = `${sessionPrefix}-${process.pid}-${slug(request.request_id, 'request')}`;
+  const session = createPlaywrightSessionName(sessionPrefix);
   const paths = assetPathsForRequest(request, { assetDir, outputDir });
   fs.mkdirSync(path.dirname(paths.screenshot_absolute_path), { recursive: true });
 


### PR DESCRIPTION
## Summary

Fixes Browser Evidence Capture V0 session naming so multiple capture requests in one Node process do not collide in `playwright-cli` socket/session state.

`playwright-cli` derives short socket names from the leading session text. The previous session name put the unique request slug too late (`browser-evidence-<pid>-<request>`), so adjacent requests could share the effective socket prefix and the second request failed with `EADDRINUSE`. This moves compact unique entropy near the front of the session name.

## Verification

- `./aos ready` -> `ready=true mode=repo daemon=reachable tap=active`
- `node --test tests/toolkit/browser-evidence-capture.test.mjs` -> pass, 3 tests
- `git diff --check` -> pass

## Broad Suite Context

On `origin/main`, `node --test tests/toolkit/*.test.mjs` no longer fails the browser-evidence capture cases after this patch, but the glob still has unrelated main-state toolkit failures in radial/Zag/Wiki KB areas. Those areas are already part of draft PR #368 (`gdi/toolkit-panel-theme-consistency-audit-v0`). This PR stays scoped to the browser evidence base failure found during final verification for #368.
