### PR TITLE
Move persona recipes into dock skills

### DIFF
--- a/.docks/foreman/AGENTS.md
+++ b/.docks/foreman/AGENTS.md
@@ -167,12 +167,13 @@ the plain work-card instruction above. If a shared helper would inject ceremony,
 use a Foreman-specific plain clipboard copy path and report the copied payload
 plus timestamp in the dock-level chat-visible shape.
 
-Use `docs/recipes/gdi-work-card-authoring.md` as the flexible authoring shape:
-fresh context, read-first files, state rediscovery, exact files to inspect,
-hard boundaries, verification, and completion-report slots. Add specialty slots
-only when the slice needs them. When dirty worktrees or large proof artifacts
-would make review harder, ask for the recipe's path-scoped completion summary;
-skip that extra shape for tiny fixes where it adds noise.
+Use `.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md`
+as the flexible authoring shape: fresh context, read-first files, state
+rediscovery, exact files to inspect, hard boundaries, verification, and
+completion-report slots. Add specialty slots only when the slice needs them.
+When dirty worktrees or large proof artifacts would make review harder, ask for
+the reference's path-scoped completion summary; skip that extra shape for tiny
+fixes where it adds noise.
 
 Do not paste long implementation instructions directly into the clipboard goal
 unless the task is genuinely small. If Foreman creates draft evidence, label it

--- a/.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md
+++ b/.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md
@@ -1,13 +1,14 @@
-# Recipe: GDI Work Card Authoring
+# GDI Work Card Authoring
 
-Use this recipe when Foreman writes or revises a work card for a fresh GDI
+Use this reference when Foreman writes or revises a work card for a fresh GDI
 session. The goal is reliable context transfer without freezing one permanent
 prompt format. GDI starts from a new context window, so the work card must carry
 the minimum map needed to rediscover state, inspect the right files, avoid old
 wrong paths, and verify the slice.
 
-This is a recipe, not a schema. Omit slots that do not apply. Add specialty
-slots when the slice crosses a boundary.
+This is a Foreman session-transfer reference, not a role-neutral recipe or a
+schema. Omit slots that do not apply. Add specialty slots when the slice crosses
+a boundary.
 
 ## Core Shape
 
@@ -282,7 +283,8 @@ Use when GDI prepares work for Operator:
 Use for architecture, recipe, issue, or instruction work:
 
 - name the source-of-truth boundary: `AGENTS.md`, subtree `AGENTS.md`,
-  `docs/recipes/`, `docs/design/`, `docs/api/`, or `shared/schemas/`;
+  `.docks/`, `docs/recipes/`, `docs/design/`, `docs/api/`, or
+  `shared/schemas/`;
 - avoid duplicating long policy in multiple files;
 - update provider-specific compatibility files only as pointers when possible;
 - run contradiction scans for retired phrases or superseded paths.

--- a/.docks/foreman/skills/session-transfer/references/gdi.md
+++ b/.docks/foreman/skills/session-transfer/references/gdi.md
@@ -33,6 +33,10 @@ For non-trivial GDI work, create or update a work card with:
 - Verification.
 - Completion Report.
 
+For the full flexible authoring shape, read
+`references/gdi-work-card-authoring.md`. Keep that detail in the work card, not
+in the clipboard dispatch.
+
 When the card lives on a branch that is not `origin/main`, the dispatch should
 also mention the branch:
 

--- a/.docks/gdi/skills/work-retrospective/SKILL.md
+++ b/.docks/gdi/skills/work-retrospective/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: work-retrospective
-description: Use after a bounded goal is achieved, failed, paused, or handed off when the user asks for a retrospective, friction report, after-action review, lessons learned, or feedback about what should be improved in product ergonomics, operational procedures, tests, tooling, docs, architecture, or engineering workflow. Especially useful for GDI goal work where implementation evidence can reveal better primitives, clearer harnesses, or process improvements.
+description: Use after a bounded goal is achieved, failed, paused, or handed off when the user asks for a retrospective, friction report, after-action review, lessons learned, AOS/GDI exit interview, or feedback about what should be improved in product ergonomics, operational procedures, tests, tooling, docs, architecture, or engineering workflow. Especially useful for GDI goal work where implementation evidence can reveal better primitives, clearer harnesses, or process improvements.
 ---
 
 # Work Retrospective
@@ -19,6 +19,14 @@ Look for friction in:
 - reviewability issues such as dirty worktrees, noisy output, hidden state, or brittle verification.
 
 Do not invent broad roadmap work from weak evidence. Prefer concrete observations grounded in what happened during the goal.
+
+## Specialized References
+
+When the user asks for an AOS/GDI exit interview, command-surface interview, or
+forced-AOS friction report, read
+`references/aos-control-surface-interview.md` before writing the retrospective.
+That reference is a specialized shape inside this skill, not a separate recipe
+or durable planning artifact.
 
 ## Inputs To Reconstruct
 

--- a/.docks/gdi/skills/work-retrospective/references/aos-control-surface-interview.md
+++ b/.docks/gdi/skills/work-retrospective/references/aos-control-surface-interview.md
@@ -1,9 +1,10 @@
-# Recipe: AOS GDI Exit Interview
+# AOS Control-Surface Exit Interview
 
-Use this recipe when a Goal Driven Implementation session has completed its
-implementation, verification, and commits, but before it marks the goal complete
-or emits its final handoff. The interview is read-only. Its purpose is to learn
-how well the AOS command surface served an agent that was required to use it.
+Use this reference with the parent `work-retrospective` skill when a Goal Driven
+Implementation session has completed its implementation, verification, and
+commits, and the user asks for an AOS/GDI exit interview or command-surface
+friction report. The interview is read-only. Its purpose is to learn how well
+the AOS command surface served an agent that was required to use it.
 
 The output should capture friction, misunderstandings, useful affordances,
 missing command shape, stale help, verification gaps, and any place where forced
@@ -178,8 +179,9 @@ and the result of a real trade-off.
 
 ## Output Contract
 
-The final response may be prose, but it should preserve the headings above. If
-a downstream collector needs JSON, wrap the same fields in:
+The parent `work-retrospective` skill owns the temp report artifact. Inside that
+report, preserve the headings above. If a downstream collector needs JSON, wrap
+the same fields in:
 
 ```json
 {

--- a/docs/design/aos-surface-stack-v0-checkpoint-hygiene-report.md
+++ b/docs/design/aos-surface-stack-v0-checkpoint-hygiene-report.md
@@ -61,7 +61,8 @@ These paths are documentation source-of-truth for the checkpoint:
 - `ARCHITECTURE.md`, `README.md`, `docs/api/`, `docs/adr/`, and
   `docs/design/aos-*`.
 - `docs/recipes/aos-surface-interaction-decision-tree.md`,
-  `docs/recipes/gdi-work-card-authoring.md`, and related workflow recipes.
+  `.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md`,
+  and related workflow references.
 - Surface-stack work cards under `docs/design/work-cards/`.
 
 ### Checkpoint Hygiene Added During This Pass

--- a/docs/design/work-cards/adr-namespace-audit-v0.md
+++ b/docs/design/work-cards/adr-namespace-audit-v0.md
@@ -50,7 +50,7 @@ namespace change in this slice.
 - `docs/agents/domain.md`
 - `docs/recipes/context-doc-maintenance.md`
 - `docs/design/notes/matt-pocock-context-integration-audit-2026-05-20.md`
-- `docs/recipes/gdi-work-card-authoring.md`
+- `.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md`
 - every file under `docs/adr/`
 - every file under `docs/decisions/`
 

--- a/docs/design/work-cards/adr-namespace-consolidation-v0.md
+++ b/docs/design/work-cards/adr-namespace-consolidation-v0.md
@@ -51,7 +51,7 @@ toolkit platform decision.
 - `docs/recipes/context-doc-maintenance.md`
 - `docs/design/notes/matt-pocock-context-integration-audit-2026-05-20.md`
 - `docs/design/notes/adr-namespace-audit-2026-05-20.md`
-- `docs/recipes/gdi-work-card-authoring.md`
+- `.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md`
 - every file under `docs/adr/`
 - `docs/decisions/ADR-001-toolkit-platform-strategy.md`
 

--- a/docs/design/work-cards/annotation-candidate-helper-neutralization-v0.md
+++ b/docs/design/work-cards/annotation-candidate-helper-neutralization-v0.md
@@ -43,7 +43,7 @@ helpers may remain in `surface-inspector-annotations.js`.
 - `AGENTS.md`
 - `packages/toolkit/AGENTS.md`
 - `apps/sigil/AGENTS.md`
-- `docs/recipes/gdi-work-card-authoring.md`
+- `.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md`
 - `docs/api/toolkit/workbench.md`
 - `packages/toolkit/workbench/annotation-candidates.js`
 - `packages/toolkit/workbench/annotation-projection.js`

--- a/docs/design/work-cards/annotation-session-surface-inspector-adapter-boundary-v0.md
+++ b/docs/design/work-cards/annotation-session-surface-inspector-adapter-boundary-v0.md
@@ -48,7 +48,7 @@ After this slice:
 
 - `AGENTS.md`
 - `packages/toolkit/AGENTS.md`
-- `docs/recipes/gdi-work-card-authoring.md`
+- `.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md`
 - `docs/api/toolkit/workbench.md`
 - `docs/design/work-cards/annotation-candidate-helper-neutralization-v0.md`
 - `docs/design/work-cards/annotation-projection-reveal-normalization-v0.md`

--- a/docs/design/work-cards/architecture-context-audit-validation-v0.md
+++ b/docs/design/work-cards/architecture-context-audit-validation-v0.md
@@ -38,7 +38,7 @@ slice.
 - `ARCHITECTURE.md`
 - `CONTEXT.md`
 - `docs/design/notes/architecture-context-codebase-audit-2026-05-20.md`
-- `docs/recipes/gdi-work-card-authoring.md`
+- `.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md`
 - `docs/api/aos.md`
 - `docs/api/toolkit/components.md`
 - `packages/toolkit/AGENTS.md`

--- a/docs/design/work-cards/context-maintenance-sop-v0.md
+++ b/docs/design/work-cards/context-maintenance-sop-v0.md
@@ -54,7 +54,7 @@ This is a governance/SOP slice, not a stale-doc implementation sweep.
 - `docs/agents/domain.md`
 - `docs/design/notes/matt-pocock-context-integration-audit-2026-05-20.md`
 - `docs/recipes/agent-entry-paths-and-verification.md`
-- `docs/recipes/gdi-work-card-authoring.md`
+- `.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md`
 - `docs/design/work-cards/context-live-doc-stale-sweep-v0.md`
 - `/Users/Michael/Code/mattpocock-skills/skills/engineering/grill-with-docs/SKILL.md`
 - `/Users/Michael/Code/mattpocock-skills/skills/engineering/grill-with-docs/CONTEXT-FORMAT.md`

--- a/docs/design/work-cards/gdi-conditional-stop-notices-v0.md
+++ b/docs/design/work-cards/gdi-conditional-stop-notices-v0.md
@@ -63,7 +63,7 @@ Michael's requested product behavior is:
 - `.docks/harness/dock-hook-runner.sh`
 - `.docks/foreman/skills/session-transfer/SKILL.md`
 - `.docks/foreman/skills/session-transfer/references/gdi.md`
-- `docs/recipes/gdi-work-card-authoring.md`
+- `.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md`
 - `tests/dock-hook-isolation.sh`
 - `tests/dock-handoff-clipboard.sh`
 - `tests/help-contract.sh`
@@ -137,7 +137,7 @@ Inspect first, then choose the narrowest correct layer. Likely areas:
 - `.docks/gdi/README.md`
 - `.docks/foreman/skills/session-transfer/references/gdi.md`
 - `.docks/foreman/skills/session-transfer/SKILL.md`
-- `docs/recipes/gdi-work-card-authoring.md`
+- `.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md`
 - `tests/dock-hook-isolation.sh`
 
 A reasonable implementation shape is:

--- a/docs/design/work-cards/generated-artifact-lifecycle-policy-v0.md
+++ b/docs/design/work-cards/generated-artifact-lifecycle-policy-v0.md
@@ -51,7 +51,7 @@ runtime records versus generated projections.
 - `docs/design/evidence-workflow-block-abstraction-tracker.md`
 - `docs/design/user-signal-surface.md`
 - `docs/recipes/layered-subject-expressions.md`
-- `docs/recipes/gdi-work-card-authoring.md`
+- `.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md`
 - `docs/api/aos.md`
 - `docs/api/toolkit/workbench.md`
 - `docs/wiki/repo-docs-projection-v0.json`

--- a/docs/design/work-cards/path-scoped-handoff-and-diff-summaries-v0.md
+++ b/docs/design/work-cards/path-scoped-handoff-and-diff-summaries-v0.md
@@ -32,7 +32,7 @@ dirty state remains without turning every small fix into a heavy template.
 
 - `AGENTS.md`
 - `.docks/foreman/AGENTS.md`
-- `docs/recipes/gdi-work-card-authoring.md`
+- `.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md`
 - `docs/recipes/agent-entry-paths-and-verification.md`
 - `docs/design/work-cards/surface-stack-integration-checkpoint-hygiene-v0.md`
 - `docs/design/work-cards/surface-stack-retrospective-followups-v0.md`
@@ -103,7 +103,7 @@ smallest clear way to prevent stale "next follow-up" recommendations.
 
 This is docs/governance and dock-local workflow hygiene. Likely files are:
 
-- `docs/recipes/gdi-work-card-authoring.md`
+- `.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md`
 - `docs/recipes/agent-entry-paths-and-verification.md`
 - `.docks/foreman/AGENTS.md`
 - `.docks/gdi/skills/work-retrospective/SKILL.md`

--- a/docs/design/work-cards/surface-stack-retrospective-followups-v0.md
+++ b/docs/design/work-cards/surface-stack-retrospective-followups-v0.md
@@ -129,7 +129,7 @@ Smallest useful slice:
 
 Likely files:
 
-- `docs/recipes/gdi-work-card-authoring.md`
+- `.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md`
 - `docs/recipes/agent-entry-paths-and-verification.md`
 - `.docks/foreman/AGENTS.md` if Foreman-specific routing language needs to be
   sharpened.

--- a/docs/design/work-cards/toolkit-3d-radial-menu-workbench-v0.md
+++ b/docs/design/work-cards/toolkit-3d-radial-menu-workbench-v0.md
@@ -46,7 +46,7 @@ the reticle menu item face/glyph should keep facing the camera through resolved
 - `AGENTS.md`
 - `packages/toolkit/AGENTS.md`
 - `apps/sigil/AGENTS.md`
-- `docs/recipes/gdi-work-card-authoring.md`
+- `.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md`
 - `docs/api/toolkit/runtime.md`
 - `docs/api/toolkit/workbench.md`
 - `docs/api/toolkit/components.md`

--- a/docs/design/work-cards/toolkit-integrity-guardrails-v0.md
+++ b/docs/design/work-cards/toolkit-integrity-guardrails-v0.md
@@ -44,7 +44,7 @@ The first planned consumers to name in the report context are `InfoTag` in
 - `packages/toolkit/AGENTS.md`
 - `packages/toolkit/controls/AGENTS.md`
 - `packages/toolkit/panel/AGENTS.md`
-- `docs/recipes/gdi-work-card-authoring.md`
+- `.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md`
 - `tests/toolkit/style-contracts.test.mjs`
 - `tests/toolkit/toolkit-api-docs-contract.test.mjs`
 

--- a/docs/design/work-cards/toolkit-surface-interaction-decision-tree-v0.md
+++ b/docs/design/work-cards/toolkit-surface-interaction-decision-tree-v0.md
@@ -46,7 +46,7 @@ coherent deliverable:
 - `packages/toolkit/runtime/AGENTS.md`
 - `packages/toolkit/panel/AGENTS.md`
 - `apps/sigil/AGENTS.md`
-- `docs/recipes/gdi-work-card-authoring.md`
+- `.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md`
 - `docs/design/work-cards/toolkit-surface-resource-scope-v0.md`
 
 ## Rediscover State


### PR DESCRIPTION
## Summary

- Move Foreman-specific GDI work-card authoring guidance from `docs/recipes/` into the Foreman session-transfer skill references.
- Move the GDI/AOS exit-interview shape from `docs/recipes/` into the GDI work-retrospective skill references.
- Update Foreman/GDI skill guidance and existing work-card links to the new dock-local reference paths.
- Leave `docs/recipes/` with role-neutral recipe files only.

## Verification

- rg -n "docs/recipes/gdi-work-card-authoring|docs/recipes/aos-gdi-exit-interview|Recipe: GDI Work Card Authoring|Recipe: AOS GDI Exit Interview" AGENTS.md .docks docs shared tests || true
- bash tests/dock-hook-isolation.sh
- git diff --check
- find docs/recipes -maxdepth 1 -type f -name '*.md' -print | sort
