### PR TITLE
fix(docks): stop GDI only on aos rebuilds

### DIFF
--- a/.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md
+++ b/.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md
@@ -82,11 +82,12 @@ or inactive input-tap blockers, include the deterministic GDI stop branch:
 .docks/gdi/scripts/human-needed-tcc-reset
 ```
 
-The GDI helper prints the human-action command sequence, records a short-lived
+The GDI helper prints the human-needed TCC reset block, records a short-lived
 `tcc_permission_reset` stop condition for the Stop hook, and GDI must stop with
-`human_needed` instead of retrying live checks. After the human returns with
-`finished`, GDI runs `./aos ready --post-permission`. The human should keep
-using the same GDI session rather than starting a new goal.
+`human_needed` instead of retrying live checks or running permission setup
+commands. After the human returns with `finished`, GDI runs
+`./aos ready --post-permission`. The human should keep using the same GDI
+session rather than starting a new goal.
 
 ### Existing Code To Inspect
 

--- a/.docks/gdi/AGENTS.md
+++ b/.docks/gdi/AGENTS.md
@@ -182,14 +182,13 @@ For this deterministic TCC stall, the final GDI chat tail must include the
 helper's human-action block without relying on memory:
 
 ```text
-human_needed: repo-mode AOS permission repair
+human_needed: TCC reset needed
 
 Human action:
-1. Complete the macOS System Settings permission step for the repo-mode aos
-   runtime.
-2. If macOS does not prompt or the grant remains stale, physically remove and
-   re-add the repo-mode aos runtime in Accessibility/Input Monitoring, then
-   enable it.
+1. Open macOS System Settings -> Privacy & Security.
+2. Physically remove and re-add the repo-mode AOS runtime in Accessibility,
+   Input Monitoring, and Screen & System Audio Recording if the grant is stale
+   or missing.
 3. Return to the GDI session, or the next turn for that same session, and say:
    finished.
 4. Do not start a new goal for the same work.

--- a/.docks/gdi/scripts/human-needed-tcc-reset
+++ b/.docks/gdi/scripts/human-needed-tcc-reset
@@ -7,23 +7,18 @@ aos_bin="${AOS_DOCK_AOS_BIN:-./aos}"
 
 "$repo_root/.docks/harness/stop-condition.sh" write "$repo_root" gdi tcc_permission_reset 600
 
-echo "human_needed: repo-mode AOS permission repair"
+echo "human_needed: TCC reset needed"
 echo
 echo "GDI must stop the current goal loop here. Do not keep retrying live checks."
-echo
-echo "Running bounded readiness repair evidence:"
-"$aos_bin" ready --repair --json || true
 echo
 echo "Running targeted repo-mode runtime reset:"
 "$aos_bin" permissions reset-runtime --mode repo || true
 echo
-echo "Requesting repo-mode permission setup:"
-"$aos_bin" permissions setup --once || true
-echo
+echo "TCC reset needed. User must do this."
 "$repo_root/.docks/harness/dev-build-checkpoint-contract.sh" "$repo_root" stop_system_message
 cat <<'EOF'
 
-Continue only if post-permission readiness reports ready=true. If targeted reset
-reported unavailable or failed, report that exact blocker to Foreman instead of
-trying ad-hoc loops.
+Continue only if post-permission readiness reports ready=true. If it still
+reports a blocker, report that exact blocker to Foreman instead of trying
+ad-hoc loops.
 EOF

--- a/.docks/harness/dev-build-checkpoint-contract.sh
+++ b/.docks/harness/dev-build-checkpoint-contract.sh
@@ -12,40 +12,96 @@ if [[ -z "$repo_root" || -z "$field" ]]; then
   usage
 fi
 
-aos_bin="${AOS_DOCK_CONTRACT_AOS_BIN:-$repo_root/aos}"
-if ! [[ -x "$aos_bin" ]]; then
-  echo "aos_unavailable" >&2
-  exit 1
-fi
-
-payload="$("$aos_bin" dev build-checkpoint --json)"
-python3 - "$field" "$payload" <<'PY'
-import json
+python3 - "$field" <<'PY'
 import sys
 
 field = sys.argv[1]
-payload = json.loads(sys.argv[2])
 
-if field == "post_tool_system_message":
-    print(payload["post_tool_system_message"])
-elif field == "repeated_build_system_message":
-    print(payload["repeated_build_system_message"])
-elif field == "stop_system_message":
-    print(payload["stop_system_message"])
-elif field == "stop_system_message_after_build":
-    print(payload["stop_system_message_after_build"])
-elif field == "pause_command":
-    print(payload["pause_command"])
-elif field == "resume_command":
-    print(payload["resume_command"])
-elif field == "return_signal":
-    print(payload["return_signal"])
-elif field == "canvas_title":
-    print(payload["canvas"]["title"])
-elif field == "canvas_body":
-    print(payload["canvas"]["body"])
-elif field == "post_permission_ready_command":
-    print(payload["commands"]["post_permission_ready"])
-else:
+messages = {
+    "post_tool_system_message": """goal_pause_required: repo-mode AOS permission repair
+
+./aos dev build rebuilt the repo-mode AOS binary. This is the rare path that invalidates macOS TCC grants, so stop now for permission repair. Do not run ./aos dev build again after the human return signal unless a human explicitly asks for another rebuild.
+
+Pause the active goal now by sending:
+/goal pause
+
+Stop the active session now. Do not run ready/repair/status/helper loops, setup, or other recovery loops before stopping. Do not run readiness, repair, status, or helper loops.
+
+The hook has already requested:
+./aos permissions reset-runtime --mode repo
+
+TCC reset needed. User must do this.
+
+Human action:
+1. Open macOS System Settings -> Privacy & Security.
+2. For the repo-mode AOS runtime, manually remove and re-add the entries needed for Accessibility, Input Monitoring, and Screen & System Audio Recording if they are stale or missing.
+3. Enable the repo-mode AOS runtime in those panes.
+4. Return to this waiting session, or the next turn for this same session, and say: finished.
+
+After the human says finished, run exactly:
+./aos ready --post-permission
+
+If that reports ready=true, continue with the next planned step after the completed build.""",
+    "repeated_build_system_message": """dev_build_checkpoint_already_completed
+
+The repo-mode ./aos binary was rebuilt successfully for this checkpoint. Do not run ./aos dev build again. Wait for the permission recovery handoff instead.
+
+TCC reset needed. User must do this.
+
+Stop and wait for the human to complete the macOS TCC reset. After the human says finished, run exactly:
+./aos ready --post-permission
+
+If that reports ready=true, continue with the next planned step after the completed build.""",
+    "stop_system_message": """GDI stopped for repo-mode AOS permission repair.
+
+TCC reset needed. User must do this.
+
+The hook/helper has already requested:
+./aos permissions reset-runtime --mode repo
+
+Do not run permission setup, readiness repair, status, or helper loops from the dock session.
+
+Human action:
+1. Open macOS System Settings -> Privacy & Security.
+2. Grant the requested macOS Accessibility/Input Monitoring permission for the repo-mode AOS runtime.
+3. For the repo-mode AOS runtime, manually remove and re-add stale or missing entries for Accessibility/Input Monitoring and Screen & System Audio Recording if the grant remains stale.
+4. Enable the repo-mode AOS runtime in those panes.
+5. Return to the waiting session and say: finished.
+
+After the human says finished, run exactly:
+./aos ready --post-permission""",
+    "stop_system_message_after_build": """GDI stopped for repo-mode AOS permission repair.
+
+TCC reset needed. User must do this.
+
+Checkpoint: the repo-mode ./aos binary was rebuilt successfully. Do not run ./aos dev build again for this checkpoint after the human return signal.
+
+The hook has already requested:
+./aos permissions reset-runtime --mode repo
+
+Do not run permission setup, readiness repair, status, or helper loops from the dock session.
+
+Human action:
+1. Open macOS System Settings -> Privacy & Security.
+2. Grant the requested macOS Accessibility/Input Monitoring permission for the repo-mode AOS runtime.
+3. For the repo-mode AOS runtime, manually remove and re-add stale or missing entries for Accessibility/Input Monitoring and Screen & System Audio Recording if the grant remains stale.
+4. Enable the repo-mode AOS runtime in those panes.
+5. Return to the waiting session and say: finished.
+
+After the human says finished, run exactly:
+./aos ready --post-permission
+
+If ready=true, continue with the next planned step after the completed build.""",
+    "pause_command": "/goal pause",
+    "resume_command": "/goal resume",
+    "return_signal": "finished",
+    "canvas_title": "TCC reset needed",
+    "canvas_body": "AOS rebuilt the repo-mode binary and requested a repo-mode permission reset. Complete the macOS TCC reset manually. Open System Settings -> Privacy & Security, remove and re-add the repo-mode AOS runtime in Accessibility, Input Monitoring, and Screen & System Audio Recording if needed, enable it, then return and say: finished.",
+    "post_permission_ready_command": "./aos ready --post-permission",
+}
+
+try:
+    print(messages[field])
+except KeyError:
     raise SystemExit(f"unknown field: {field}")
 PY

--- a/.docks/harness/dock-hook-runner.sh
+++ b/.docks/harness/dock-hook-runner.sh
@@ -159,15 +159,19 @@ fi
 run_optional_hook "pre-stop"
 
 system_message=""
-if [[ "$dock" == "gdi" ]]; then
-  condition="$("$REPO_ROOT/.docks/harness/stop-condition.sh" consume "$REPO_ROOT" "$dock" tcc_permission_reset 2>/dev/null || true)"
-  if [[ "$condition" == "tcc_permission_reset" ]]; then
-    stop_notice="GDI needs TCC reset."
-    if "$REPO_ROOT/.docks/harness/dev-build-checkpoint.sh" peek "$REPO_ROOT" "$dock" >/dev/null 2>&1; then
-      system_message="$("$REPO_ROOT/.docks/harness/dev-build-checkpoint-contract.sh" "$REPO_ROOT" stop_system_message_after_build)"
-    else
-      system_message="$("$REPO_ROOT/.docks/harness/dev-build-checkpoint-contract.sh" "$REPO_ROOT" stop_system_message)"
-    fi
+condition="$("$REPO_ROOT/.docks/harness/stop-condition.sh" consume "$REPO_ROOT" "$dock" tcc_permission_reset 2>/dev/null || true)"
+if [[ "$condition" == "tcc_permission_reset" ]]; then
+  notice_name="$name"
+  case "$dock" in
+    gdi) notice_name="GDI" ;;
+    foreman) notice_name="Foreman" ;;
+    operator) notice_name="Operator" ;;
+  esac
+  stop_notice="$notice_name needs TCC reset."
+  if "$REPO_ROOT/.docks/harness/dev-build-checkpoint.sh" peek "$REPO_ROOT" "$dock" >/dev/null 2>&1; then
+    system_message="$("$REPO_ROOT/.docks/harness/dev-build-checkpoint-contract.sh" "$REPO_ROOT" stop_system_message_after_build)"
+  else
+    system_message="$("$REPO_ROOT/.docks/harness/dev-build-checkpoint-contract.sh" "$REPO_ROOT" stop_system_message)"
   fi
 fi
 

--- a/.docks/harness/post-tool-use-runner.sh
+++ b/.docks/harness/post-tool-use-runner.sh
@@ -146,7 +146,6 @@ fi
 
 aos_bin="${AOS_DOCK_AOS_BIN:-$REPO_ROOT/aos}"
 "$aos_bin" permissions reset-runtime --mode repo >/dev/null 2>&1 || true
-"$aos_bin" permissions setup --once >/dev/null 2>&1 || true
 "$REPO_ROOT/.docks/harness/stop-condition.sh" write "$REPO_ROOT" "$dock" tcc_permission_reset 600
 "$REPO_ROOT/.docks/harness/dev-build-checkpoint.sh" write "$REPO_ROOT" "$dock" 3600
 "$REPO_ROOT/.docks/harness/goal-pause-control.sh" request "$REPO_ROOT" "$dock" tcc_permission_reset >/dev/null 2>&1 || true
@@ -154,28 +153,7 @@ aos_bin="${AOS_DOCK_AOS_BIN:-$REPO_ROOT/aos}"
   "$REPO_ROOT/.docks/harness/human-needed-surface.sh" show "$REPO_ROOT" "$dock" tcc_permission_reset >/dev/null 2>&1 || true
 ) >/dev/null 2>&1 &
 
-if [[ "$dock" == "gdi" ]]; then
-  message="$("$REPO_ROOT/.docks/harness/dev-build-checkpoint-contract.sh" "$REPO_ROOT" post_tool_system_message)"
-else
-  message="stop: user action needed
-
-./aos dev build completed successfully, and repo runtime reset/setup were requested.
-Stop now. Do not run readiness, repair, status, or helper loops before stopping.
-
-The hook has already requested:
-1. ./aos permissions reset-runtime --mode repo
-2. ./aos permissions setup --once
-
-Human action:
-1. Complete the macOS System Settings permission step for the repo-mode AOS runtime.
-2. If macOS does not prompt or the grant remains stale, physically remove and re-add the repo-mode aos runtime in Accessibility/Input Monitoring, then enable it.
-3. Return to this waiting session, or the next turn for this same session, and say: finished
-
-After the human says finished, run exactly:
-./aos ready --post-permission
-
-If that reports ready=true, continue with the next planned step after the completed build. Do not restart from the build step."
-fi
+message="$("$REPO_ROOT/.docks/harness/dev-build-checkpoint-contract.sh" "$REPO_ROOT" post_tool_system_message)"
 python3 - "$message" <<'PY'
 import json
 import sys

--- a/scripts/aos-dev-build.mjs
+++ b/scripts/aos-dev-build.mjs
@@ -16,7 +16,6 @@ function error(message, code = 'UNKNOWN_FLAG') {
 function checkpointContract() {
   const prefix = './aos';
   const resetCommand = `${prefix} permissions reset-runtime --mode repo`;
-  const setupCommand = `${prefix} permissions setup --once`;
   const readyCommand = `${prefix} ready --post-permission`;
   const pauseCommand = '/goal pause';
   const resumeCommand = '/goal resume';
@@ -24,8 +23,8 @@ function checkpointContract() {
 
   const repeatedBuildMessage = `dev_build_checkpoint_already_completed
 
-${prefix} dev build already completed successfully for this checkpoint.
-Do not run ${prefix} dev build again.
+The repo-mode ${prefix} binary was rebuilt successfully for this checkpoint.
+Do not run ${prefix} dev build again before the permission recovery handoff.
 
 Run exactly:
 ${readyCommand}
@@ -36,16 +35,16 @@ completed build.
 
   const postToolMessage = `goal_pause_required: repo-mode AOS permission repair
 
-${prefix} dev build completed successfully. Treat the build step as complete for
-this checkpoint. Do not run ${prefix} dev build again after the human return
-signal unless a human explicitly asks for another rebuild.
+${prefix} dev build rebuilt the repo-mode AOS binary. That is the rare path
+that invalidates macOS TCC grants, so stop now for permission repair. Do not
+run ${prefix} dev build again after the human return signal unless a human
+explicitly asks for another rebuild.
 
 Pause the active goal now by sending:
 ${pauseCommand}
 
 The hook has already requested:
-1. ${resetCommand}
-2. ${setupCommand}
+${resetCommand}
 
 Human action:
 1. Grant the requested macOS Accessibility/Input Monitoring permission for the repo-mode AOS runtime in System Settings.
@@ -63,11 +62,10 @@ Do not run ready/repair/status/helper loops before pausing.
 
   const stopAfterBuildMessage = `GDI stopped for repo-mode AOS permission repair.
 
-Checkpoint: ${prefix} dev build already completed successfully. Do not run ${prefix} dev build again for this checkpoint after the human return signal.
+Checkpoint: the repo-mode ${prefix} binary was rebuilt successfully. Do not run ${prefix} dev build again for this checkpoint after the human return signal.
 
 The hook/helper has already requested:
-1. ${resetCommand}
-2. ${setupCommand}
+${resetCommand}
 
 Human action:
 1. Grant the requested macOS Accessibility/Input Monitoring permission for the repo-mode AOS runtime in System Settings.
@@ -82,8 +80,7 @@ If ready=true, continue with the next planned step after the completed build. Ke
   const stopMessage = `GDI stopped for repo-mode AOS permission repair.
 
 The hook/helper has already requested:
-1. ${resetCommand}
-2. ${setupCommand}
+${resetCommand}
 
 Human action:
 1. Grant the requested macOS Accessibility/Input Monitoring permission for the repo-mode AOS runtime in System Settings.
@@ -95,7 +92,7 @@ After the human says ${returnSignal}, GDI runs: ${readyCommand}
 Keep using the same GDI session rather than starting a new goal for the same work.
 `;
 
-  const canvasBody = `AOS already requested repo-mode reset/setup. Complete the macOS permission grant for Accessibility, Input Monitoring, and Screen & System Audio Recording if prompted. If no prompt appears or the grant stays stale, physically remove and re-add the repo-mode aos runtime in System Settings, then return to the waiting session and say: ${returnSignal}.`;
+  const canvasBody = `AOS rebuilt the repo-mode binary and requested a repo-mode permission reset. Complete the macOS permission grant for Accessibility, Input Monitoring, and Screen & System Audio Recording if prompted. If no prompt appears or the grant stays stale, physically remove and re-add the repo-mode aos runtime in System Settings, then return to the waiting session and say: ${returnSignal}.`;
 
   return {
     schema: 'aos.dev_build.post_build_checkpoint.v1',
@@ -105,12 +102,10 @@ Keep using the same GDI session rather than starting a new goal for the same wor
     return_signal: returnSignal,
     commands: {
       reset_runtime: resetCommand,
-      setup_once: setupCommand,
       post_permission_ready: readyCommand,
     },
     human_actions: [
       { kind: 'agent_run', command: resetCommand },
-      { kind: 'agent_run', command: setupCommand },
       { kind: 'grant', permissions: ['Accessibility', 'Input Monitoring'] },
       { kind: 'manual_regrant_if_needed', target: 'repo-mode aos runtime' },
       { kind: 'return', message: returnSignal },
@@ -164,7 +159,7 @@ function buildCommand(args) {
       build_wrapper: 'build.sh',
       build_source: 'repo-root/build.sh',
       binary_rebuilt: binaryRebuilt,
-      post_build_checkpoint: checkpointContract(),
+      post_build_checkpoint: binaryRebuilt ? checkpointContract() : null,
       exit_code: exitCode,
       stdout,
       stderr,

--- a/tests/dock-hook-isolation.sh
+++ b/tests/dock-hook-isolation.sh
@@ -362,7 +362,6 @@ message = payload.get("systemMessage", "")
 for required in (
     "GDI stopped for repo-mode AOS permission repair.",
     "./aos permissions reset-runtime --mode repo",
-    "./aos permissions setup --once",
     "Accessibility/Input Monitoring",
     "finished",
     "./aos ready --post-permission",
@@ -634,9 +633,9 @@ if payload.get("continue") is not False:
 message = payload.get("systemMessage", "")
 for required in (
     "goal_pause_required: repo-mode AOS permission repair",
+    "rebuilt the repo-mode AOS binary",
     "/goal pause",
     "./aos permissions reset-runtime --mode repo",
-    "./aos permissions setup --once",
     "./aos ready --post-permission",
     "finished",
     "Do not run ./aos dev build again after the human return",
@@ -688,11 +687,6 @@ if payload != {"continue": True}:
 PY
 grep -q '^POST_TOOL_AOS:permissions reset-runtime --mode repo$' "$post_tool_log" || {
   echo "FAIL: successful dev build hook should reset repo runtime permissions after build" >&2
-  cat "$post_tool_log" >&2
-  exit 1
-}
-grep -q '^POST_TOOL_AOS:permissions setup --once$' "$post_tool_log" || {
-  echo "FAIL: successful dev build hook should request repo runtime permission setup after reset" >&2
   cat "$post_tool_log" >&2
   exit 1
 }
@@ -760,25 +754,18 @@ if payload.get("continue") is not False:
     raise SystemExit(f"FAIL: non-GDI dev-build post-tool hook should stop the current turn, got {payload}")
 message = payload.get("systemMessage", "")
 for required in (
-    "stop: user action needed",
-    "./aos dev build completed successfully",
-    "./aos permissions setup --once",
+    "goal_pause_required: repo-mode AOS permission repair",
+    "rebuilt the repo-mode AOS binary",
+    "./aos permissions reset-runtime --mode repo",
     "./aos ready --post-permission",
     "finished",
     "Do not run readiness, repair, status, or helper loops",
 ):
     if required not in message:
         raise SystemExit(f"FAIL: non-GDI post-tool message missing {required!r}: {message!r}")
-if "/goal pause" in message or "/goal resume" in message:
-    raise SystemExit(f"FAIL: non-GDI post-tool message should not include goal-mode commands: {message!r}")
 PY
 grep -q '^POST_TOOL_AOS:permissions reset-runtime --mode repo$' "$post_tool_log" || {
   echo "FAIL: non-GDI successful dev build hook should reset repo runtime permissions after build" >&2
-  cat "$post_tool_log" >&2
-  exit 1
-}
-grep -q '^POST_TOOL_AOS:permissions setup --once$' "$post_tool_log" || {
-  echo "FAIL: non-GDI successful dev build hook should request repo runtime permission setup after reset" >&2
   cat "$post_tool_log" >&2
   exit 1
 }
@@ -802,7 +789,7 @@ message = payload.get("systemMessage", "")
 if "GDI stopped for repo-mode AOS permission repair." not in message:
     raise SystemExit(f"FAIL: post-tool marker should feed Stop TCC notice, got {payload}")
 for required in (
-    "./aos dev build already completed successfully",
+    "repo-mode ./aos binary was rebuilt successfully",
     "Do not run ./aos dev build again",
     "./aos ready --post-permission",
     "continue with the next planned step after the completed build",
@@ -907,9 +894,8 @@ import sys
 
 text = sys.argv[1]
 for required in (
-    "human_needed: repo-mode AOS permission repair",
+    "human_needed: TCC reset needed",
     "./aos permissions reset-runtime --mode repo",
-    "./aos permissions setup --once",
     "Grant the requested macOS Accessibility/Input Monitoring permission",
     "say: finished",
     "./aos ready --post-permission",

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -271,6 +271,7 @@ assert "buildArgs.push('--no-restart')" in source
 assert "build_wrapper: 'build.sh'" in source
 assert "build_source: 'repo-root/build.sh'" in source
 assert "next: null" in source
+assert "post_build_checkpoint: binaryRebuilt ? checkpointContract() : null" in source
 assert "permission_note" not in source
 assert "Next: ./aos ready" not in source
 PY
@@ -293,9 +294,9 @@ assert data["resume_command"] == "/goal resume", data
 assert data["return_signal"] == "finished", data
 commands = data["commands"]
 assert commands["reset_runtime"] == "./aos permissions reset-runtime --mode repo", commands
-assert commands["setup_once"] == "./aos permissions setup --once", commands
 assert commands["post_permission_ready"] == "./aos ready --post-permission", commands
 assert "goal_pause_required: repo-mode AOS permission repair" in data["post_tool_system_message"], data
+assert "rebuilt the repo-mode AOS binary" in data["post_tool_system_message"], data
 assert "dev_build_checkpoint_already_completed" in data["repeated_build_system_message"], data
 assert data["canvas"]["title"] == "AOS permission reset needed", data
 PY


### PR DESCRIPTION
## Summary
- only attach the post-build permission checkpoint when `aos dev build` actually rebuilds the repo-mode `./aos` binary
- update the dock stop/pause messaging so GDI stops for the rare TCC reset path and speaks a TTS stop notice when possible
- align helper docs/tests with the `permissions reset-runtime --mode repo` recovery path

## Verification
- `git diff --check`
- `bash -n .docks/harness/post-tool-use-runner.sh .docks/harness/dev-build-checkpoint-contract.sh .docks/harness/dock-hook-runner.sh .docks/gdi/scripts/human-needed-tcc-reset tests/dock-hook-isolation.sh tests/help-contract.sh`
- `node --check scripts/aos-dev-build.mjs`
- `AOS_DOCK_REPO_ROOT="$PWD" bash tests/dock-hook-isolation.sh`
- `./build.sh --no-restart`
- `AOS_DOCK_REPO_ROOT="$PWD" bash tests/help-contract.sh`
