### PR TITLE
Add toolkit control UX tree fragments

### DIFF
--- a/docs/api/toolkit/components.md
+++ b/docs/api/toolkit/components.md
@@ -9,6 +9,16 @@ feel like AOS app controls instead of raw browser defaults. Controls attach to
 ordinary semantic HTML and dispatch normal DOM events so panels can remain
 domain-specific.
 
+`controls/ux-tree.js` starts toolkit control UX tree adoption with read-only
+shadow fragments for buttons, toggles, and segmented button groups. Use
+`createButtonUxTreeFragment()`, `createToggleUxTreeFragment()`, or
+`createButtonGroupUxTreeFragment()` when a surface needs inspectable data for
+existing control bindings. The helpers return plain JSON `aos_ux_tree` objects
+validated by the toolkit runtime shape: node identity, existing pointer/keyboard
+gestures, allowlisted command handler refs, grouped option ownership relations,
+and current state metadata. They do not execute commands, install a command
+registry, persist overrides, or expose a binding editor.
+
 `number-field.js` provides focused wheel and arrow-key stepping for numeric
 fields marked with `data-aos-control="number-field"`. It uses the field's
 native `step`, `min`, and `max` attributes, dispatches bubbling `input` and

--- a/packages/toolkit/controls/index.js
+++ b/packages/toolkit/controls/index.js
@@ -1,6 +1,12 @@
 export { createButton, renderButtonHtml } from './button.js';
 export { createButtonGroup } from './button-group.js';
 export { createToggle, renderToggleHtml } from './toggle.js';
+export {
+  CONTROL_UX_TREE_RUNTIME_STATE,
+  createButtonGroupUxTreeFragment,
+  createButtonUxTreeFragment,
+  createToggleUxTreeFragment,
+} from './ux-tree.js';
 export { createTextField, renderTextFieldHtml } from './text-field.js';
 export { createSelect, renderSelectHtml } from './select.js';
 export { createCheckboxGroup, renderCheckboxHtml } from './checkbox-group.js';

--- a/packages/toolkit/controls/ux-tree.js
+++ b/packages/toolkit/controls/ux-tree.js
@@ -1,0 +1,297 @@
+import { createUxTree } from '../runtime/ux-tree.js';
+
+export const CONTROL_UX_TREE_RUNTIME_STATE = 'read_only_shadow';
+
+const HANDLER_REF_PATTERN = /^[A-Za-z0-9_.:-]+$/;
+const CONTROL_SOURCE_REFS = Object.freeze({
+  button: [
+    { kind: 'repo_path', path: 'packages/toolkit/controls/button.js' },
+    { kind: 'repo_path', path: 'packages/toolkit/controls/ux-tree.js' },
+  ],
+  toggle: [
+    { kind: 'repo_path', path: 'packages/toolkit/controls/toggle.js' },
+    { kind: 'repo_path', path: 'packages/toolkit/controls/ux-tree.js' },
+  ],
+  buttonGroup: [
+    { kind: 'repo_path', path: 'packages/toolkit/controls/button-group.js' },
+    { kind: 'repo_path', path: 'packages/toolkit/controls/ux-tree.js' },
+  ],
+});
+
+function text(value, fallback = '') {
+  const normalized = String(value ?? '').replace(/\s+/g, ' ').trim();
+  return normalized || fallback;
+}
+
+function list(value) {
+  return Array.isArray(value) ? value.filter((entry) => entry !== undefined && entry !== null) : [];
+}
+
+function safeSegment(value, fallback) {
+  const normalized = text(value, fallback)
+    .replace(/[^A-Za-z0-9_.:-]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return normalized || fallback;
+}
+
+function jsonClone(value) {
+  if (value === undefined) return undefined;
+  try {
+    const serialized = JSON.stringify(value);
+    if (serialized === undefined) return undefined;
+    return JSON.parse(serialized);
+  } catch {
+    return String(value);
+  }
+}
+
+function jsonObject(entries) {
+  const object = {};
+  for (const [key, value] of Object.entries(entries)) {
+    const cloned = jsonClone(value);
+    if (cloned !== undefined) object[key] = cloned;
+  }
+  return object;
+}
+
+function handlerRef(value, fallback) {
+  const ref = text(value, fallback);
+  if (!HANDLER_REF_PATTERN.test(ref)) {
+    throw new TypeError(`UX tree handler_ref must be an allowlisted reference: ${ref}`);
+  }
+  return ref;
+}
+
+function baseControlId(config = {}, fallback) {
+  return safeSegment(config.uxNodeId ?? config.uxId ?? config.id ?? config.name, fallback);
+}
+
+function labelFor(config = {}, fallback) {
+  return text(config.uxLabel ?? config.label ?? config.ariaLabel ?? config.title, fallback);
+}
+
+function readOnlyMetadata(controlFamily, extra = {}) {
+  return {
+    runtime_state: CONTROL_UX_TREE_RUNTIME_STATE,
+    producer: 'toolkit.controls',
+    control_family: controlFamily,
+    intent: 'inspect_only',
+    command_execution: 'future_adapter',
+    ...jsonClone(extra),
+  };
+}
+
+function command({ id, label, handler_ref, parameters = {}, metadata = {} }) {
+  return {
+    id,
+    label,
+    handler_ref,
+    parameters: jsonClone(parameters) || {},
+    safety: { execution: 'allowlisted' },
+    metadata: readOnlyMetadata('command', metadata),
+  };
+}
+
+function binding({ id, node_id, gesture, command_id, parameters = {}, metadata = {}, priority = 10 }) {
+  return {
+    id,
+    node_id,
+    mode: 'global',
+    gesture,
+    command_id,
+    enabled: true,
+    priority,
+    consume_policy: 'observe',
+    parameters: jsonClone(parameters) || {},
+    metadata: readOnlyMetadata('binding', metadata),
+  };
+}
+
+function resolveTree(input, options = {}) {
+  return createUxTree(input, { strict: options.strict !== false });
+}
+
+export function createButtonUxTreeFragment(config = {}, options = {}) {
+  const nodeId = baseControlId(config, 'toolkit.controls.button');
+  const commandId = `${nodeId}.activate`;
+  const label = labelFor(config, 'Button');
+  return resolveTree({
+    id: `${nodeId}.ux_tree`,
+    label: `${label} UX Tree`,
+    owner: text(options.owner ?? config.owner, 'toolkit.controls'),
+    source_refs: CONTROL_SOURCE_REFS.button,
+    modes: [{ id: 'global', label: 'Global' }],
+    nodes: [
+      {
+        id: nodeId,
+        label,
+        role: 'button',
+        node_type: 'control',
+        metadata: {
+          runtime_state: CONTROL_UX_TREE_RUNTIME_STATE,
+          state: jsonObject({
+            disabled: !!config.disabled,
+            pressed: config.pressed ?? config.ariaPressed,
+            variant: config.variant,
+            type: config.type || 'button',
+          }),
+        },
+      },
+    ],
+    commands: [
+      command({
+        id: commandId,
+        label: `Activate ${label}`,
+        handler_ref: handlerRef(config.uxHandlerRef ?? config.handler_ref, 'toolkit.controls.button.activate'),
+      }),
+    ],
+    bindings: [
+      binding({ id: `${nodeId}.pointer.click`, node_id: nodeId, gesture: 'pointer.left.click', command_id: commandId }),
+      binding({ id: `${nodeId}.keyboard.enter`, node_id: nodeId, gesture: 'keyboard.enter', command_id: commandId }),
+      binding({ id: `${nodeId}.keyboard.space`, node_id: nodeId, gesture: 'keyboard.space', command_id: commandId }),
+    ],
+    relations: [],
+    settings: {},
+    metadata: readOnlyMetadata('button'),
+  }, options);
+}
+
+export function createToggleUxTreeFragment(config = {}, options = {}) {
+  const nodeId = baseControlId(config, 'toolkit.controls.toggle');
+  const commandId = `${nodeId}.toggle`;
+  const label = labelFor(config, 'Toggle');
+  return resolveTree({
+    id: `${nodeId}.ux_tree`,
+    label: `${label} UX Tree`,
+    owner: text(options.owner ?? config.owner, 'toolkit.controls'),
+    source_refs: CONTROL_SOURCE_REFS.toggle,
+    modes: [{ id: 'global', label: 'Global' }],
+    nodes: [
+      {
+        id: nodeId,
+        label,
+        role: 'switch',
+        node_type: 'control',
+        metadata: {
+          runtime_state: CONTROL_UX_TREE_RUNTIME_STATE,
+          state: jsonObject({
+            checked: !!config.checked,
+            disabled: !!config.disabled,
+            name: config.name,
+          }),
+        },
+      },
+    ],
+    commands: [
+      command({
+        id: commandId,
+        label: `Toggle ${label}`,
+        handler_ref: handlerRef(config.uxHandlerRef ?? config.handler_ref, 'toolkit.controls.toggle.change'),
+      }),
+    ],
+    bindings: [
+      binding({ id: `${nodeId}.pointer.click`, node_id: nodeId, gesture: 'pointer.left.click', command_id: commandId }),
+      binding({ id: `${nodeId}.keyboard.space`, node_id: nodeId, gesture: 'keyboard.space', command_id: commandId }),
+    ],
+    relations: [],
+    settings: {},
+    metadata: readOnlyMetadata('toggle'),
+  }, options);
+}
+
+export function createButtonGroupUxTreeFragment(config = {}, options = {}) {
+  const groupId = baseControlId(config, 'toolkit.controls.segmented');
+  const groupLabel = labelFor(config, 'Segmented Control');
+  const optionConfigs = list(config.options);
+  const optionNodes = optionConfigs.map((option, index) => {
+    const valueSegment = safeSegment(option.uxNodeId ?? option.id ?? option.value, `option_${index + 1}`);
+    const optionId = `${groupId}.${valueSegment}`;
+    return {
+      option,
+      index,
+      node: {
+        id: optionId,
+        parent_id: groupId,
+        label: text(option.uxLabel ?? option.label ?? option.value, `Option ${index + 1}`),
+        role: 'button',
+        node_type: 'control_option',
+        metadata: {
+          runtime_state: CONTROL_UX_TREE_RUNTIME_STATE,
+          state: jsonObject({
+            value: option.value,
+            selected: option.value === config.value,
+            danger: !!option.danger,
+            disabled: !!option.disabled,
+          }),
+        },
+      },
+    };
+  });
+  const nextCommandId = `${groupId}.select_next`;
+  const previousCommandId = `${groupId}.select_previous`;
+
+  return resolveTree({
+    id: `${groupId}.ux_tree`,
+    label: `${groupLabel} UX Tree`,
+    owner: text(options.owner ?? config.owner, 'toolkit.controls'),
+    source_refs: CONTROL_SOURCE_REFS.buttonGroup,
+    modes: [{ id: 'global', label: 'Global' }],
+    nodes: [
+      {
+        id: groupId,
+        label: groupLabel,
+        role: 'group',
+        node_type: 'control_group',
+        children: optionNodes.map((entry) => entry.node.id),
+        metadata: {
+          runtime_state: CONTROL_UX_TREE_RUNTIME_STATE,
+          state: jsonObject({
+            value: config.value ?? null,
+            option_count: optionNodes.length,
+          }),
+        },
+      },
+      ...optionNodes.map((entry) => entry.node),
+    ],
+    commands: [
+      ...optionNodes.map(({ node, option }) => command({
+        id: `${node.id}.select`,
+        label: `Select ${node.label}`,
+        handler_ref: handlerRef(option.uxHandlerRef ?? config.uxHandlerRef ?? config.handler_ref, 'toolkit.controls.segmented.select_option'),
+        parameters: jsonObject({ value: option.value }),
+        metadata: { option_node_id: node.id },
+      })),
+      command({
+        id: nextCommandId,
+        label: `Select next ${groupLabel} option`,
+        handler_ref: handlerRef(config.uxNextHandlerRef, 'toolkit.controls.segmented.select_next'),
+      }),
+      command({
+        id: previousCommandId,
+        label: `Select previous ${groupLabel} option`,
+        handler_ref: handlerRef(config.uxPreviousHandlerRef, 'toolkit.controls.segmented.select_previous'),
+      }),
+    ],
+    bindings: optionNodes.flatMap(({ node }) => {
+      const selectCommandId = `${node.id}.select`;
+      return [
+        binding({ id: `${node.id}.pointer.click`, node_id: node.id, gesture: 'pointer.left.click', command_id: selectCommandId }),
+        binding({ id: `${node.id}.keyboard.enter`, node_id: node.id, gesture: 'keyboard.enter', command_id: selectCommandId }),
+        binding({ id: `${node.id}.keyboard.space`, node_id: node.id, gesture: 'keyboard.space', command_id: selectCommandId }),
+        binding({ id: `${node.id}.keyboard.arrow_right`, node_id: node.id, gesture: 'keyboard.arrow_right', command_id: nextCommandId, priority: 20 }),
+        binding({ id: `${node.id}.keyboard.arrow_down`, node_id: node.id, gesture: 'keyboard.arrow_down', command_id: nextCommandId, priority: 20 }),
+        binding({ id: `${node.id}.keyboard.arrow_left`, node_id: node.id, gesture: 'keyboard.arrow_left', command_id: previousCommandId, priority: 20 }),
+        binding({ id: `${node.id}.keyboard.arrow_up`, node_id: node.id, gesture: 'keyboard.arrow_up', command_id: previousCommandId, priority: 20 }),
+      ];
+    }),
+    relations: optionNodes.map(({ node }) => ({
+      id: `${groupId}.owns.${node.id}`,
+      relation_type: 'owns',
+      from_node_id: groupId,
+      to_node_id: node.id,
+      metadata: readOnlyMetadata('button_group_relation'),
+    })),
+    settings: {},
+    metadata: readOnlyMetadata('button_group'),
+  }, options);
+}

--- a/packages/toolkit/controls/ux-tree.js
+++ b/packages/toolkit/controls/ux-tree.js
@@ -5,16 +5,16 @@ export const CONTROL_UX_TREE_RUNTIME_STATE = 'read_only_shadow';
 const HANDLER_REF_PATTERN = /^[A-Za-z0-9_.:-]+$/;
 const CONTROL_SOURCE_REFS = Object.freeze({
   button: [
-    { kind: 'repo_path', path: 'packages/toolkit/controls/button.js' },
-    { kind: 'repo_path', path: 'packages/toolkit/controls/ux-tree.js' },
+    { id: 'toolkit-controls-button', kind: 'source', ref: 'packages/toolkit/controls/button.js' },
+    { id: 'toolkit-controls-ux-tree', kind: 'source', ref: 'packages/toolkit/controls/ux-tree.js' },
   ],
   toggle: [
-    { kind: 'repo_path', path: 'packages/toolkit/controls/toggle.js' },
-    { kind: 'repo_path', path: 'packages/toolkit/controls/ux-tree.js' },
+    { id: 'toolkit-controls-toggle', kind: 'source', ref: 'packages/toolkit/controls/toggle.js' },
+    { id: 'toolkit-controls-ux-tree', kind: 'source', ref: 'packages/toolkit/controls/ux-tree.js' },
   ],
   buttonGroup: [
-    { kind: 'repo_path', path: 'packages/toolkit/controls/button-group.js' },
-    { kind: 'repo_path', path: 'packages/toolkit/controls/ux-tree.js' },
+    { id: 'toolkit-controls-button-group', kind: 'source', ref: 'packages/toolkit/controls/button-group.js' },
+    { id: 'toolkit-controls-ux-tree', kind: 'source', ref: 'packages/toolkit/controls/ux-tree.js' },
   ],
 });
 

--- a/tests/toolkit/controls-ux-tree.test.mjs
+++ b/tests/toolkit/controls-ux-tree.test.mjs
@@ -12,6 +12,13 @@ function assertJsonOnly(value) {
   assert.deepEqual(JSON.parse(JSON.stringify(value)), value);
 }
 
+function assertSourceRefs(value, expected) {
+  assert.deepEqual(value.source_refs, [
+    expected,
+    { id: 'toolkit-controls-ux-tree', kind: 'source', ref: 'packages/toolkit/controls/ux-tree.js' },
+  ]);
+}
+
 test('button UX tree fragment describes activation gestures without runtime callbacks', () => {
   const fragment = createButtonUxTreeFragment({
     id: 'save-button',
@@ -23,6 +30,7 @@ test('button UX tree fragment describes activation gestures without runtime call
   });
 
   assert.equal(fragment.validation.ok, true);
+  assertSourceRefs(fragment, { id: 'toolkit-controls-button', kind: 'source', ref: 'packages/toolkit/controls/button.js' });
   assert.equal(fragment.metadata.runtime_state, CONTROL_UX_TREE_RUNTIME_STATE);
   assert.deepEqual(fragment.nodes.map((node) => node.id), ['save-button']);
   assert.equal(fragment.nodes[0].metadata.state.disabled, true);
@@ -47,6 +55,7 @@ test('toggle UX tree fragment describes change gestures and current state as dat
   });
 
   assert.equal(fragment.validation.ok, true);
+  assertSourceRefs(fragment, { id: 'toolkit-controls-toggle', kind: 'source', ref: 'packages/toolkit/controls/toggle.js' });
   assert.equal(fragment.nodes[0].role, 'switch');
   assert.deepEqual(fragment.nodes[0].metadata.state, {
     checked: true,
@@ -75,6 +84,7 @@ test('segmented button group UX tree fragment owns option nodes and maps select/
   });
 
   assert.equal(fragment.validation.ok, true);
+  assertSourceRefs(fragment, { id: 'toolkit-controls-button-group', kind: 'source', ref: 'packages/toolkit/controls/button-group.js' });
   assert.deepEqual(fragment.nodes.map((node) => node.id), [
     'view-mode',
     'view-mode.edit',

--- a/tests/toolkit/controls-ux-tree.test.mjs
+++ b/tests/toolkit/controls-ux-tree.test.mjs
@@ -1,0 +1,112 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  CONTROL_UX_TREE_RUNTIME_STATE,
+  createButtonGroupUxTreeFragment,
+  createButtonUxTreeFragment,
+  createToggleUxTreeFragment,
+} from '../../packages/toolkit/controls/index.js';
+import { uxTreeBindingsForGesture, uxTreeRelationsByType } from '../../packages/toolkit/runtime/ux-tree.js';
+
+function assertJsonOnly(value) {
+  assert.deepEqual(JSON.parse(JSON.stringify(value)), value);
+}
+
+test('button UX tree fragment describes activation gestures without runtime callbacks', () => {
+  const fragment = createButtonUxTreeFragment({
+    id: 'save-button',
+    label: 'Save',
+    variant: 'primary',
+    disabled: true,
+    onClick() {},
+    document: { createElement() {} },
+  });
+
+  assert.equal(fragment.validation.ok, true);
+  assert.equal(fragment.metadata.runtime_state, CONTROL_UX_TREE_RUNTIME_STATE);
+  assert.deepEqual(fragment.nodes.map((node) => node.id), ['save-button']);
+  assert.equal(fragment.nodes[0].metadata.state.disabled, true);
+  assert.equal(fragment.commands[0].handler_ref, 'toolkit.controls.button.activate');
+  assert.deepEqual(fragment.bindings.map((binding) => binding.gesture), [
+    'pointer.left.click',
+    'keyboard.enter',
+    'keyboard.space',
+  ]);
+  assertJsonOnly(fragment);
+  assert.doesNotMatch(JSON.stringify(fragment), /onClick|createElement/);
+});
+
+test('toggle UX tree fragment describes change gestures and current state as data', () => {
+  const fragment = createToggleUxTreeFragment({
+    id: 'snap-toggle',
+    label: 'Snap',
+    checked: true,
+    disabled: false,
+    name: 'snap',
+    onChange() {},
+  });
+
+  assert.equal(fragment.validation.ok, true);
+  assert.equal(fragment.nodes[0].role, 'switch');
+  assert.deepEqual(fragment.nodes[0].metadata.state, {
+    checked: true,
+    disabled: false,
+    name: 'snap',
+  });
+  assert.equal(fragment.commands[0].id, 'snap-toggle.toggle');
+  assert.equal(fragment.commands[0].handler_ref, 'toolkit.controls.toggle.change');
+  assert.deepEqual(fragment.bindings.map((binding) => binding.gesture), [
+    'pointer.left.click',
+    'keyboard.space',
+  ]);
+  assertJsonOnly(fragment);
+});
+
+test('segmented button group UX tree fragment owns option nodes and maps select/navigation gestures', () => {
+  const fragment = createButtonGroupUxTreeFragment({
+    id: 'view-mode',
+    label: 'View Mode',
+    value: 'preview',
+    options: [
+      { value: 'edit', label: 'Edit' },
+      { value: 'preview', label: 'Preview' },
+      { value: 'diff', label: 'Diff', danger: true },
+    ],
+  });
+
+  assert.equal(fragment.validation.ok, true);
+  assert.deepEqual(fragment.nodes.map((node) => node.id), [
+    'view-mode',
+    'view-mode.edit',
+    'view-mode.preview',
+    'view-mode.diff',
+  ]);
+  assert.deepEqual(fragment.nodes[0].children, ['view-mode.edit', 'view-mode.preview', 'view-mode.diff']);
+  assert.equal(fragment.nodes[2].metadata.state.selected, true);
+  assert.equal(fragment.commands.find((command) => command.id === 'view-mode.preview.select').parameters.value, 'preview');
+  assert.deepEqual(uxTreeRelationsByType(fragment, 'owns').map((relation) => relation.to_node_id), [
+    'view-mode.edit',
+    'view-mode.preview',
+    'view-mode.diff',
+  ]);
+  assert.deepEqual(uxTreeBindingsForGesture(fragment, {
+    nodeId: 'view-mode.preview',
+    gesture: 'pointer.left.click',
+  }).map((binding) => binding.command_id), ['view-mode.preview.select']);
+  assert.deepEqual(uxTreeBindingsForGesture(fragment, {
+    nodeId: 'view-mode.preview',
+    gesture: 'keyboard.arrow_right',
+  }).map((binding) => binding.command_id), ['view-mode.select_next']);
+  assert.deepEqual(uxTreeBindingsForGesture(fragment, {
+    nodeId: 'view-mode.preview',
+    gesture: 'keyboard.arrow_left',
+  }).map((binding) => binding.command_id), ['view-mode.select_previous']);
+  assertJsonOnly(fragment);
+});
+
+test('control UX tree helpers reject unsafe handler refs', () => {
+  assert.throws(
+    () => createButtonUxTreeFragment({ id: 'unsafe', uxHandlerRef: 'alert(1)' }),
+    /allowlisted reference/,
+  );
+});


### PR DESCRIPTION
## Summary
- add helper-only read-only UX tree fragments for toolkit buttons, toggles, and segmented button groups
- export the helpers from `packages/toolkit/controls/index.js`
- document the toolkit control UX tree adoption state in `docs/api/toolkit/components.md`
- fix review feedback so emitted `source_refs` use canonical `{ id, kind, ref }` objects

## Verification
- `node --check packages/toolkit/controls/ux-tree.js`
- `node --test tests/toolkit/controls-ux-tree.test.mjs tests/toolkit/runtime-ux-tree.test.mjs tests/schemas/aos-ux-tree-v0.test.mjs`
- `git diff --check`

## Stack
Base branch: `gdi/sigil-ux-tree-pre-toolkit-adoption-closure-v0`

Foreman review accepted the correction at `fe75b6995f97fbababe12f486d1d0b6b8bd36870`.