### PR TITLE
feat(toolkit): add html file workbench

### DIFF
--- a/docs/api/toolkit/components.md
+++ b/docs/api/toolkit/components.md
@@ -79,6 +79,55 @@ type scale, heading/list spacing, code blocks, rules, and links. Workbenches
 keep their own artifact chrome, panes, toolbars, loading states, semantic refs,
 and edit/save affordances.
 
+## HTML File Workbench
+
+`packages/toolkit/components/html-file-workbench/` is the file-backed toolkit
+workbench for standalone local `.html` and `.htm` files. It is separate from
+`html-workbench-expression`: HTML File Workbench edits durable source files and
+previews their current text, while HTML Workbench Expression hosts generated
+annotation-ready projections with metadata.
+
+Launch a local file with:
+
+```bash
+packages/toolkit/components/html-file-workbench/launch.sh /path/to/demo.html
+```
+
+The default canvas id is `html-file-workbench`; set `CANVAS_ID=...` to override
+it. The launcher rejects missing files, non-HTML extensions, and files larger
+than `AOS_HTML_FILE_WORKBENCH_MAX_BYTES` bytes, defaulting to 1 MiB.
+
+The component accepts:
+
+- `html_file.open` with `{ path, content }`
+- `html_file.text.patch` with `{ content }`
+- `html_file.save.result`
+- `html_file.preview.reload`
+- `html_file.revert`
+
+It emits `html-file-workbench/save.requested` with
+`{ type: "html_file.save.request", path, content, content_length }`. Agents can
+persist the current editor content with:
+
+```bash
+packages/toolkit/components/html-file-workbench/save-current.sh html-file-workbench
+```
+
+The save helper reads `window.__htmlFileWorkbenchState` through
+`./aos show eval`, refuses to create missing targets or save non-HTML paths,
+writes UTF-8 text to the target file, and posts `html_file.save.result` back to
+the panel so dirty state clears.
+
+The live preview renders `state.previewContent` through an iframe `srcdoc` with
+a sandbox that allows same-file scripts and form-style demo interaction but does
+not include `allow-same-origin`, so preview scripts cannot directly reach the
+workbench shell DOM. Reload Preview explicitly copies editor source into the
+iframe; syntax or runtime errors inside the preview do not replace the editor.
+
+Smoke tests can inspect `window.__htmlFileWorkbenchState`, which includes
+`path`, `dirty`, `content`, `content_length`, `content_hash`, `preview_mode`,
+`preview_revision`, `preview_content_length`, and `last_result`.
+
 ## Decision Gate
 
 `aos://toolkit/components/decision-gate/index.html` is the blocking gate

--- a/docs/design/work-cards/html-file-workbench-v0.md
+++ b/docs/design/work-cards/html-file-workbench-v0.md
@@ -1,0 +1,261 @@
+# HTML File Workbench V0
+
+## Transfer
+
+- Recipient: GDI
+- Transfer kind: GDI round
+- Source artifact: `docs/design/work-cards/html-file-workbench-v0.md`
+- Single next goal: add a simple file-backed HTML viewer/editor workbench for local standalone `.html` files.
+- Branch/base: start from the current `main` worktree containing this card; expected output branch pattern is `gdi/html-file-workbench-v0`.
+- Stop conditions: completed with evidence, failed with technical blocker, stalled/human_needed for repo-mode permission or product direction.
+
+## Fresh Context Contract
+
+GDI starts from a fresh context window in `/Users/Michael/Code/agent-os`. Do not
+work in `.docks/`. Do not assume branch, daemon, canvas, issue, prior chat, or
+implementation state. Read and rediscover before editing.
+
+## Goal
+
+Make AOS have a simple HTML file workbench analogous to the existing Markdown
+Workbench, but scoped to standalone local `.html` files like:
+
+```text
+/Users/Michael/Code/tmp/undulating-background.html
+```
+
+The user asked whether we have an AOS viewer/editor for simple HTML demos, then
+asked Foreman to route GDI to make it.
+
+The new workbench should let a user open a local HTML file in an AOS panel,
+edit the source, see a live preview, save back to the file, and reload/revert
+without leaving AOS.
+
+## Read First
+
+- `AGENTS.md`
+- `packages/toolkit/AGENTS.md`
+- `docs/api/aos.md`
+- `docs/api/toolkit.md`
+- `docs/api/toolkit/components.md`
+- `docs/api/toolkit/panel-window.md`
+- `packages/toolkit/components/markdown-workbench/launch.sh`
+- `packages/toolkit/components/markdown-workbench/index.js`
+- `packages/toolkit/components/markdown-workbench/model.js`
+- `packages/toolkit/components/html-workbench-expression/index.js`
+- `packages/toolkit/components/html-workbench-expression/launch.sh`
+- `docs/design/work-cards/aos-html-workbench-expression-v0.md`
+
+## Rediscover State
+
+Run:
+
+```bash
+git status --short --branch
+./aos dev recommend --json
+```
+
+For live AOS verification, run:
+
+```bash
+./aos ready
+```
+
+If `./aos ready` or a bounded live check reports repo-mode Accessibility, Input
+Monitoring, or inactive input-tap blockers, run:
+
+```bash
+.docks/gdi/scripts/human-needed-tcc-reset
+```
+
+Then stop with `human_needed` and report the script output. After the human
+returns with "ready", run:
+
+```bash
+./aos ready --post-permission
+```
+
+Only continue live checks if it reports ready. Deterministic unit tests may
+continue without live AOS if they do not need daemon input.
+
+## Existing Code To Inspect
+
+- `packages/toolkit/components/markdown-workbench/` - file-backed editor
+  pattern, source/preview split, save/revert workflow, launcher shape.
+- `packages/toolkit/components/html-workbench-expression/` - existing
+  annotation-ready HTML projection; useful contrast, but not the target surface.
+- `packages/toolkit/controls/textarea.js` - shared textarea control.
+- `packages/toolkit/controls/button.js` - shared button rendering/creation.
+- `packages/toolkit/panel/index.js` and `packages/toolkit/panel/layouts/` -
+  panel mounting and layout helpers.
+- `docs/api/aos.md` - current `show create --file`, `show update --file`, and
+  canvas semantics.
+- `tests/toolkit/markdown-workbench-layout.test.mjs` and adjacent toolkit
+  component tests - deterministic component test style.
+
+## Required Behavior
+
+### Component
+
+Add a new reusable toolkit component, likely:
+
+```text
+packages/toolkit/components/html-file-workbench/
+```
+
+Expected surface behavior:
+
+- opens as an AOS panel with manifest name `html-file-workbench`;
+- accepts an event such as `html_file.open` with `{ path, content }`;
+- renders a source editor and live preview;
+- tracks dirty state when source changes;
+- supports Save, Revert, Reload Preview, and Close controls;
+- exposes `window.__htmlFileWorkbenchState` with enough state for smoke tests:
+  path, dirty, content length/hash, preview mode, last result/status;
+- emits a save request/result shape that an agent helper can use to write the
+  current source to disk;
+- provides a launch helper that opens a local `.html` file and posts its source
+  into the workbench.
+
+Suggested launch command shape:
+
+```bash
+packages/toolkit/components/html-file-workbench/launch.sh /Users/Michael/Code/tmp/undulating-background.html
+```
+
+Default canvas id should be `html-file-workbench`, overrideable with
+`CANVAS_ID=...`.
+
+### Editing And Save
+
+GDI may choose either a helper-script save model like Markdown Workbench or a
+direct local save helper invoked by Foreman/agent, but the contract must be
+clear and deterministic.
+
+Minimum acceptable save path:
+
+- a component Save action emits or records a save request containing the target
+  path and current content;
+- a repo helper such as
+  `packages/toolkit/components/html-file-workbench/save-current.sh
+  html-file-workbench` writes the current source back to the file through
+  `./aos show eval`;
+- successful save clears dirty state or records a save result that the panel can
+  consume.
+
+If GDI can keep the implementation smaller with the exact Markdown Workbench
+save-current pattern, prefer that.
+
+### Preview
+
+Preview must be useful for standalone demos like the anchor FX lab:
+
+- render the current HTML in an iframe or equivalent contained preview surface;
+- preserve CSS and scripts inside the preview well enough for local demos to
+  run interactively;
+- do not let preview scripts reach the workbench shell DOM;
+- keep preview refresh explicit enough that syntax errors do not destroy the
+  editor shell;
+- show preview errors or blocked state visibly instead of going blank.
+
+Use a sandboxed iframe unless a narrower existing toolkit pattern is clearly
+better. If sandboxing prevents local interactive demos from working, document
+the tradeoff and choose the safest mode that still supports same-file CSS/JS
+inside `srcdoc`.
+
+### Source Handling
+
+- Treat the local `.html` file as the durable source.
+- Do not create a metadata sidecar requirement for simple file editing.
+- Do not require the generated HTML Expression schema.
+- Do not mutate files outside the target path.
+- Guard against accidental binary/huge-file opens with a reasonable size check
+  or error result.
+- Preserve the exact text content on no-op open/save cycles.
+
+### Relationship To Existing HTML Workbench Expression
+
+Keep `html-workbench-expression` intact. It is for safe annotation-ready
+projections with metadata and semantic targets. The new workbench is for simple
+file-backed source editing and live preview.
+
+Do not merge the two in this slice unless the existing abstraction already makes
+that trivial. A wrapper around shared helpers is fine; a broad rewrite is not.
+
+## Scope
+
+Ownership boundary: toolkit component/workbench layer plus focused docs/tests.
+
+Likely paths:
+
+- `packages/toolkit/components/html-file-workbench/index.html`
+- `packages/toolkit/components/html-file-workbench/index.js`
+- `packages/toolkit/components/html-file-workbench/styles.css`
+- `packages/toolkit/components/html-file-workbench/launch.sh`
+- `packages/toolkit/components/html-file-workbench/save-current.sh`
+- `tests/toolkit/html-file-workbench.test.mjs`
+- `docs/api/toolkit/components.md` or another scoped toolkit API doc
+
+GDI may adjust paths after inspecting current toolkit conventions.
+
+## Hard Boundaries / Non-Goals
+
+- Do not implement a full IDE, syntax highlighter, formatter, bundler, npm
+  runtime, asset server, or browser automation layer.
+- Do not replace Markdown Workbench.
+- Do not replace or remodel `html-workbench-expression`.
+- Do not add arbitrary dynamic npm installs.
+- Do not execute preview HTML in the parent workbench DOM.
+- Do not add daemon/native primitives unless a truly blocking gap is discovered;
+  report that to Foreman instead.
+- Do not edit `/Users/Michael/Code/tmp/undulating-background.html` except as an
+  optional live smoke target after the component exists.
+
+## Verification
+
+Run deterministic checks first:
+
+```bash
+node --test tests/toolkit/html-file-workbench.test.mjs
+node --test tests/toolkit/markdown-workbench-layout.test.mjs tests/toolkit/html-workbench-expression.test.mjs
+git diff --check
+```
+
+Also run `node --check` on new JS files if they are not covered by `node --test`.
+
+If `./aos ready` passes, run a bounded live smoke:
+
+```bash
+packages/toolkit/components/html-file-workbench/launch.sh /Users/Michael/Code/tmp/undulating-background.html
+./aos show wait --id html-file-workbench --manifest html-file-workbench --timeout 5s
+./aos show eval --id html-file-workbench --js 'JSON.stringify(window.__htmlFileWorkbenchState)'
+```
+
+Live smoke should prove:
+
+- manifest readiness passes;
+- state names the opened file path;
+- source editor exists and contains HTML;
+- preview iframe exists and has non-empty rendered content;
+- changing source marks dirty and Reload Preview updates the preview;
+- save helper can write a harmless temporary copy or no-op save without
+  corrupting the target.
+
+If testing against the real tmp demo feels risky, copy it to a temp file and use
+the temp file for save/revert proof.
+
+## Completion Report
+
+Report back to Foreman with:
+
+- files changed;
+- behavior implemented;
+- exact tests run and pass/fail results;
+- live AOS smoke result, or the exact readiness/TCC blocker;
+- whether `/Users/Michael/Code/tmp/undulating-background.html` was used only as
+  a smoke target or left untouched;
+- any generated/untracked artifacts;
+- known limitations of the preview sandbox;
+- recommended next slice, if one remains.
+
+Use a path-scoped summary if unrelated dirty state exists.

--- a/packages/toolkit/components/html-file-workbench/index.html
+++ b/packages/toolkit/components/html-file-workbench/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../_base/theme.css">
+<link rel="stylesheet" href="../../panel/defaults.css">
+<link rel="stylesheet" href="../../controls/defaults.css">
+<link rel="stylesheet" href="../../workbench/defaults.css">
+<link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+<script type="module">
+import { mountPanel, Single } from '../../panel/index.js'
+import HtmlFileWorkbench from './index.js'
+
+try {
+  mountPanel({
+    title: 'HTML File Workbench',
+    layout: Single(HtmlFileWorkbench),
+    maximize: true,
+    resizable: true,
+    resize: { minWidth: 760, minHeight: 520 },
+  })
+} catch (error) {
+  document.body.dataset.mountError = String(error?.message || error)
+  document.body.innerHTML = `<pre style="padding:12px;color:#ffd166;background:#050a0e;height:100%;overflow:auto">${String(error?.stack || error)}</pre>`
+  throw error
+}
+</script>
+</body>
+</html>

--- a/packages/toolkit/components/html-file-workbench/index.js
+++ b/packages/toolkit/components/html-file-workbench/index.js
@@ -1,0 +1,251 @@
+import { renderButtonHtml } from '../../controls/button.js';
+import { createTextarea } from '../../controls/textarea.js';
+import {
+  applyHtmlFileSaveResult,
+  applyHtmlFileTextPatch,
+  buildHtmlFileSaveRequest,
+  createHtmlFileWorkbenchState,
+  HTML_FILE_OPEN_TYPE,
+  HTML_FILE_SAVE_RESULT_TYPE,
+  HTML_FILE_TEXT_PATCH_TYPE,
+  htmlFileWorkbenchSnapshot,
+  openHtmlFile,
+  reloadHtmlFilePreview,
+  revertHtmlFile,
+  setHtmlFileContent,
+  sha256Hex,
+} from './model.js';
+
+function el(tag, className, textContent) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (textContent !== undefined) node.textContent = textContent;
+  return node;
+}
+
+function lineCount(value = '') {
+  return String(value).length ? String(value).split(/\r\n|\r|\n/).length : 0;
+}
+
+function hasHtmlShape(content = '') {
+  return /<!doctype html|<html[\s>]|<body[\s>]|<script[\s>]|<style[\s>]/i.test(String(content));
+}
+
+export default function HtmlFileWorkbench(options = {}) {
+  let host = null;
+  const state = createHtmlFileWorkbenchState(options.document || {});
+  const dom = {};
+
+  function emit(type, payload) {
+    if (host?.emit) host.emit(type, payload);
+  }
+
+  function syncTitle() {
+    host?.setTitle?.(`HTML File / Workbench${state.dirty ? ' *' : ''}`);
+  }
+
+  function syncStats() {
+    dom.stats.textContent = `${lineCount(state.content)} lines · ${state.content.length} chars`;
+    dom.previewStatus.textContent = state.previewMode === 'srcdoc'
+      ? `Preview revision ${state.previewRevision}`
+      : 'Preview blocked';
+    dom.warning.hidden = hasHtmlShape(state.content);
+  }
+
+  function syncPreview() {
+    dom.previewFrame.removeAttribute('src');
+    dom.previewFrame.setAttribute('sandbox', 'allow-scripts allow-forms allow-modals allow-pointer-lock allow-popups');
+    dom.previewFrame.srcdoc = state.previewContent;
+  }
+
+  function syncInspectableState() {
+    window.__htmlFileWorkbenchState = htmlFileWorkbenchSnapshot(state);
+  }
+
+  function refreshHash() {
+    void sha256Hex(state.content).then((hash) => {
+      state.contentHash = hash;
+      syncInspectableState();
+    });
+  }
+
+  function sync({ replaceEditorValue = false, refreshPreview = false } = {}) {
+    dom.path.textContent = state.path;
+    dom.root.dataset.dirty = String(state.dirty);
+    dom.dirty.textContent = state.dirty ? 'Unsaved changes' : 'Saved';
+    dom.saveButton.disabled = !state.dirty;
+    dom.saveButton.setAttribute('aria-disabled', String(!state.dirty));
+    if (replaceEditorValue && dom.editor.value !== state.content) {
+      dom.editor.value = state.content;
+    }
+    syncTitle();
+    syncStats();
+    if (refreshPreview) syncPreview();
+    syncInspectableState();
+    refreshHash();
+  }
+
+  function requestSave() {
+    const request = buildHtmlFileSaveRequest(state);
+    emit('save.requested', request);
+    sync();
+    return request;
+  }
+
+  function setContent(content) {
+    setHtmlFileContent(state, content);
+    sync();
+  }
+
+  function handleEditorKeydown(event) {
+    const key = String(event.key || '').toLowerCase();
+    if ((event.metaKey || event.ctrlKey) && key === 's') {
+      event.preventDefault();
+      requestSave();
+    }
+  }
+
+  function render() {
+    const root = el('div', 'html-file-workbench-root');
+    root.setAttribute('role', 'group');
+    root.setAttribute('aria-label', 'HTML File Workbench');
+    root.dataset.aosRef = 'html-file-workbench:root';
+    root.dataset.aosSurface = 'html-file-workbench';
+    root.dataset.semanticTargetId = 'root';
+    dom.root = root;
+
+    root.innerHTML = `
+      <header class="html-file-workbench-toolbar" role="toolbar" aria-label="HTML file tools">
+        <div class="html-file-workbench-file" title="Current HTML file">
+          <strong data-role="path" data-aos-ref="html-file-workbench:current-path" data-aos-surface="html-file-workbench" data-semantic-target-id="current-path"></strong>
+          <span data-role="dirty" data-aos-ref="html-file-workbench:dirty-state" data-aos-surface="html-file-workbench" data-semantic-target-id="dirty-state"></span>
+        </div>
+        <div class="html-file-workbench-actions">
+          ${renderButtonHtml({ label: 'Reload Preview', rawAttributes: 'data-action="reload-preview" data-aos-ref="html-file-workbench:reload-preview" data-aos-action="reload_preview" data-aos-surface="html-file-workbench" data-semantic-target-id="reload-preview"' })}
+          ${renderButtonHtml({ label: 'Revert', rawAttributes: 'data-action="revert" data-aos-ref="html-file-workbench:revert" data-aos-action="revert_html_file" data-aos-surface="html-file-workbench" data-semantic-target-id="revert"' })}
+          ${renderButtonHtml({ label: 'Save', rawAttributes: 'data-action="save" data-aos-ref="html-file-workbench:save" data-aos-action="save_html_file" data-aos-surface="html-file-workbench" data-semantic-target-id="save"' })}
+          ${renderButtonHtml({ label: 'Close', rawAttributes: 'data-action="close" data-aos-ref="html-file-workbench:close" data-aos-action="close_html_file" data-aos-surface="html-file-workbench" data-semantic-target-id="close"' })}
+        </div>
+      </header>
+      <main class="html-file-workbench-main">
+        <section class="html-file-workbench-source" aria-label="HTML source" data-aos-ref="html-file-workbench:source-pane" data-aos-surface="html-file-workbench" data-semantic-target-id="source-pane"></section>
+        <section class="html-file-workbench-preview" aria-label="Live HTML preview" data-aos-ref="html-file-workbench:preview-pane" data-aos-surface="html-file-workbench" data-semantic-target-id="preview-pane">
+          <iframe class="html-file-workbench-preview-frame" title="HTML preview" data-role="preview-frame" data-aos-ref="html-file-workbench:preview-frame" data-aos-surface="html-file-workbench" data-semantic-target-id="preview-frame"></iframe>
+          <div class="html-file-workbench-preview-empty" data-role="preview-empty">Preview will render after an HTML file opens.</div>
+        </section>
+      </main>
+      <footer class="html-file-workbench-status" aria-label="HTML file status">
+        <span data-role="stats"></span>
+        <span data-role="preview-status"></span>
+        <span class="html-file-workbench-warning" data-role="warning" hidden>Source does not look like a standalone HTML document.</span>
+      </footer>
+    `;
+
+    const editorControl = createTextarea({
+      document,
+      spellcheck: false,
+      ariaLabel: 'HTML source editor',
+      dataset: {
+        aosRef: 'html-file-workbench:source-editor',
+        aosAction: 'edit_html_file',
+        aosSurface: 'html-file-workbench',
+        semanticTargetId: 'source-editor',
+      },
+    });
+    root.querySelector('.html-file-workbench-source')?.appendChild(editorControl.el);
+
+    dom.path = root.querySelector('[data-role="path"]');
+    dom.dirty = root.querySelector('[data-role="dirty"]');
+    dom.editor = editorControl.el;
+    dom.saveButton = root.querySelector('[data-action="save"]');
+    dom.stats = root.querySelector('[data-role="stats"]');
+    dom.previewStatus = root.querySelector('[data-role="preview-status"]');
+    dom.warning = root.querySelector('[data-role="warning"]');
+    dom.previewFrame = root.querySelector('[data-role="preview-frame"]');
+    dom.previewEmpty = root.querySelector('[data-role="preview-empty"]');
+
+    dom.editor.addEventListener('input', () => setContent(dom.editor.value));
+    dom.editor.addEventListener('keydown', handleEditorKeydown);
+    dom.previewFrame.addEventListener('load', () => {
+      dom.previewEmpty.hidden = true;
+      state.lastResult = {
+        type: 'html_file.preview.load.result',
+        status: 'loaded',
+        path: state.path,
+        preview_revision: state.previewRevision,
+      };
+      syncStats();
+      syncInspectableState();
+    });
+    dom.previewFrame.addEventListener('error', () => {
+      dom.previewEmpty.hidden = false;
+      dom.previewEmpty.textContent = 'Preview failed to load.';
+      state.lastResult = {
+        type: 'html_file.preview.load.result',
+        status: 'rejected',
+        path: state.path,
+        preview_revision: state.previewRevision,
+      };
+      syncStats();
+      syncInspectableState();
+    });
+    root.querySelector('[data-action="reload-preview"]').addEventListener('click', () => {
+      reloadHtmlFilePreview(state);
+      sync({ refreshPreview: true });
+    });
+    root.querySelector('[data-action="revert"]').addEventListener('click', () => {
+      revertHtmlFile(state);
+      sync({ replaceEditorValue: true, refreshPreview: true });
+    });
+    dom.saveButton.addEventListener('click', requestSave);
+    root.querySelector('[data-action="close"]').addEventListener('click', () => {
+      emit('close.requested', { type: 'html_file.close.request', path: state.path, dirty: state.dirty });
+    });
+
+    sync({ replaceEditorValue: true, refreshPreview: true });
+    return root;
+  }
+
+  function onMessage(message = {}) {
+    const type = message.type || message.payload?.type;
+    if (type === HTML_FILE_OPEN_TYPE) {
+      openHtmlFile(state, message);
+      sync({ replaceEditorValue: true, refreshPreview: true });
+    } else if (type === HTML_FILE_TEXT_PATCH_TYPE) {
+      applyHtmlFileTextPatch(state, message);
+      sync({ replaceEditorValue: true });
+    } else if (type === HTML_FILE_SAVE_RESULT_TYPE) {
+      applyHtmlFileSaveResult(state, message);
+      sync({ replaceEditorValue: true });
+    } else if (type === 'html_file.preview.reload') {
+      reloadHtmlFilePreview(state);
+      sync({ refreshPreview: true });
+    } else if (type === 'html_file.revert') {
+      revertHtmlFile(state);
+      sync({ replaceEditorValue: true, refreshPreview: true });
+    }
+  }
+
+  return {
+    manifest: {
+      name: 'html-file-workbench',
+      title: 'HTML File Workbench',
+      accepts: [HTML_FILE_OPEN_TYPE, HTML_FILE_TEXT_PATCH_TYPE, HTML_FILE_SAVE_RESULT_TYPE, 'html_file.preview.reload', 'html_file.revert'],
+      emits: ['html-file-workbench/save.requested', 'html-file-workbench/close.requested'],
+      channelPrefix: 'html-file-workbench',
+      defaultSize: { w: 1180, h: 760 },
+    },
+
+    render(host_) {
+      host = host_;
+      host.contentEl.style.overflow = 'hidden';
+      return render();
+    },
+
+    onMessage,
+
+    serialize() {
+      return htmlFileWorkbenchSnapshot(state);
+    },
+  };
+}

--- a/packages/toolkit/components/html-file-workbench/launch.sh
+++ b/packages/toolkit/components/html-file-workbench/launch.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# launch.sh - Open a local standalone HTML file in the HTML File Workbench.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null || pwd)"
+source "$ROOT/scripts/aos-content-scope.sh"
+
+AOS="${AOS:-$ROOT/aos}"
+CANVAS_ID="${CANVAS_ID:-html-file-workbench}"
+PANEL_W="${AOS_HTML_FILE_WORKBENCH_W:-1180}"
+PANEL_H="${AOS_HTML_FILE_WORKBENCH_H:-760}"
+TOOLKIT_CONTENT_ROOT="${AOS_TOOLKIT_CONTENT_ROOT:-$(aos_content_root_key_for toolkit "$ROOT")}"
+TARGET_FILE="${1:-}"
+MAX_BYTES="${AOS_HTML_FILE_WORKBENCH_MAX_BYTES:-1048576}"
+
+if [[ ! -x "$AOS" ]]; then
+  echo "aos binary not found at $AOS" >&2
+  exit 1
+fi
+
+if [[ -z "$TARGET_FILE" ]]; then
+  echo "usage: $0 /path/to/file.html" >&2
+  exit 2
+fi
+
+if [[ ! -f "$TARGET_FILE" ]]; then
+  echo "HTML file not found: $TARGET_FILE" >&2
+  exit 1
+fi
+
+TARGET_FILE="$(cd "$(dirname "$TARGET_FILE")" && pwd)/$(basename "$TARGET_FILE")"
+TARGET_FILE_LOWER="$(printf '%s' "$TARGET_FILE" | tr '[:upper:]' '[:lower:]')"
+case "$TARGET_FILE_LOWER" in
+  *.html|*.htm) ;;
+  *)
+    echo "Target must be a .html or .htm file: $TARGET_FILE" >&2
+    exit 1
+    ;;
+esac
+
+SIZE="$(wc -c < "$TARGET_FILE" | tr -d '[:space:]')"
+if [[ "$SIZE" -gt "$MAX_BYTES" ]]; then
+  echo "HTML file is too large for the V0 workbench: $SIZE bytes > $MAX_BYTES bytes" >&2
+  exit 1
+fi
+
+"$AOS" show remove --id "$CANVAS_ID" 2>/dev/null || true
+
+aos_ensure_content_roots_live "$AOS" \
+  "$TOOLKIT_CONTENT_ROOT" "$ROOT/packages/toolkit"
+
+DISPLAY_JSON="$("$AOS" graph displays --json 2>/dev/null || echo '{"data":{"displays":[]}}')"
+GEOMETRY="$(
+  echo "$DISPLAY_JSON" | PANEL_W="$PANEL_W" PANEL_H="$PANEL_H" python3 -c '
+import json, os, sys
+
+payload = json.load(sys.stdin)
+displays = payload.get("data", {}).get("displays", payload.get("displays", [])) if isinstance(payload, dict) else payload
+main = next((entry for entry in displays if entry.get("is_main")), displays[0] if displays else None)
+rect = (main or {}).get("visible_bounds") or (main or {}).get("bounds") or {}
+x = int(rect.get("x", 0))
+y = int(rect.get("y", 0))
+w = int(rect.get("w", 1728))
+h = int(rect.get("h", 1117))
+panel_w = min(int(os.environ["PANEL_W"]), max(760, w - 48))
+panel_h = min(int(os.environ["PANEL_H"]), max(520, h - 96))
+print(x + 24, y + 64, panel_w, panel_h)
+' 2>/dev/null || echo "24 64 $PANEL_W $PANEL_H"
+)"
+
+read -r X Y W H <<<"$GEOMETRY"
+
+"$AOS" show create \
+  --id "$CANVAS_ID" \
+  --at "$X,$Y,$W,$H" \
+  --interactive \
+  --focus \
+  --scope global \
+  --url "aos://$TOOLKIT_CONTENT_ROOT/components/html-file-workbench/index.html" >/dev/null
+
+"$AOS" show wait \
+  --id "$CANVAS_ID" \
+  --manifest html-file-workbench \
+  --js 'typeof window.__htmlFileWorkbenchState === "object"' \
+  --timeout 5s >/dev/null
+
+CONTENT_JSON="$(TARGET_FILE="$TARGET_FILE" python3 -c '
+import json, os, pathlib
+path = pathlib.Path(os.environ["TARGET_FILE"]).resolve()
+print(json.dumps({
+    "type": "html_file.open",
+    "path": str(path),
+    "content": path.read_text(encoding="utf-8"),
+}))
+')"
+
+"$AOS" show post --id "$CANVAS_ID" --event "$CONTENT_JSON" >/dev/null
+
+echo "HTML File Workbench launched at ${X},${Y} (${W}x${H})"
+echo "Canvas: $CANVAS_ID"
+echo "File: $TARGET_FILE"
+echo "Agent save helper: packages/toolkit/components/html-file-workbench/save-current.sh $CANVAS_ID"

--- a/packages/toolkit/components/html-file-workbench/model.js
+++ b/packages/toolkit/components/html-file-workbench/model.js
@@ -1,0 +1,184 @@
+export const HTML_FILE_WORKBENCH_SCHEMA_VERSION = '2026-05-21';
+export const HTML_FILE_WORKBENCH_SURFACE = 'html-file-workbench';
+export const HTML_FILE_OPEN_TYPE = 'html_file.open';
+export const HTML_FILE_SAVE_RESULT_TYPE = 'html_file.save.result';
+export const HTML_FILE_TEXT_PATCH_TYPE = 'html_file.text.patch';
+
+function text(value, fallback = '') {
+  const normalized = String(value ?? '').trim();
+  return normalized || fallback;
+}
+
+function cloneJson(value) {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function payloadFromMessage(message = {}) {
+  return message.payload && typeof message.payload === 'object' ? message.payload : message;
+}
+
+function requestId(prefix = 'html-file-save') {
+  const random = Math.random().toString(36).slice(2, 10);
+  return `${prefix}-${Date.now().toString(36)}-${random}`;
+}
+
+export async function sha256Hex(value) {
+  const input = String(value ?? '');
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle || typeof TextEncoder === 'undefined') {
+    let hash = 0;
+    for (let index = 0; index < input.length; index += 1) {
+      hash = ((hash << 5) - hash + input.charCodeAt(index)) | 0;
+    }
+    return `fallback:${(hash >>> 0).toString(16).padStart(8, '0')}`;
+  }
+  const bytes = new TextEncoder().encode(input);
+  const digest = await subtle.digest('SHA-256', bytes);
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export function createHtmlFileWorkbenchState({
+  path = 'untitled.html',
+  content = '',
+  savedContent = content,
+  dirty = false,
+  previewContent = content,
+  previewMode = 'srcdoc',
+} = {}) {
+  const current = String(content ?? '');
+  return {
+    path: text(path, 'untitled.html'),
+    content: current,
+    savedContent: String(savedContent ?? current),
+    dirty: !!dirty,
+    previewContent: String(previewContent ?? current),
+    previewMode: previewMode === 'blocked' ? 'blocked' : 'srcdoc',
+    previewRevision: 0,
+    contentHash: '',
+    lastResult: null,
+  };
+}
+
+export function openHtmlFile(state, message = {}) {
+  const payload = payloadFromMessage(message);
+  const path = text(payload.path, 'untitled.html');
+  const content = String(payload.content ?? '');
+  state.path = path;
+  state.content = content;
+  state.savedContent = String(payload.savedContent ?? content);
+  state.dirty = state.content !== state.savedContent;
+  state.previewContent = content;
+  state.previewMode = 'srcdoc';
+  state.previewRevision += 1;
+  state.lastResult = {
+    type: 'html_file.open.result',
+    schema_version: HTML_FILE_WORKBENCH_SCHEMA_VERSION,
+    status: 'opened',
+    path,
+    bytes: new TextEncoder().encode(content).byteLength,
+  };
+  return state.lastResult;
+}
+
+export function setHtmlFileContent(state, content) {
+  state.content = String(content ?? '');
+  state.dirty = state.content !== state.savedContent;
+  return state;
+}
+
+export function reloadHtmlFilePreview(state) {
+  state.previewContent = state.content;
+  state.previewMode = 'srcdoc';
+  state.previewRevision += 1;
+  state.lastResult = {
+    type: 'html_file.preview.reload.result',
+    schema_version: HTML_FILE_WORKBENCH_SCHEMA_VERSION,
+    status: 'reloaded',
+    path: state.path,
+    preview_revision: state.previewRevision,
+  };
+  return state.lastResult;
+}
+
+export function revertHtmlFile(state) {
+  state.content = state.savedContent;
+  state.dirty = false;
+  state.previewContent = state.savedContent;
+  state.previewMode = 'srcdoc';
+  state.previewRevision += 1;
+  state.lastResult = {
+    type: 'html_file.revert.result',
+    schema_version: HTML_FILE_WORKBENCH_SCHEMA_VERSION,
+    status: 'reverted',
+    path: state.path,
+  };
+  return state.lastResult;
+}
+
+export function buildHtmlFileSaveRequest(state) {
+  const request = {
+    type: 'html_file.save.request',
+    schema_version: HTML_FILE_WORKBENCH_SCHEMA_VERSION,
+    request_id: requestId(),
+    path: state.path,
+    content: state.content,
+    content_length: state.content.length,
+  };
+  state.lastResult = request;
+  return request;
+}
+
+export function applyHtmlFileSaveResult(state, message = {}) {
+  const payload = payloadFromMessage(message);
+  const status = text(payload.status, 'unknown');
+  if (status === 'saved') {
+    const content = Object.prototype.hasOwnProperty.call(payload, 'content')
+      ? String(payload.content ?? '')
+      : state.content;
+    state.content = content;
+    state.savedContent = content;
+    state.dirty = false;
+  }
+  state.lastResult = {
+    type: HTML_FILE_SAVE_RESULT_TYPE,
+    schema_version: HTML_FILE_WORKBENCH_SCHEMA_VERSION,
+    request_id: payload.request_id || null,
+    status,
+    path: text(payload.path, state.path),
+    message: text(payload.message),
+  };
+  return state.lastResult;
+}
+
+export function applyHtmlFileTextPatch(state, message = {}) {
+  const payload = payloadFromMessage(message);
+  if (Object.prototype.hasOwnProperty.call(payload, 'content')) {
+    setHtmlFileContent(state, payload.content);
+  }
+  state.lastResult = {
+    type: 'html_file.text.patch.result',
+    schema_version: HTML_FILE_WORKBENCH_SCHEMA_VERSION,
+    status: 'applied',
+    path: state.path,
+  };
+  return state.lastResult;
+}
+
+export function htmlFileWorkbenchSnapshot(state) {
+  return {
+    surface: HTML_FILE_WORKBENCH_SURFACE,
+    schema_version: HTML_FILE_WORKBENCH_SCHEMA_VERSION,
+    path: state.path,
+    dirty: state.dirty,
+    content: state.content,
+    content_length: state.content.length,
+    content_hash: state.contentHash || '',
+    preview_mode: state.previewMode,
+    preview_revision: state.previewRevision,
+    preview_content_length: state.previewContent.length,
+    last_result: state.lastResult ? cloneJson(state.lastResult) : null,
+  };
+}

--- a/packages/toolkit/components/html-file-workbench/save-current.sh
+++ b/packages/toolkit/components/html-file-workbench/save-current.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# save-current.sh - Persist the current HTML File Workbench canvas state.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(git -C "$DIR" rev-parse --show-toplevel 2>/dev/null || pwd)"
+AOS="${AOS:-$ROOT/aos}"
+CANVAS_ID="${1:-${CANVAS_ID:-html-file-workbench}}"
+
+if [[ ! -x "$AOS" ]]; then
+  echo "aos binary not found at $AOS" >&2
+  exit 1
+fi
+
+EVAL_JSON="$("$AOS" show eval --id "$CANVAS_ID" --js 'JSON.stringify(window.__htmlFileWorkbenchState || null)')"
+
+SAVE_JSON="$(
+  EVAL_JSON="$EVAL_JSON" python3 -c '
+import json, os, pathlib
+
+try:
+    outer = json.loads(os.environ["EVAL_JSON"])
+    snapshot = json.loads(outer.get("result") or "null")
+except Exception as error:
+    raise SystemExit(f"failed to read html file workbench state: {error}")
+
+if not isinstance(snapshot, dict):
+    raise SystemExit("html file workbench state is unavailable")
+
+path = pathlib.Path(snapshot.get("path") or "").expanduser().resolve()
+content = str(snapshot.get("content") or "")
+if not str(path).lower().endswith((".html", ".htm")):
+    raise SystemExit(f"refusing to save non-HTML target: {path}")
+if not path.exists():
+    raise SystemExit(f"refusing to create missing file from workbench save: {path}")
+if not path.is_file():
+    raise SystemExit(f"refusing to save non-file target: {path}")
+
+path.write_text(content, encoding="utf-8")
+print(json.dumps({
+    "type": "html_file.save.result",
+    "status": "saved",
+    "path": str(path),
+    "content": content,
+    "message": "saved by html-file-workbench/save-current.sh",
+}))
+'
+)"
+
+"$AOS" show post --id "$CANVAS_ID" --event "$SAVE_JSON" >/dev/null
+
+echo "$SAVE_JSON"

--- a/packages/toolkit/components/html-file-workbench/styles.css
+++ b/packages/toolkit/components/html-file-workbench/styles.css
@@ -1,0 +1,173 @@
+.html-file-workbench-root {
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  color: rgba(235, 255, 255, 0.94);
+  background: rgba(8, 10, 14, 0.96);
+  font: var(--aos-type-body, 12px/1.4 var(--font-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif));
+}
+
+.html-file-workbench-toolbar {
+  min-height: 42px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-bottom: 1px solid rgba(122, 241, 255, 0.16);
+  background: rgba(10, 16, 22, 0.92);
+  box-sizing: border-box;
+}
+
+.html-file-workbench-file {
+  flex: 1 1 220px;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.html-file-workbench-file strong {
+  min-width: 0;
+  overflow: hidden;
+  color: rgba(235, 255, 255, 0.92);
+  font: 680 11px/1.3 var(--font-mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.html-file-workbench-file span {
+  flex: 0 0 auto;
+  color: rgba(220, 255, 255, 0.58);
+  font: var(--aos-type-caption, 11px/1.35 var(--font-ui));
+}
+
+.html-file-workbench-root[data-dirty="true"] .html-file-workbench-file span {
+  color: #ffd166;
+}
+
+.html-file-workbench-actions {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.html-file-workbench-actions button {
+  min-height: 28px;
+  padding: 3px 8px;
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.html-file-workbench-actions button:disabled {
+  opacity: 0.42;
+  cursor: default;
+}
+
+.html-file-workbench-main {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(280px, 0.46fr) minmax(320px, 0.54fr);
+  overflow: hidden;
+}
+
+.html-file-workbench-source,
+.html-file-workbench-preview {
+  min-width: 0;
+  min-height: 0;
+}
+
+.html-file-workbench-source {
+  border-right: 1px solid rgba(122, 241, 255, 0.14);
+  background: #202123;
+}
+
+.html-file-workbench-source textarea {
+  width: 100%;
+  height: 100%;
+  resize: none;
+  box-sizing: border-box;
+  border: 0;
+  outline: none;
+  padding: 16px 18px 28px;
+  background: #202123;
+  color: #f0f1ea;
+  font: 12px/1.58 var(--font-mono);
+  tab-size: 2;
+}
+
+.html-file-workbench-source textarea::selection {
+  background: rgba(122, 241, 255, 0.28);
+}
+
+.html-file-workbench-preview {
+  position: relative;
+  background: #f7f7f4;
+}
+
+.html-file-workbench-preview-frame {
+  width: 100%;
+  height: 100%;
+  display: block;
+  border: 0;
+  background: #fff;
+}
+
+.html-file-workbench-preview-empty {
+  position: absolute;
+  inset: 14px auto auto 14px;
+  max-width: min(420px, calc(100% - 28px));
+  padding: 8px 10px;
+  border: 1px solid rgba(24, 28, 34, 0.18);
+  border-radius: 6px;
+  color: rgba(18, 22, 28, 0.72);
+  background: rgba(255, 255, 255, 0.86);
+  font: var(--aos-type-caption, 11px/1.35 var(--font-ui));
+  pointer-events: none;
+}
+
+.html-file-workbench-preview-empty[hidden],
+.html-file-workbench-warning[hidden] {
+  display: none;
+}
+
+.html-file-workbench-status {
+  min-height: 26px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 9px;
+  border-top: 1px solid rgba(122, 241, 255, 0.13);
+  color: rgba(220, 255, 255, 0.62);
+  background: rgba(8, 12, 16, 0.94);
+  font: var(--aos-type-code, 10px/1.45 var(--font-mono));
+  box-sizing: border-box;
+}
+
+.html-file-workbench-warning {
+  color: #ffd166;
+}
+
+@media (max-width: 860px) {
+  .html-file-workbench-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .html-file-workbench-actions {
+    overflow-x: auto;
+  }
+
+  .html-file-workbench-main {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(260px, 0.5fr) minmax(260px, 0.5fr);
+  }
+
+  .html-file-workbench-source {
+    border-right: 0;
+    border-bottom: 1px solid rgba(122, 241, 255, 0.14);
+  }
+}

--- a/tests/toolkit/html-file-workbench.test.mjs
+++ b/tests/toolkit/html-file-workbench.test.mjs
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+import {
+  applyHtmlFileSaveResult,
+  buildHtmlFileSaveRequest,
+  createHtmlFileWorkbenchState,
+  htmlFileWorkbenchSnapshot,
+  openHtmlFile,
+  reloadHtmlFilePreview,
+  revertHtmlFile,
+  setHtmlFileContent,
+} from '../../packages/toolkit/components/html-file-workbench/model.js';
+
+const repo = new URL('../../', import.meta.url);
+
+async function repoText(path) {
+  return readFile(new URL(path, repo), 'utf8');
+}
+
+test('HTML file workbench state opens, dirties, previews, reverts, and saves', () => {
+  const state = createHtmlFileWorkbenchState();
+  const opened = openHtmlFile(state, {
+    type: 'html_file.open',
+    path: '/tmp/demo.html',
+    content: '<!doctype html><html><body><h1>Demo</h1></body></html>',
+  });
+
+  assert.equal(opened.status, 'opened');
+  assert.equal(state.path, '/tmp/demo.html');
+  assert.equal(state.dirty, false);
+  assert.equal(state.previewRevision, 1);
+
+  setHtmlFileContent(state, '<!doctype html><html><body><h1>Changed</h1></body></html>');
+  assert.equal(state.dirty, true);
+  assert.equal(state.previewContent.includes('Demo'), true);
+
+  const preview = reloadHtmlFilePreview(state);
+  assert.equal(preview.status, 'reloaded');
+  assert.equal(state.previewContent.includes('Changed'), true);
+
+  const request = buildHtmlFileSaveRequest(state);
+  assert.equal(request.type, 'html_file.save.request');
+  assert.equal(request.path, '/tmp/demo.html');
+  assert.equal(request.content.includes('Changed'), true);
+
+  const result = applyHtmlFileSaveResult(state, {
+    type: 'html_file.save.result',
+    request_id: request.request_id,
+    status: 'saved',
+    path: '/tmp/demo.html',
+  });
+  assert.equal(result.status, 'saved');
+  assert.equal(state.dirty, false);
+
+  setHtmlFileContent(state, '<!doctype html><html><body><h1>Unsaved</h1></body></html>');
+  revertHtmlFile(state);
+  assert.equal(state.content.includes('Changed'), true);
+  assert.equal(state.dirty, false);
+});
+
+test('HTML file workbench snapshot exposes smoke-test state', () => {
+  const state = createHtmlFileWorkbenchState({
+    path: '/tmp/demo.html',
+    content: '<html></html>',
+    dirty: true,
+  });
+  const snapshot = htmlFileWorkbenchSnapshot(state);
+
+  assert.equal(snapshot.surface, 'html-file-workbench');
+  assert.equal(snapshot.path, '/tmp/demo.html');
+  assert.equal(snapshot.dirty, true);
+  assert.equal(snapshot.content, '<html></html>');
+  assert.equal(snapshot.content_length, 13);
+  assert.equal(snapshot.preview_mode, 'srcdoc');
+  assert.equal(snapshot.last_result, null);
+});
+
+test('HTML file workbench component contract uses panel, iframe sandbox, and expected events', async () => {
+  const js = await repoText('packages/toolkit/components/html-file-workbench/index.js');
+  const html = await repoText('packages/toolkit/components/html-file-workbench/index.html');
+  const css = await repoText('packages/toolkit/components/html-file-workbench/styles.css');
+  const launch = await repoText('packages/toolkit/components/html-file-workbench/launch.sh');
+  const save = await repoText('packages/toolkit/components/html-file-workbench/save-current.sh');
+
+  assert.match(html, /mountPanel/);
+  assert.match(html, /Single\(HtmlFileWorkbench\)/);
+  assert.match(html, /maximize:\s*true/);
+  assert.match(html, /resizable:\s*true/);
+  assert.match(js, /name:\s*'html-file-workbench'/);
+  assert.match(js, /accepts:\s*\[[^\]]*HTML_FILE_OPEN_TYPE[^\]]*HTML_FILE_SAVE_RESULT_TYPE/s);
+  assert.match(js, /emits:\s*\[[^\]]*'html-file-workbench\/save\.requested'/s);
+  assert.match(js, /window\.__htmlFileWorkbenchState = htmlFileWorkbenchSnapshot\(state\)/);
+  assert.match(js, /createTextarea\(\{[\s\S]*ariaLabel: 'HTML source editor'/);
+  assert.match(js, /dom\.previewFrame\.srcdoc = state\.previewContent/);
+  assert.match(js, /sandbox', 'allow-scripts allow-forms allow-modals allow-pointer-lock allow-popups'/);
+  assert.doesNotMatch(js, /allow-same-origin/);
+  assert.match(js, /data-action="reload-preview"/);
+  assert.match(js, /data-action="revert"/);
+  assert.match(js, /data-action="save"/);
+  assert.match(js, /data-action="close"/);
+  assert.match(css, /\.html-file-workbench-main\s*\{[\s\S]*grid-template-columns:/);
+  assert.match(css, /\.html-file-workbench-preview-frame\s*\{[\s\S]*border:\s*0/);
+  assert.match(launch, /MAX_BYTES/);
+  assert.match(launch, /html_file\.open/);
+  assert.match(launch, /--manifest html-file-workbench/);
+  assert.match(save, /window\.__htmlFileWorkbenchState/);
+  assert.match(save, /html_file\.save\.result/);
+  assert.match(save, /endswith\(\(".html", ".htm"\)\)/);
+});


### PR DESCRIPTION
## Summary

- Add `html-file-workbench`, a file-backed toolkit component for local `.html`/`.htm` files.
- Provide source editing, sandboxed iframe preview, Reload Preview/Revert/Save/Close controls, launcher, and save helper.
- Document the component contract and add focused deterministic tests.

## Verification

- `node --test tests/toolkit/html-file-workbench.test.mjs`
- `node --test tests/toolkit/markdown-workbench-layout.test.mjs tests/toolkit/html-workbench-expression.test.mjs`
- `node --test tests/toolkit/*.test.mjs`
- `bash tests/help-contract.sh`
- `node --check packages/toolkit/components/html-file-workbench/index.js`
- `node --check packages/toolkit/components/html-file-workbench/model.js`
- `git diff --check origin/main...HEAD`
- `./aos ready`

## Live Smoke

Ran against a temp copy of `/Users/Michael/Code/tmp/undulating-background.html`: launch, manifest wait, state inspection, edit dirtying, explicit preview reload, sandbox check without `allow-same-origin`, helper save, and dirty-state clear. The original demo file was not mutated.
