### PR TITLE
Route context menu right-click through UX tree commands

### DIFF
--- a/apps/sigil/renderer/live-modules/context-menu-input.js
+++ b/apps/sigil/renderer/live-modules/context-menu-input.js
@@ -1,0 +1,55 @@
+import { SIGIL_CONTEXT_MENU_COMMAND_INPUTS } from './ux-tree-command-registry.js';
+
+function pointerFromMessage(msg = {}) {
+    if (typeof msg.x !== 'number' || typeof msg.y !== 'number') return null;
+    return { x: msg.x, y: msg.y, valid: true };
+}
+
+export function resolveContextMenuRightClickRoute(msg = {}, {
+    isOpen = false,
+    isDuplicateOpenClick = () => false,
+} = {}) {
+    if (msg?.type !== 'right_mouse_down') {
+        return { handled: false, reason: 'event_not_supported' };
+    }
+
+    const pointer = pointerFromMessage(msg);
+    if (isOpen) {
+        if (pointer && isDuplicateOpenClick(pointer.x, pointer.y)) {
+            return {
+                handled: true,
+                direct: 'duplicate_open_echo',
+                pointer,
+            };
+        }
+        return {
+            handled: true,
+            command: 'toggle',
+            input: SIGIL_CONTEXT_MENU_COMMAND_INPUTS.toggle,
+            pointer,
+            fallback: 'toggle',
+        };
+    }
+
+    if (!pointer) {
+        return {
+            handled: true,
+            direct: 'right_click_away',
+            pointer: null,
+            fallback: 'right_click_away',
+            reason: 'missing_pointer',
+        };
+    }
+
+    return {
+        handled: true,
+        command: 'open',
+        input: SIGIL_CONTEXT_MENU_COMMAND_INPUTS.open,
+        pointer,
+        fallback: 'open',
+    };
+}
+
+export function contextMenuOpenCommandOpened(result = {}) {
+    return result?.executed === true && result?.handler_result === true;
+}

--- a/apps/sigil/renderer/live-modules/main.js
+++ b/apps/sigil/renderer/live-modules/main.js
@@ -63,6 +63,10 @@ import {
     resolveSelectionModeInputRoute,
 } from './selection-mode-input.js';
 import {
+    contextMenuOpenCommandOpened,
+    resolveContextMenuRightClickRoute,
+} from './context-menu-input.js';
+import {
     currentSigilRoot,
     currentToolkitRoot,
     sigilUrl,
@@ -2790,6 +2794,16 @@ const sigilUxCommandRegistry = createSigilUxTreeCommandRegistry({
     selectionModeCommit: (reason) => commitSelectionMode(reason),
     selectionModeCycleTarget: (delta) => cycleSelectionModeTarget(delta),
     selectionModeAcquire: (pointer) => acquireSelectionModeCandidates(pointer),
+    contextMenuOpen: (pointer) => (
+        pointer && typeof pointer.x === 'number' && typeof pointer.y === 'number'
+            ? openContextMenuAt(pointer.x, pointer.y)
+            : false
+    ),
+    contextMenuToggle: () => {
+        contextMenu.close('right-click-toggle');
+        cancelInteraction('right-click-toggle');
+        return true;
+    },
 });
 
 function recordUxCommandRuntime(result = {}, { fallback = false } = {}) {
@@ -2840,6 +2854,20 @@ function executeSelectionModeEscapeCommand(msg = {}) {
     return executeSelectionModeCommand(SIGIL_SELECTION_MODE_ESCAPE_COMMAND_INPUT, msg, {
         fallback: () => exitSelectionMode('escape'),
     });
+}
+
+function executeContextMenuRightClickCommand(route = {}, msg = {}) {
+    const result = executeSigilUxTreeCommand(sigilUxTreeSnapshot(), {
+        input: route.input || {},
+        registry: sigilUxCommandRegistry,
+        context: {
+            source: 'handleInputEvent',
+            msg,
+            pointer: route.pointer || null,
+        },
+    });
+    recordUxCommandRuntime(result, { fallback: result.executed !== true });
+    return result;
 }
 
 function acquireSelectionModeCandidates(point = null) {
@@ -3574,24 +3602,36 @@ function handleInputEvent(msg) {
             return;
         case 'right_mouse_down':
             recordInteraction('context-menu:right-down', { x: msg.x, y: msg.y, open: contextMenu.isOpen() });
-            if (contextMenu.isOpen()) {
-                if (
-                    typeof msg.x === 'number'
-                    && typeof msg.y === 'number'
-                    && isDuplicateContextMenuOpenClick(msg.x, msg.y)
-                ) {
+            {
+                const route = resolveContextMenuRightClickRoute(msg, {
+                    isOpen: contextMenu.isOpen(),
+                    isDuplicateOpenClick: isDuplicateContextMenuOpenClick,
+                });
+                if (route.direct === 'duplicate_open_echo') {
                     recordInteraction('context-menu:right-down-duplicate-ignored', { x: msg.x, y: msg.y });
                     return;
                 }
-                recordInteraction('context-menu:right-down-close-open-menu', { x: msg.x, y: msg.y });
-                contextMenu.close('right-click-toggle');
-                cancelInteraction('right-click-toggle');
+                if (route.command === 'toggle') {
+                    recordInteraction('context-menu:right-down-close-open-menu', { x: msg.x, y: msg.y });
+                    const result = executeContextMenuRightClickCommand(route, msg);
+                    if (result.executed !== true) {
+                        contextMenu.close('right-click-toggle');
+                        cancelInteraction('right-click-toggle');
+                    }
+                    return;
+                }
+                if (route.command === 'open') {
+                    const result = executeContextMenuRightClickCommand(route, msg);
+                    if (contextMenuOpenCommandOpened(result)) return;
+                    if (result.executed !== true && openContextMenuAt(msg.x, msg.y)) return;
+                    contextMenu.close('right-click-away');
+                    cancelInteraction('right-click');
+                    return;
+                }
+                contextMenu.close('right-click-away');
+                cancelInteraction('right-click');
                 return;
             }
-            if (typeof msg.x === 'number' && typeof msg.y === 'number' && openContextMenuAt(msg.x, msg.y)) return;
-            contextMenu.close('right-click-away');
-            cancelInteraction('right-click');
-            return;
         case 'key_down':
             if (msg.key_code === 53) {
                 contextMenu.close('escape');

--- a/apps/sigil/renderer/live-modules/main.js
+++ b/apps/sigil/renderer/live-modules/main.js
@@ -38,10 +38,10 @@ import {
 import { createFastTravelController } from './fast-travel.js';
 import { createSigilRadialGestureMenu } from './radial-gesture-menu.js';
 import { radialItemPointerMetrics } from './radial-gesture-runtime.js';
-import { createSigilRadialActivationRequest } from './radial-menu-activation.js';
 import { createRadialActivationTransitionController } from './radial-activation-transition.js';
 import { createRadialMenuTargetSurface } from './radial-menu-target-surface.js';
 import { createSigilRadialGestureVisuals } from './radial-gesture-visuals.js';
+import { createSigilRadialItemActionDispatcher } from './radial-item-action-dispatch.js';
 import {
     annotationReticleReleaseDisposition,
     buildAnnotationReticleOverlayModel,
@@ -1518,84 +1518,29 @@ function sigilUxTreeReadiness() {
     });
 }
 
-function radialActivationInputFromContext(context = {}) {
-    return context.input && typeof context.input === 'object'
-        ? {
-            ...context.input,
-            pointer: context.input.pointer || context.pointer || null,
-        }
-        : context.input || {
-            kind: 'gesture',
-            source: 'sigil.avatar',
-            pointer: context.pointer || null,
-        };
-}
-
-function createRadialActivationForCommand(item, snapshot, context = {}) {
-    const input = radialActivationInputFromContext(context);
-    return createSigilRadialActivationRequest({
-        item,
-        snapshot,
-        input,
-        source: context.source || 'sigil.avatar',
-        agentTerminalCanvasId: AGENT_TERMINAL_CANVAS_ID,
-        wikiWorkbenchCanvasId: WIKI_WORKBENCH_CANVAS_ID,
-        wikiPath: WIKI_WORKBENCH_DEFAULT_PATH,
-    });
-}
-
-function performRadialItemAction(item, snapshot, context = {}) {
-    if (item?.action === 'annotationMode' || item?.id === SIGIL_ANNOTATION_RETICLE_ITEM_ID) {
-        enterAnnotationReticle(context.pointer || snapshot?.pointer || liveJs.pointerPos, 'radial-item');
-        host.post('sigil.annotation_reticle.enter', {
-            item_id: item?.id,
-            entry_source: liveJs.annotationReticle?.entry_source,
-            input: context.input || null,
-            snapshot: liveJs.annotationReticle,
-        });
-        return { action: 'annotation_reticle_entered', item_id: item?.id || null };
-    }
-    if (item?.action === 'annotationSnapshot' || item?.id === SIGIL_ANNOTATION_CAMERA_ITEM_ID) {
-        const requested = context.reason === 'radial-camera-target-surface-recovery'
-            ? requestAnnotationSnapshot('radial-camera-target-surface-recovery')
-            : requestAnnotationSnapshot(context.reason || 'radial-camera');
-        return { action: 'annotation_snapshot_requested', requested };
-    }
-
-    let activation = context.activation || createRadialActivationForCommand(item, snapshot, context);
-    liveJs.lastRadialActivation = activation;
-    host.post('sigil.radial_menu.activation', activation);
-    if (radialActivationTransition.start(activation, snapshot, { startedAt: state.globalTime })) {
-        activation = sendActivationUpdate(activation, 'item_transition', {
-            transition: activation.transition,
-        });
-    }
-    if (item?.action === 'contextMenu') {
-        const opened = openContextMenuAt(liveJs.avatarPos.x, liveJs.avatarPos.y, { force: true });
-        sendActivationUpdate(activation, 'completed', { result: { opened: 'context-menu' } });
-        return { action: 'context_menu_opened', opened };
-    }
-    if (item?.action === 'agentTerminal' || item?.action === 'codexTerminal') {
-        const result = toggleUtilityCanvas('agent-terminal');
-        sendActivationUpdate(activation, 'completed', { result: { canvas_id: AGENT_TERMINAL_CANVAS_ID } });
-        return { action: 'agent_terminal_opened', canvas_id: AGENT_TERMINAL_CANVAS_ID, result };
-    }
-    if (item?.action === 'wikiGraph') {
-        const result = openWikiWorkbench(WIKI_WORKBENCH_DEFAULT_PATH, activation).catch((error) => {
-            console.warn('[sigil] wiki workbench activation failed:', error);
-            sendActivationUpdate(activation, 'failed', {
-                error: String(error?.message || error),
-            });
-            return { error: String(error?.message || error) };
-        });
-        return { action: 'wiki_graph_opened', canvas_id: WIKI_WORKBENCH_CANVAS_ID, result };
-    }
-    host.post('sigil.radial_menu.action', {
-        action: item?.action || item?.id || 'unknown',
-    });
-    sendActivationUpdate(activation, 'completed', { result: { action: item?.action || item?.id || 'unknown' } });
-    return { action: item?.action || item?.id || 'unknown' };
-}
+const radialItemActionDispatcher = createSigilRadialItemActionDispatcher({
+    agentTerminalCanvasId: AGENT_TERMINAL_CANVAS_ID,
+    wikiWorkbenchCanvasId: WIKI_WORKBENCH_CANVAS_ID,
+    wikiPath: WIKI_WORKBENCH_DEFAULT_PATH,
+    annotationReticleItemId: SIGIL_ANNOTATION_RETICLE_ITEM_ID,
+    annotationCameraItemId: SIGIL_ANNOTATION_CAMERA_ITEM_ID,
+    getPointer: () => liveJs.pointerPos,
+    getAvatarPos: () => liveJs.avatarPos,
+    setLastRadialActivation: (activation) => {
+        liveJs.lastRadialActivation = activation;
+    },
+    post: (type, payload) => host.post(type, payload),
+    warn: (...args) => console.warn(...args),
+    startActivationTransition: (activation, snapshot) => (
+        radialActivationTransition.start(activation, snapshot, { startedAt: state.globalTime })
+    ),
+    sendActivationUpdate,
+    enterAnnotationReticle,
+    requestAnnotationSnapshot,
+    openContextMenuAt,
+    toggleUtilityCanvas,
+    openWikiWorkbench,
+});
 
 function executeRadialItemCommand(item, snapshot, context = {}) {
     const result = executeSigilUxTreeCommand(sigilUxTreeSnapshot(), {
@@ -1606,14 +1551,14 @@ function executeRadialItemCommand(item, snapshot, context = {}) {
             item,
             snapshot,
             pointer: context.pointer || snapshot?.pointer || liveJs.pointerPos,
-            input: radialActivationInputFromContext(context),
+            input: radialItemActionDispatcher.inputFromContext(context),
             reason: context.reason || 'radial-camera',
             path: WIKI_WORKBENCH_DEFAULT_PATH,
         },
     });
     recordUxCommandRuntime(result, { fallback: result.executed !== true });
     if (result.executed !== true) {
-        performRadialItemAction(item, snapshot, context);
+        radialItemActionDispatcher.dispatch(item, snapshot, context);
     }
     return result;
 }
@@ -2864,9 +2809,7 @@ const sigilUxCommandRegistry = createSigilUxTreeCommandRegistry({
         setInteractionState('RADIAL', 'press-threshold-radial');
         return { state: liveJs.currentState, snapshot: liveJs.radialGestureMenu };
     },
-    radialReleaseItem: (item, payload = {}) => (
-        performRadialItemAction(item, payload.context?.snapshot || null, payload.context || {})
-    ),
+    radialReleaseItem: radialItemActionDispatcher.commandHandlers.radialReleaseItem,
     selectionModeEnter: (pointer) => {
         enterSelectionMode(pointer, 'avatar-double-click');
         resetAvatarDoubleClick();
@@ -2878,34 +2821,16 @@ const sigilUxCommandRegistry = createSigilUxTreeCommandRegistry({
     selectionModeCommit: (reason) => commitSelectionMode(reason),
     selectionModeCycleTarget: (delta) => cycleSelectionModeTarget(delta),
     selectionModeAcquire: (pointer) => acquireSelectionModeCandidates(pointer),
-    contextMenuOpen: (pointer, payload = {}) => {
-        if (payload.context?.item) {
-            return performRadialItemAction(payload.context.item, payload.context.snapshot, payload.context);
-        }
-        return pointer && typeof pointer.x === 'number' && typeof pointer.y === 'number'
-            ? openContextMenuAt(pointer.x, pointer.y)
-            : false;
-    },
+    contextMenuOpen: radialItemActionDispatcher.commandHandlers.contextMenuOpen,
     contextMenuToggle: () => {
         contextMenu.close('right-click-toggle');
         cancelInteraction('right-click-toggle');
         return true;
     },
-    annotationReticleEnter: (pointer, payload = {}) => (
-        performRadialItemAction(payload.context?.item || { id: SIGIL_ANNOTATION_RETICLE_ITEM_ID, action: 'annotationMode' }, payload.context?.snapshot || null, {
-            ...(payload.context || {}),
-            pointer,
-        })
-    ),
-    annotationCameraCaptureBundle: (_reason, payload = {}) => (
-        performRadialItemAction(payload.context?.item || { id: SIGIL_ANNOTATION_CAMERA_ITEM_ID, action: 'annotationSnapshot' }, payload.context?.snapshot || null, payload.context || {})
-    ),
-    wikiGraphOpen: (_path, payload = {}) => (
-        performRadialItemAction(payload.context?.item || { id: 'wiki-graph', action: 'wikiGraph' }, payload.context?.snapshot || null, payload.context || {})
-    ),
-    agentTerminalOpen: (_kind, payload = {}) => (
-        performRadialItemAction(payload.context?.item || { id: 'agent-terminal', action: 'agentTerminal' }, payload.context?.snapshot || null, payload.context || {})
-    ),
+    annotationReticleEnter: radialItemActionDispatcher.commandHandlers.annotationReticleEnter,
+    annotationCameraCaptureBundle: radialItemActionDispatcher.commandHandlers.annotationCameraCaptureBundle,
+    wikiGraphOpen: radialItemActionDispatcher.commandHandlers.wikiGraphOpen,
+    agentTerminalOpen: radialItemActionDispatcher.commandHandlers.agentTerminalOpen,
 });
 
 function recordUxCommandRuntime(result = {}, { fallback = false } = {}) {

--- a/apps/sigil/renderer/live-modules/main.js
+++ b/apps/sigil/renderer/live-modules/main.js
@@ -81,11 +81,14 @@ import {
 import { buildAvatarObjectRegistry } from './avatar-object-control.js';
 import { createSigilUxTree, createSigilUxTreeShadowResolver } from './ux-tree.js';
 import {
+    SIGIL_AVATAR_COMMAND_INPUTS,
     SIGIL_SELECTION_MODE_COMMAND_INPUTS,
     SIGIL_SELECTION_MODE_ESCAPE_COMMAND_INPUT,
+    SIGIL_RADIAL_COMMAND_INPUTS,
     createSigilUxTreeCommandRegistry,
     executeSigilUxTreeCommand,
 } from './ux-tree-command-registry.js';
+import { createSigilUxTreeReadinessAudit } from './ux-tree-readiness.js';
 import { createSigilContextMenu } from '../../context-menu/menu.js';
 import { loadAgent } from '../agent-loader.js';
 import { createSessionVitalityController } from '../session-vitality.js';
@@ -1509,72 +1512,116 @@ function sigilUxTreeShadowResolver() {
     return createSigilUxTreeShadowResolver(sigilUxTreeSnapshot());
 }
 
+function sigilUxTreeReadiness() {
+    return createSigilUxTreeReadinessAudit(sigilUxTreeSnapshot(), {
+        registry: sigilUxCommandRegistry,
+    });
+}
+
+function radialActivationInputFromContext(context = {}) {
+    return context.input && typeof context.input === 'object'
+        ? {
+            ...context.input,
+            pointer: context.input.pointer || context.pointer || null,
+        }
+        : context.input || {
+            kind: 'gesture',
+            source: 'sigil.avatar',
+            pointer: context.pointer || null,
+        };
+}
+
+function createRadialActivationForCommand(item, snapshot, context = {}) {
+    const input = radialActivationInputFromContext(context);
+    return createSigilRadialActivationRequest({
+        item,
+        snapshot,
+        input,
+        source: context.source || 'sigil.avatar',
+        agentTerminalCanvasId: AGENT_TERMINAL_CANVAS_ID,
+        wikiWorkbenchCanvasId: WIKI_WORKBENCH_CANVAS_ID,
+        wikiPath: WIKI_WORKBENCH_DEFAULT_PATH,
+    });
+}
+
+function performRadialItemAction(item, snapshot, context = {}) {
+    if (item?.action === 'annotationMode' || item?.id === SIGIL_ANNOTATION_RETICLE_ITEM_ID) {
+        enterAnnotationReticle(context.pointer || snapshot?.pointer || liveJs.pointerPos, 'radial-item');
+        host.post('sigil.annotation_reticle.enter', {
+            item_id: item?.id,
+            entry_source: liveJs.annotationReticle?.entry_source,
+            input: context.input || null,
+            snapshot: liveJs.annotationReticle,
+        });
+        return { action: 'annotation_reticle_entered', item_id: item?.id || null };
+    }
+    if (item?.action === 'annotationSnapshot' || item?.id === SIGIL_ANNOTATION_CAMERA_ITEM_ID) {
+        const requested = context.reason === 'radial-camera-target-surface-recovery'
+            ? requestAnnotationSnapshot('radial-camera-target-surface-recovery')
+            : requestAnnotationSnapshot(context.reason || 'radial-camera');
+        return { action: 'annotation_snapshot_requested', requested };
+    }
+
+    let activation = context.activation || createRadialActivationForCommand(item, snapshot, context);
+    liveJs.lastRadialActivation = activation;
+    host.post('sigil.radial_menu.activation', activation);
+    if (radialActivationTransition.start(activation, snapshot, { startedAt: state.globalTime })) {
+        activation = sendActivationUpdate(activation, 'item_transition', {
+            transition: activation.transition,
+        });
+    }
+    if (item?.action === 'contextMenu') {
+        const opened = openContextMenuAt(liveJs.avatarPos.x, liveJs.avatarPos.y, { force: true });
+        sendActivationUpdate(activation, 'completed', { result: { opened: 'context-menu' } });
+        return { action: 'context_menu_opened', opened };
+    }
+    if (item?.action === 'agentTerminal' || item?.action === 'codexTerminal') {
+        const result = toggleUtilityCanvas('agent-terminal');
+        sendActivationUpdate(activation, 'completed', { result: { canvas_id: AGENT_TERMINAL_CANVAS_ID } });
+        return { action: 'agent_terminal_opened', canvas_id: AGENT_TERMINAL_CANVAS_ID, result };
+    }
+    if (item?.action === 'wikiGraph') {
+        const result = openWikiWorkbench(WIKI_WORKBENCH_DEFAULT_PATH, activation).catch((error) => {
+            console.warn('[sigil] wiki workbench activation failed:', error);
+            sendActivationUpdate(activation, 'failed', {
+                error: String(error?.message || error),
+            });
+            return { error: String(error?.message || error) };
+        });
+        return { action: 'wiki_graph_opened', canvas_id: WIKI_WORKBENCH_CANVAS_ID, result };
+    }
+    host.post('sigil.radial_menu.action', {
+        action: item?.action || item?.id || 'unknown',
+    });
+    sendActivationUpdate(activation, 'completed', { result: { action: item?.action || item?.id || 'unknown' } });
+    return { action: item?.action || item?.id || 'unknown' };
+}
+
+function executeRadialItemCommand(item, snapshot, context = {}) {
+    const result = executeSigilUxTreeCommand(sigilUxTreeSnapshot(), {
+        input: SIGIL_RADIAL_COMMAND_INPUTS.itemRelease(item?.id),
+        registry: sigilUxCommandRegistry,
+        context: {
+            source: context.source || 'sigil.radial_menu',
+            item,
+            snapshot,
+            pointer: context.pointer || snapshot?.pointer || liveJs.pointerPos,
+            input: radialActivationInputFromContext(context),
+            reason: context.reason || 'radial-camera',
+            path: WIKI_WORKBENCH_DEFAULT_PATH,
+        },
+    });
+    recordUxCommandRuntime(result, { fallback: result.executed !== true });
+    if (result.executed !== true) {
+        performRadialItemAction(item, snapshot, context);
+    }
+    return result;
+}
+
 const radialGestureMenu = createSigilRadialGestureMenu({
     state,
     onCommitItem(item, snapshot, context = {}) {
-        if (item?.action === 'annotationMode' || item?.id === SIGIL_ANNOTATION_RETICLE_ITEM_ID) {
-            enterAnnotationReticle(context.pointer || snapshot?.pointer || liveJs.pointerPos, 'radial-item');
-            host.post('sigil.annotation_reticle.enter', {
-                item_id: item?.id,
-                entry_source: liveJs.annotationReticle?.entry_source,
-                input: context.input || null,
-                snapshot: liveJs.annotationReticle,
-            });
-            return;
-        }
-        if (item?.action === 'annotationSnapshot' || item?.id === SIGIL_ANNOTATION_CAMERA_ITEM_ID) {
-            requestAnnotationSnapshot('radial-camera');
-            return;
-        }
-        const input = context.input && typeof context.input === 'object'
-            ? {
-                ...context.input,
-                pointer: context.input.pointer || context.pointer || null,
-            }
-            : context.input || {
-                kind: 'gesture',
-                source: 'sigil.avatar',
-                pointer: context.pointer || null,
-            };
-        let activation = createSigilRadialActivationRequest({
-            item,
-            snapshot,
-            input,
-            source: context.source || 'sigil.avatar',
-            agentTerminalCanvasId: AGENT_TERMINAL_CANVAS_ID,
-            wikiWorkbenchCanvasId: WIKI_WORKBENCH_CANVAS_ID,
-            wikiPath: WIKI_WORKBENCH_DEFAULT_PATH,
-        });
-        liveJs.lastRadialActivation = activation;
-        host.post('sigil.radial_menu.activation', activation);
-        if (radialActivationTransition.start(activation, snapshot, { startedAt: state.globalTime })) {
-            activation = sendActivationUpdate(activation, 'item_transition', {
-                transition: activation.transition,
-            });
-        }
-        if (item?.action === 'contextMenu') {
-            openContextMenuAt(liveJs.avatarPos.x, liveJs.avatarPos.y, { force: true });
-            sendActivationUpdate(activation, 'completed', { result: { opened: 'context-menu' } });
-            return;
-        }
-        if (item?.action === 'agentTerminal' || item?.action === 'codexTerminal') {
-            toggleUtilityCanvas('agent-terminal');
-            sendActivationUpdate(activation, 'completed', { result: { canvas_id: AGENT_TERMINAL_CANVAS_ID } });
-            return;
-        }
-        if (item?.action === 'wikiGraph') {
-            void openWikiWorkbench(WIKI_WORKBENCH_DEFAULT_PATH, activation).catch((error) => {
-                console.warn('[sigil] wiki workbench activation failed:', error);
-                sendActivationUpdate(activation, 'failed', {
-                    error: String(error?.message || error),
-                });
-            });
-            return;
-        }
-        host.post('sigil.radial_menu.action', {
-            action: item?.action || item?.id || 'unknown',
-        });
-        sendActivationUpdate(activation, 'completed', { result: { action: item?.action || item?.id || 'unknown' } });
+        executeRadialItemCommand(item, snapshot, context);
     },
 });
 let omegaTrailTravelKey = null;
@@ -2790,20 +2837,75 @@ function exitSelectionMode(reason = 'cancel') {
 }
 
 const sigilUxCommandRegistry = createSigilUxTreeCommandRegistry({
+    avatarPressBegin: (pointer) => {
+        if (!pointer) return false;
+        liveJs.mousedownPos = { x: pointer.x, y: pointer.y };
+        liveJs.mousedownAvatarPos = { x: liveJs.avatarPos.x, y: liveJs.avatarPos.y };
+        setInteractionState('PRESS', 'mousedown-on-avatar');
+        return { state: liveJs.currentState, pointer };
+    },
+    avatarGotoBegin: (pointer) => {
+        if (!pointer) return false;
+        clearGestureState();
+        fastTravel.clearGesture('press-click');
+        consumeAvatarDoubleClick(pointer.x, pointer.y);
+        setInteractionState('GOTO', 'press-click');
+        return { state: liveJs.currentState, pointer };
+    },
+    radialBegin: (pointer) => {
+        if (!pointer) return false;
+        liveJs.radialGestureMenu = radialGestureMenu.start(
+            { ...liveJs.avatarPos, valid: true },
+            { x: pointer.x, y: pointer.y, valid: true }
+        );
+        if (applyRadialGestureMove(radialGestureMenu.move({ x: pointer.x, y: pointer.y, valid: true }), pointer.x, pointer.y)) {
+            return { state: liveJs.currentState, snapshot: liveJs.radialGestureMenu };
+        }
+        setInteractionState('RADIAL', 'press-threshold-radial');
+        return { state: liveJs.currentState, snapshot: liveJs.radialGestureMenu };
+    },
+    radialReleaseItem: (item, payload = {}) => (
+        performRadialItemAction(item, payload.context?.snapshot || null, payload.context || {})
+    ),
+    selectionModeEnter: (pointer) => {
+        enterSelectionMode(pointer, 'avatar-double-click');
+        resetAvatarDoubleClick();
+        markSelectionModeEntryReleasePending();
+        setInteractionState('IDLE', 'selection-mode-enter');
+        return liveJs.selectionMode;
+    },
     selectionModeCancel: () => exitSelectionMode('escape'),
     selectionModeCommit: (reason) => commitSelectionMode(reason),
     selectionModeCycleTarget: (delta) => cycleSelectionModeTarget(delta),
     selectionModeAcquire: (pointer) => acquireSelectionModeCandidates(pointer),
-    contextMenuOpen: (pointer) => (
-        pointer && typeof pointer.x === 'number' && typeof pointer.y === 'number'
+    contextMenuOpen: (pointer, payload = {}) => {
+        if (payload.context?.item) {
+            return performRadialItemAction(payload.context.item, payload.context.snapshot, payload.context);
+        }
+        return pointer && typeof pointer.x === 'number' && typeof pointer.y === 'number'
             ? openContextMenuAt(pointer.x, pointer.y)
-            : false
-    ),
+            : false;
+    },
     contextMenuToggle: () => {
         contextMenu.close('right-click-toggle');
         cancelInteraction('right-click-toggle');
         return true;
     },
+    annotationReticleEnter: (pointer, payload = {}) => (
+        performRadialItemAction(payload.context?.item || { id: SIGIL_ANNOTATION_RETICLE_ITEM_ID, action: 'annotationMode' }, payload.context?.snapshot || null, {
+            ...(payload.context || {}),
+            pointer,
+        })
+    ),
+    annotationCameraCaptureBundle: (_reason, payload = {}) => (
+        performRadialItemAction(payload.context?.item || { id: SIGIL_ANNOTATION_CAMERA_ITEM_ID, action: 'annotationSnapshot' }, payload.context?.snapshot || null, payload.context || {})
+    ),
+    wikiGraphOpen: (_path, payload = {}) => (
+        performRadialItemAction(payload.context?.item || { id: 'wiki-graph', action: 'wikiGraph' }, payload.context?.snapshot || null, payload.context || {})
+    ),
+    agentTerminalOpen: (_kind, payload = {}) => (
+        performRadialItemAction(payload.context?.item || { id: 'agent-terminal', action: 'agentTerminal' }, payload.context?.snapshot || null, payload.context || {})
+    ),
 });
 
 function recordUxCommandRuntime(result = {}, { fallback = false } = {}) {
@@ -2867,6 +2969,25 @@ function executeContextMenuRightClickCommand(route = {}, msg = {}) {
         },
     });
     recordUxCommandRuntime(result, { fallback: result.executed !== true });
+    return result;
+}
+
+function executeAvatarCommand(input, msg = {}, {
+    pointer = null,
+    fallback = null,
+    source = 'handleInputEvent',
+} = {}) {
+    const result = executeSigilUxTreeCommand(sigilUxTreeSnapshot(), {
+        input,
+        registry: sigilUxCommandRegistry,
+        context: {
+            source,
+            msg,
+            pointer,
+        },
+    });
+    recordUxCommandRuntime(result, { fallback: result.executed !== true });
+    if (result.executed !== true && typeof fallback === 'function') fallback();
     return result;
 }
 
@@ -3398,17 +3519,27 @@ function handleLeftMouseDown(x, y) {
     switch (liveJs.currentState) {
         case 'IDLE':
             if (!isOnAvatar(x, y)) return;
-            liveJs.mousedownPos = { x, y };
-            liveJs.mousedownAvatarPos = { x: liveJs.avatarPos.x, y: liveJs.avatarPos.y };
-            setInteractionState('PRESS', 'mousedown-on-avatar');
+            executeAvatarCommand(SIGIL_AVATAR_COMMAND_INPUTS.pressBegin, { type: 'left_mouse_down', x, y }, {
+                pointer: { x, y, valid: true },
+                fallback: () => {
+                    liveJs.mousedownPos = { x, y };
+                    liveJs.mousedownAvatarPos = { x: liveJs.avatarPos.x, y: liveJs.avatarPos.y };
+                    setInteractionState('PRESS', 'mousedown-on-avatar');
+                },
+            });
             return;
         case 'GOTO':
             if (isOnAvatar(x, y)) {
                 if (consumeAvatarDoubleClick(x, y)) {
-                    enterSelectionMode({ x, y, valid: true }, 'avatar-double-click');
-                    resetAvatarDoubleClick();
-                    markSelectionModeEntryReleasePending();
-                    setInteractionState('IDLE', 'selection-mode-enter');
+                    executeAvatarCommand(SIGIL_AVATAR_COMMAND_INPUTS.selectionModeEnter, { type: 'left_mouse_down', x, y }, {
+                        pointer: { x, y, valid: true },
+                        fallback: () => {
+                            enterSelectionMode({ x, y, valid: true }, 'avatar-double-click');
+                            resetAvatarDoubleClick();
+                            markSelectionModeEntryReleasePending();
+                            setInteractionState('IDLE', 'selection-mode-enter');
+                        },
+                    });
                     return;
                 }
                 clearGestureState();
@@ -3434,10 +3565,15 @@ function handleLeftMouseUp(x, y) {
                 setInteractionState('IDLE', 'press-release-fast-travel');
                 return;
             }
-            clearGestureState();
-            fastTravel.clearGesture('press-click');
-            consumeAvatarDoubleClick(x, y);
-            setInteractionState('GOTO', 'press-click');
+            executeAvatarCommand(SIGIL_AVATAR_COMMAND_INPUTS.gotoBegin, { type: 'left_mouse_up', x, y }, {
+                pointer: { x, y, valid: true },
+                fallback: () => {
+                    clearGestureState();
+                    fastTravel.clearGesture('press-click');
+                    consumeAvatarDoubleClick(x, y);
+                    setInteractionState('GOTO', 'press-click');
+                },
+            });
             return;
         case 'RADIAL': {
             const result = radialGestureMenu.release({ x, y, valid: true }, {
@@ -3513,12 +3649,17 @@ function handleMouseMove(x, y) {
     }
     if (liveJs.currentState !== 'PRESS' || !liveJs.mousedownPos) return;
     if (distance(x, y, liveJs.mousedownPos.x, liveJs.mousedownPos.y) < liveJs.dragThreshold) return;
-    liveJs.radialGestureMenu = radialGestureMenu.start(
-        { ...liveJs.avatarPos, valid: true },
-        { x, y, valid: true }
-    );
-    if (applyRadialGestureMove(radialGestureMenu.move({ x, y, valid: true }), x, y)) return;
-    setInteractionState('RADIAL', 'press-threshold-radial');
+    executeAvatarCommand(SIGIL_AVATAR_COMMAND_INPUTS.radialBegin, { type: 'left_mouse_dragged', x, y }, {
+        pointer: { x, y, valid: true },
+        fallback: () => {
+            liveJs.radialGestureMenu = radialGestureMenu.start(
+                { ...liveJs.avatarPos, valid: true },
+                { x, y, valid: true }
+            );
+            if (applyRadialGestureMove(radialGestureMenu.move({ x, y, valid: true }), x, y)) return;
+            setInteractionState('RADIAL', 'press-threshold-radial');
+        },
+    });
 }
 
 function handleInputEvent(msg) {
@@ -3778,10 +3919,26 @@ function handleRadialTargetSurfaceEvent(payload = {}) {
     if (payload.kind !== 'radial_item_click') return;
     if (liveJs.currentState !== 'RADIAL' || !liveJs.radialGestureMenu) {
         if (payload.itemId === SIGIL_ANNOTATION_CAMERA_ITEM_ID || payload.itemAction === 'annotationSnapshot') {
-            const requested = requestAnnotationSnapshot('radial-camera-target-surface-recovery');
+            const recoveryItem = {
+                id: payload.itemId || SIGIL_ANNOTATION_CAMERA_ITEM_ID,
+                action: payload.itemAction || 'annotationSnapshot',
+            };
+            const commandResult = executeRadialItemCommand(recoveryItem, null, {
+                input: {
+                    kind: 'click',
+                    source: 'sigil.radial-target-surface',
+                    item_id: payload.itemId,
+                    canvas_id: radialTargetSurface.id,
+                },
+                source: 'sigil.radial-target-surface',
+                pointer: receipt.worldPoint || liveJs.pointerPos,
+                reason: 'radial-camera-target-surface-recovery',
+            });
             interactionTrace.record('radial-surface:recovered', {
                 reason: 'camera-click-after-radial-cleanup',
-                requested,
+                requested: commandResult.handler_result?.requested || null,
+                command_id: commandResult.command_id,
+                executed: commandResult.executed,
                 ...receipt,
             });
             clearGestureState();
@@ -4557,6 +4714,7 @@ window.__sigilDebug = {
             inputRegions: sigilInputRegions?.snapshot?.() ?? null,
             radialTargetSurface: radialTargetSurface.snapshot(),
             uxTree: sigilUxTreeSnapshot(),
+            uxTreeReadiness: sigilUxTreeReadiness(),
             transition: visibilityTransition.active?.effect ?? null,
             surface: desktopWorldSurface ? {
                 segment: desktopWorldSurface.segment,
@@ -4575,6 +4733,9 @@ window.__sigilDebug = {
     },
     uxTreeShadow(input) {
         return sigilUxTreeShadowResolver().resolve(input || {});
+    },
+    uxTreeReadiness() {
+        return sigilUxTreeReadiness();
     },
     uxTreeCommand(input, registry = {}) {
         return executeSigilUxTreeCommand(sigilUxTreeSnapshot(), {

--- a/apps/sigil/renderer/live-modules/radial-item-action-dispatch.js
+++ b/apps/sigil/renderer/live-modules/radial-item-action-dispatch.js
@@ -1,0 +1,160 @@
+import { createSigilRadialActivationRequest } from './radial-menu-activation.js';
+
+function point(value = null) {
+    const x = Number(value?.x);
+    const y = Number(value?.y);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+    return { x, y, valid: value?.valid !== false };
+}
+
+function radialActivationInputFromContext(context = {}) {
+    return context.input && typeof context.input === 'object'
+        ? {
+            ...context.input,
+            pointer: context.input.pointer || context.pointer || null,
+        }
+        : context.input || {
+            kind: 'gesture',
+            source: 'sigil.avatar',
+            pointer: context.pointer || null,
+        };
+}
+
+function actionForItem(item = {}) {
+    return String(item?.action || item?.id || 'unknown');
+}
+
+export function createSigilRadialItemActionDispatcher({
+    agentTerminalCanvasId = 'sigil-agent-terminal',
+    wikiWorkbenchCanvasId = 'sigil-wiki-workbench',
+    wikiPath = 'aos/concepts/employer-brand-workflow-map.md',
+    annotationReticleItemId = 'annotation-mode',
+    annotationCameraItemId = 'annotation-camera',
+    getPointer = () => null,
+    getAvatarPos = () => null,
+    setLastRadialActivation = () => {},
+    post = () => {},
+    warn = () => {},
+    createActivationRequest = createSigilRadialActivationRequest,
+    startActivationTransition = () => false,
+    sendActivationUpdate = () => null,
+    enterAnnotationReticle = () => null,
+    requestAnnotationSnapshot = () => false,
+    openContextMenuAt = () => false,
+    toggleUtilityCanvas = () => false,
+    openWikiWorkbench = () => Promise.resolve(false),
+} = {}) {
+    function createActivation(item, snapshot, context = {}) {
+        return createActivationRequest({
+            item,
+            snapshot,
+            input: radialActivationInputFromContext(context),
+            source: context.source || 'sigil.avatar',
+            agentTerminalCanvasId,
+            wikiWorkbenchCanvasId,
+            wikiPath,
+        });
+    }
+
+    function postActivationStart(item, snapshot, context = {}) {
+        let activation = context.activation || createActivation(item, snapshot, context);
+        setLastRadialActivation(activation);
+        post('sigil.radial_menu.activation', activation);
+        if (startActivationTransition(activation, snapshot)) {
+            activation = sendActivationUpdate(activation, 'item_transition', {
+                transition: activation.transition,
+            }) || activation;
+        }
+        return activation;
+    }
+
+    function dispatch(item = {}, snapshot = null, context = {}) {
+        const action = actionForItem(item);
+        if (action === 'annotationMode' || item?.id === annotationReticleItemId) {
+            const pointer = context.pointer || point(snapshot?.pointer) || getPointer();
+            const nextSnapshot = enterAnnotationReticle(pointer, 'radial-item');
+            post('sigil.annotation_reticle.enter', {
+                item_id: item?.id,
+                entry_source: nextSnapshot?.entry_source,
+                input: context.input || null,
+                snapshot: nextSnapshot,
+            });
+            return { action: 'annotation_reticle_entered', item_id: item?.id || null };
+        }
+        if (action === 'annotationSnapshot' || item?.id === annotationCameraItemId) {
+            const reason = context.reason === 'radial-camera-target-surface-recovery'
+                ? 'radial-camera-target-surface-recovery'
+                : context.reason || 'radial-camera';
+            const requested = requestAnnotationSnapshot(reason);
+            return { action: 'annotation_snapshot_requested', requested };
+        }
+
+        const activation = postActivationStart(item, snapshot, context);
+        if (action === 'contextMenu') {
+            const avatarPos = getAvatarPos() || {};
+            const opened = openContextMenuAt(avatarPos.x, avatarPos.y, { force: true });
+            sendActivationUpdate(activation, 'completed', { result: { opened: 'context-menu' } });
+            return { action: 'context_menu_opened', opened };
+        }
+        if (action === 'agentTerminal' || action === 'codexTerminal') {
+            const result = toggleUtilityCanvas('agent-terminal');
+            sendActivationUpdate(activation, 'completed', { result: { canvas_id: agentTerminalCanvasId } });
+            return { action: 'agent_terminal_opened', canvas_id: agentTerminalCanvasId, result };
+        }
+        if (action === 'wikiGraph') {
+            const result = openWikiWorkbench(wikiPath, activation).catch((error) => {
+                warn('[sigil] wiki workbench activation failed:', error);
+                sendActivationUpdate(activation, 'failed', {
+                    error: String(error?.message || error),
+                });
+                return { error: String(error?.message || error) };
+            });
+            return { action: 'wiki_graph_opened', canvas_id: wikiWorkbenchCanvasId, result };
+        }
+
+        post('sigil.radial_menu.action', { action });
+        sendActivationUpdate(activation, 'completed', { result: { action } });
+        return { action };
+    }
+
+    function dispatchContextMenuOpen(pointer, payload = {}) {
+        if (payload.context?.item) {
+            return dispatch(payload.context.item, payload.context.snapshot, {
+                ...(payload.context || {}),
+                pointer,
+            });
+        }
+        return pointer && typeof pointer.x === 'number' && typeof pointer.y === 'number'
+            ? openContextMenuAt(pointer.x, pointer.y)
+            : false;
+    }
+
+    const commandHandlers = Object.freeze({
+        radialReleaseItem: (item, payload = {}) => (
+            dispatch(item, payload.context?.snapshot || null, payload.context || {})
+        ),
+        contextMenuOpen: dispatchContextMenuOpen,
+        annotationReticleEnter: (pointer, payload = {}) => (
+            dispatch(payload.context?.item || { id: annotationReticleItemId, action: 'annotationMode' }, payload.context?.snapshot || null, {
+                ...(payload.context || {}),
+                pointer,
+            })
+        ),
+        annotationCameraCaptureBundle: (_reason, payload = {}) => (
+            dispatch(payload.context?.item || { id: annotationCameraItemId, action: 'annotationSnapshot' }, payload.context?.snapshot || null, payload.context || {})
+        ),
+        wikiGraphOpen: (_path, payload = {}) => (
+            dispatch(payload.context?.item || { id: 'wiki-graph', action: 'wikiGraph' }, payload.context?.snapshot || null, payload.context || {})
+        ),
+        agentTerminalOpen: (_kind, payload = {}) => (
+            dispatch(payload.context?.item || { id: 'agent-terminal', action: 'agentTerminal' }, payload.context?.snapshot || null, payload.context || {})
+        ),
+    });
+
+    return Object.freeze({
+        commandHandlers,
+        createActivation,
+        dispatch,
+        inputFromContext: radialActivationInputFromContext,
+    });
+}

--- a/apps/sigil/renderer/live-modules/ux-tree-command-registry.js
+++ b/apps/sigil/renderer/live-modules/ux-tree-command-registry.js
@@ -48,6 +48,40 @@ export const SIGIL_CONTEXT_MENU_COMMAND_INPUTS = Object.freeze({
     }),
 });
 
+export const SIGIL_AVATAR_COMMAND_INPUTS = Object.freeze({
+    pressBegin: Object.freeze({
+        nodeId: 'sigil.avatar.body',
+        mode: 'idle',
+        gesture: 'pointer.left.press',
+    }),
+    gotoBegin: Object.freeze({
+        nodeId: 'sigil.avatar.body',
+        mode: 'press',
+        gesture: 'pointer.left.release',
+    }),
+    radialBegin: Object.freeze({
+        nodeId: 'sigil.avatar.body',
+        mode: 'press',
+        gesture: 'pointer.left.drag_threshold',
+    }),
+    selectionModeEnter: Object.freeze({
+        nodeId: 'sigil.avatar.body',
+        mode: 'goto',
+        gesture: 'pointer.left.double_click',
+    }),
+});
+
+export const SIGIL_RADIAL_COMMAND_INPUTS = Object.freeze({
+    itemRelease(itemId) {
+        return {
+            nodeId: `sigil.avatar.radial_menu.item.${text(itemId, 'unknown')}`,
+            mode: 'radial',
+            gesture: 'pointer.left.release',
+            itemId: text(itemId, 'unknown'),
+        };
+    },
+});
+
 const ALLOWLISTED_EXECUTION = 'allowlisted';
 const HAS_OWN = Object.prototype.hasOwnProperty;
 
@@ -126,23 +160,47 @@ function registryHandler(registry = {}, command = {}) {
 }
 
 export function createSigilUxTreeCommandRegistry({
+    avatarPressBegin,
+    avatarGotoBegin,
+    radialBegin,
+    radialReleaseItem,
+    selectionModeEnter,
     selectionModeCancel,
     selectionModeCommit,
     selectionModeCycleTarget,
     selectionModeAcquire,
     contextMenuOpen,
     contextMenuToggle,
+    annotationReticleEnter,
+    annotationCameraCaptureBundle,
+    wikiGraphOpen,
+    agentTerminalOpen,
 } = {}) {
     const registry = {};
     if (typeof contextMenuOpen === 'function') {
-        registry['sigil.context_menu.open'] = ({ context } = {}) => (
-            contextMenuOpen(context?.pointer || null)
+        registry['sigil.context_menu.open'] = (payload = {}) => (
+            contextMenuOpen(payload.context?.pointer || null, payload)
         );
     }
     if (typeof contextMenuToggle === 'function') {
-        registry['sigil.context_menu.toggle'] = ({ context } = {}) => (
-            contextMenuToggle(context?.pointer || null)
+        registry['sigil.context_menu.toggle'] = (payload = {}) => (
+            contextMenuToggle(payload.context?.pointer || null, payload)
         );
+    }
+    if (typeof avatarPressBegin === 'function') {
+        registry['sigil.avatar.press.begin'] = (payload = {}) => avatarPressBegin(payload.context?.pointer || null, payload);
+    }
+    if (typeof avatarGotoBegin === 'function') {
+        registry['sigil.avatar.goto.begin'] = (payload = {}) => avatarGotoBegin(payload.context?.pointer || null, payload);
+    }
+    if (typeof radialBegin === 'function') {
+        registry['sigil.radial.begin'] = (payload = {}) => radialBegin(payload.context?.pointer || null, payload);
+    }
+    if (typeof radialReleaseItem === 'function') {
+        registry['sigil.radial.release_item'] = (payload = {}) => radialReleaseItem(payload.context?.item || null, payload);
+    }
+    if (typeof selectionModeEnter === 'function') {
+        registry['sigil.selection_mode.enter'] = (payload = {}) => selectionModeEnter(payload.context?.pointer || null, payload);
     }
     if (typeof selectionModeCancel === 'function') {
         registry['sigil.selection_mode.cancel'] = selectionModeCancel;
@@ -160,6 +218,18 @@ export function createSigilUxTreeCommandRegistry({
         registry['sigil.selection_mode.acquire'] = ({ context } = {}) => (
             selectionModeAcquire(context?.pointer || null)
         );
+    }
+    if (typeof annotationReticleEnter === 'function') {
+        registry['sigil.annotation_reticle.enter'] = (payload = {}) => annotationReticleEnter(payload.context?.pointer || null, payload);
+    }
+    if (typeof annotationCameraCaptureBundle === 'function') {
+        registry['sigil.annotation_camera.capture_bundle'] = (payload = {}) => annotationCameraCaptureBundle(payload.context?.reason || 'radial-camera', payload);
+    }
+    if (typeof wikiGraphOpen === 'function') {
+        registry['sigil.wiki_graph.open'] = (payload = {}) => wikiGraphOpen(payload.context?.path || null, payload);
+    }
+    if (typeof agentTerminalOpen === 'function') {
+        registry['sigil.agent_terminal.open'] = (payload = {}) => agentTerminalOpen(payload.context?.kind || 'agent-terminal', payload);
     }
     return Object.freeze(registry);
 }

--- a/apps/sigil/renderer/live-modules/ux-tree-command-registry.js
+++ b/apps/sigil/renderer/live-modules/ux-tree-command-registry.js
@@ -35,6 +35,19 @@ export const SIGIL_SELECTION_MODE_COMMAND_INPUTS = Object.freeze({
     }),
 });
 
+export const SIGIL_CONTEXT_MENU_COMMAND_INPUTS = Object.freeze({
+    open: Object.freeze({
+        nodeId: 'sigil.avatar.body',
+        mode: 'idle',
+        gesture: 'pointer.right.click',
+    }),
+    toggle: Object.freeze({
+        nodeId: 'sigil.avatar.context_menu',
+        mode: 'global',
+        gesture: 'pointer.right.click',
+    }),
+});
+
 const ALLOWLISTED_EXECUTION = 'allowlisted';
 const HAS_OWN = Object.prototype.hasOwnProperty;
 
@@ -117,8 +130,20 @@ export function createSigilUxTreeCommandRegistry({
     selectionModeCommit,
     selectionModeCycleTarget,
     selectionModeAcquire,
+    contextMenuOpen,
+    contextMenuToggle,
 } = {}) {
     const registry = {};
+    if (typeof contextMenuOpen === 'function') {
+        registry['sigil.context_menu.open'] = ({ context } = {}) => (
+            contextMenuOpen(context?.pointer || null)
+        );
+    }
+    if (typeof contextMenuToggle === 'function') {
+        registry['sigil.context_menu.toggle'] = ({ context } = {}) => (
+            contextMenuToggle(context?.pointer || null)
+        );
+    }
     if (typeof selectionModeCancel === 'function') {
         registry['sigil.selection_mode.cancel'] = selectionModeCancel;
     }

--- a/apps/sigil/renderer/live-modules/ux-tree-readiness.js
+++ b/apps/sigil/renderer/live-modules/ux-tree-readiness.js
@@ -1,3 +1,12 @@
+import { toolkitSpecifier } from './content-roots.js';
+
+const {
+    resolveUxTree,
+    uxTreeCommandById,
+} = await import(toolkitSpecifier('runtime/ux-tree.js', {
+    local: '../../../../packages/toolkit/runtime/ux-tree.js',
+}));
+
 const HAS_OWN = Object.prototype.hasOwnProperty;
 
 const DEFAULT_ROUTED_BINDING_IDS = Object.freeze(new Set([
@@ -88,8 +97,11 @@ function registryHandler(registry = {}, command = {}) {
         text(command.id),
     ].filter(Boolean);
     for (const key of keys) {
-        if (registry instanceof Map && typeof registry.get(key) === 'function') {
-            return { key, registered: true };
+        if (registry instanceof Map) {
+            if (typeof registry.get(key) === 'function') {
+                return { key, registered: true };
+            }
+            continue;
         }
         if (ownFunction(registry, key)) {
             return { key, registered: true };
@@ -141,8 +153,33 @@ function classifyBinding(binding = {}, {
     routedBindingIds = DEFAULT_ROUTED_BINDING_IDS,
     deferredBindings = {},
     runtimeMechanicBindings = {},
+    tree = {},
+    registry = {},
 } = {}) {
     if (routedBindingIds.has(binding.id) || radialItemReleaseBinding(binding)) {
+        const command = uxTreeCommandById(tree, binding.command_id);
+        if (!command) {
+            return {
+                id: binding.id,
+                command_id: binding.command_id,
+                node_id: binding.node_id,
+                gesture: binding.gesture,
+                status: 'routed_missing_command',
+                reason: `Routed binding references missing command ${binding.command_id || '(empty)'}.`,
+            };
+        }
+        const handler = registryHandler(registry, command);
+        if (!handler.registered) {
+            return {
+                id: binding.id,
+                command_id: binding.command_id,
+                node_id: binding.node_id,
+                gesture: binding.gesture,
+                status: 'routed_missing_handler',
+                handler_ref: command.handler_ref || command.id,
+                reason: `Routed binding command ${command.id} has no registered handler.`,
+            };
+        }
         return {
             id: binding.id,
             command_id: binding.command_id,
@@ -197,11 +234,56 @@ function relationTopology(tree = {}) {
         }));
 }
 
+function validationFailures(tree = {}, resolvedTree = tree) {
+    const failures = [];
+    const seen = new Set();
+    function push(error = {}, source = 'tree.validation') {
+        const code = error.code || source;
+        const path = error.path || '';
+        const message = error.message || `${source} is not ok`;
+        const key = `${source}\0${code}\0${path}\0${message}`;
+        if (seen.has(key)) return;
+        seen.add(key);
+        failures.push({
+            kind: 'validation',
+            id: source,
+            code,
+            path,
+            reason: message,
+        });
+    }
+
+    if (tree?.validation?.ok !== true) {
+        const errors = list(tree?.validation?.errors);
+        if (errors.length > 0) {
+            for (const error of errors) push(error, 'tree.validation');
+        } else {
+            push({ code: 'tree.validation', message: 'Resolved UX tree validation must be ok.' }, 'tree.validation');
+        }
+    }
+    if (resolvedTree?.validation?.ok !== true) {
+        const errors = list(resolvedTree?.validation?.errors);
+        if (errors.length > 0) {
+            for (const error of errors) push(error, 'canonical.validation');
+        } else {
+            push({ code: 'canonical.validation', message: 'Canonical UX tree validation must be ok.' }, 'canonical.validation');
+        }
+    }
+    return failures;
+}
+
 export function createSigilUxTreeReadinessAudit(tree = {}, options = {}) {
-    const commandCoverage = list(tree.commands).map((command) => classifyCommand(command, options));
-    const bindingCoverage = list(tree.bindings).map((binding) => classifyBinding(binding, options));
+    const resolvedTree = resolveUxTree(tree, { strict: false });
+    const validationFailureList = validationFailures(tree, resolvedTree);
+    const commandCoverage = list(resolvedTree.commands).map((command) => classifyCommand(command, options));
+    const bindingOptions = {
+        ...options,
+        tree: resolvedTree,
+    };
+    const bindingCoverage = list(resolvedTree.bindings).map((binding) => classifyBinding(binding, bindingOptions));
     const unclassifiedCommands = commandCoverage.filter((entry) => entry.status === 'unclassified_missing_handler');
     const unclassifiedBindings = bindingCoverage.filter((entry) => entry.status === 'unclassified');
+    const routedBindingFailures = bindingCoverage.filter((entry) => entry.status === 'routed_missing_command' || entry.status === 'routed_missing_handler');
     const routedBindings = bindingCoverage.filter((entry) => entry.status === 'routed_through_ux_command_adapter');
     const deferredBindings = bindingCoverage.filter((entry) => entry.status === 'deferred');
     const runtimeMechanicBindings = bindingCoverage.filter((entry) => entry.status === 'runtime_mechanic');
@@ -209,27 +291,40 @@ export function createSigilUxTreeReadinessAudit(tree = {}, options = {}) {
     return {
         schema: 'sigil_ux_tree_readiness_audit',
         version: 1,
-        ok: unclassifiedCommands.length === 0 && unclassifiedBindings.length === 0,
+        ok: validationFailureList.length === 0
+            && unclassifiedCommands.length === 0
+            && unclassifiedBindings.length === 0
+            && routedBindingFailures.length === 0,
         summary: {
             commands_total: commandCoverage.length,
             commands_registered: commandCoverage.filter((entry) => entry.status === 'registered_runtime_handler').length,
             commands_unclassified: unclassifiedCommands.length,
             bindings_total: bindingCoverage.length,
             bindings_routed: routedBindings.length,
+            bindings_routed_missing_command: bindingCoverage.filter((entry) => entry.status === 'routed_missing_command').length,
+            bindings_routed_missing_handler: bindingCoverage.filter((entry) => entry.status === 'routed_missing_handler').length,
             bindings_deferred: deferredBindings.length,
             bindings_runtime_mechanic: runtimeMechanicBindings.length,
             bindings_unclassified: unclassifiedBindings.length,
-            relations_topology: relationTopology(tree).length,
+            validation_errors: validationFailureList.length,
+            relations_topology: relationTopology(resolvedTree).length,
             direct_runtime_mechanics: DEFAULT_RUNTIME_MECHANICS.length,
         },
         commandCoverage,
         bindingCoverage,
         directRuntimeMechanics: cloneJson(DEFAULT_RUNTIME_MECHANICS),
-        relationTopology: relationTopology(tree),
+        relationTopology: relationTopology(resolvedTree),
         failures: [
+            ...validationFailureList,
             ...unclassifiedCommands.map((entry) => ({
                 kind: 'command',
                 id: entry.id,
+                reason: entry.reason,
+            })),
+            ...routedBindingFailures.map((entry) => ({
+                kind: 'binding',
+                id: entry.id,
+                command_id: entry.command_id,
                 reason: entry.reason,
             })),
             ...unclassifiedBindings.map((entry) => ({

--- a/apps/sigil/renderer/live-modules/ux-tree-readiness.js
+++ b/apps/sigil/renderer/live-modules/ux-tree-readiness.js
@@ -1,0 +1,242 @@
+const HAS_OWN = Object.prototype.hasOwnProperty;
+
+const DEFAULT_ROUTED_BINDING_IDS = Object.freeze(new Set([
+    'sigil.avatar.context_menu.right_click',
+    'sigil.avatar.context_menu.right_click_toggle',
+    'sigil.avatar.press.left_press',
+    'sigil.avatar.goto.left_release',
+    'sigil.avatar.radial.drag_threshold',
+    'sigil.avatar.selection_mode.double_click',
+    'sigil.selection_mode.escape',
+    'sigil.selection_mode.enter',
+    'sigil.selection_mode.tab',
+    'sigil.selection_mode.arrow_up',
+    'sigil.selection_mode.arrow_down',
+    'sigil.selection_mode.left_click_acquire',
+]));
+
+const DEFAULT_RUNTIME_MECHANICS = Object.freeze([
+    {
+        id: 'sigil.selection_mode.entry_release',
+        category: 'guard',
+        reason: 'Suppresses the mouse-up that completes Selection Mode entry; not a user-editable command.',
+    },
+    {
+        id: 'sigil.selection_mode.avatar_exit_double_click',
+        category: 'guard',
+        reason: 'Selection Mode avatar double-click exit is a local mode guard, not an entered command binding.',
+    },
+    {
+        id: 'sigil.selection_mode.render_only_pointer',
+        category: 'state_machine',
+        reason: 'Pointer move and drag events refresh hover/render state without invoking a command.',
+    },
+    {
+        id: 'sigil.context_menu.duplicate_echo',
+        category: 'guard',
+        reason: 'Duplicate right-click echo suppression protects the existing context-menu toggle path.',
+    },
+    {
+        id: 'sigil.context_menu.right_click_away',
+        category: 'fallback',
+        reason: 'Missing pointer coordinates close or cancel the context menu instead of executing a command.',
+    },
+    {
+        id: 'sigil.radial.pointer_tracking',
+        category: 'gesture_recognition',
+        reason: 'Radial hover, fast-travel handoff, reentry, and target-surface drag tracking remain runtime mechanics.',
+    },
+    {
+        id: 'sigil.radial.release_fallbacks',
+        category: 'fallback',
+        reason: 'Release fallback preserves fast-travel and cancellation behavior when no radial command commits.',
+    },
+    {
+        id: 'sigil.annotation_reticle.preview_commit',
+        category: 'state_machine',
+        reason: 'Reticle preview, live-anchor acquisition, and release commit remain annotation runtime mechanics.',
+    },
+]);
+
+function text(value, fallback = '') {
+    const normalized = String(value ?? '').replace(/\s+/g, ' ').trim();
+    return normalized || fallback;
+}
+
+function list(value) {
+    return Array.isArray(value) ? value.filter((entry) => entry !== undefined && entry !== null) : [];
+}
+
+function cloneJson(value) {
+    if (value === undefined) return undefined;
+    return JSON.parse(JSON.stringify(value));
+}
+
+function ownValue(object, key) {
+    if (!object || typeof object !== 'object' || !HAS_OWN.call(object, key)) return undefined;
+    return object[key];
+}
+
+function ownFunction(object, key) {
+    const value = ownValue(object, key);
+    return typeof value === 'function' ? value : null;
+}
+
+function registryHandler(registry = {}, command = {}) {
+    const keys = [
+        text(command.handler_ref),
+        text(command.id),
+    ].filter(Boolean);
+    for (const key of keys) {
+        if (registry instanceof Map && typeof registry.get(key) === 'function') {
+            return { key, registered: true };
+        }
+        if (ownFunction(registry, key)) {
+            return { key, registered: true };
+        }
+        const nestedHandlers = ownValue(registry, 'handlers');
+        if (ownFunction(nestedHandlers, key)) {
+            return { key, registered: true };
+        }
+    }
+    return { key: keys[0] || null, registered: false };
+}
+
+function radialItemReleaseBinding(binding = {}) {
+    return text(binding.id).startsWith('sigil.radial.item.release.')
+        && text(binding.parameters?.item_id);
+}
+
+function classifyCommand(command = {}, {
+    registry = {},
+    commandStatuses = {},
+} = {}) {
+    const handler = registryHandler(registry, command);
+    if (handler.registered) {
+        return {
+            id: command.id,
+            handler_ref: command.handler_ref || command.id,
+            status: 'registered_runtime_handler',
+            handler_key: handler.key,
+        };
+    }
+    const explicit = commandStatuses[command.id] || null;
+    if (explicit) {
+        return {
+            id: command.id,
+            handler_ref: command.handler_ref || command.id,
+            status: explicit.status || 'deferred',
+            reason: explicit.reason || '',
+        };
+    }
+    return {
+        id: command.id,
+        handler_ref: command.handler_ref || command.id,
+        status: 'unclassified_missing_handler',
+        reason: 'No allowlisted runtime handler or explicit deferred status was provided.',
+    };
+}
+
+function classifyBinding(binding = {}, {
+    routedBindingIds = DEFAULT_ROUTED_BINDING_IDS,
+    deferredBindings = {},
+    runtimeMechanicBindings = {},
+} = {}) {
+    if (routedBindingIds.has(binding.id) || radialItemReleaseBinding(binding)) {
+        return {
+            id: binding.id,
+            command_id: binding.command_id,
+            node_id: binding.node_id,
+            gesture: binding.gesture,
+            status: 'routed_through_ux_command_adapter',
+        };
+    }
+    const deferred = deferredBindings[binding.id] || null;
+    if (deferred) {
+        return {
+            id: binding.id,
+            command_id: binding.command_id,
+            node_id: binding.node_id,
+            gesture: binding.gesture,
+            status: 'deferred',
+            reason: deferred.reason || '',
+        };
+    }
+    const mechanic = runtimeMechanicBindings[binding.id] || null;
+    if (mechanic) {
+        return {
+            id: binding.id,
+            command_id: binding.command_id,
+            node_id: binding.node_id,
+            gesture: binding.gesture,
+            status: 'runtime_mechanic',
+            category: mechanic.category || 'runtime_mechanic',
+            reason: mechanic.reason || '',
+        };
+    }
+    return {
+        id: binding.id,
+        command_id: binding.command_id,
+        node_id: binding.node_id,
+        gesture: binding.gesture,
+        status: 'unclassified',
+        reason: 'Binding is neither routed, explicitly deferred, nor classified as a non-command runtime mechanic.',
+    };
+}
+
+function relationTopology(tree = {}) {
+    return list(tree.relations)
+        .filter((relation) => ['triggers', 'opens', 'anchors', 'targets'].includes(relation?.relation_type))
+        .map((relation) => ({
+            id: relation.id,
+            relation_type: relation.relation_type,
+            from_node_id: relation.from_node_id,
+            to_node_id: relation.to_node_id,
+            source_metadata: cloneJson(relation.source_metadata || {}),
+            metadata: cloneJson(relation.metadata || {}),
+        }));
+}
+
+export function createSigilUxTreeReadinessAudit(tree = {}, options = {}) {
+    const commandCoverage = list(tree.commands).map((command) => classifyCommand(command, options));
+    const bindingCoverage = list(tree.bindings).map((binding) => classifyBinding(binding, options));
+    const unclassifiedCommands = commandCoverage.filter((entry) => entry.status === 'unclassified_missing_handler');
+    const unclassifiedBindings = bindingCoverage.filter((entry) => entry.status === 'unclassified');
+    const routedBindings = bindingCoverage.filter((entry) => entry.status === 'routed_through_ux_command_adapter');
+    const deferredBindings = bindingCoverage.filter((entry) => entry.status === 'deferred');
+    const runtimeMechanicBindings = bindingCoverage.filter((entry) => entry.status === 'runtime_mechanic');
+
+    return {
+        schema: 'sigil_ux_tree_readiness_audit',
+        version: 1,
+        ok: unclassifiedCommands.length === 0 && unclassifiedBindings.length === 0,
+        summary: {
+            commands_total: commandCoverage.length,
+            commands_registered: commandCoverage.filter((entry) => entry.status === 'registered_runtime_handler').length,
+            commands_unclassified: unclassifiedCommands.length,
+            bindings_total: bindingCoverage.length,
+            bindings_routed: routedBindings.length,
+            bindings_deferred: deferredBindings.length,
+            bindings_runtime_mechanic: runtimeMechanicBindings.length,
+            bindings_unclassified: unclassifiedBindings.length,
+            relations_topology: relationTopology(tree).length,
+            direct_runtime_mechanics: DEFAULT_RUNTIME_MECHANICS.length,
+        },
+        commandCoverage,
+        bindingCoverage,
+        directRuntimeMechanics: cloneJson(DEFAULT_RUNTIME_MECHANICS),
+        relationTopology: relationTopology(tree),
+        failures: [
+            ...unclassifiedCommands.map((entry) => ({
+                kind: 'command',
+                id: entry.id,
+                reason: entry.reason,
+            })),
+            ...unclassifiedBindings.map((entry) => ({
+                kind: 'binding',
+                id: entry.id,
+                reason: entry.reason,
+            })),
+        ],
+    };
+}

--- a/apps/sigil/renderer/live-modules/ux-tree.js
+++ b/apps/sigil/renderer/live-modules/ux-tree.js
@@ -16,8 +16,10 @@ const SIGIL_UX_SOURCE_REFS = Object.freeze([
     { id: 'sigil-main', kind: 'source', ref: 'apps/sigil/renderer/live-modules/main.js' },
     { id: 'selection-mode-input', kind: 'source', ref: 'apps/sigil/renderer/live-modules/selection-mode-input.js' },
     { id: 'input-regions', kind: 'source', ref: 'apps/sigil/renderer/live-modules/input-regions.js' },
+    { id: 'context-menu-input', kind: 'source', ref: 'apps/sigil/renderer/live-modules/context-menu-input.js' },
     { id: 'radial-gesture-menu', kind: 'source', ref: 'apps/sigil/renderer/live-modules/radial-gesture-menu.js' },
     { id: 'radial-menu-activation', kind: 'source', ref: 'apps/sigil/renderer/live-modules/radial-menu-activation.js' },
+    { id: 'radial-menu-target-surface', kind: 'source', ref: 'apps/sigil/renderer/live-modules/radial-menu-target-surface.js' },
     { id: 'sigil-radial-menu', kind: 'resource', ref: 'apps/sigil/renderer/radial-menu/sigil-radial-menu.json' },
 ]);
 
@@ -74,6 +76,18 @@ function binding(id, nodeId, mode, gesture, commandId, extra = {}) {
         consume_policy: 'consume',
         parameters: {},
         source_metadata: sourceMetadata('apps/sigil/renderer/live-modules/main.js'),
+        ...extra,
+    };
+}
+
+function relation(id, relationType, fromNodeId, toNodeId, extra = {}) {
+    return {
+        id,
+        relation_type: relationType,
+        from_node_id: fromNodeId,
+        to_node_id: toNodeId,
+        source_metadata: {},
+        metadata: {},
         ...extra,
     };
 }
@@ -277,6 +291,89 @@ function bindingList(radialMenu) {
     ];
 }
 
+function relationList() {
+    return [
+        relation('sigil.avatar.body.opens_context_menu', 'opens', 'sigil.avatar.body', 'sigil.avatar.context_menu', {
+            source_metadata: sourceMetadata('apps/sigil/renderer/live-modules/context-menu-input.js', {
+                binding_id: 'sigil.avatar.context_menu.right_click',
+                command_id: 'sigil.context_menu.open',
+            }),
+            metadata: {
+                gesture: 'pointer.right.click',
+            },
+        }),
+        relation('sigil.avatar.body.triggers_radial_menu', 'triggers', 'sigil.avatar.body', 'sigil.avatar.radial_menu', {
+            source_metadata: sourceMetadata('apps/sigil/renderer/live-modules/radial-gesture-menu.js', {
+                binding_id: 'sigil.avatar.radial.drag_threshold',
+                command_id: 'sigil.radial.begin',
+            }),
+            metadata: {
+                gesture: 'pointer.left.drag_threshold',
+            },
+        }),
+        relation('sigil.avatar.body.triggers_selection_mode', 'triggers', 'sigil.avatar.body', 'sigil.avatar.selection_mode', {
+            source_metadata: sourceMetadata('apps/sigil/renderer/live-modules/selection-mode-input.js', {
+                binding_id: 'sigil.avatar.selection_mode.double_click',
+                command_id: 'sigil.selection_mode.enter',
+            }),
+            metadata: {
+                gesture: 'pointer.left.double_click',
+            },
+        }),
+        relation('sigil.avatar.anchors_radial_menu', 'anchors', 'sigil.avatar', 'sigil.avatar.radial_menu', {
+            source_metadata: sourceMetadata('apps/sigil/renderer/live-modules/radial-gesture-menu.js'),
+            metadata: {
+                anchor: {
+                    kind: 'avatar_position',
+                    state_ref: 'liveJs.avatarPos',
+                },
+            },
+        }),
+        relation('sigil.avatar.body.anchors_context_menu', 'anchors', 'sigil.avatar.body', 'sigil.avatar.context_menu', {
+            source_metadata: sourceMetadata('apps/sigil/renderer/live-modules/context-menu-input.js'),
+            metadata: {
+                anchor: {
+                    kind: 'pointer_open_point',
+                    state_ref: 'contextMenu.openPoint',
+                },
+            },
+        }),
+        relation('sigil.avatar.radial_menu.targets_items', 'targets', 'sigil.avatar.radial_menu', 'sigil.avatar.radial_menu.item.*', {
+            source_metadata: sourceMetadata('apps/sigil/renderer/live-modules/radial-menu-target-surface.js'),
+            metadata: {
+                target_surface: {
+                    kind: 'radial_menu_targets',
+                    lifecycle: 'active_radial_phase',
+                    hit_source_ref: 'radialTargetSurface',
+                    collection_ref: 'sigil.avatar.radial_menu.item.*',
+                },
+            },
+        }),
+        relation('sigil.avatar.context_menu.targets_input_region', 'targets', 'sigil.avatar.context_menu', 'sigil.avatar.context_menu', {
+            source_metadata: sourceMetadata('apps/sigil/renderer/live-modules/context-menu-input.js'),
+            metadata: {
+                target_surface: {
+                    kind: 'input_region',
+                    lifecycle: 'context_menu_open',
+                    hit_source_ref: 'sigil-context-menu-input-region',
+                    consume_policy: 'captured',
+                },
+            },
+        }),
+        relation('sigil.avatar.selection_mode.targets_input_region', 'targets', 'sigil.avatar.selection_mode', 'sigil.avatar.selection_mode', {
+            source_metadata: sourceMetadata('apps/sigil/renderer/live-modules/selection-mode-input.js'),
+            metadata: {
+                target_surface: {
+                    kind: 'input_region',
+                    lifecycle: 'selection_mode_active',
+                    hit_source_ref: 'sigil-selection-mode-input-region',
+                    consume_policy: 'captured',
+                },
+            },
+        }),
+    ];
+}
+
 function settingsFor(radialMenu, state = {}) {
     const radialItems = {};
     for (const item of Array.isArray(radialMenu.items) ? radialMenu.items : []) {
@@ -333,6 +430,7 @@ export function createSigilUxTree({ state = {}, metadata = {} } = {}) {
         nodes: nodeList(radialMenu),
         commands: commandList(),
         bindings: bindingList(radialMenu),
+        relations: relationList(),
         settings: settingsFor(radialMenu, state),
         metadata: {
             runtime_state: 'read_only_shadow',

--- a/apps/sigil/renderer/live-modules/ux-tree.js
+++ b/apps/sigil/renderer/live-modules/ux-tree.js
@@ -122,6 +122,7 @@ function commandList() {
     return [
         command('sigil.context_menu.open', 'Open context menu', 'Open the current Sigil context menu.'),
         command('sigil.context_menu.toggle', 'Toggle context menu', 'Toggle the current Sigil context menu.'),
+        command('sigil.avatar.press.begin', 'Begin avatar press', 'Begin the existing avatar left-press state.'),
         command('sigil.avatar.goto.begin', 'Begin GOTO', 'Begin the existing avatar GOTO behavior.'),
         command('sigil.radial.begin', 'Begin radial gesture', 'Begin the existing radial gesture path.'),
         command('sigil.radial.release_item', 'Release radial item', 'Release the active radial item through the current activation path.'),
@@ -257,7 +258,7 @@ function bindingList(radialMenu) {
             consume_policy: 'route',
             source_metadata: sourceMetadata('apps/sigil/renderer/live-modules/main.js', { event_type: 'right_mouse_down' }),
         }),
-        binding('sigil.avatar.goto.left_press', 'sigil.avatar.body', 'idle', 'pointer.left.press', 'sigil.avatar.goto.begin', {
+        binding('sigil.avatar.press.left_press', 'sigil.avatar.body', 'idle', 'pointer.left.press', 'sigil.avatar.press.begin', {
             priority: 80,
             consume_policy: 'route',
             source_metadata: sourceMetadata('apps/sigil/renderer/live-modules/main.js', { event_type: 'left_mouse_down' }),
@@ -433,8 +434,8 @@ export function createSigilUxTree({ state = {}, metadata = {} } = {}) {
         relations: relationList(),
         settings: settingsFor(radialMenu, state),
         metadata: {
-            runtime_state: 'read_only_shadow',
-            behavior_cutover: false,
+            runtime_state: 'sigil_side_command_routed',
+            behavior_cutover: true,
             generated_at: new Date().toISOString(),
             radial_menu_id: radialMenu.id,
             ...cloneJson(metadata),

--- a/docs/api/toolkit/components.md
+++ b/docs/api/toolkit/components.md
@@ -9,6 +9,16 @@ feel like AOS app controls instead of raw browser defaults. Controls attach to
 ordinary semantic HTML and dispatch normal DOM events so panels can remain
 domain-specific.
 
+`controls/ux-tree.js` starts toolkit control UX tree adoption with read-only
+shadow fragments for buttons, toggles, and segmented button groups. Use
+`createButtonUxTreeFragment()`, `createToggleUxTreeFragment()`, or
+`createButtonGroupUxTreeFragment()` when a surface needs inspectable data for
+existing control bindings. The helpers return plain JSON `aos_ux_tree` objects
+validated by the toolkit runtime shape: node identity, existing pointer/keyboard
+gestures, allowlisted command handler refs, grouped option ownership relations,
+and current state metadata. They do not execute commands, install a command
+registry, persist overrides, or expose a binding editor.
+
 `number-field.js` provides focused wheel and arrow-key stepping for numeric
 fields marked with `data-aos-control="number-field"`. It uses the field's
 native `step`, `min`, and `max` attributes, dispatches bubbling `input` and

--- a/docs/api/toolkit/components.md
+++ b/docs/api/toolkit/components.md
@@ -13,7 +13,10 @@ domain-specific.
 shadow fragments for buttons, toggles, and segmented button groups. Use
 `createButtonUxTreeFragment()`, `createToggleUxTreeFragment()`, or
 `createButtonGroupUxTreeFragment()` when a surface needs inspectable data for
-existing control bindings. The helpers return plain JSON `aos_ux_tree` objects
+existing control bindings. Factory-created `createButton()`, `createToggle()`,
+and `createButtonGroup()` controls also expose `getUxTreeFragment(options = {})`
+on their return values so callers can discover the same read-only fragment from
+the live control object. The helpers return plain JSON `aos_ux_tree` objects
 validated by the toolkit runtime shape: node identity, existing pointer/keyboard
 gestures, allowlisted command handler refs, grouped option ownership relations,
 and current state metadata. They do not execute commands, install a command

--- a/docs/api/toolkit/controls.md
+++ b/docs/api/toolkit/controls.md
@@ -37,14 +37,19 @@ control.
 
 | Factory | Purpose | Core methods |
 | --- | --- | --- |
-| `createButton({ label, variant, disabled, onClick })` | single pressable button with `primary`, `secondary`, `danger`, or `ghost` styling | `setLabel`, `setDisabled`, `on('click')`, `destroy` |
-| `createButtonGroup({ options, value, onChange })` | exclusive choice button row using `.aos-segmented` | `getValue`, `setValue`, `on('change')`, `destroy` |
-| `createToggle({ label, checked, onChange })` | boolean switch backed by an accessible hidden checkbox | `getValue`, `setValue`, `on('change')`, `destroy` |
+| `createButton({ label, variant, disabled, onClick })` | single pressable button with `primary`, `secondary`, `danger`, or `ghost` styling | `setLabel`, `setDisabled`, `getUxTreeFragment(options = {})`, `on('click')`, `destroy` |
+| `createButtonGroup({ options, value, onChange })` | exclusive choice button row using `.aos-segmented` | `getValue`, `setValue`, `getUxTreeFragment(options = {})`, `on('change')`, `destroy` |
+| `createToggle({ label, checked, onChange })` | boolean switch backed by an accessible hidden checkbox | `getValue`, `setValue`, `getUxTreeFragment(options = {})`, `on('change')`, `destroy` |
 | `createTextField({ value, placeholder, label, maxLength, validate, onChange, onCommit })` | single-line text input with inline error state | `getValue`, `setValue`, `setError`, `on('change')`, `on('commit')`, `destroy` |
 | `createTextarea({ value, placeholder, rows, maxLength, spellcheck, readOnly, onChange, onCommit })` | native multi-line text area using shared textarea styling | `getValue`, `setValue`, `setReadOnly`, `on('change')`, `on('commit')`, `destroy` |
 | `createCheckboxGroup({ options, value, onChange })` | multi-choice checkbox column with select-all when there are at least three options | `getValue`, `setValue`, `on('change')`, `destroy` |
 | `createSelect({ options, value, label, onChange })` | native single-value select | `getValue`, `setValue`, `on('change')`, `destroy` |
 | `createTimerBar({ totalMs, direction, display, flashThresholdMs, flashIntervalMs, onExpire })` | cosmetic count-down/count-up timer with digital or pie display | `start`, `pause`, `resume`, `reset`, `getRemainingMs`, `destroy` |
+
+`createButton()`, `createToggle()`, and `createButtonGroup()` expose
+`getUxTreeFragment(options = {})` for read-only UX tree fragment discovery from
+the live control object. The fragment is inspection data only; it does not
+execute commands, persist bindings, or expose editable binding state.
 
 ## Zag Primitives
 

--- a/docs/api/toolkit/controls.md
+++ b/docs/api/toolkit/controls.md
@@ -50,6 +50,10 @@ control.
 `getUxTreeFragment(options = {})` for read-only UX tree fragment discovery from
 the live control object. The fragment is inspection data only; it does not
 execute commands, persist bindings, or expose editable binding state.
+Factory-created toggles honor `disabled` on the underlying checkbox.
+Factory-created button groups honor option-level `disabled` on the live option
+buttons; disabled options are skipped by pointer and arrow-key selection and
+reported as disabled in factory-returned UX tree fragments.
 
 ## Zag Primitives
 

--- a/docs/design/sigil-ux-tree-pre-toolkit-adoption-closure-v0.md
+++ b/docs/design/sigil-ux-tree-pre-toolkit-adoption-closure-v0.md
@@ -1,0 +1,73 @@
+# Sigil UX Tree Pre Toolkit Adoption Closure V0
+
+Status: Sigil-side closure checkpoint before toolkit-wide adoption.
+
+Sigil now acts as the reference implementation for the operating model:
+
+```text
+UX tree nodes
+  -> bindings
+  -> generic relations
+  -> allowlisted command adapter
+  -> existing runtime functions
+```
+
+The Sigil UX tree names user-visible avatar, context-menu, Selection Mode,
+radial-menu, radial item, annotation reticle/camera, wiki graph, and Agent
+Terminal interactions. Runtime handlers stay in the Sigil command registry; the
+tree still carries command names and metadata only.
+
+## What Sigil Proves
+
+- Avatar left press, GOTO entry, avatar double-click Selection Mode entry,
+  radial drag-threshold entry, Selection Mode keyboard/pointer commands,
+  context-menu right-click commands, and radial item release actions can route
+  through the same allowlisted UX command adapter.
+- Radial gesture release and radial target-surface item clicks converge on the
+  same item command dispatch path.
+- Radial item actions map to command handlers for context menu, Agent Terminal,
+  annotation reticle, annotation camera bundle capture, and wiki graph.
+- `window.__sigilDebug.snapshot().uxTreeReadiness` and
+  `window.__sigilDebug.uxTreeReadiness()` report command handler coverage,
+  routed bindings, direct runtime mechanics, and trigger/anchor/target topology.
+- The readiness audit fails closed when a UX tree binding is neither routed,
+  explicitly deferred, nor classified as a runtime mechanic.
+
+## Not Toolkit Adoption Yet
+
+This checkpoint does not ask toolkit controls, components, panels, or workbench
+surfaces to emit UX tree fragments. Toolkit remains a consumer of the shared UX
+tree schema and runtime helpers, while Sigil owns this local readiness audit and
+runtime registry wiring.
+
+The direct paths that remain in Sigil are intentionally runtime mechanics:
+gesture recognition, hover and fast-travel state machines, duplicate-event
+guards, Selection Mode entry-release suppression, context-menu fallback, and
+annotation reticle preview/commit mechanics.
+
+## Next Adoption Start
+
+Toolkit adoption should start by selecting one toolkit-owned control or panel
+family and having it emit its own UX tree fragment with nodes, bindings,
+commands, and relations. That work should reuse the existing schema/runtime
+helpers and only add generic relation vocabulary if the need is broader than
+Sigil.
+
+The first adoption slice should not copy Sigil's readiness helper wholesale.
+Instead, it should define a toolkit-level equivalent once more than one toolkit
+surface emits fragments and needs shared coverage reporting.
+
+## Verification Surfaces
+
+- `tests/renderer/sigil-ux-tree.test.mjs`
+- `tests/renderer/sigil-ux-tree-command-registry.test.mjs`
+- `tests/renderer/sigil-ux-tree-readiness.test.mjs`
+- `tests/renderer/sigil-selection-mode-input.test.mjs`
+- `tests/renderer/sigil-context-menu-input.test.mjs`
+- `tests/renderer/radial-gesture-menu.test.mjs`
+- `tests/renderer/radial-menu-activation.test.mjs`
+- `tests/renderer/radial-menu-target-surface.test.mjs`
+- `tests/renderer/annotation-reticle.test.mjs`
+
+The debug readiness payload is the durable runtime evidence for what is already
+data-routed and what remains direct by design.

--- a/docs/design/work-cards/sigil-ux-tree-pre-toolkit-adoption-closure-v0.md
+++ b/docs/design/work-cards/sigil-ux-tree-pre-toolkit-adoption-closure-v0.md
@@ -1,0 +1,399 @@
+# Sigil UX Tree Pre Toolkit Adoption Closure V0
+
+## Recipient
+
+GDI.
+
+## Transfer Kind
+
+Implementation round.
+
+## Single Goal
+
+Finish the Sigil-side UX tree operating-model proof so the project is ready to
+start toolkit-wide adoption in a later slice.
+
+This is a multi-phase closure card. It should complete the remaining Sigil
+interaction cutovers and readiness gates, but it must stop before converting
+toolkit controls/components/panels to emit their own UX tree fragments.
+
+## Branch / Base
+
+- `branch_from`: `gdi/sigil-ux-tree-trigger-anchor-relations-v0`
+- `required_start_ref`: `origin/gdi/sigil-ux-tree-trigger-anchor-relations-v0`
+- `implementation_base_sha`: `f84276ea9ada95ae1d181a2ddb904fbf61659ffc`
+- Expected output branch: `gdi/sigil-ux-tree-pre-toolkit-adoption-closure-v0`
+- This is stacked on PR #387, which is stacked on #386, #385, #384, #383, and
+  #382.
+- Commit the completed slice. Push the output branch for review if branch-push
+  credentials are available. Do not open a PR unless explicitly reassigned.
+
+## What "Ready For Toolkit Adoption" Means
+
+After this slice, Sigil should be a credible reference implementation of the
+operating model:
+
+```text
+UX tree nodes
+  -> bindings
+  -> generic relations
+  -> allowlisted command adapter
+  -> existing runtime functions
+```
+
+The desired checkpoint is:
+
+- Sigil's user-visible avatar, context-menu, Selection Mode, radial-menu,
+  reticle/camera, wiki graph, and terminal launch interactions are represented
+  in the UX tree.
+- Remaining direct runtime branches are classified as gesture recognition,
+  physics/state-machine mechanics, guards, fallback, or platform plumbing rather
+  than unmodeled user-facing bindings.
+- No avatar-specific canvas ownership assumption is required to understand
+  trigger/anchor/target relationships.
+- Debug/tests can prove what is already data-routed and what remains direct by
+  design.
+- Toolkit adoption can begin next by asking toolkit controls/components/panels
+  to emit their own UX tree fragments.
+
+Do not start that toolkit adoption here.
+
+## Read First
+
+- `docs/design/work-cards/sigil-ux-tree-trigger-anchor-relations-v0.md`
+- `docs/design/work-cards/sigil-ux-tree-context-menu-bindings-cutover-v0.md`
+- `apps/sigil/renderer/live-modules/main.js`
+- `apps/sigil/renderer/live-modules/ux-tree.js`
+- `apps/sigil/renderer/live-modules/ux-tree-command-registry.js`
+- `apps/sigil/renderer/live-modules/selection-mode-input.js`
+- `apps/sigil/renderer/live-modules/context-menu-input.js`
+- `apps/sigil/renderer/live-modules/radial-gesture-menu.js`
+- `apps/sigil/renderer/live-modules/radial-menu-activation.js`
+- `apps/sigil/renderer/live-modules/radial-menu-target-surface.js`
+- `apps/sigil/renderer/live-modules/annotation-reticle.js`
+- `apps/sigil/renderer/radial-menu/sigil-radial-menu.json`
+- `apps/sigil/renderer/radial-menu-defaults.js`
+- `packages/toolkit/runtime/ux-tree.js`
+- `packages/toolkit/workbench/ux-tree-subject.js`
+- `tests/renderer/sigil-ux-tree.test.mjs`
+- `tests/renderer/sigil-ux-tree-command-registry.test.mjs`
+- `tests/renderer/sigil-selection-mode-input.test.mjs`
+- `tests/renderer/sigil-context-menu-input.test.mjs`
+- `tests/renderer/radial-gesture-menu.test.mjs`
+- `tests/renderer/radial-menu-activation.test.mjs`
+- `tests/renderer/radial-menu-target-surface.test.mjs`
+- `tests/renderer/annotation-reticle.test.mjs`
+
+## Current Completed Baseline
+
+These paths have already been cut over to the UX tree command adapter:
+
+- Selection Mode Escape.
+- Selection Mode Enter/Return.
+- Selection Mode Tab/ArrowUp/ArrowDown.
+- Selection Mode non-avatar left-click acquire.
+- Context-menu right-click open/toggle.
+
+These model pieces exist:
+
+- `aos_ux_tree` schema/runtime/toolkit helpers.
+- Strict command handler refs and allowlisted execution.
+- Generic relations: `triggers`, `opens`, `anchors`, `targets`, `owns`.
+- Sigil projection for avatar/context-menu/radial-menu/Selection Mode
+  relations.
+
+## Remaining Pre-Adoption Work
+
+### Phase 1: Add A Sigil UX Routing Readiness Audit
+
+Create a small deterministic audit helper for Sigil's UX tree and runtime
+adapter status. Suggested location:
+
+- `apps/sigil/renderer/live-modules/ux-tree-readiness.js`
+
+The audit should answer, as data:
+
+- Which UX tree commands have registered runtime handlers?
+- Which UX tree bindings are intentionally routed through the UX command
+  adapter?
+- Which bindings remain direct, and why?
+- Which direct paths are guards/gesture recognition/state-machine mechanics
+  rather than user-editable command bindings?
+- Which relations describe trigger/anchor/target-surface topology?
+
+Expose the result in debug state, for example:
+
+- `window.__sigilDebug.snapshot().uxTreeReadiness`
+- `window.__sigilDebug.uxTreeReadiness()`
+
+Add tests that fail if a binding is neither:
+
+- routed through the UX command adapter;
+- explicitly deferred with a reason; nor
+- explicitly classified as a non-command runtime mechanic.
+
+Keep this audit Sigil-local. Do not require toolkit controls to adopt it yet.
+
+### Phase 2: Complete Command Registry Coverage For Sigil Commands
+
+Extend the Sigil command registry so every command currently emitted by
+`apps/sigil/renderer/live-modules/ux-tree.js` has an explicit status:
+
+- executable through a registered allowlisted handler;
+- intentionally shadow-only/deferred with a reason; or
+- not a user-facing command and should be renamed/removed from the UX tree.
+
+At minimum, decide and implement the status for:
+
+- `sigil.avatar.goto.begin`
+- `sigil.radial.begin`
+- `sigil.radial.release_item`
+- `sigil.selection_mode.enter`
+- `sigil.annotation_reticle.enter`
+- `sigil.annotation_camera.capture_bundle`
+- `sigil.wiki_graph.open`
+- `sigil.agent_terminal.open`
+
+Prefer real allowlisted handlers where the runtime function already exists and
+the behavior can be preserved. If a command name is too coarse or misleading,
+rename/split it in the UX tree and tests rather than preserving stale
+vocabulary.
+
+Hard safety rule: the UX tree still names commands only. Runtime closures remain
+in the Sigil registry. No eval, dynamic imports, or executable tree values.
+
+### Phase 3: Cut Over Remaining Low-Risk Sigil Bindings
+
+Cut over remaining user-facing Sigil bindings that can be safely routed through
+the adapter without changing behavior.
+
+Expected candidates:
+
+- avatar double-click in `GOTO` enters Selection Mode;
+- avatar left press/release GOTO behavior, if the route can be expressed
+  clearly without lying about command names;
+- avatar drag-threshold radial begin;
+- radial menu item release/action dispatch;
+- radial target surface item click dispatch;
+- radial camera recovery click path, if it can share the same command handler
+  without weakening recovery behavior.
+
+Do not force a bad abstraction. Gesture recognition and physics may remain
+direct mechanics if they are explicitly classified by the readiness audit. For
+example, radial hover/fast-travel movement and target-surface pointer tracking
+are probably state-machine mechanics, not user-editable commands.
+
+For each cutover:
+
+- keep the existing guard order;
+- keep explicit fallback to the old direct runtime function;
+- record `ux-command` debug evidence;
+- add deterministic tests around route decision and command execution.
+
+### Phase 4: Route Radial Item Actions Through Commands
+
+The radial menu should not remain a private switchboard of item actions once the
+relations model exists. Route radial item release/action handling through the
+same command adapter where practical.
+
+Target actions:
+
+- context menu item -> `sigil.context_menu.open`
+- agent terminal item -> `sigil.agent_terminal.open`
+- annotation mode item -> `sigil.annotation_reticle.enter`
+- annotation camera item -> `sigil.annotation_camera.capture_bundle`
+- wiki graph item -> `sigil.wiki_graph.open`
+
+Keep radial gesture math and item hit detection in the radial runtime. The
+cutover target is action dispatch after the runtime has identified the committed
+item.
+
+The gesture release path and radial target-surface click path should converge
+on the same item-action dispatch helper so they cannot drift.
+
+### Phase 5: Tighten UX Tree Relations Around Radial Items
+
+After radial item action dispatch is routed, update Sigil's relation projection
+if needed so the model expresses:
+
+- avatar body triggers radial menu;
+- avatar anchors radial menu;
+- radial menu targets radial item collection;
+- each radial item invokes or maps to its command;
+- radial target surface is implementation metadata, not conceptual ownership.
+
+If relation vocabulary needs one more generic type such as `invokes`, add it
+only if it improves the model for more than Sigil. Otherwise keep invocation in
+bindings/commands and avoid relation creep.
+
+### Phase 6: Remove Or Mark Stale Duplicate Paths
+
+Clean up dead or misleading code created by the incremental cutover.
+
+Examples:
+
+- duplicate route helpers that can be unified;
+- stale comments claiming a path is shadow-only after it is live-routed;
+- debug names that imply avatar-specific canvas ownership;
+- UX tree commands that no longer correspond to a real command.
+
+Do not remove direct fallback paths unless tests prove the command adapter path
+and old direct path are equivalent. Fallback can remain for safety, but it must
+be explicit and observable.
+
+### Phase 7: Durable Docs And Adoption Gate
+
+Add a short durable note that names the handoff point before toolkit adoption.
+Suggested file:
+
+- `docs/design/sigil-ux-tree-pre-toolkit-adoption-closure-v0.md`
+
+It should summarize:
+
+- what Sigil now proves;
+- what is deliberately not toolkit adoption yet;
+- how toolkit adoption should start next;
+- what tests/debug views show the readiness state;
+- any remaining explicit Sigil-only exceptions.
+
+Update existing UX tree docs only as needed. Avoid broad narrative churn.
+
+## Hard Boundaries
+
+- Do not start converting toolkit controls/components/panels to emit UX tree
+  fragments.
+- Do not add persistence, user-editable settings, or editor UI.
+- Do not change radial menu visuals, geometry, or physics.
+- Do not change Selection Mode behavior.
+- Do not change context menu layout or item behavior.
+- Do not remove fallback unless the old and new paths are proven equivalent.
+- Do not introduce dynamic command execution.
+- Do not model canvas IDs as conceptual ownership. Canvas/input-region IDs stay
+  in hit-source or target-surface implementation metadata.
+
+## Acceptance Criteria
+
+- Sigil has a deterministic UX tree readiness audit.
+- Every Sigil UX tree binding/command is routed, deferred with a reason, or
+  classified as non-command runtime mechanics.
+- Remaining safely routable Sigil-owned bindings are routed through the UX tree
+  command adapter.
+- Radial item action dispatch is command-adapter based or explicitly deferred
+  with a documented reason.
+- Gesture/physics/direct runtime mechanics are named as mechanics, not hidden
+  user-facing bindings.
+- Debug state exposes the readiness audit and recent command/fallback evidence.
+- Existing stacked behavior remains unchanged.
+- A short design note marks the point where toolkit adoption can begin next.
+
+## Suggested Tests
+
+Add or update tests for:
+
+- readiness audit covers every command and binding in `createSigilUxTree()`;
+- no unclassified direct user-facing binding remains;
+- avatar double-click Selection Mode entry command path, if cut over;
+- radial begin command path, if cut over;
+- radial item action dispatch for context menu, terminal, reticle, camera, and
+  wiki graph;
+- radial target-surface click and gesture release share dispatch semantics;
+- fallback paths record fallback evidence and call the old direct behavior;
+- existing relation tests still prove trigger/anchor/target separation;
+- existing Selection Mode/context-menu tests still pass.
+
+Avoid source-text-only assertions where behavior can be tested through exported
+pure helpers. Source-text assertions are acceptable only for guarding broad
+runtime integration that is otherwise hard to instantiate in Node.
+
+## Verification
+
+Run at least:
+
+```bash
+./aos dev recommend --json --files \
+  apps/sigil/renderer/live-modules/main.js \
+  apps/sigil/renderer/live-modules/ux-tree.js \
+  apps/sigil/renderer/live-modules/ux-tree-command-registry.js \
+  apps/sigil/renderer/live-modules/selection-mode-input.js \
+  apps/sigil/renderer/live-modules/context-menu-input.js \
+  apps/sigil/renderer/live-modules/radial-gesture-menu.js \
+  apps/sigil/renderer/live-modules/radial-menu-target-surface.js \
+  tests/renderer/sigil-ux-tree.test.mjs \
+  tests/renderer/sigil-ux-tree-command-registry.test.mjs
+
+node --check apps/sigil/renderer/live-modules/main.js
+node --check apps/sigil/renderer/live-modules/ux-tree.js
+node --check apps/sigil/renderer/live-modules/ux-tree-command-registry.js
+node --check apps/sigil/renderer/live-modules/selection-mode-input.js
+node --check apps/sigil/renderer/live-modules/context-menu-input.js
+node --check apps/sigil/renderer/live-modules/radial-gesture-menu.js
+node --check apps/sigil/renderer/live-modules/radial-menu-target-surface.js
+node --test tests/renderer/sigil-ux-tree.test.mjs \
+  tests/renderer/sigil-ux-tree-command-registry.test.mjs \
+  tests/renderer/sigil-selection-mode-input.test.mjs \
+  tests/renderer/sigil-context-menu-input.test.mjs \
+  tests/renderer/radial-gesture-menu.test.mjs \
+  tests/renderer/radial-menu-activation.test.mjs \
+  tests/renderer/radial-menu-target-surface.test.mjs \
+  tests/renderer/radial-object-control.test.mjs \
+  tests/renderer/radial-item-editor.test.mjs \
+  tests/renderer/annotation-reticle.test.mjs
+node --test tests/toolkit/runtime-ux-tree.test.mjs \
+  tests/toolkit/ux-tree-subject.test.mjs \
+  tests/schemas/aos-ux-tree-v0.test.mjs
+git diff --check
+```
+
+Run broader checks if changed files imply them:
+
+```bash
+node --test tests/renderer/*.test.mjs
+node --test tests/toolkit/*.test.mjs
+node --test tests/schemas/*.test.mjs
+./aos dev build
+bash tests/help-contract.sh
+```
+
+Run `./aos ready`. If it reports a repo-mode TCC/input-tap blocker, stop and
+use:
+
+```bash
+.docks/gdi/scripts/human-needed-tcc-reset
+```
+
+Then rerun:
+
+```bash
+./aos ready --post-permission
+```
+
+after the human returns with `finished`.
+
+## Stop Conditions
+
+Stop and report instead of forcing the implementation if:
+
+- a remaining binding requires product judgment about its intended user-visible
+  semantics;
+- a command name would need a breaking schema vocabulary change;
+- live behavior would change to complete the cutover;
+- radial item dispatch cannot be unified without destabilizing reticle/camera
+  behavior.
+
+If one of these occurs, still complete the readiness audit and mark the blocker
+as an explicit deferred item with evidence.
+
+## Completion Report
+
+Include:
+
+- branch name;
+- head SHA and base SHA;
+- changed files;
+- list of bindings/commands routed in this slice;
+- list of bindings/commands explicitly deferred or classified as mechanics;
+- confirmation that toolkit adoption did not start;
+- tests and checks run;
+- whether the next recommended slice is toolkit read-only UX tree fragments;
+- `git status --short --branch`;
+- `git show --stat HEAD`.

--- a/docs/design/work-cards/sigil-ux-tree-trigger-anchor-relations-v0.md
+++ b/docs/design/work-cards/sigil-ux-tree-trigger-anchor-relations-v0.md
@@ -1,0 +1,304 @@
+# Sigil UX Tree Trigger Anchor Relations V0
+
+## Recipient
+
+GDI.
+
+## Transfer Kind
+
+Implementation round.
+
+## Single Goal
+
+Add generic UX tree relationship modeling for trigger, open, anchor, and target
+surface relationships, then project Sigil avatar/context-menu/radial-menu
+relationships through that model without changing runtime behavior.
+
+This intentionally comes before more radial item release cutover work. The goal
+is to avoid baking in bespoke assumptions like "the avatar hit canvas owns the
+radial menu canvas." Avatar should be one instance of a generic UX relationship
+pattern.
+
+## Branch / Base
+
+- `branch_from`: `gdi/sigil-ux-tree-context-menu-bindings-cutover-v0`
+- `required_start_ref`: `origin/gdi/sigil-ux-tree-context-menu-bindings-cutover-v0`
+- `implementation_base_sha`: `780d46aadeb167098953c00ff9a6c1218895318f`
+- Expected output branch: `gdi/sigil-ux-tree-trigger-anchor-relations-v0`
+- This is stacked on PR #386, which is stacked on #385, #384, #383, and #382.
+- Commit the completed slice. Push the output branch for review if branch-push
+  credentials are available. Do not open a PR unless explicitly reassigned.
+
+## Direction Change
+
+Before this decision, the next likely implementation slice was radial item
+release cutover. That would continue moving behavior into the command adapter,
+but it would still leave the structural relationship between avatar, context
+menu, radial menu, and their hit surfaces mostly implicit.
+
+The adjusted direction is:
+
+1. Make trigger/anchor/target-surface relationships explicit and generic.
+2. Keep the current Sigil runtime as an adapter/projection of those
+   relationships.
+3. Resume radial item release and broader avatar/radial cutovers after the
+   model no longer implies avatar-specific surface coupling.
+
+## Product Direction
+
+The UX tree should represent:
+
+```text
+any UX node
+  can have hit/source representation
+  can bind gestures/keys to commands
+  can trigger/open another UX node
+  can anchor another UX node
+  can expose target surfaces for hit testing/accessibility
+```
+
+For Sigil, avatar is only the first implementation:
+
+```text
+sigil.avatar.body
+  triggers/opens sigil.avatar.context_menu
+  triggers sigil.avatar.radial_menu
+
+sigil.avatar
+  anchors sigil.avatar.radial_menu
+
+sigil.avatar.body
+  anchors sigil.avatar.context_menu
+
+sigil.avatar.radial_menu
+  exposes radial item target surface
+
+sigil.avatar.context_menu
+  exposes context menu input/target region
+```
+
+Do not model this as "canvas A owns canvas B." Canvases and input regions are
+hit-source or target-surface implementations, not the conceptual owner.
+
+## Read First
+
+- `shared/schemas/aos-ux-tree-v0.schema.json`
+- `shared/schemas/aos-ux-tree-v0.md`
+- `shared/schemas/fixtures/aos-ux-tree-v0/valid/sigil-avatar.json`
+- `packages/toolkit/runtime/ux-tree.js`
+- `packages/toolkit/workbench/ux-tree-subject.js`
+- `apps/sigil/renderer/live-modules/ux-tree.js`
+- `apps/sigil/renderer/live-modules/main.js`
+- `apps/sigil/renderer/live-modules/input-regions.js`
+- `apps/sigil/renderer/live-modules/radial-menu-target-surface.js`
+- `apps/sigil/renderer/live-modules/context-menu-input.js`
+- `apps/sigil/renderer/live-modules/ux-tree-command-registry.js`
+- `tests/schemas/aos-ux-tree-v0.test.mjs`
+- `tests/toolkit/runtime-ux-tree.test.mjs`
+- `tests/toolkit/ux-tree-subject.test.mjs`
+- `tests/renderer/sigil-ux-tree.test.mjs`
+- `tests/renderer/sigil-context-menu-input.test.mjs`
+
+## Required Work
+
+### 1. Extend the UX tree contract
+
+Add a generic relationship model to `aos_ux_tree`.
+
+Prefer a top-level keyed array:
+
+```json
+{
+  "relations": [
+    {
+      "id": "sigil.avatar.body.opens_context_menu",
+      "relation_type": "opens",
+      "from_node_id": "sigil.avatar.body",
+      "to_node_id": "sigil.avatar.context_menu",
+      "source_metadata": {},
+      "metadata": {}
+    }
+  ]
+}
+```
+
+Expected relation types for this slice:
+
+- `triggers`
+- `opens`
+- `anchors`
+- `targets`
+- `owns`
+
+If a more precise vocabulary emerges while reading the code, use it, but keep
+it generic and document it. Do not create avatar-specific relation fields.
+
+Support target-surface metadata as plain JSON under the relation metadata, for
+example:
+
+```json
+{
+  "relation_type": "targets",
+  "from_node_id": "sigil.avatar.radial_menu",
+  "to_node_id": "sigil.avatar.radial_menu.item.*",
+  "metadata": {
+    "target_surface": {
+      "kind": "radial_menu_targets",
+      "lifecycle": "active_radial_phase",
+      "hit_source_ref": "radialTargetSurface"
+    }
+  }
+}
+```
+
+Schema/runtime requirements:
+
+- `relations` must be allowed by the JSON schema.
+- Runtime normalization must preserve relations.
+- `relations` must merge by stable `id`, like nodes/commands/bindings.
+- Runtime validation must report unknown `from_node_id` or `to_node_id` when
+  they refer to concrete node IDs.
+- Wildcard or collection refs such as `sigil.avatar.radial_menu.item.*` are
+  acceptable in V0 only if documented and validated as relation targets rather
+  than node IDs.
+- Relation metadata must remain plain JSON; no executable values.
+
+### 2. Project Sigil's current relationships
+
+Update `apps/sigil/renderer/live-modules/ux-tree.js` so
+`createSigilUxTree()` includes generic relations for at least:
+
+- `sigil.avatar.body` opens `sigil.avatar.context_menu`;
+- `sigil.avatar.body` triggers `sigil.avatar.radial_menu`;
+- `sigil.avatar.body` triggers `sigil.avatar.selection_mode` if you judge
+  double-click entry should be represented in the same relation family;
+- `sigil.avatar` anchors `sigil.avatar.radial_menu`;
+- `sigil.avatar.body` anchors `sigil.avatar.context_menu`;
+- `sigil.avatar.radial_menu` targets its item nodes through the radial target
+  surface implementation;
+- `sigil.avatar.context_menu` targets/captures through the context menu input
+  region implementation;
+- `sigil.avatar.selection_mode` targets/captures through the active
+  Selection Mode input region implementation.
+
+Keep node `parent_id` and `children` as structural hierarchy. Relations should
+capture behavior/topology that is not pure containment.
+
+### 3. Add runtime helpers
+
+Add small helpers in `packages/toolkit/runtime/ux-tree.js`, such as:
+
+- `normalizeUxTreeRelation(relation, options)`
+- `uxTreeRelationsForNode(tree, nodeId, options)`
+- `uxTreeRelationsByType(tree, relationType)`
+
+Use the existing helper style and keep dependencies low.
+
+### 4. Update docs, fixture, and workbench subject
+
+Update:
+
+- schema docs;
+- valid Sigil fixture;
+- any workbench subject/read-only projection so relations are discoverable by
+  tools/editors.
+
+The workbench view does not need a rich UI. It only needs to expose relations
+as part of the inspectable UX tree subject.
+
+## Hard Boundaries
+
+- Do not change live runtime behavior in this slice.
+- Do not cut over radial item release, radial start, avatar double-click, or
+  reticle/camera commands.
+- Do not create avatar-specific schema fields.
+- Do not model canvas IDs as conceptual ownership. Canvas/input-region IDs
+  belong in hit-source or target-surface implementation metadata.
+- Do not add persistence, editor UI, or user settings writes.
+- Do not change context menu or radial menu visuals.
+
+## Acceptance Criteria
+
+- `aos_ux_tree` supports generic relations.
+- Runtime normalization, merge, and validation handle relations.
+- Sigil UX tree exposes trigger/open/anchor/target relations for avatar,
+  context menu, radial menu, and Selection Mode.
+- The relation model clearly separates conceptual nodes from implementation
+  surfaces/canvases.
+- Existing command binding cutovers continue to pass.
+- No live behavior changes are introduced.
+
+## Suggested Tests
+
+Add or update tests for:
+
+- valid fixture with relations passes schema validation;
+- runtime preserves and normalizes relations;
+- relations merge by stable `id`;
+- unknown concrete relation node refs produce validation errors;
+- wildcard relation targets are allowed only for documented collection targets;
+- Sigil UX tree contains expected relations:
+  - avatar body opens context menu;
+  - avatar body triggers radial menu;
+  - avatar anchors radial menu;
+  - radial menu targets radial item collection via target-surface metadata;
+  - context menu target/capture relation references the context menu input
+    region implementation.
+
+## Verification
+
+Run at least:
+
+```bash
+./aos dev recommend --json --files \
+  shared/schemas/aos-ux-tree-v0.schema.json \
+  shared/schemas/aos-ux-tree-v0.md \
+  packages/toolkit/runtime/ux-tree.js \
+  packages/toolkit/workbench/ux-tree-subject.js \
+  apps/sigil/renderer/live-modules/ux-tree.js \
+  tests/schemas/aos-ux-tree-v0.test.mjs \
+  tests/toolkit/runtime-ux-tree.test.mjs \
+  tests/toolkit/ux-tree-subject.test.mjs \
+  tests/renderer/sigil-ux-tree.test.mjs
+
+node --check packages/toolkit/runtime/ux-tree.js
+node --check packages/toolkit/workbench/ux-tree-subject.js
+node --check apps/sigil/renderer/live-modules/ux-tree.js
+node --test tests/schemas/aos-ux-tree-v0.test.mjs
+node --test tests/toolkit/runtime-ux-tree.test.mjs \
+  tests/toolkit/ux-tree-subject.test.mjs
+node --test tests/renderer/sigil-ux-tree.test.mjs \
+  tests/renderer/sigil-ux-tree-command-registry.test.mjs \
+  tests/renderer/sigil-context-menu-input.test.mjs \
+  tests/renderer/sigil-selection-mode-input.test.mjs
+git diff --check
+```
+
+Run `./aos ready` if it is cheap. If it reports a repo-mode TCC/input-tap
+blocker, stop and use:
+
+```bash
+.docks/gdi/scripts/human-needed-tcc-reset
+```
+
+Then rerun:
+
+```bash
+./aos ready --post-permission
+```
+
+after the human returns with `finished`.
+
+## Completion Report
+
+Include:
+
+- branch name;
+- head SHA and base SHA;
+- changed files;
+- summary of relation vocabulary added;
+- confirmation that live behavior did not change;
+- tests and checks run;
+- next recommended binding family after relations are accepted;
+- `git status --short --branch`;
+- `git show --stat HEAD`.

--- a/docs/design/work-cards/toolkit-ux-tree-control-fragments-v0.md
+++ b/docs/design/work-cards/toolkit-ux-tree-control-fragments-v0.md
@@ -1,0 +1,165 @@
+# Toolkit UX Tree Control Fragments V0
+
+## Transfer
+
+- Recipient: GDI
+- Transfer kind: GDI round
+- Source branch: `origin/gdi/sigil-ux-tree-pre-toolkit-adoption-closure-v0`
+- Output branch: `gdi/toolkit-ux-tree-control-fragments-v0`
+- Base stack: PR #388, `gdi/sigil-ux-tree-pre-toolkit-adoption-closure-v0`
+- Goal owner: toolkit controls
+
+GDI starts from a fresh context window. Do not assume branch, worktree, daemon,
+canvas, issue, runtime readiness, or prior implementation state. Read and
+rediscover before editing.
+
+## Goal
+
+Start the toolkit adoption path by making basic toolkit controls able to expose
+read-only UX tree fragments for their existing user interaction bindings.
+
+This is the first toolkit-owned producer after the Sigil reference
+implementation. It should prove that a normal toolkit control can describe:
+
+- its node identity;
+- the gestures it already handles;
+- the command name those gestures imply;
+- ownership/target relations where useful;
+- inspect-only metadata suitable for a future workbench editor.
+
+Do not build a user-editable binding editor yet. Do not add toolkit command
+execution or persistence yet.
+
+## Read First
+
+- `AGENTS.md`
+- `packages/toolkit/AGENTS.md`
+- `packages/toolkit/controls/AGENTS.md`
+- `packages/toolkit/runtime/AGENTS.md`
+- `docs/design/sigil-ux-tree-pre-toolkit-adoption-closure-v0.md`
+- `docs/api/toolkit/components.md`
+- `docs/api/toolkit/workbench.md`
+- `shared/schemas/aos-ux-tree-v0.md`
+- `shared/schemas/aos-ux-tree-v0.schema.json`
+
+## Rediscover State
+
+```bash
+git status --short --branch
+git fetch origin
+git switch -c gdi/toolkit-ux-tree-control-fragments-v0 origin/gdi/sigil-ux-tree-pre-toolkit-adoption-closure-v0
+./aos dev recommend --json --files packages/toolkit/controls docs/api/toolkit/components.md docs/api/toolkit/workbench.md shared/schemas/aos-ux-tree-v0.schema.json
+```
+
+This slice should be deterministic. `./aos ready` is optional unless your
+implementation touches live canvas/runtime behavior, which it should not.
+
+## Existing Code To Inspect
+
+- `packages/toolkit/runtime/ux-tree.js` - canonical UX tree normalization,
+  merging, validation, relation helpers, and strict safety checks.
+- `packages/toolkit/workbench/ux-tree-subject.js` - existing read-only
+  workbench subject projection for full UX trees.
+- `packages/toolkit/controls/button.js` - current button DOM/events.
+- `packages/toolkit/controls/toggle.js` - current toggle DOM/events.
+- `packages/toolkit/controls/button-group.js` - current segmented button group
+  DOM/events and keyboard navigation.
+- `packages/toolkit/controls/index.js` - public controls export surface.
+- `tests/toolkit/controls-button.test.mjs`
+- `tests/toolkit/controls-toggle.test.mjs`
+- `tests/toolkit/controls-button-group.test.mjs`
+- `tests/toolkit/runtime-ux-tree.test.mjs`
+- `tests/toolkit/ux-tree-subject.test.mjs`
+
+## Required Behavior
+
+Add a small toolkit-controls UX tree fragment layer.
+
+The preferred shape is a new module such as
+`packages/toolkit/controls/ux-tree.js` that exports focused helpers for basic
+controls. GDI may adjust names after inspecting the code, but keep the public
+surface small and explicit.
+
+At minimum cover these control families:
+
+- button activation;
+- toggle change/toggle;
+- segmented button group option selection.
+
+The helpers should produce JSON-only UX tree fragments or full read-only trees
+that can be validated by the existing `createUxTree` / `resolveUxTree`
+runtime helpers. The output must not contain functions, DOM nodes, event
+objects, binary payloads, `data:` refs, or `blob:` refs.
+
+The fragments should include, as appropriate:
+
+- stable node ids derived from explicit control ids or caller-supplied UX ids;
+- commands with allowlisted `handler_ref` strings;
+- bindings for current gestures, for example pointer click, Space/Enter button
+  activation, Space toggle activation, and segmented group arrow/select
+  behavior;
+- `owns` or `targets` relations for grouped controls/options when useful;
+- metadata that clearly marks the fragment as `read_only_shadow` or equivalent,
+  not live command execution;
+- current value/disabled state only as data, not behavior.
+
+Existing controls may expose their fragment additively, for example through a
+returned `uxTreeFragment` / `getUxTreeFragment()` member or through helper
+functions that accept the same config shape. Choose the least invasive pattern
+that still lets a caller discover the mapping in a regular way.
+
+## Hard Boundaries
+
+- Do not add a toolkit command registry or execute commands from the UX tree in
+  this slice.
+- Do not add user persistence, CRUD, override patches, or a binding editor.
+- Do not copy `apps/sigil/renderer/live-modules/ux-tree-readiness.js` into the
+  toolkit. A toolkit-wide readiness/audit helper belongs after multiple
+  toolkit surfaces emit fragments.
+- Do not change existing control behavior, DOM event timing, keyboard handling,
+  or CSS.
+- Do not change the `aos_ux_tree` schema unless inspection proves a strict
+  schema bug blocks this slice.
+- Do not touch Sigil runtime code except for docs references if absolutely
+  necessary.
+
+## Suggested Implementation Areas
+
+- Add `packages/toolkit/controls/ux-tree.js`.
+- Export the new helpers from `packages/toolkit/controls/index.js`.
+- Add focused tests in `tests/toolkit/controls-ux-tree.test.mjs`.
+- Add or update narrowly scoped assertions in the existing button, toggle, and
+  button-group tests only if the control factories expose fragments directly.
+- Update `docs/api/toolkit/components.md` to document the read-only control UX
+  fragment adoption state.
+- Update `docs/api/toolkit/workbench.md` only if the workbench subject docs need
+  to explain how assembled toolkit-control UX trees are inspected.
+
+## Verification
+
+Run the recommendation first, then deterministic checks:
+
+```bash
+./aos dev recommend --json --files packages/toolkit/controls docs/api/toolkit/components.md docs/api/toolkit/workbench.md shared/schemas/aos-ux-tree-v0.schema.json
+node --check packages/toolkit/controls/ux-tree.js
+node --test tests/toolkit/controls-ux-tree.test.mjs tests/toolkit/controls-button.test.mjs tests/toolkit/controls-toggle.test.mjs tests/toolkit/controls-button-group.test.mjs tests/toolkit/runtime-ux-tree.test.mjs tests/toolkit/ux-tree-subject.test.mjs
+git diff --check
+```
+
+If the implementation changes package exports or shared runtime helpers, also
+run the relevant broader toolkit tests recommended by `./aos dev recommend`.
+
+## Completion Report
+
+Report:
+
+- branch and head SHA;
+- files changed;
+- exact control families covered;
+- whether fragments are helper-only or exposed on factory return values;
+- whether any schema/runtime changes were needed;
+- tests run with exact pass/fail result;
+- local-only state, if any;
+- remaining follow-up recommendation for the next toolkit adoption slice.
+
+Commit and push the branch. Do not open a PR.

--- a/packages/toolkit/controls/button-group.js
+++ b/packages/toolkit/controls/button-group.js
@@ -1,5 +1,5 @@
 import { createEventHub, dispatchDomEvent, ownerDocument } from './_events.js';
-import { createButtonGroupUxTreeFragment } from './ux-tree.js';
+import { buttonGroupOptionValueMatches, createButtonGroupUxTreeFragment } from './ux-tree.js';
 
 export function createButtonGroup(config = {}) {
   const doc = ownerDocument(config);
@@ -20,7 +20,7 @@ export function createButtonGroup(config = {}) {
 
   const renderPressed = () => {
     for (const button of buttons) {
-      const selected = button.dataset.value === String(value);
+      const selected = buttonGroupOptionValueMatches(button.dataset.value, value);
       button.setAttribute('aria-pressed', String(selected));
       button.classList.toggle('active', selected);
       button.tabIndex = selected || value === null ? 0 : -1;

--- a/packages/toolkit/controls/button-group.js
+++ b/packages/toolkit/controls/button-group.js
@@ -1,4 +1,5 @@
 import { createEventHub, dispatchDomEvent, ownerDocument } from './_events.js';
+import { createButtonGroupUxTreeFragment } from './ux-tree.js';
 
 export function createButtonGroup(config = {}) {
   const doc = ownerDocument(config);
@@ -72,6 +73,13 @@ export function createButtonGroup(config = {}) {
       return value;
     },
     setValue,
+    getUxTreeFragment(fragmentOptions = {}) {
+      return createButtonGroupUxTreeFragment({
+        ...config,
+        options,
+        value,
+      }, fragmentOptions);
+    },
     on(type, callback) {
       return type === 'change' ? hub.on(type, callback) : () => {};
     },

--- a/packages/toolkit/controls/button-group.js
+++ b/packages/toolkit/controls/button-group.js
@@ -23,7 +23,7 @@ export function createButtonGroup(config = {}) {
       const selected = buttonGroupOptionValueMatches(button.dataset.value, value);
       button.setAttribute('aria-pressed', String(selected));
       button.classList.toggle('active', selected);
-      button.tabIndex = selected || value === null ? 0 : -1;
+      button.tabIndex = button.disabled ? -1 : (selected || value === null ? 0 : -1);
     }
   };
 
@@ -38,9 +38,18 @@ export function createButtonGroup(config = {}) {
     if (options.emit !== false) emitChange();
   };
 
-  const selectIndex = (index) => {
+  const selectableIndex = (index, step) => {
     if (!buttons.length) return;
-    const normalized = (index + buttons.length) % buttons.length;
+    for (let offset = 0; offset < buttons.length; offset += 1) {
+      const normalized = (index + (offset * step) + buttons.length) % buttons.length;
+      if (!buttons[normalized].disabled) return normalized;
+    }
+    return undefined;
+  };
+
+  const selectIndex = (index, step = 1) => {
+    const normalized = selectableIndex(index, step);
+    if (normalized === undefined) return;
     buttons[normalized].focus?.();
     setValue(options[normalized]?.value ?? null);
   };
@@ -50,15 +59,21 @@ export function createButtonGroup(config = {}) {
     button.type = 'button';
     button.textContent = option.label ?? String(option.value ?? '');
     button.dataset.value = String(option.value);
+    button.disabled = !!option.disabled;
+    if (button.disabled) button.setAttribute('aria-disabled', 'true');
     if (option.danger) button.classList.add('danger');
-    button.addEventListener('click', () => setValue(option.value));
+    button.addEventListener('click', () => {
+      if (button.disabled) return;
+      setValue(option.value);
+    });
     button.addEventListener('keydown', (event) => {
+      if (button.disabled) return;
       if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
         event.preventDefault?.();
-        selectIndex(index + 1);
+        selectIndex(index + 1, 1);
       } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
         event.preventDefault?.();
-        selectIndex(index - 1);
+        selectIndex(index - 1, -1);
       }
     });
     buttons.push(button);
@@ -74,9 +89,13 @@ export function createButtonGroup(config = {}) {
     },
     setValue,
     getUxTreeFragment(fragmentOptions = {}) {
+      const optionStates = options.map((option, index) => ({
+        ...option,
+        disabled: !!buttons[index]?.disabled,
+      }));
       return createButtonGroupUxTreeFragment({
         ...config,
-        options,
+        options: optionStates,
         value,
       }, fragmentOptions);
     },

--- a/packages/toolkit/controls/button.js
+++ b/packages/toolkit/controls/button.js
@@ -1,5 +1,6 @@
 import { createEventHub, dispatchDomEvent, ownerDocument } from './_events.js';
 import { attributeParts, escapeHtml } from './_html.js';
+import { createButtonUxTreeFragment } from './ux-tree.js';
 
 const VARIANTS = new Set(['primary', 'secondary', 'danger', 'ghost']);
 
@@ -40,6 +41,7 @@ export function createButton(config = {}) {
   const doc = ownerDocument(config);
   const hub = createEventHub();
   const el = doc.createElement('button');
+  let currentLabel = '';
   el.type = config.type || 'button';
   el.setAttribute('class', buttonClassName(config));
 
@@ -51,7 +53,8 @@ export function createButton(config = {}) {
   };
 
   const setLabel = (label = '') => {
-    el.textContent = String(label);
+    currentLabel = String(label);
+    el.textContent = currentLabel;
   };
 
   const setDisabled = (disabled = false) => {
@@ -96,6 +99,13 @@ export function createButton(config = {}) {
     el,
     setLabel,
     setDisabled,
+    getUxTreeFragment(options = {}) {
+      return createButtonUxTreeFragment({
+        ...config,
+        label: currentLabel,
+        disabled: !!el.disabled,
+      }, options);
+    },
     on(type, callback) {
       return type === 'click' ? hub.on(type, callback) : () => {};
     },

--- a/packages/toolkit/controls/index.js
+++ b/packages/toolkit/controls/index.js
@@ -1,6 +1,12 @@
 export { createButton, renderButtonHtml } from './button.js';
 export { createButtonGroup } from './button-group.js';
 export { createToggle, renderToggleHtml } from './toggle.js';
+export {
+  CONTROL_UX_TREE_RUNTIME_STATE,
+  createButtonGroupUxTreeFragment,
+  createButtonUxTreeFragment,
+  createToggleUxTreeFragment,
+} from './ux-tree.js';
 export { createTextField, renderTextFieldHtml } from './text-field.js';
 export { createSelect, renderSelectHtml } from './select.js';
 export { createCheckboxGroup, renderCheckboxHtml } from './checkbox-group.js';

--- a/packages/toolkit/controls/toggle.js
+++ b/packages/toolkit/controls/toggle.js
@@ -35,6 +35,7 @@ export function createToggle(config = {}) {
   el.classList.add('aos-toggle');
   input.type = 'checkbox';
   input.checked = !!config.checked;
+  input.disabled = !!config.disabled;
   input.classList.add('aos-toggle-input');
   switchEl.classList.add('aos-toggle-switch');
   thumb.classList.add('aos-toggle-thumb');

--- a/packages/toolkit/controls/toggle.js
+++ b/packages/toolkit/controls/toggle.js
@@ -1,5 +1,6 @@
 import { createEventHub, dispatchDomEvent, ownerDocument } from './_events.js';
 import { attributeParts, escapeHtml } from './_html.js';
+import { createToggleUxTreeFragment } from './ux-tree.js';
 
 export function renderToggleHtml(config = {}) {
   const wrapperClasses = ['aos-toggle'];
@@ -65,6 +66,13 @@ export function createToggle(config = {}) {
       if (input.checked === next) return;
       input.checked = next;
       if (options.emit) emitChange();
+    },
+    getUxTreeFragment(options = {}) {
+      return createToggleUxTreeFragment({
+        ...config,
+        checked: !!input.checked,
+        disabled: !!input.disabled,
+      }, options);
     },
     on(type, callback) {
       return type === 'change' ? hub.on(type, callback) : () => {};

--- a/packages/toolkit/controls/ux-tree.js
+++ b/packages/toolkit/controls/ux-tree.js
@@ -54,6 +54,11 @@ function jsonObject(entries) {
   return object;
 }
 
+export function buttonGroupOptionValueMatches(optionValue, currentValue) {
+  const normalizedValue = currentValue === undefined ? null : currentValue;
+  return String(optionValue) === String(normalizedValue);
+}
+
 function handlerRef(value, fallback) {
   const ref = text(value, fallback);
   if (!HANDLER_REF_PATTERN.test(ref)) {
@@ -219,7 +224,7 @@ export function createButtonGroupUxTreeFragment(config = {}, options = {}) {
           runtime_state: CONTROL_UX_TREE_RUNTIME_STATE,
           state: jsonObject({
             value: option.value,
-            selected: option.value === config.value,
+            selected: buttonGroupOptionValueMatches(option.value, config.value),
             danger: !!option.danger,
             disabled: !!option.disabled,
           }),

--- a/packages/toolkit/controls/ux-tree.js
+++ b/packages/toolkit/controls/ux-tree.js
@@ -1,0 +1,297 @@
+import { createUxTree } from '../runtime/ux-tree.js';
+
+export const CONTROL_UX_TREE_RUNTIME_STATE = 'read_only_shadow';
+
+const HANDLER_REF_PATTERN = /^[A-Za-z0-9_.:-]+$/;
+const CONTROL_SOURCE_REFS = Object.freeze({
+  button: [
+    { kind: 'repo_path', path: 'packages/toolkit/controls/button.js' },
+    { kind: 'repo_path', path: 'packages/toolkit/controls/ux-tree.js' },
+  ],
+  toggle: [
+    { kind: 'repo_path', path: 'packages/toolkit/controls/toggle.js' },
+    { kind: 'repo_path', path: 'packages/toolkit/controls/ux-tree.js' },
+  ],
+  buttonGroup: [
+    { kind: 'repo_path', path: 'packages/toolkit/controls/button-group.js' },
+    { kind: 'repo_path', path: 'packages/toolkit/controls/ux-tree.js' },
+  ],
+});
+
+function text(value, fallback = '') {
+  const normalized = String(value ?? '').replace(/\s+/g, ' ').trim();
+  return normalized || fallback;
+}
+
+function list(value) {
+  return Array.isArray(value) ? value.filter((entry) => entry !== undefined && entry !== null) : [];
+}
+
+function safeSegment(value, fallback) {
+  const normalized = text(value, fallback)
+    .replace(/[^A-Za-z0-9_.:-]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return normalized || fallback;
+}
+
+function jsonClone(value) {
+  if (value === undefined) return undefined;
+  try {
+    const serialized = JSON.stringify(value);
+    if (serialized === undefined) return undefined;
+    return JSON.parse(serialized);
+  } catch {
+    return String(value);
+  }
+}
+
+function jsonObject(entries) {
+  const object = {};
+  for (const [key, value] of Object.entries(entries)) {
+    const cloned = jsonClone(value);
+    if (cloned !== undefined) object[key] = cloned;
+  }
+  return object;
+}
+
+function handlerRef(value, fallback) {
+  const ref = text(value, fallback);
+  if (!HANDLER_REF_PATTERN.test(ref)) {
+    throw new TypeError(`UX tree handler_ref must be an allowlisted reference: ${ref}`);
+  }
+  return ref;
+}
+
+function baseControlId(config = {}, fallback) {
+  return safeSegment(config.uxNodeId ?? config.uxId ?? config.id ?? config.name, fallback);
+}
+
+function labelFor(config = {}, fallback) {
+  return text(config.uxLabel ?? config.label ?? config.ariaLabel ?? config.title, fallback);
+}
+
+function readOnlyMetadata(controlFamily, extra = {}) {
+  return {
+    runtime_state: CONTROL_UX_TREE_RUNTIME_STATE,
+    producer: 'toolkit.controls',
+    control_family: controlFamily,
+    intent: 'inspect_only',
+    command_execution: 'future_adapter',
+    ...jsonClone(extra),
+  };
+}
+
+function command({ id, label, handler_ref, parameters = {}, metadata = {} }) {
+  return {
+    id,
+    label,
+    handler_ref,
+    parameters: jsonClone(parameters) || {},
+    safety: { execution: 'allowlisted' },
+    metadata: readOnlyMetadata('command', metadata),
+  };
+}
+
+function binding({ id, node_id, gesture, command_id, parameters = {}, metadata = {}, priority = 10 }) {
+  return {
+    id,
+    node_id,
+    mode: 'global',
+    gesture,
+    command_id,
+    enabled: true,
+    priority,
+    consume_policy: 'observe',
+    parameters: jsonClone(parameters) || {},
+    metadata: readOnlyMetadata('binding', metadata),
+  };
+}
+
+function resolveTree(input, options = {}) {
+  return createUxTree(input, { strict: options.strict !== false });
+}
+
+export function createButtonUxTreeFragment(config = {}, options = {}) {
+  const nodeId = baseControlId(config, 'toolkit.controls.button');
+  const commandId = `${nodeId}.activate`;
+  const label = labelFor(config, 'Button');
+  return resolveTree({
+    id: `${nodeId}.ux_tree`,
+    label: `${label} UX Tree`,
+    owner: text(options.owner ?? config.owner, 'toolkit.controls'),
+    source_refs: CONTROL_SOURCE_REFS.button,
+    modes: [{ id: 'global', label: 'Global' }],
+    nodes: [
+      {
+        id: nodeId,
+        label,
+        role: 'button',
+        node_type: 'control',
+        metadata: {
+          runtime_state: CONTROL_UX_TREE_RUNTIME_STATE,
+          state: jsonObject({
+            disabled: !!config.disabled,
+            pressed: config.pressed ?? config.ariaPressed,
+            variant: config.variant,
+            type: config.type || 'button',
+          }),
+        },
+      },
+    ],
+    commands: [
+      command({
+        id: commandId,
+        label: `Activate ${label}`,
+        handler_ref: handlerRef(config.uxHandlerRef ?? config.handler_ref, 'toolkit.controls.button.activate'),
+      }),
+    ],
+    bindings: [
+      binding({ id: `${nodeId}.pointer.click`, node_id: nodeId, gesture: 'pointer.left.click', command_id: commandId }),
+      binding({ id: `${nodeId}.keyboard.enter`, node_id: nodeId, gesture: 'keyboard.enter', command_id: commandId }),
+      binding({ id: `${nodeId}.keyboard.space`, node_id: nodeId, gesture: 'keyboard.space', command_id: commandId }),
+    ],
+    relations: [],
+    settings: {},
+    metadata: readOnlyMetadata('button'),
+  }, options);
+}
+
+export function createToggleUxTreeFragment(config = {}, options = {}) {
+  const nodeId = baseControlId(config, 'toolkit.controls.toggle');
+  const commandId = `${nodeId}.toggle`;
+  const label = labelFor(config, 'Toggle');
+  return resolveTree({
+    id: `${nodeId}.ux_tree`,
+    label: `${label} UX Tree`,
+    owner: text(options.owner ?? config.owner, 'toolkit.controls'),
+    source_refs: CONTROL_SOURCE_REFS.toggle,
+    modes: [{ id: 'global', label: 'Global' }],
+    nodes: [
+      {
+        id: nodeId,
+        label,
+        role: 'switch',
+        node_type: 'control',
+        metadata: {
+          runtime_state: CONTROL_UX_TREE_RUNTIME_STATE,
+          state: jsonObject({
+            checked: !!config.checked,
+            disabled: !!config.disabled,
+            name: config.name,
+          }),
+        },
+      },
+    ],
+    commands: [
+      command({
+        id: commandId,
+        label: `Toggle ${label}`,
+        handler_ref: handlerRef(config.uxHandlerRef ?? config.handler_ref, 'toolkit.controls.toggle.change'),
+      }),
+    ],
+    bindings: [
+      binding({ id: `${nodeId}.pointer.click`, node_id: nodeId, gesture: 'pointer.left.click', command_id: commandId }),
+      binding({ id: `${nodeId}.keyboard.space`, node_id: nodeId, gesture: 'keyboard.space', command_id: commandId }),
+    ],
+    relations: [],
+    settings: {},
+    metadata: readOnlyMetadata('toggle'),
+  }, options);
+}
+
+export function createButtonGroupUxTreeFragment(config = {}, options = {}) {
+  const groupId = baseControlId(config, 'toolkit.controls.segmented');
+  const groupLabel = labelFor(config, 'Segmented Control');
+  const optionConfigs = list(config.options);
+  const optionNodes = optionConfigs.map((option, index) => {
+    const valueSegment = safeSegment(option.uxNodeId ?? option.id ?? option.value, `option_${index + 1}`);
+    const optionId = `${groupId}.${valueSegment}`;
+    return {
+      option,
+      index,
+      node: {
+        id: optionId,
+        parent_id: groupId,
+        label: text(option.uxLabel ?? option.label ?? option.value, `Option ${index + 1}`),
+        role: 'button',
+        node_type: 'control_option',
+        metadata: {
+          runtime_state: CONTROL_UX_TREE_RUNTIME_STATE,
+          state: jsonObject({
+            value: option.value,
+            selected: option.value === config.value,
+            danger: !!option.danger,
+            disabled: !!option.disabled,
+          }),
+        },
+      },
+    };
+  });
+  const nextCommandId = `${groupId}.select_next`;
+  const previousCommandId = `${groupId}.select_previous`;
+
+  return resolveTree({
+    id: `${groupId}.ux_tree`,
+    label: `${groupLabel} UX Tree`,
+    owner: text(options.owner ?? config.owner, 'toolkit.controls'),
+    source_refs: CONTROL_SOURCE_REFS.buttonGroup,
+    modes: [{ id: 'global', label: 'Global' }],
+    nodes: [
+      {
+        id: groupId,
+        label: groupLabel,
+        role: 'group',
+        node_type: 'control_group',
+        children: optionNodes.map((entry) => entry.node.id),
+        metadata: {
+          runtime_state: CONTROL_UX_TREE_RUNTIME_STATE,
+          state: jsonObject({
+            value: config.value ?? null,
+            option_count: optionNodes.length,
+          }),
+        },
+      },
+      ...optionNodes.map((entry) => entry.node),
+    ],
+    commands: [
+      ...optionNodes.map(({ node, option }) => command({
+        id: `${node.id}.select`,
+        label: `Select ${node.label}`,
+        handler_ref: handlerRef(option.uxHandlerRef ?? config.uxHandlerRef ?? config.handler_ref, 'toolkit.controls.segmented.select_option'),
+        parameters: jsonObject({ value: option.value }),
+        metadata: { option_node_id: node.id },
+      })),
+      command({
+        id: nextCommandId,
+        label: `Select next ${groupLabel} option`,
+        handler_ref: handlerRef(config.uxNextHandlerRef, 'toolkit.controls.segmented.select_next'),
+      }),
+      command({
+        id: previousCommandId,
+        label: `Select previous ${groupLabel} option`,
+        handler_ref: handlerRef(config.uxPreviousHandlerRef, 'toolkit.controls.segmented.select_previous'),
+      }),
+    ],
+    bindings: optionNodes.flatMap(({ node }) => {
+      const selectCommandId = `${node.id}.select`;
+      return [
+        binding({ id: `${node.id}.pointer.click`, node_id: node.id, gesture: 'pointer.left.click', command_id: selectCommandId }),
+        binding({ id: `${node.id}.keyboard.enter`, node_id: node.id, gesture: 'keyboard.enter', command_id: selectCommandId }),
+        binding({ id: `${node.id}.keyboard.space`, node_id: node.id, gesture: 'keyboard.space', command_id: selectCommandId }),
+        binding({ id: `${node.id}.keyboard.arrow_right`, node_id: node.id, gesture: 'keyboard.arrow_right', command_id: nextCommandId, priority: 20 }),
+        binding({ id: `${node.id}.keyboard.arrow_down`, node_id: node.id, gesture: 'keyboard.arrow_down', command_id: nextCommandId, priority: 20 }),
+        binding({ id: `${node.id}.keyboard.arrow_left`, node_id: node.id, gesture: 'keyboard.arrow_left', command_id: previousCommandId, priority: 20 }),
+        binding({ id: `${node.id}.keyboard.arrow_up`, node_id: node.id, gesture: 'keyboard.arrow_up', command_id: previousCommandId, priority: 20 }),
+      ];
+    }),
+    relations: optionNodes.map(({ node }) => ({
+      id: `${groupId}.owns.${node.id}`,
+      relation_type: 'owns',
+      from_node_id: groupId,
+      to_node_id: node.id,
+      metadata: readOnlyMetadata('button_group_relation'),
+    })),
+    settings: {},
+    metadata: readOnlyMetadata('button_group'),
+  }, options);
+}

--- a/packages/toolkit/controls/ux-tree.js
+++ b/packages/toolkit/controls/ux-tree.js
@@ -5,16 +5,16 @@ export const CONTROL_UX_TREE_RUNTIME_STATE = 'read_only_shadow';
 const HANDLER_REF_PATTERN = /^[A-Za-z0-9_.:-]+$/;
 const CONTROL_SOURCE_REFS = Object.freeze({
   button: [
-    { kind: 'repo_path', path: 'packages/toolkit/controls/button.js' },
-    { kind: 'repo_path', path: 'packages/toolkit/controls/ux-tree.js' },
+    { id: 'toolkit-controls-button', kind: 'source', ref: 'packages/toolkit/controls/button.js' },
+    { id: 'toolkit-controls-ux-tree', kind: 'source', ref: 'packages/toolkit/controls/ux-tree.js' },
   ],
   toggle: [
-    { kind: 'repo_path', path: 'packages/toolkit/controls/toggle.js' },
-    { kind: 'repo_path', path: 'packages/toolkit/controls/ux-tree.js' },
+    { id: 'toolkit-controls-toggle', kind: 'source', ref: 'packages/toolkit/controls/toggle.js' },
+    { id: 'toolkit-controls-ux-tree', kind: 'source', ref: 'packages/toolkit/controls/ux-tree.js' },
   ],
   buttonGroup: [
-    { kind: 'repo_path', path: 'packages/toolkit/controls/button-group.js' },
-    { kind: 'repo_path', path: 'packages/toolkit/controls/ux-tree.js' },
+    { id: 'toolkit-controls-button-group', kind: 'source', ref: 'packages/toolkit/controls/button-group.js' },
+    { id: 'toolkit-controls-ux-tree', kind: 'source', ref: 'packages/toolkit/controls/ux-tree.js' },
   ],
 });
 

--- a/packages/toolkit/runtime/ux-tree.js
+++ b/packages/toolkit/runtime/ux-tree.js
@@ -1,9 +1,10 @@
 export const UX_TREE_SCHEMA = 'aos_ux_tree';
 export const UX_TREE_VERSION = '0.1.0';
 
-const KEYED_ARRAYS = new Set(['nodes', 'commands', 'bindings', 'modes']);
+const KEYED_ARRAYS = new Set(['nodes', 'commands', 'bindings', 'modes', 'relations']);
 const HANDLER_REF_PATTERN = /^[A-Za-z0-9_.:-]+$/;
 const ALLOWLISTED_EXECUTION = 'allowlisted';
+const UX_TREE_RELATION_TYPES = new Set(['triggers', 'opens', 'anchors', 'targets', 'owns']);
 
 function isPlainObject(value) {
   return !!value && typeof value === 'object' && !Array.isArray(value);
@@ -135,6 +136,11 @@ function hasExecutableValue(value, seen = new Set()) {
   return Object.values(value).some((entry) => hasExecutableValue(entry, seen));
 }
 
+function isCollectionRelationTarget(value) {
+  const ref = text(value);
+  return ref.endsWith('.*') && ref.indexOf('*') === ref.length - 1;
+}
+
 export function normalizeUxTreeNode(node = {}, options = {}) {
   const id = text(node.id || options.id);
   return {
@@ -184,6 +190,18 @@ export function normalizeUxTreeBinding(binding = {}, options = {}) {
   };
 }
 
+export function normalizeUxTreeRelation(relation = {}, options = {}) {
+  const id = text(relation.id || options.id);
+  return {
+    id,
+    relation_type: text(relation.relation_type || relation.type),
+    from_node_id: text(relation.from_node_id),
+    to_node_id: text(relation.to_node_id),
+    source_metadata: cloneJson(relation.source_metadata || {}),
+    metadata: cloneJson(relation.metadata || {}),
+  };
+}
+
 export function mergeUxTreeDefinitions(base = {}, override = {}) {
   return mergeUxTreeValue(base, override);
 }
@@ -217,6 +235,7 @@ function validateUxTree(tree = {}) {
   const nodeIds = new Set();
   const commandIds = new Set();
   const modeIds = new Set(['global']);
+  const relationIds = new Set();
 
   errors.push(...validateEmbeddedRefs(tree.source_refs, {
     pathPrefix: '/source_refs',
@@ -257,6 +276,44 @@ function validateUxTree(tree = {}) {
     if (binding.mode && !modeIds.has(binding.mode)) errors.push(validationError('binding.mode_ref', `binding ${binding.id || index} references unknown mode ${binding.mode}`, `/bindings/${index}/mode`));
     if (!text(binding.gesture)) errors.push(validationError('binding.gesture', `bindings[${index}].gesture is required`, `/bindings/${index}/gesture`));
   }
+  for (const [index, relation] of list(tree.relations).entries()) {
+    const relationId = text(relation.id);
+    const relationType = text(relation.relation_type);
+    const fromNodeId = text(relation.from_node_id);
+    const toNodeId = text(relation.to_node_id);
+    const toIsCollection = isCollectionRelationTarget(toNodeId);
+
+    if (!relationId) {
+      errors.push(validationError('relation.id', `relations[${index}].id is required`, `/relations/${index}/id`));
+    } else if (relationIds.has(relationId)) {
+      errors.push(validationError('relation.duplicate', `duplicate relation id ${relationId}`, `/relations/${index}/id`));
+    }
+    if (relationId) relationIds.add(relationId);
+
+    if (!relationType) {
+      errors.push(validationError('relation.type', `relations[${index}].relation_type is required`, `/relations/${index}/relation_type`));
+    } else if (!UX_TREE_RELATION_TYPES.has(relationType)) {
+      errors.push(validationError('relation.type', `relation ${relationId || index} uses unsupported type ${relationType}`, `/relations/${index}/relation_type`));
+    }
+
+    if (!fromNodeId) {
+      errors.push(validationError('relation.from_node_id', `relations[${index}].from_node_id is required`, `/relations/${index}/from_node_id`));
+    } else if (!nodeIds.has(fromNodeId)) {
+      errors.push(validationError('relation.from_node_ref', `relation ${relationId || index} references unknown from_node_id ${fromNodeId}`, `/relations/${index}/from_node_id`));
+    }
+
+    if (!toNodeId) {
+      errors.push(validationError('relation.to_node_id', `relations[${index}].to_node_id is required`, `/relations/${index}/to_node_id`));
+    } else if (toIsCollection && relationType !== 'targets') {
+      errors.push(validationError('relation.collection_target', `relation ${relationId || index} collection targets are only valid for targets relations`, `/relations/${index}/to_node_id`));
+    } else if (!toIsCollection && !nodeIds.has(toNodeId)) {
+      errors.push(validationError('relation.to_node_ref', `relation ${relationId || index} references unknown to_node_id ${toNodeId}`, `/relations/${index}/to_node_id`));
+    }
+
+    if (hasExecutableValue(relation.source_metadata) || hasExecutableValue(relation.metadata)) {
+      errors.push(validationError('relation.metadata.executable', 'relation metadata must be plain JSON values', `/relations/${index}/metadata`));
+    }
+  }
   return { ok: errors.length === 0, errors };
 }
 
@@ -274,6 +331,7 @@ export function resolveUxTree(input = {}, options = {}) {
     nodes: list(source.nodes).map((node) => normalizeUxTreeNode(node)),
     commands: list(source.commands).map((command) => normalizeUxTreeCommand(command)),
     bindings: list(source.bindings).map((binding) => normalizeUxTreeBinding(binding)),
+    relations: list(source.relations).map((relation) => normalizeUxTreeRelation(relation)),
     settings: cloneJson(source.settings || {}),
     metadata: cloneJson(source.metadata || {}),
   };
@@ -304,4 +362,23 @@ export function uxTreeBindingsForGesture(tree = {}, { nodeId = '', mode = 'globa
 export function uxTreeCommandById(tree = {}, commandId = '') {
   const id = text(commandId);
   return list(tree.commands).find((command) => command.id === id) || null;
+}
+
+export function uxTreeRelationsByType(tree = {}, relationType = '') {
+  const type = text(relationType);
+  return list(tree.relations).filter((relation) => !type || relation.relation_type === type);
+}
+
+export function uxTreeRelationsForNode(tree = {}, nodeId = '', options = {}) {
+  const id = text(nodeId);
+  const direction = text(options.direction, 'any');
+  const type = text(options.relationType || options.relation_type);
+  return list(tree.relations)
+    .filter((relation) => !type || relation.relation_type === type)
+    .filter((relation) => {
+      if (!id) return true;
+      if (direction === 'from' || direction === 'outgoing') return relation.from_node_id === id;
+      if (direction === 'to' || direction === 'incoming') return relation.to_node_id === id;
+      return relation.from_node_id === id || relation.to_node_id === id;
+    });
 }

--- a/packages/toolkit/workbench/ux-tree-subject.js
+++ b/packages/toolkit/workbench/ux-tree-subject.js
@@ -4,6 +4,7 @@ export const UX_TREE_SUBJECT_TYPE = 'aos.ux_tree';
 export const UX_TREE_RESOURCE_FACETS = Object.freeze({
   overview: 'ux-tree-overview',
   bindings: 'ux-tree-bindings',
+  relations: 'ux-tree-relations',
   commands: 'ux-tree-commands',
   settings: 'ux-tree-settings',
   rawJson: 'ux-tree-json',
@@ -77,6 +78,7 @@ export function createUxTreeWorkbenchSubject({
     contracts: [
       'aos.ux_tree',
       'aos.ux_tree.bindings',
+      'aos.ux_tree.relations',
       'aos.ux_tree.commands',
       'aos.ux_tree.settings',
     ],
@@ -90,6 +92,7 @@ export function createUxTreeWorkbenchSubject({
         metadata: {
           node_count: list(tree.nodes).length,
           binding_count: list(tree.bindings).length,
+          relation_count: list(tree.relations).length,
           command_count: list(tree.commands).length,
         },
       }),
@@ -99,6 +102,13 @@ export function createUxTreeWorkbenchSubject({
         label: 'Bindings',
         contracts: ['aos.ux_tree.bindings'],
         hosts: hostsFor(UX_TREE_RESOURCE_FACETS.bindings),
+      }),
+      facet({
+        key: UX_TREE_RESOURCE_FACETS.relations,
+        layer: 'model',
+        label: 'Relations',
+        contracts: ['aos.ux_tree.relations'],
+        hosts: hostsFor(UX_TREE_RESOURCE_FACETS.relations),
       }),
       facet({
         key: UX_TREE_RESOURCE_FACETS.commands,
@@ -132,8 +142,10 @@ export function createUxTreeWorkbenchSubject({
       version: tree.version || null,
       node_count: list(tree.nodes).length,
       binding_count: list(tree.bindings).length,
+      relation_count: list(tree.relations).length,
       command_count: list(tree.commands).length,
       bindings: cloneJson(list(tree.bindings)),
+      relations: cloneJson(list(tree.relations)),
       commands: cloneJson(list(tree.commands)),
       settings: cloneJson(tree.settings || {}),
       raw_tree: cloneJson(tree),

--- a/shared/schemas/aos-ux-tree-v0.md
+++ b/shared/schemas/aos-ux-tree-v0.md
@@ -2,8 +2,8 @@
 
 `aos_ux_tree` is the first canonical data shape for inspectable UX
 affordances. It represents interface nodes, mode-scoped gesture bindings,
-allowlisted command references, and plain JSON settings without changing runtime
-behavior by itself.
+generic node relationships, allowlisted command references, and plain JSON
+settings without changing runtime behavior by itself.
 
 The intended flow is:
 
@@ -32,9 +32,37 @@ persistence are future cutover work.
 - `nodes`: addressable UI affordances.
 - `commands`: declarative references to allowlisted handlers.
 - `bindings`: gesture-to-command links scoped by node and mode.
+- `relations`: generic topology and behavior links between nodes.
 - `settings`: plain JSON subtrees for radial geometry, radial menu config,
   visual overlays, and future override patches.
 - `metadata`: producer/runtime notes.
+
+## Relations
+
+`relations[]` captures behavior and topology that is not pure containment.
+`parent_id` and `children` remain the structural hierarchy; relations describe
+how one node triggers, opens, anchors, targets, or owns another node without
+implying that a canvas or input region is the conceptual owner.
+
+Each relation has a stable `id`, `relation_type`, `from_node_id`, `to_node_id`,
+optional `source_metadata`, and optional `metadata`. The V0 relation vocabulary
+is:
+
+- `triggers`: a source node can start behavior associated with another node.
+- `opens`: a source node opens another UX node or surface.
+- `anchors`: a source node provides placement/topology anchoring for another
+  node.
+- `targets`: a source node exposes concrete or collection target surfaces used
+  for hit testing, input routing, or accessibility.
+- `owns`: a generic ownership relation for cases that are conceptual ownership,
+  not merely canvas containment.
+
+Concrete `from_node_id` and `to_node_id` values are validated against known
+nodes. V0 also allows documented collection targets ending in `.*`, such as
+`sigil.avatar.radial_menu.item.*`, only on `targets` relations. Implementation
+surfaces and canvas/input-region identifiers belong in plain JSON relation
+metadata, for example under `metadata.target_surface`, rather than in
+avatar-specific schema fields.
 
 ## Safety Rules
 
@@ -43,6 +71,8 @@ an execution adapter may later map to an allowlisted runtime function. Settings
 and parameters are plain JSON. Asset-like values must be refs, not embedded
 binary or `data:` payloads.
 
-Bindings reference known node and command IDs. The JSON Schema covers the
-structural contract; `resolveUxTree()` additionally reports invalid references
-in `validation.errors` and can throw in strict mode.
+Bindings reference known node and command IDs. Relations reference known
+concrete node IDs, with the documented V0 exception for `targets` collection
+refs ending in `.*`. The JSON Schema covers the structural contract;
+`resolveUxTree()` additionally reports invalid references in
+`validation.errors` and can throw in strict mode.

--- a/shared/schemas/aos-ux-tree-v0.schema.json
+++ b/shared/schemas/aos-ux-tree-v0.schema.json
@@ -15,6 +15,7 @@
     "nodes",
     "commands",
     "bindings",
+    "relations",
     "settings",
     "metadata"
   ],
@@ -50,6 +51,10 @@
     "bindings": {
       "type": "array",
       "items": { "$ref": "#/$defs/Binding" }
+    },
+    "relations": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Relation" }
     },
     "settings": {
       "type": "object",
@@ -239,6 +244,27 @@
         "metadata": {
           "type": "object",
           "additionalProperties": true
+        }
+      }
+    },
+    "Relation": {
+      "type": "object",
+      "required": ["id", "relation_type", "from_node_id", "to_node_id"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "relation_type": {
+          "enum": ["triggers", "opens", "anchors", "targets", "owns"]
+        },
+        "from_node_id": { "type": "string", "minLength": 1 },
+        "to_node_id": { "type": "string", "minLength": 1 },
+        "source_metadata": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/JsonValue" }
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/JsonValue" }
         }
       }
     }

--- a/shared/schemas/fixtures/aos-ux-tree-v0/invalid/embedded-resource.json
+++ b/shared/schemas/fixtures/aos-ux-tree-v0/invalid/embedded-resource.json
@@ -25,6 +25,7 @@
     }
   ],
   "bindings": [],
+  "relations": [],
   "settings": {},
   "metadata": {}
 }

--- a/shared/schemas/fixtures/aos-ux-tree-v0/invalid/executable-command.json
+++ b/shared/schemas/fixtures/aos-ux-tree-v0/invalid/executable-command.json
@@ -19,6 +19,7 @@
     }
   ],
   "bindings": [],
+  "relations": [],
   "settings": {},
   "metadata": {}
 }

--- a/shared/schemas/fixtures/aos-ux-tree-v0/invalid/unknown-binding-ref.json
+++ b/shared/schemas/fixtures/aos-ux-tree-v0/invalid/unknown-binding-ref.json
@@ -32,6 +32,7 @@
       "source_metadata": {}
     }
   ],
+  "relations": [],
   "settings": {},
   "metadata": {}
 }

--- a/shared/schemas/fixtures/aos-ux-tree-v0/valid/sigil-avatar.json
+++ b/shared/schemas/fixtures/aos-ux-tree-v0/valid/sigil-avatar.json
@@ -226,6 +226,128 @@
       "source_metadata": {}
     }
   ],
+  "relations": [
+    {
+      "id": "sigil.avatar.body.opens_context_menu",
+      "relation_type": "opens",
+      "from_node_id": "sigil.avatar.body",
+      "to_node_id": "sigil.avatar.context_menu",
+      "source_metadata": {
+        "source": "apps/sigil/renderer/live-modules/context-menu-input.js",
+        "binding_id": "sigil.avatar.context_menu.right_click",
+        "command_id": "sigil.context_menu.open"
+      },
+      "metadata": {
+        "gesture": "pointer.right.click"
+      }
+    },
+    {
+      "id": "sigil.avatar.body.triggers_radial_menu",
+      "relation_type": "triggers",
+      "from_node_id": "sigil.avatar.body",
+      "to_node_id": "sigil.avatar.radial_menu",
+      "source_metadata": {
+        "source": "apps/sigil/renderer/live-modules/radial-gesture-menu.js"
+      },
+      "metadata": {
+        "gesture": "pointer.left.drag_threshold"
+      }
+    },
+    {
+      "id": "sigil.avatar.body.triggers_selection_mode",
+      "relation_type": "triggers",
+      "from_node_id": "sigil.avatar.body",
+      "to_node_id": "sigil.avatar.selection_mode",
+      "source_metadata": {
+        "source": "apps/sigil/renderer/live-modules/selection-mode-input.js",
+        "binding_id": "sigil.avatar.selection_mode.double_click",
+        "command_id": "sigil.selection_mode.enter"
+      },
+      "metadata": {
+        "gesture": "pointer.left.double_click"
+      }
+    },
+    {
+      "id": "sigil.avatar.anchors_radial_menu",
+      "relation_type": "anchors",
+      "from_node_id": "sigil.avatar",
+      "to_node_id": "sigil.avatar.radial_menu",
+      "source_metadata": {
+        "source": "apps/sigil/renderer/live-modules/radial-gesture-menu.js"
+      },
+      "metadata": {
+        "anchor": {
+          "kind": "avatar_position",
+          "state_ref": "liveJs.avatarPos"
+        }
+      }
+    },
+    {
+      "id": "sigil.avatar.body.anchors_context_menu",
+      "relation_type": "anchors",
+      "from_node_id": "sigil.avatar.body",
+      "to_node_id": "sigil.avatar.context_menu",
+      "source_metadata": {
+        "source": "apps/sigil/renderer/live-modules/context-menu-input.js"
+      },
+      "metadata": {
+        "anchor": {
+          "kind": "pointer_open_point"
+        }
+      }
+    },
+    {
+      "id": "sigil.avatar.radial_menu.targets_items",
+      "relation_type": "targets",
+      "from_node_id": "sigil.avatar.radial_menu",
+      "to_node_id": "sigil.avatar.radial_menu.item.*",
+      "source_metadata": {
+        "source": "apps/sigil/renderer/live-modules/radial-menu-target-surface.js"
+      },
+      "metadata": {
+        "target_surface": {
+          "kind": "radial_menu_targets",
+          "lifecycle": "active_radial_phase",
+          "hit_source_ref": "radialTargetSurface",
+          "collection_ref": "sigil.avatar.radial_menu.item.*"
+        }
+      }
+    },
+    {
+      "id": "sigil.avatar.context_menu.targets_input_region",
+      "relation_type": "targets",
+      "from_node_id": "sigil.avatar.context_menu",
+      "to_node_id": "sigil.avatar.context_menu",
+      "source_metadata": {
+        "source": "apps/sigil/renderer/live-modules/context-menu-input.js"
+      },
+      "metadata": {
+        "target_surface": {
+          "kind": "input_region",
+          "lifecycle": "context_menu_open",
+          "hit_source_ref": "sigil-context-menu-input-region",
+          "consume_policy": "captured"
+        }
+      }
+    },
+    {
+      "id": "sigil.avatar.selection_mode.targets_input_region",
+      "relation_type": "targets",
+      "from_node_id": "sigil.avatar.selection_mode",
+      "to_node_id": "sigil.avatar.selection_mode",
+      "source_metadata": {
+        "source": "apps/sigil/renderer/live-modules/selection-mode-input.js"
+      },
+      "metadata": {
+        "target_surface": {
+          "kind": "input_region",
+          "lifecycle": "selection_mode_active",
+          "hit_source_ref": "sigil-selection-mode-input-region",
+          "consume_policy": "captured"
+        }
+      }
+    }
+  ],
   "settings": {
     "avatar": { "hit_radius": 40 },
     "radial": {

--- a/tests/renderer/annotation-reticle.test.mjs
+++ b/tests/renderer/annotation-reticle.test.mjs
@@ -829,6 +829,7 @@ test('Sigil defers Surface Inspector opening out of the radial drag reticle entr
 
 test('Sigil records and recovers delayed radial camera target-surface clicks', () => {
   const source = readFileSync(path.join(repoRoot, 'apps/sigil/renderer/live-modules/main.js'), 'utf8')
+  const dispatchSource = readFileSync(path.join(repoRoot, 'apps/sigil/renderer/live-modules/radial-item-action-dispatch.js'), 'utf8')
 
   assert.match(source, /type: event\.type/)
   assert.match(source, /radialTargetSurfaceReceiptEvidence/)
@@ -836,7 +837,9 @@ test('Sigil records and recovers delayed radial camera target-surface clicks', (
   assert.match(source, /payload\.kind === 'radial_item_pointer_move' \|\| payload\.kind === 'radial_surface_pointer_move'/)
   assert.match(source, /handleLeftMouseUp\(receipt\.worldPoint\.x, receipt\.worldPoint\.y\)/)
   assert.match(source, /payload\.itemId === SIGIL_ANNOTATION_CAMERA_ITEM_ID \|\| payload\.itemAction === 'annotationSnapshot'/)
-  assert.match(source, /requestAnnotationSnapshot\('radial-camera-target-surface-recovery'\)/)
+  assert.match(source, /reason: 'radial-camera-target-surface-recovery'/)
+  assert.match(dispatchSource, /requestAnnotationSnapshot\(reason\)/)
+  assert.match(dispatchSource, /context\.reason === 'radial-camera-target-surface-recovery'/)
   assert.match(source, /host\.post\('canvas_inspector\.capture_bundle', \{[\s\S]*trigger: 'sigil_radial_camera'/)
   assert.match(source, /reason: 'camera-click-after-radial-cleanup'/)
   assert.match(source, /radialTargetSurfaceActive: radialTargetSurface\.snapshot\(\)\.interactive/)

--- a/tests/renderer/radial-item-action-dispatch.test.mjs
+++ b/tests/renderer/radial-item-action-dispatch.test.mjs
@@ -1,0 +1,102 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createSigilRadialItemActionDispatcher } from '../../apps/sigil/renderer/live-modules/radial-item-action-dispatch.js'
+
+function createDispatcherHarness() {
+  const calls = []
+  const dispatcher = createSigilRadialItemActionDispatcher({
+    agentTerminalCanvasId: 'agent-canvas',
+    wikiWorkbenchCanvasId: 'wiki-canvas',
+    wikiPath: 'aos/example.md',
+    getPointer: () => ({ x: 10, y: 11, valid: true }),
+    getAvatarPos: () => ({ x: 88, y: 99, valid: true }),
+    setLastRadialActivation(activation) {
+      calls.push(['last', activation.item_id])
+    },
+    post(type, payload) {
+      calls.push(['post', type, payload.item_id || payload.action || null])
+    },
+    createActivationRequest({ item, input }) {
+      return {
+        item_id: item.id,
+        action: item.action,
+        input_source: input,
+        transition: { preset: 'test' },
+      }
+    },
+    startActivationTransition() {
+      calls.push(['transition'])
+      return true
+    },
+    sendActivationUpdate(activation, phase, extra) {
+      calls.push(['update', phase, extra?.result || extra?.transition || null])
+      return { ...activation, phase }
+    },
+    enterAnnotationReticle(pointer, reason) {
+      calls.push(['reticle', pointer, reason])
+      return { entry_source: reason, active: true }
+    },
+    requestAnnotationSnapshot(reason) {
+      calls.push(['snapshot', reason])
+      return { requested: true, reason }
+    },
+    openContextMenuAt(x, y, options) {
+      calls.push(['context', x, y, options])
+      return true
+    },
+    toggleUtilityCanvas(kind) {
+      calls.push(['toggle', kind])
+      return { visible: true }
+    },
+    openWikiWorkbench(path, activation) {
+      calls.push(['wiki', path, activation.item_id])
+      return Promise.resolve({ visible: true })
+    },
+  })
+  return { calls, dispatcher }
+}
+
+test('radial item dispatcher shares context-menu item behavior between fallback and command handlers', () => {
+  const item = { id: 'context-menu', action: 'contextMenu' }
+  const snapshot = { pointer: { x: 44, y: 55, valid: true } }
+  const { calls, dispatcher } = createDispatcherHarness()
+
+  assert.deepEqual(
+    dispatcher.dispatch(item, snapshot, { input: { kind: 'gesture' } }),
+    { action: 'context_menu_opened', opened: true }
+  )
+  assert.deepEqual(
+    dispatcher.commandHandlers.contextMenuOpen({ x: 1, y: 2, valid: true }, {
+      context: { item, snapshot, input: { kind: 'click' } },
+    }),
+    { action: 'context_menu_opened', opened: true }
+  )
+
+  assert.equal(calls.filter((call) => call[0] === 'context').length, 2)
+  assert.deepEqual(calls.filter((call) => call[0] === 'context').map((call) => call.slice(1, 3)), [
+    [88, 99],
+    [88, 99],
+  ])
+  assert.equal(calls.filter((call) => call[0] === 'post' && call[1] === 'sigil.radial_menu.activation').length, 2)
+})
+
+test('radial item dispatcher routes camera recovery through the same snapshot request command path', () => {
+  const { calls, dispatcher } = createDispatcherHarness()
+
+  assert.deepEqual(
+    dispatcher.commandHandlers.annotationCameraCaptureBundle('ignored', {
+      context: {
+        item: { id: 'annotation-camera', action: 'annotationSnapshot' },
+        reason: 'radial-camera-target-surface-recovery',
+      },
+    }),
+    {
+      action: 'annotation_snapshot_requested',
+      requested: { requested: true, reason: 'radial-camera-target-surface-recovery' },
+    }
+  )
+
+  assert.deepEqual(calls, [
+    ['snapshot', 'radial-camera-target-surface-recovery'],
+  ])
+})

--- a/tests/renderer/sigil-context-menu-input.test.mjs
+++ b/tests/renderer/sigil-context-menu-input.test.mjs
@@ -1,0 +1,69 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  contextMenuOpenCommandOpened,
+  resolveContextMenuRightClickRoute,
+} from '../../apps/sigil/renderer/live-modules/context-menu-input.js'
+
+test('context menu right-click routing suppresses duplicate open echoes before toggle', () => {
+  const calls = []
+  const route = resolveContextMenuRightClickRoute({ type: 'right_mouse_down', x: 10, y: 20 }, {
+    isOpen: true,
+    isDuplicateOpenClick(x, y) {
+      calls.push([x, y])
+      return true
+    },
+  })
+
+  assert.equal(route.handled, true)
+  assert.equal(route.direct, 'duplicate_open_echo')
+  assert.equal(route.command, undefined)
+  assert.deepEqual(route.pointer, { x: 10, y: 20, valid: true })
+  assert.deepEqual(calls, [[10, 20]])
+})
+
+test('context menu right-click routing chooses toggle for non-duplicate open menus', () => {
+  const route = resolveContextMenuRightClickRoute({ type: 'right_mouse_down', x: 12, y: 24 }, {
+    isOpen: true,
+    isDuplicateOpenClick: () => false,
+  })
+
+  assert.equal(route.handled, true)
+  assert.equal(route.command, 'toggle')
+  assert.equal(route.input.nodeId, 'sigil.avatar.context_menu')
+  assert.equal(route.input.mode, 'global')
+  assert.equal(route.input.gesture, 'pointer.right.click')
+  assert.deepEqual(route.pointer, { x: 12, y: 24, valid: true })
+})
+
+test('context menu right-click routing chooses open only with numeric coordinates and closed menu', () => {
+  const open = resolveContextMenuRightClickRoute({ type: 'right_mouse_down', x: 1, y: 2 }, {
+    isOpen: false,
+  })
+  const missingCoordinates = resolveContextMenuRightClickRoute({ type: 'right_mouse_down', x: '1', y: 2 }, {
+    isOpen: false,
+  })
+
+  assert.equal(open.command, 'open')
+  assert.equal(open.input.nodeId, 'sigil.avatar.body')
+  assert.equal(open.input.mode, 'idle')
+  assert.equal(open.input.gesture, 'pointer.right.click')
+  assert.deepEqual(open.pointer, { x: 1, y: 2, valid: true })
+  assert.equal(missingCoordinates.direct, 'right_click_away')
+  assert.equal(missingCoordinates.command, undefined)
+})
+
+test('context menu right-click routing treats rejected open commands as right-click-away fallback', () => {
+  assert.equal(contextMenuOpenCommandOpened({
+    executed: true,
+    handler_result: true,
+  }), true)
+  assert.equal(contextMenuOpenCommandOpened({
+    executed: true,
+    handler_result: false,
+  }), false)
+  assert.equal(contextMenuOpenCommandOpened({
+    executed: false,
+    reason: 'handler_not_registered',
+  }), false)
+})

--- a/tests/renderer/sigil-ux-tree-command-registry.test.mjs
+++ b/tests/renderer/sigil-ux-tree-command-registry.test.mjs
@@ -2,6 +2,7 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { createSigilUxTree } from '../../apps/sigil/renderer/live-modules/ux-tree.js'
 import {
+  SIGIL_CONTEXT_MENU_COMMAND_INPUTS,
   SIGIL_SELECTION_MODE_COMMAND_INPUTS,
   SIGIL_SELECTION_MODE_ESCAPE_COMMAND_INPUT,
   createSigilUxTreeCommandRegistry,
@@ -69,6 +70,65 @@ test('Sigil UX command adapter reports missing handler without executing', () =>
   assert.equal(result.matched, true)
   assert.equal(result.executed, false)
   assert.equal(result.command_id, 'sigil.selection_mode.cancel')
+  assert.equal(result.reason, 'handler_not_registered')
+  assert.equal(result.errors[0].code, 'command.handler.missing')
+})
+
+test('Sigil UX command adapter executes context menu open handler with pointer context', () => {
+  const pointer = { x: 44, y: 55, valid: true }
+  let seenPointer = null
+  const registry = createSigilUxTreeCommandRegistry({
+    contextMenuOpen(nextPointer) {
+      seenPointer = nextPointer
+      return true
+    },
+  })
+
+  const result = executeSigilUxTreeCommand(createSigilUxTree(), {
+    input: SIGIL_CONTEXT_MENU_COMMAND_INPUTS.open,
+    registry,
+    context: { pointer },
+  })
+
+  assert.equal(seenPointer, pointer)
+  assert.equal(result.command_id, 'sigil.context_menu.open')
+  assert.equal(result.binding_id, 'sigil.avatar.context_menu.right_click')
+  assert.equal(result.executed, true)
+  assert.equal(result.handler_result, true)
+})
+
+test('Sigil UX command adapter executes context menu toggle handler with pointer context', () => {
+  const pointer = { x: 66, y: 77, valid: true }
+  let seenPointer = null
+  const registry = createSigilUxTreeCommandRegistry({
+    contextMenuToggle(nextPointer) {
+      seenPointer = nextPointer
+      return { closed: true }
+    },
+  })
+
+  const result = executeSigilUxTreeCommand(createSigilUxTree(), {
+    input: SIGIL_CONTEXT_MENU_COMMAND_INPUTS.toggle,
+    registry,
+    context: { pointer },
+  })
+
+  assert.equal(seenPointer, pointer)
+  assert.equal(result.command_id, 'sigil.context_menu.toggle')
+  assert.equal(result.binding_id, 'sigil.avatar.context_menu.right_click_toggle')
+  assert.equal(result.executed, true)
+  assert.deepEqual(result.handler_result, { closed: true })
+})
+
+test('Sigil UX command adapter reports missing context menu handler without executing', () => {
+  const result = executeSigilUxTreeCommand(createSigilUxTree(), {
+    input: SIGIL_CONTEXT_MENU_COMMAND_INPUTS.open,
+    registry: createSigilUxTreeCommandRegistry(),
+  })
+
+  assert.equal(result.matched, true)
+  assert.equal(result.executed, false)
+  assert.equal(result.command_id, 'sigil.context_menu.open')
   assert.equal(result.reason, 'handler_not_registered')
   assert.equal(result.errors[0].code, 'command.handler.missing')
 })

--- a/tests/renderer/sigil-ux-tree-command-registry.test.mjs
+++ b/tests/renderer/sigil-ux-tree-command-registry.test.mjs
@@ -2,7 +2,9 @@ import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { createSigilUxTree } from '../../apps/sigil/renderer/live-modules/ux-tree.js'
 import {
+  SIGIL_AVATAR_COMMAND_INPUTS,
   SIGIL_CONTEXT_MENU_COMMAND_INPUTS,
+  SIGIL_RADIAL_COMMAND_INPUTS,
   SIGIL_SELECTION_MODE_COMMAND_INPUTS,
   SIGIL_SELECTION_MODE_ESCAPE_COMMAND_INPUT,
   createSigilUxTreeCommandRegistry,
@@ -390,4 +392,102 @@ test('Sigil UX command adapter reports missing Selection Mode commit handler wit
   assert.equal(result.command_id, 'sigil.selection_mode.commit')
   assert.equal(result.reason, 'handler_not_registered')
   assert.equal(result.errors[0].code, 'command.handler.missing')
+})
+
+test('Sigil UX command adapter executes avatar press, GOTO, radial begin, and Selection Mode entry handlers', () => {
+  const calls = []
+  const registry = createSigilUxTreeCommandRegistry({
+    avatarPressBegin(pointer) {
+      calls.push(['press', pointer])
+      return { state: 'PRESS' }
+    },
+    avatarGotoBegin(pointer) {
+      calls.push(['goto', pointer])
+      return { state: 'GOTO' }
+    },
+    radialBegin(pointer) {
+      calls.push(['radial', pointer])
+      return { state: 'RADIAL' }
+    },
+    selectionModeEnter(pointer) {
+      calls.push(['selection', pointer])
+      return { active: true }
+    },
+  })
+  const pointer = { x: 10, y: 20, valid: true }
+  const cases = [
+    [SIGIL_AVATAR_COMMAND_INPUTS.pressBegin, 'sigil.avatar.press.begin', 'sigil.avatar.press.left_press'],
+    [SIGIL_AVATAR_COMMAND_INPUTS.gotoBegin, 'sigil.avatar.goto.begin', 'sigil.avatar.goto.left_release'],
+    [SIGIL_AVATAR_COMMAND_INPUTS.radialBegin, 'sigil.radial.begin', 'sigil.avatar.radial.drag_threshold'],
+    [SIGIL_AVATAR_COMMAND_INPUTS.selectionModeEnter, 'sigil.selection_mode.enter', 'sigil.avatar.selection_mode.double_click'],
+  ]
+
+  for (const [input, commandId, bindingId] of cases) {
+    const result = executeSigilUxTreeCommand(createSigilUxTree(), {
+      input,
+      registry,
+      context: { pointer },
+    })
+    assert.equal(result.executed, true)
+    assert.equal(result.command_id, commandId)
+    assert.equal(result.binding_id, bindingId)
+  }
+  assert.deepEqual(calls.map(([name]) => name), ['press', 'goto', 'radial', 'selection'])
+  assert.deepEqual(calls.map(([, seenPointer]) => seenPointer), [pointer, pointer, pointer, pointer])
+})
+
+test('Sigil UX command adapter routes radial item actions through their command handlers', () => {
+  const calls = []
+  const registry = createSigilUxTreeCommandRegistry({
+    contextMenuOpen(pointer, payload) {
+      calls.push(['context', pointer, payload.context.item.id])
+      return { opened: true }
+    },
+    agentTerminalOpen(kind, payload) {
+      calls.push(['agent', kind, payload.context.item.id])
+      return { canvas: 'agent-terminal' }
+    },
+    annotationReticleEnter(pointer, payload) {
+      calls.push(['reticle', pointer, payload.context.item.id])
+      return { active: true }
+    },
+    annotationCameraCaptureBundle(reason, payload) {
+      calls.push(['camera', reason, payload.context.item.id])
+      return { captured: true }
+    },
+    wikiGraphOpen(path, payload) {
+      calls.push(['wiki', path, payload.context.item.id])
+      return { canvas: 'wiki' }
+    },
+  })
+  const pointer = { x: 33, y: 44, valid: true }
+  const cases = [
+    ['context-menu', 'sigil.context_menu.open'],
+    ['agent-terminal', 'sigil.agent_terminal.open'],
+    ['annotation-mode', 'sigil.annotation_reticle.enter'],
+    ['annotation-camera', 'sigil.annotation_camera.capture_bundle'],
+    ['wiki-graph', 'sigil.wiki_graph.open'],
+  ]
+
+  for (const [itemId, commandId] of cases) {
+    const result = executeSigilUxTreeCommand(createSigilUxTree({
+      state: {
+        annotationReticle: { camera_available: true, live_anchor_count: 1 },
+      },
+    }), {
+      input: SIGIL_RADIAL_COMMAND_INPUTS.itemRelease(itemId),
+      registry,
+      context: {
+        pointer,
+        item: { id: itemId },
+        reason: 'test-camera',
+        path: 'aos/test.md',
+      },
+    })
+    assert.equal(result.executed, true, itemId)
+    assert.equal(result.command_id, commandId, itemId)
+    assert.equal(result.binding_id, `sigil.radial.item.release.${itemId}`, itemId)
+  }
+
+  assert.deepEqual(calls.map(([kind]) => kind), ['context', 'agent', 'reticle', 'camera', 'wiki'])
 })

--- a/tests/renderer/sigil-ux-tree-readiness.test.mjs
+++ b/tests/renderer/sigil-ux-tree-readiness.test.mjs
@@ -4,6 +4,10 @@ import { createSigilUxTree } from '../../apps/sigil/renderer/live-modules/ux-tre
 import { createSigilUxTreeCommandRegistry } from '../../apps/sigil/renderer/live-modules/ux-tree-command-registry.js'
 import { createSigilUxTreeReadinessAudit } from '../../apps/sigil/renderer/live-modules/ux-tree-readiness.js'
 
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value))
+}
+
 function completeRegistry() {
   return createSigilUxTreeCommandRegistry({
     avatarPressBegin() {},
@@ -53,6 +57,66 @@ test('Sigil UX tree readiness audit proves command handlers, routed bindings, me
   assert.ok(relationIds.has('sigil.avatar.body.triggers_radial_menu'))
   assert.ok(relationIds.has('sigil.avatar.anchors_radial_menu'))
   assert.ok(relationIds.has('sigil.avatar.radial_menu.targets_items'))
+})
+
+test('Sigil UX tree readiness audit fails closed for invalid tree validation', () => {
+  const tree = cloneJson(createSigilUxTree())
+  tree.validation = {
+    ok: false,
+    errors: [{ code: 'tree.invalid', message: 'test invalid tree', path: '/test' }],
+  }
+
+  const audit = createSigilUxTreeReadinessAudit(tree, {
+    registry: completeRegistry(),
+  })
+
+  assert.equal(audit.ok, false)
+  assert.equal(audit.summary.validation_errors, 1)
+  assert.ok(audit.failures.some((failure) => (
+    failure.kind === 'validation'
+      && failure.code === 'tree.invalid'
+      && failure.path === '/test'
+  )))
+})
+
+test('Sigil UX tree readiness audit fails closed for routed bindings with missing commands', () => {
+  const tree = cloneJson(createSigilUxTree())
+  tree.validation = { ok: true, errors: [] }
+  tree.commands = tree.commands.filter((command) => command.id !== 'sigil.context_menu.open')
+
+  const audit = createSigilUxTreeReadinessAudit(tree, {
+    registry: completeRegistry(),
+  })
+
+  assert.equal(audit.ok, false)
+  assert.ok(audit.summary.validation_errors > 0)
+  assert.ok(audit.summary.bindings_routed_missing_command > 0)
+  assert.ok(audit.failures.some((failure) => (
+    failure.kind === 'binding'
+      && failure.id === 'sigil.avatar.context_menu.right_click'
+      && failure.command_id === 'sigil.context_menu.open'
+  )))
+})
+
+test('Sigil UX tree readiness audit fails closed for invalid relation topology', () => {
+  const tree = cloneJson(createSigilUxTree())
+  tree.validation = { ok: true, errors: [] }
+  tree.relations = tree.relations.map((relation) => relation.id === 'sigil.avatar.anchors_radial_menu'
+    ? {
+        ...relation,
+        to_node_id: 'sigil.missing.radial_menu',
+      }
+    : relation)
+
+  const audit = createSigilUxTreeReadinessAudit(tree, {
+    registry: completeRegistry(),
+  })
+
+  assert.equal(audit.ok, false)
+  assert.ok(audit.failures.some((failure) => (
+    failure.kind === 'validation'
+      && failure.code === 'relation.to_node_ref'
+  )))
 })
 
 test('Sigil UX tree readiness audit fails closed for unregistered commands and unclassified bindings', () => {

--- a/tests/renderer/sigil-ux-tree-readiness.test.mjs
+++ b/tests/renderer/sigil-ux-tree-readiness.test.mjs
@@ -1,0 +1,79 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createSigilUxTree } from '../../apps/sigil/renderer/live-modules/ux-tree.js'
+import { createSigilUxTreeCommandRegistry } from '../../apps/sigil/renderer/live-modules/ux-tree-command-registry.js'
+import { createSigilUxTreeReadinessAudit } from '../../apps/sigil/renderer/live-modules/ux-tree-readiness.js'
+
+function completeRegistry() {
+  return createSigilUxTreeCommandRegistry({
+    avatarPressBegin() {},
+    avatarGotoBegin() {},
+    radialBegin() {},
+    radialReleaseItem() {},
+    selectionModeEnter() {},
+    selectionModeCancel() {},
+    selectionModeCommit() {},
+    selectionModeCycleTarget() {},
+    selectionModeAcquire() {},
+    contextMenuOpen() {},
+    contextMenuToggle() {},
+    annotationReticleEnter() {},
+    annotationCameraCaptureBundle() {},
+    wikiGraphOpen() {},
+    agentTerminalOpen() {},
+  })
+}
+
+test('Sigil UX tree readiness audit proves command handlers, routed bindings, mechanics, and relations', () => {
+  const tree = createSigilUxTree()
+  const audit = createSigilUxTreeReadinessAudit(tree, {
+    registry: completeRegistry(),
+  })
+
+  assert.equal(audit.schema, 'sigil_ux_tree_readiness_audit')
+  assert.equal(audit.ok, true)
+  assert.equal(audit.failures.length, 0)
+  assert.equal(audit.summary.commands_total, tree.commands.length)
+  assert.equal(audit.summary.commands_registered, tree.commands.length)
+  assert.equal(audit.summary.bindings_total, tree.bindings.length)
+  assert.equal(audit.summary.bindings_routed, tree.bindings.length)
+  assert.equal(audit.summary.bindings_unclassified, 0)
+
+  const commandStatuses = new Map(audit.commandCoverage.map((entry) => [entry.id, entry.status]))
+  for (const command of tree.commands) {
+    assert.equal(commandStatuses.get(command.id), 'registered_runtime_handler', command.id)
+  }
+
+  const mechanicIds = new Set(audit.directRuntimeMechanics.map((entry) => entry.id))
+  assert.ok(mechanicIds.has('sigil.radial.pointer_tracking'))
+  assert.ok(mechanicIds.has('sigil.selection_mode.entry_release'))
+  assert.ok(mechanicIds.has('sigil.context_menu.duplicate_echo'))
+
+  const relationIds = new Set(audit.relationTopology.map((entry) => entry.id))
+  assert.ok(relationIds.has('sigil.avatar.body.triggers_radial_menu'))
+  assert.ok(relationIds.has('sigil.avatar.anchors_radial_menu'))
+  assert.ok(relationIds.has('sigil.avatar.radial_menu.targets_items'))
+})
+
+test('Sigil UX tree readiness audit fails closed for unregistered commands and unclassified bindings', () => {
+  const tree = createSigilUxTree()
+  const audit = createSigilUxTreeReadinessAudit({
+    ...tree,
+    bindings: [
+      ...tree.bindings,
+      {
+        id: 'sigil.test.unclassified',
+        node_id: 'sigil.avatar.body',
+        mode: 'idle',
+        gesture: 'pointer.middle.click',
+        command_id: 'sigil.context_menu.open',
+      },
+    ],
+  }, {
+    registry: {},
+  })
+
+  assert.equal(audit.ok, false)
+  assert.ok(audit.failures.some((failure) => failure.kind === 'command' && failure.id === 'sigil.context_menu.open'))
+  assert.ok(audit.failures.some((failure) => failure.kind === 'binding' && failure.id === 'sigil.test.unclassified'))
+})

--- a/tests/renderer/sigil-ux-tree.test.mjs
+++ b/tests/renderer/sigil-ux-tree.test.mjs
@@ -73,6 +73,11 @@ test('Sigil shadow resolver maps avatar and Selection Mode gestures to current c
     gesture: 'pointer.right.click',
   }), 'sigil.context_menu.open')
   assert.equal(commandFor({
+    nodeId: 'sigil.avatar.context_menu',
+    mode: 'global',
+    gesture: 'pointer.right.click',
+  }), 'sigil.context_menu.toggle')
+  assert.equal(commandFor({
     nodeId: 'sigil.avatar.body',
     mode: 'goto',
     gesture: 'pointer.left.double_click',

--- a/tests/renderer/sigil-ux-tree.test.mjs
+++ b/tests/renderer/sigil-ux-tree.test.mjs
@@ -66,6 +66,45 @@ test('Sigil UX tree represents current command allowlist and plain radial settin
   assert.equal(typeof tree.commands[0].handler_ref, 'string')
 })
 
+test('Sigil UX tree exposes generic trigger, open, anchor, and target relations', () => {
+  const tree = createSigilUxTree()
+  const relations = new Map(tree.relations.map((relation) => [relation.id, relation]))
+
+  assert.equal(tree.validation.ok, true)
+  assert.deepEqual(relations.get('sigil.avatar.body.opens_context_menu'), {
+    id: 'sigil.avatar.body.opens_context_menu',
+    relation_type: 'opens',
+    from_node_id: 'sigil.avatar.body',
+    to_node_id: 'sigil.avatar.context_menu',
+    source_metadata: {
+      source: 'apps/sigil/renderer/live-modules/context-menu-input.js',
+      binding_id: 'sigil.avatar.context_menu.right_click',
+      command_id: 'sigil.context_menu.open',
+    },
+    metadata: {
+      gesture: 'pointer.right.click',
+    },
+  })
+  assert.equal(relations.get('sigil.avatar.body.triggers_radial_menu').relation_type, 'triggers')
+  assert.equal(relations.get('sigil.avatar.body.triggers_radial_menu').to_node_id, 'sigil.avatar.radial_menu')
+  assert.equal(relations.get('sigil.avatar.body.triggers_selection_mode').to_node_id, 'sigil.avatar.selection_mode')
+  assert.equal(relations.get('sigil.avatar.anchors_radial_menu').from_node_id, 'sigil.avatar')
+  assert.equal(relations.get('sigil.avatar.body.anchors_context_menu').relation_type, 'anchors')
+  assert.equal(relations.get('sigil.avatar.radial_menu.targets_items').to_node_id, 'sigil.avatar.radial_menu.item.*')
+  assert.equal(
+    relations.get('sigil.avatar.radial_menu.targets_items').metadata.target_surface.hit_source_ref,
+    'radialTargetSurface',
+  )
+  assert.equal(
+    relations.get('sigil.avatar.context_menu.targets_input_region').metadata.target_surface.hit_source_ref,
+    'sigil-context-menu-input-region',
+  )
+  assert.equal(
+    relations.get('sigil.avatar.selection_mode.targets_input_region').metadata.target_surface.hit_source_ref,
+    'sigil-selection-mode-input-region',
+  )
+})
+
 test('Sigil shadow resolver maps avatar and Selection Mode gestures to current command IDs', () => {
   assert.equal(commandFor({
     nodeId: 'sigil.avatar.body',

--- a/tests/renderer/sigil-ux-tree.test.mjs
+++ b/tests/renderer/sigil-ux-tree.test.mjs
@@ -46,6 +46,7 @@ test('Sigil UX tree represents current command allowlist and plain radial settin
   for (const id of [
     'sigil.context_menu.open',
     'sigil.context_menu.toggle',
+    'sigil.avatar.press.begin',
     'sigil.avatar.goto.begin',
     'sigil.radial.begin',
     'sigil.radial.release_item',
@@ -116,6 +117,16 @@ test('Sigil shadow resolver maps avatar and Selection Mode gestures to current c
     mode: 'global',
     gesture: 'pointer.right.click',
   }), 'sigil.context_menu.toggle')
+  assert.equal(commandFor({
+    nodeId: 'sigil.avatar.body',
+    mode: 'idle',
+    gesture: 'pointer.left.press',
+  }), 'sigil.avatar.press.begin')
+  assert.equal(commandFor({
+    nodeId: 'sigil.avatar.body',
+    mode: 'press',
+    gesture: 'pointer.left.release',
+  }), 'sigil.avatar.goto.begin')
   assert.equal(commandFor({
     nodeId: 'sigil.avatar.body',
     mode: 'goto',

--- a/tests/toolkit/controls-button-group.test.mjs
+++ b/tests/toolkit/controls-button-group.test.mjs
@@ -54,3 +54,23 @@ test('createButtonGroup exposes a UX tree fragment for current selected value', 
   assert.equal(optionNode.metadata.state.selected, true);
   assert.deepEqual(fragment.relations.map((relation) => relation.relation_type), ['owns', 'owns', 'owns']);
 });
+
+test('button group UX tree selection matches pressed DOM state for string-equivalent values', () => {
+  const document = createFakeDocument();
+  const group = createButtonGroup({
+    document,
+    id: 'numeric',
+    options: [{ value: 1, label: 'One' }],
+    value: 1,
+  });
+
+  group.setValue('1', { emit: false });
+
+  const button = group.el.querySelectorAll('button')[0];
+  const fragment = group.getUxTreeFragment();
+  const optionNode = fragment.nodes.find((node) => node.id === 'numeric.1');
+
+  assert.equal(button.getAttribute('aria-pressed'), 'true');
+  assert.equal(optionNode.metadata.state.selected, true);
+  assert.equal(optionNode.metadata.state.selected, button.getAttribute('aria-pressed') === 'true');
+});

--- a/tests/toolkit/controls-button-group.test.mjs
+++ b/tests/toolkit/controls-button-group.test.mjs
@@ -16,6 +16,7 @@ test('createButtonGroup returns shape and reflects initial value', () => {
 
   assert.equal(typeof group.getValue, 'function');
   assert.equal(typeof group.setValue, 'function');
+  assert.equal(typeof group.getUxTreeFragment, 'function');
   assert.equal(typeof group.on, 'function');
   assert.equal(typeof group.destroy, 'function');
   assert.equal(buttons[1].getAttribute('aria-pressed'), 'true');
@@ -36,4 +37,20 @@ test('button group setValue and keyboard navigation update value', () => {
   buttons[1].dispatchEvent(new FakeEvent('keydown', { key: 'ArrowRight' }));
   assert.equal(group.getValue(), 'c');
   assert.equal(buttons[2].getAttribute('aria-pressed'), 'true');
+});
+
+test('createButtonGroup exposes a UX tree fragment for current selected value', () => {
+  const document = createFakeDocument();
+  const group = createButtonGroup({ document, id: 'view-mode', label: 'View Mode', options, value: 'a' });
+
+  group.setValue('c', { emit: false });
+
+  const fragment = group.getUxTreeFragment();
+  const optionNode = fragment.nodes.find((node) => node.id === 'view-mode.c');
+
+  assert.equal(fragment.validation.ok, true);
+  assert.equal(fragment.nodes[0].id, 'view-mode');
+  assert.equal(fragment.nodes[0].metadata.state.value, 'c');
+  assert.equal(optionNode.metadata.state.selected, true);
+  assert.deepEqual(fragment.relations.map((relation) => relation.relation_type), ['owns', 'owns', 'owns']);
 });

--- a/tests/toolkit/controls-button-group.test.mjs
+++ b/tests/toolkit/controls-button-group.test.mjs
@@ -74,3 +74,36 @@ test('button group UX tree selection matches pressed DOM state for string-equiva
   assert.equal(optionNode.metadata.state.selected, true);
   assert.equal(optionNode.metadata.state.selected, button.getAttribute('aria-pressed') === 'true');
 });
+
+test('button group disabled options match DOM state and are skipped by user selection', () => {
+  const document = createFakeDocument();
+  const group = createButtonGroup({
+    document,
+    id: 'mode',
+    options: [
+      { value: 'edit', label: 'Edit' },
+      { value: 'preview', label: 'Preview', disabled: true },
+      { value: 'diff', label: 'Diff' },
+    ],
+    value: 'edit',
+  });
+  const changes = [];
+  group.on('change', (value) => changes.push(value));
+
+  const buttons = group.el.querySelectorAll('button');
+  buttons[1].dispatchEvent(new FakeEvent('click'));
+  assert.equal(group.getValue(), 'edit');
+  assert.deepEqual(changes, []);
+
+  buttons[0].dispatchEvent(new FakeEvent('keydown', { key: 'ArrowRight' }));
+  assert.equal(group.getValue(), 'diff');
+  assert.deepEqual(changes, ['diff']);
+
+  const fragment = group.getUxTreeFragment();
+  const disabledNode = fragment.nodes.find((node) => node.id === 'mode.preview');
+
+  assert.equal(buttons[1].disabled, true);
+  assert.equal(buttons[1].getAttribute('aria-disabled'), 'true');
+  assert.equal(disabledNode.metadata.state.disabled, buttons[1].disabled);
+  assert.equal(disabledNode.metadata.state.selected, false);
+});

--- a/tests/toolkit/controls-button.test.mjs
+++ b/tests/toolkit/controls-button.test.mjs
@@ -10,6 +10,7 @@ test('createButton returns shape and button element with variant class', () => {
   assert.equal(button.el.tagName, 'BUTTON');
   assert.equal(typeof button.setLabel, 'function');
   assert.equal(typeof button.setDisabled, 'function');
+  assert.equal(typeof button.getUxTreeFragment, 'function');
   assert.equal(typeof button.on, 'function');
   assert.equal(typeof button.destroy, 'function');
   assert.equal(button.el.classList.contains('aos-button'), true);
@@ -33,6 +34,26 @@ test('createButton toggles disabled attribute and click listeners', () => {
   button.el.dispatchEvent(new FakeEvent('click'));
   assert.equal(clicks, 1);
   button.destroy();
+});
+
+test('createButton exposes a UX tree fragment for current label and disabled state', () => {
+  const document = createFakeDocument();
+  const button = createButton({ document, id: 'save-button', label: 'Save', disabled: false });
+
+  button.setLabel('Save As');
+  button.setDisabled(true);
+
+  const fragment = button.getUxTreeFragment();
+
+  assert.equal(fragment.validation.ok, true);
+  assert.equal(fragment.nodes[0].id, 'save-button');
+  assert.equal(fragment.nodes[0].label, 'Save As');
+  assert.equal(fragment.nodes[0].metadata.state.disabled, true);
+  assert.deepEqual(fragment.bindings.map((binding) => binding.gesture), [
+    'pointer.left.click',
+    'keyboard.enter',
+    'keyboard.space',
+  ]);
 });
 
 test('createButton stamps DOM metadata used by component render paths', () => {

--- a/tests/toolkit/controls-toggle.test.mjs
+++ b/tests/toolkit/controls-toggle.test.mjs
@@ -34,6 +34,17 @@ test('createToggle exposes a UX tree fragment for current checked state', () => 
   assert.equal(fragment.commands[0].handler_ref, 'toolkit.controls.toggle.change');
 });
 
+test('createToggle honors disabled config in DOM and UX tree state', () => {
+  const document = createFakeDocument();
+  const toggle = createToggle({ document, id: 'readonly-toggle', label: 'Read Only', disabled: true });
+  const input = toggle.el.querySelector('input');
+
+  const fragment = toggle.getUxTreeFragment();
+
+  assert.equal(input.disabled, true);
+  assert.equal(fragment.nodes[0].metadata.state.disabled, true);
+});
+
 test('toggle change fires from underlying input', () => {
   const document = createFakeDocument();
   const toggle = createToggle({ document, checked: false });

--- a/tests/toolkit/controls-toggle.test.mjs
+++ b/tests/toolkit/controls-toggle.test.mjs
@@ -9,6 +9,7 @@ test('createToggle returns shape and tracks value', () => {
 
   assert.equal(typeof toggle.getValue, 'function');
   assert.equal(typeof toggle.setValue, 'function');
+  assert.equal(typeof toggle.getUxTreeFragment, 'function');
   assert.equal(typeof toggle.on, 'function');
   assert.equal(typeof toggle.destroy, 'function');
   assert.equal(toggle.getValue(), true);
@@ -16,6 +17,21 @@ test('createToggle returns shape and tracks value', () => {
   assert.equal(toggle.getValue(), false);
   toggle.setValue(true);
   assert.equal(toggle.getValue(), true);
+});
+
+test('createToggle exposes a UX tree fragment for current checked state', () => {
+  const document = createFakeDocument();
+  const toggle = createToggle({ document, id: 'snap-toggle', label: 'Snap', checked: false });
+
+  toggle.setValue(true);
+
+  const fragment = toggle.getUxTreeFragment();
+
+  assert.equal(fragment.validation.ok, true);
+  assert.equal(fragment.nodes[0].id, 'snap-toggle');
+  assert.equal(fragment.nodes[0].label, 'Snap');
+  assert.equal(fragment.nodes[0].metadata.state.checked, true);
+  assert.equal(fragment.commands[0].handler_ref, 'toolkit.controls.toggle.change');
 });
 
 test('toggle change fires from underlying input', () => {

--- a/tests/toolkit/controls-ux-tree.test.mjs
+++ b/tests/toolkit/controls-ux-tree.test.mjs
@@ -12,6 +12,13 @@ function assertJsonOnly(value) {
   assert.deepEqual(JSON.parse(JSON.stringify(value)), value);
 }
 
+function assertSourceRefs(value, expected) {
+  assert.deepEqual(value.source_refs, [
+    expected,
+    { id: 'toolkit-controls-ux-tree', kind: 'source', ref: 'packages/toolkit/controls/ux-tree.js' },
+  ]);
+}
+
 test('button UX tree fragment describes activation gestures without runtime callbacks', () => {
   const fragment = createButtonUxTreeFragment({
     id: 'save-button',
@@ -23,6 +30,7 @@ test('button UX tree fragment describes activation gestures without runtime call
   });
 
   assert.equal(fragment.validation.ok, true);
+  assertSourceRefs(fragment, { id: 'toolkit-controls-button', kind: 'source', ref: 'packages/toolkit/controls/button.js' });
   assert.equal(fragment.metadata.runtime_state, CONTROL_UX_TREE_RUNTIME_STATE);
   assert.deepEqual(fragment.nodes.map((node) => node.id), ['save-button']);
   assert.equal(fragment.nodes[0].metadata.state.disabled, true);
@@ -47,6 +55,7 @@ test('toggle UX tree fragment describes change gestures and current state as dat
   });
 
   assert.equal(fragment.validation.ok, true);
+  assertSourceRefs(fragment, { id: 'toolkit-controls-toggle', kind: 'source', ref: 'packages/toolkit/controls/toggle.js' });
   assert.equal(fragment.nodes[0].role, 'switch');
   assert.deepEqual(fragment.nodes[0].metadata.state, {
     checked: true,
@@ -75,6 +84,7 @@ test('segmented button group UX tree fragment owns option nodes and maps select/
   });
 
   assert.equal(fragment.validation.ok, true);
+  assertSourceRefs(fragment, { id: 'toolkit-controls-button-group', kind: 'source', ref: 'packages/toolkit/controls/button-group.js' });
   assert.deepEqual(fragment.nodes.map((node) => node.id), [
     'view-mode',
     'view-mode.edit',

--- a/tests/toolkit/controls-ux-tree.test.mjs
+++ b/tests/toolkit/controls-ux-tree.test.mjs
@@ -1,0 +1,112 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  CONTROL_UX_TREE_RUNTIME_STATE,
+  createButtonGroupUxTreeFragment,
+  createButtonUxTreeFragment,
+  createToggleUxTreeFragment,
+} from '../../packages/toolkit/controls/index.js';
+import { uxTreeBindingsForGesture, uxTreeRelationsByType } from '../../packages/toolkit/runtime/ux-tree.js';
+
+function assertJsonOnly(value) {
+  assert.deepEqual(JSON.parse(JSON.stringify(value)), value);
+}
+
+test('button UX tree fragment describes activation gestures without runtime callbacks', () => {
+  const fragment = createButtonUxTreeFragment({
+    id: 'save-button',
+    label: 'Save',
+    variant: 'primary',
+    disabled: true,
+    onClick() {},
+    document: { createElement() {} },
+  });
+
+  assert.equal(fragment.validation.ok, true);
+  assert.equal(fragment.metadata.runtime_state, CONTROL_UX_TREE_RUNTIME_STATE);
+  assert.deepEqual(fragment.nodes.map((node) => node.id), ['save-button']);
+  assert.equal(fragment.nodes[0].metadata.state.disabled, true);
+  assert.equal(fragment.commands[0].handler_ref, 'toolkit.controls.button.activate');
+  assert.deepEqual(fragment.bindings.map((binding) => binding.gesture), [
+    'pointer.left.click',
+    'keyboard.enter',
+    'keyboard.space',
+  ]);
+  assertJsonOnly(fragment);
+  assert.doesNotMatch(JSON.stringify(fragment), /onClick|createElement/);
+});
+
+test('toggle UX tree fragment describes change gestures and current state as data', () => {
+  const fragment = createToggleUxTreeFragment({
+    id: 'snap-toggle',
+    label: 'Snap',
+    checked: true,
+    disabled: false,
+    name: 'snap',
+    onChange() {},
+  });
+
+  assert.equal(fragment.validation.ok, true);
+  assert.equal(fragment.nodes[0].role, 'switch');
+  assert.deepEqual(fragment.nodes[0].metadata.state, {
+    checked: true,
+    disabled: false,
+    name: 'snap',
+  });
+  assert.equal(fragment.commands[0].id, 'snap-toggle.toggle');
+  assert.equal(fragment.commands[0].handler_ref, 'toolkit.controls.toggle.change');
+  assert.deepEqual(fragment.bindings.map((binding) => binding.gesture), [
+    'pointer.left.click',
+    'keyboard.space',
+  ]);
+  assertJsonOnly(fragment);
+});
+
+test('segmented button group UX tree fragment owns option nodes and maps select/navigation gestures', () => {
+  const fragment = createButtonGroupUxTreeFragment({
+    id: 'view-mode',
+    label: 'View Mode',
+    value: 'preview',
+    options: [
+      { value: 'edit', label: 'Edit' },
+      { value: 'preview', label: 'Preview' },
+      { value: 'diff', label: 'Diff', danger: true },
+    ],
+  });
+
+  assert.equal(fragment.validation.ok, true);
+  assert.deepEqual(fragment.nodes.map((node) => node.id), [
+    'view-mode',
+    'view-mode.edit',
+    'view-mode.preview',
+    'view-mode.diff',
+  ]);
+  assert.deepEqual(fragment.nodes[0].children, ['view-mode.edit', 'view-mode.preview', 'view-mode.diff']);
+  assert.equal(fragment.nodes[2].metadata.state.selected, true);
+  assert.equal(fragment.commands.find((command) => command.id === 'view-mode.preview.select').parameters.value, 'preview');
+  assert.deepEqual(uxTreeRelationsByType(fragment, 'owns').map((relation) => relation.to_node_id), [
+    'view-mode.edit',
+    'view-mode.preview',
+    'view-mode.diff',
+  ]);
+  assert.deepEqual(uxTreeBindingsForGesture(fragment, {
+    nodeId: 'view-mode.preview',
+    gesture: 'pointer.left.click',
+  }).map((binding) => binding.command_id), ['view-mode.preview.select']);
+  assert.deepEqual(uxTreeBindingsForGesture(fragment, {
+    nodeId: 'view-mode.preview',
+    gesture: 'keyboard.arrow_right',
+  }).map((binding) => binding.command_id), ['view-mode.select_next']);
+  assert.deepEqual(uxTreeBindingsForGesture(fragment, {
+    nodeId: 'view-mode.preview',
+    gesture: 'keyboard.arrow_left',
+  }).map((binding) => binding.command_id), ['view-mode.select_previous']);
+  assertJsonOnly(fragment);
+});
+
+test('control UX tree helpers reject unsafe handler refs', () => {
+  assert.throws(
+    () => createButtonUxTreeFragment({ id: 'unsafe', uxHandlerRef: 'alert(1)' }),
+    /allowlisted reference/,
+  );
+});

--- a/tests/toolkit/runtime-ux-tree.test.mjs
+++ b/tests/toolkit/runtime-ux-tree.test.mjs
@@ -3,9 +3,12 @@ import assert from 'node:assert/strict'
 import {
   createUxTree,
   mergeUxTreeDefinitions,
+  normalizeUxTreeRelation,
   resolveUxTree,
   uxTreeBindingsForGesture,
   uxTreeCommandById,
+  uxTreeRelationsByType,
+  uxTreeRelationsForNode,
 } from '../../packages/toolkit/runtime/ux-tree.js'
 
 function baseTree() {
@@ -61,6 +64,17 @@ function baseTree() {
         consume_policy: 'observe',
       },
     ],
+    relations: [
+      {
+        id: 'avatar.opens.menu',
+        relation_type: 'opens',
+        from_node_id: 'avatar',
+        to_node_id: 'menu',
+        metadata: {
+          gesture: 'pointer.right.click',
+        },
+      },
+    ],
     settings: {
       radial: {
         geometry: { menuRadius: 1.8 },
@@ -75,6 +89,7 @@ test('createUxTree normalizes data and surfaces valid references', () => {
   assert.equal(tree.version, '0.1.0')
   assert.equal(tree.validation.ok, true)
   assert.deepEqual(tree.nodes.map((node) => node.id), ['avatar', 'menu'])
+  assert.deepEqual(tree.relations.map((relation) => relation.id), ['avatar.opens.menu'])
   assert.equal(uxTreeCommandById(tree, 'menu.open').handler_ref, 'menu.open')
 })
 
@@ -90,6 +105,10 @@ test('mergeUxTreeDefinitions deep-merges settings and merges stable arrays by id
     bindings: [
       { id: 'avatar.right', priority: 20 },
     ],
+    relations: [
+      { id: 'avatar.opens.menu', metadata: { anchor: 'pointer' } },
+      { id: 'avatar.targets.items', relation_type: 'targets', from_node_id: 'menu', to_node_id: 'menu.item.*' },
+    ],
     settings: {
       radial: {
         geometry: { spreadDegrees: 90 },
@@ -101,7 +120,31 @@ test('mergeUxTreeDefinitions deep-merges settings and merges stable arrays by id
   assert.equal(merged.nodes[0].label, 'Avatar Body')
   assert.equal(merged.commands.find((command) => command.id === 'radial.begin').label, 'Begin Radial Gesture')
   assert.equal(merged.bindings.find((binding) => binding.id === 'avatar.right').priority, 20)
+  assert.equal(merged.relations.find((relation) => relation.id === 'avatar.opens.menu').metadata.anchor, 'pointer')
+  assert.equal(merged.relations.find((relation) => relation.id === 'avatar.targets.items').to_node_id, 'menu.item.*')
   assert.deepEqual(merged.settings.radial.geometry, { menuRadius: 1.8, spreadDegrees: 90 })
+})
+
+test('relation helpers normalize and filter by type and node direction', () => {
+  const tree = createUxTree({
+    ...baseTree(),
+    relations: [
+      { id: 'avatar.opens.menu', relation_type: 'opens', from_node_id: 'avatar', to_node_id: 'menu' },
+      { id: 'menu.targets.items', relation_type: 'targets', from_node_id: 'menu', to_node_id: 'menu.item.*' },
+    ],
+  }, { strict: true })
+
+  assert.deepEqual(normalizeUxTreeRelation({ id: 'rel', type: 'anchors', from_node_id: 'avatar', to_node_id: 'menu' }), {
+    id: 'rel',
+    relation_type: 'anchors',
+    from_node_id: 'avatar',
+    to_node_id: 'menu',
+    source_metadata: {},
+    metadata: {},
+  })
+  assert.deepEqual(uxTreeRelationsByType(tree, 'targets').map((relation) => relation.id), ['menu.targets.items'])
+  assert.deepEqual(uxTreeRelationsForNode(tree, 'avatar', { direction: 'from' }).map((relation) => relation.id), ['avatar.opens.menu'])
+  assert.deepEqual(uxTreeRelationsForNode(tree, 'menu', { direction: 'incoming' }).map((relation) => relation.id), ['avatar.opens.menu'])
 })
 
 test('uxTreeBindingsForGesture returns enabled mode matches before lower-priority global matches', () => {
@@ -124,6 +167,58 @@ test('resolveUxTree returns validation metadata for invalid references and can t
   assert.equal(resolved.validation.ok, false)
   assert.ok(resolved.validation.errors.some((error) => error.code === 'binding.command_ref'))
   assert.throws(() => resolveUxTree(invalid, { strict: true }), /Invalid UX tree/)
+})
+
+test('resolveUxTree validates relation node references and collection targets', () => {
+  const unknownFrom = baseTree()
+  unknownFrom.relations = [
+    { id: 'missing.opens.menu', relation_type: 'opens', from_node_id: 'missing', to_node_id: 'menu' },
+  ]
+  const unknownFromResolved = resolveUxTree(unknownFrom)
+  assert.equal(unknownFromResolved.validation.ok, false)
+  assert.ok(unknownFromResolved.validation.errors.some((error) => error.code === 'relation.from_node_ref'))
+
+  const unknownTo = baseTree()
+  unknownTo.relations = [
+    { id: 'avatar.opens.missing', relation_type: 'opens', from_node_id: 'avatar', to_node_id: 'missing' },
+  ]
+  const unknownToResolved = resolveUxTree(unknownTo)
+  assert.equal(unknownToResolved.validation.ok, false)
+  assert.ok(unknownToResolved.validation.errors.some((error) => error.code === 'relation.to_node_ref'))
+
+  const wildcardTarget = resolveUxTree({
+    ...baseTree(),
+    relations: [
+      { id: 'menu.targets.items', relation_type: 'targets', from_node_id: 'menu', to_node_id: 'menu.item.*' },
+    ],
+  })
+  assert.equal(wildcardTarget.validation.ok, true)
+
+  const wildcardOpen = resolveUxTree({
+    ...baseTree(),
+    relations: [
+      { id: 'avatar.opens.items', relation_type: 'opens', from_node_id: 'avatar', to_node_id: 'menu.item.*' },
+    ],
+  })
+  assert.equal(wildcardOpen.validation.ok, false)
+  assert.ok(wildcardOpen.validation.errors.some((error) => error.code === 'relation.collection_target'))
+})
+
+test('resolveUxTree rejects executable relation metadata', () => {
+  const invalid = baseTree()
+  invalid.relations = [
+    {
+      id: 'avatar.opens.menu',
+      relation_type: 'opens',
+      from_node_id: 'avatar',
+      to_node_id: 'menu',
+      metadata: { onOpen() {} },
+    },
+  ]
+
+  const resolved = resolveUxTree(invalid)
+  assert.equal(resolved.validation.ok, false)
+  assert.ok(resolved.validation.errors.some((error) => error.code === 'relation.metadata.executable'))
 })
 
 test('resolveUxTree rejects non-string command handler refs before normalization', () => {

--- a/tests/toolkit/ux-tree-subject.test.mjs
+++ b/tests/toolkit/ux-tree-subject.test.mjs
@@ -42,6 +42,14 @@ test('UX tree workbench subject exposes read-only commands, bindings, settings, 
         consume_policy: 'observe',
       },
     ],
+    relations: [
+      {
+        id: 'sigil.avatar.opens_context_menu',
+        relation_type: 'opens',
+        from_node_id: 'sigil.avatar',
+        to_node_id: 'sigil.avatar',
+      },
+    ],
     settings: { radial: { geometry: { menuRadius: 1.8 } } },
   })
   const subject = createUxTreeWorkbenchSubject({
@@ -55,15 +63,19 @@ test('UX tree workbench subject exposes read-only commands, bindings, settings, 
   assert.equal(subject.id, uxTreeSubjectId(tree))
   assert.deepEqual(subjectCapabilities(subject), ['inspectable'])
   assert.ok(subjectContracts(subject).includes('aos.ux_tree.bindings'))
+  assert.ok(subjectContracts(subject).includes('aos.ux_tree.relations'))
   assert.deepEqual(subjectFacets(subject).map((facet) => facet.key), [
     UX_TREE_RESOURCE_FACETS.overview,
     UX_TREE_RESOURCE_FACETS.bindings,
+    UX_TREE_RESOURCE_FACETS.relations,
     UX_TREE_RESOURCE_FACETS.commands,
     UX_TREE_RESOURCE_FACETS.settings,
     UX_TREE_RESOURCE_FACETS.rawJson,
   ])
   assert.equal(subject.state.binding_count, 1)
+  assert.equal(subject.state.relation_count, 1)
   assert.equal(subject.state.command_count, 1)
+  assert.equal(subject.state.relations[0].id, 'sigil.avatar.opens_context_menu')
   assert.equal(subject.state.raw_tree.id, 'sigil.avatar.ux_tree')
   assert.equal(subject.persistence.kind, 'read_only')
 })


### PR DESCRIPTION
## Summary

- Routes only context-menu right-click open/toggle through the UX tree command adapter.
- Preserves duplicate right-click echo suppression and right-click-away fallback behavior.
- Leaves avatar left press/release, double-click Selection Mode, radial, reticle, camera, wiki graph, and terminal command paths unchanged.
- Adds focused route helper and adapter tests for context-menu command routing.

## Stack

- Stacked on #385 / `gdi/sigil-ux-tree-selection-mode-bindings-cutover-v0`.
- #385 is stacked on #384, #383, and #382.

## Verification

- `node --check apps/sigil/renderer/live-modules/main.js`
- `node --check apps/sigil/renderer/live-modules/ux-tree.js`
- `node --check apps/sigil/renderer/live-modules/ux-tree-command-registry.js`
- `node --check apps/sigil/renderer/live-modules/selection-mode-input.js`
- `node --check apps/sigil/renderer/live-modules/context-menu-input.js`
- `node --test tests/renderer/sigil-ux-tree-command-registry.test.mjs tests/renderer/sigil-ux-tree.test.mjs tests/renderer/sigil-selection-mode-input.test.mjs tests/renderer/sigil-context-menu-input.test.mjs tests/renderer/context-menu-hit-test.test.mjs tests/renderer/sigil-input-regions.test.mjs tests/renderer/radial-gesture-menu.test.mjs tests/renderer/radial-menu-activation.test.mjs tests/renderer/radial-object-control.test.mjs tests/renderer/radial-item-editor.test.mjs`
- `node --test tests/toolkit/runtime-ux-tree.test.mjs tests/toolkit/ux-tree-subject.test.mjs tests/schemas/aos-ux-tree-v0.test.mjs`
- `git diff --check bc586b3a625b49cccb45685275e69c85a3c42182..HEAD`
- `./aos ready`