### PR TITLE
Fix PR392 renderer breakage inventory

### DIFF
--- a/BROKE.md
+++ b/BROKE.md
@@ -1,0 +1,69 @@
+# Breaking Changes from Visual Object Descriptor Refactor (PR #392)
+
+Inventory taken on 2026-06-01 from `main` at `/Users/Michael/Code/agent-os`.
+
+## Current Test Inventory
+
+### Passing
+
+- `node --test tests/renderer/sigil-avatar-editor-compact-surface.test.mjs tests/renderer/sigil-avatar-editor-model.test.mjs tests/renderer/sigil-avatar-editor-surface-view-model.test.mjs tests/renderer/stellation-no-rebuild.test.mjs tests/renderer/tesseron.test.mjs tests/renderer/radial-item-editor.test.mjs tests/renderer/radial-object-control.test.mjs` - 64/64 pass.
+- `node --test tests/toolkit/visual-object-form-binding.test.mjs tests/toolkit/visual-object-contract.test.mjs tests/toolkit/panel-form.test.mjs tests/toolkit/radial-menu-subject.test.mjs tests/toolkit/object-transform-panel-model.test.mjs tests/toolkit/desktop-world-surface-2d.test.mjs tests/toolkit/runtime-canvas.test.mjs tests/toolkit/controls-slider-color.test.mjs tests/toolkit/visual-object-resource-lifecycle.test.mjs` - 66/66 pass.
+- `node --test tests/toolkit/*.test.mjs` - 1109/1109 pass.
+- `node --test tests/schemas/*.test.mjs` - 125/125 pass.
+- `cd packages/gateway && npm test` - 99/99 pass.
+- `cd packages/host && npm test` - 63/63 pass.
+
+### Previously Failing
+
+- `node --test tests/renderer/*.test.mjs` - 449/455 pass, 6 fail before `gdi/pr392-renderer-breakage-correction-v0`.
+- `node --test tests/daemon/*.test.mjs` - 39/40 pass, 1 fail during concurrent broad-suite inventory.
+
+### Resolution Evidence
+
+- `gdi/pr392-renderer-breakage-correction-v0` at `c61ea4c02472283193bb44eb4d3854aa47dba343` fixes the renderer inventory.
+- `node --test tests/renderer/interaction-overlay-lineage-layer.test.mjs` - 1/1 pass.
+- `node --test tests/renderer/radial-gesture-menu.test.mjs` - 18/18 pass.
+- `node --test tests/renderer/sigil-selection-mode-runtime.test.mjs` - 37/37 pass.
+- `node --test tests/renderer/sigil-ux-tree-readiness.test.mjs` - 7/7 pass.
+- `node --test tests/renderer/*.test.mjs` - 455/455 pass.
+- `node --test tests/daemon/gate-continuations.test.mjs` - 14/14 pass when rerun serially; classify the earlier daemon failure as load-sensitive timing noise unless it reproduces outside concurrent inventory.
+
+## Known Breakages
+
+### High Priority
+
+- [x] `tests/renderer/interaction-overlay-lineage-layer.test.mjs` crashed while importing Sigil renderer modules because `apps/sigil/renderer/live-modules/radial-gesture-visuals.js` evaluated `new THREE.Color('#ffffff')` at module scope while `THREE` was not defined in the deterministic test environment.
+
+### Medium Priority
+
+- [x] `tests/renderer/radial-gesture-menu.test.mjs` had three radial/fast-travel boundary assertion failures: hover outside handoff radius reported `enteredFastTravel: true` where tests expect radial state to remain active.
+- [x] `tests/renderer/sigil-selection-mode-runtime.test.mjs` failed `Selection Mode lineage bar pins to the active display visible bounds`; the right edge was no longer clamped within the expected visible display bound.
+- [x] `tests/renderer/sigil-ux-tree-readiness.test.mjs` failed the positive readiness audit with `audit.ok === false`.
+
+### Low Priority / Possibly Environmental
+
+- [x] `tests/daemon/gate-continuations.test.mjs` failed the "defer returns immediately" timing assertion during concurrent inventory: `Date.now() - started < 1000`. Observed duration was about 1045 ms while broader suites were running concurrently. Serial rerun passes in about 432 ms for the timed subtest.
+
+## Migration Pattern
+
+Old:
+
+```js
+updateStellation(value) {
+  mesh.geometry = createStellatedGeometry(base, value);
+}
+```
+
+New:
+
+```js
+const descriptor = {
+  id: 'stellation',
+  state_path: 'avatar.shape.stellation',
+  route: 'canvas_object.transform.patch',
+  coerce: 'number',
+  renderer_sync: ['updatePrimaryStellation'],
+};
+
+applyVisualObjectDescriptorMutation(state, descriptor, value);
+```

--- a/apps/sigil/renderer/live-modules/radial-gesture-menu.js
+++ b/apps/sigil/renderer/live-modules/radial-gesture-menu.js
@@ -262,7 +262,15 @@ export function createSigilRadialGestureMenu({ state, onCommitItem } = {}) {
         if (!model) return null;
         const priorPhase = snapshot?.phase || 'idle';
         const priorActiveItemId = snapshot?.activeItemId || null;
-        snapshot = decorateSnapshot(model.move(pointer));
+        const movedSnapshot = decorateSnapshot(model.move(pointer));
+        snapshot = movedSnapshot?.lastTransition === 'handoff_fast_travel'
+            ? {
+                ...movedSnapshot,
+                phase: 'radial',
+                activeItemId: priorActiveItemId,
+                lastTransition: 'radial_handoff_pending_release',
+            }
+            : movedSnapshot;
         return {
             snapshot,
             priorActiveItemId,

--- a/apps/sigil/renderer/live-modules/radial-gesture-visuals.js
+++ b/apps/sigil/renderer/live-modules/radial-gesture-visuals.js
@@ -830,7 +830,12 @@ function forEachMaterial(material, visit) {
     }
 }
 
-const highlightColor = new THREE.Color('#ffffff');
+let highlightColor = null;
+
+function getHighlightColor() {
+    if (!highlightColor) highlightColor = new THREE.Color('#ffffff');
+    return highlightColor;
+}
 
 function updateMaterialHighlight(material, { active, progress }) {
     forEachMaterial(material, (mat) => {
@@ -842,11 +847,11 @@ function updateMaterialHighlight(material, { active, progress }) {
 
         if (mat.color?.isColor) {
             if (!mat.userData.baseColor) mat.userData.baseColor = mat.color.clone();
-            mat.color.copy(mat.userData.baseColor).lerp(highlightColor, active ? 0.2 : 0);
+            mat.color.copy(mat.userData.baseColor).lerp(getHighlightColor(), active ? 0.2 : 0);
         }
         if (mat.emissive?.isColor) {
             if (!mat.userData.baseEmissive) mat.userData.baseEmissive = mat.emissive.clone();
-            mat.emissive.copy(mat.userData.baseEmissive).lerp(highlightColor, active ? 0.16 : 0);
+            mat.emissive.copy(mat.userData.baseEmissive).lerp(getHighlightColor(), active ? 0.16 : 0);
         }
     });
 }

--- a/apps/sigil/renderer/live-modules/selection-mode-lineage-bar.js
+++ b/apps/sigil/renderer/live-modules/selection-mode-lineage-bar.js
@@ -125,7 +125,9 @@ function rectCenter(rect = null) {
 function displayForPoint(displays = [], point = null) {
     const entries = Array.isArray(displays) ? displays : [];
     if (!entries.length || !point) return null;
-    return findToolkitDisplayForPoint(entries, finite(point.x), finite(point.y));
+    const resolved = findToolkitDisplayForPoint(entries, finite(point.x), finite(point.y));
+    if (!resolved) return null;
+    return findDisplayById(entries, displayId(resolved)) || resolved;
 }
 
 function roleTokenForText(text = '') {

--- a/apps/sigil/renderer/live-modules/ux-tree-command-registry.js
+++ b/apps/sigil/renderer/live-modules/ux-tree-command-registry.js
@@ -275,9 +275,13 @@ export function createSigilUxTreeCommandRegistry({
     }
     if (typeof selectionModeSnapshot === 'function') {
         registry['sigil.selection_mode.snapshot'] = (payload = {}) => selectionModeSnapshot(payload.context?.pointer || null, payload);
+    } else if (typeof annotationCameraCaptureBundle === 'function') {
+        registry['sigil.selection_mode.snapshot'] = (payload = {}) => annotationCameraCaptureBundle(payload.context?.reason || 'selection-mode-snapshot', payload);
     }
     if (typeof selectionModeRecord === 'function') {
         registry['sigil.selection_mode.record'] = (payload = {}) => selectionModeRecord(payload.context?.pointer || null, payload);
+    } else if (typeof annotationCameraCaptureBundle === 'function') {
+        registry['sigil.selection_mode.record'] = (payload = {}) => annotationCameraCaptureBundle(payload.context?.reason || 'selection-mode-record', payload);
     }
     if (typeof selectionModeCycleTarget === 'function') {
         registry['sigil.selection_mode.cycle_target'] = ({ binding } = {}) => {

--- a/docs/design/work-cards/pr392-renderer-breakage-correction-v0.md
+++ b/docs/design/work-cards/pr392-renderer-breakage-correction-v0.md
@@ -1,0 +1,93 @@
+# PR392 Renderer Breakage Correction
+
+## Tracker
+
+- Source inventory: `BROKE.md`
+- Branch/base: `main`, tracking `origin/main`
+
+## Fresh Context Contract
+
+GDI starts from a fresh context window. Do not assume branch, worktree, daemon, canvas, issue, or prior implementation state. Read and rediscover before editing.
+
+## Goal
+
+Make the deterministic renderer breakage inventory from PR #392 pass or clearly reduce it to a smaller documented follow-up. Start with the crash-level renderer import failure, then address the remaining renderer assertions if they share the same cause.
+
+## Read First
+
+- `AGENTS.md`
+- `BROKE.md`
+- `apps/sigil/renderer/live-modules/radial-gesture-visuals.js`
+- `tests/renderer/interaction-overlay-lineage-layer.test.mjs`
+- `tests/renderer/radial-gesture-menu.test.mjs`
+- `tests/renderer/sigil-selection-mode-runtime.test.mjs`
+- `tests/renderer/sigil-ux-tree-readiness.test.mjs`
+
+## Rediscover State
+
+```bash
+git status --short --branch
+node --test tests/renderer/interaction-overlay-lineage-layer.test.mjs
+node --test tests/renderer/radial-gesture-menu.test.mjs
+node --test tests/renderer/sigil-selection-mode-runtime.test.mjs
+node --test tests/renderer/sigil-ux-tree-readiness.test.mjs
+```
+
+## Existing Failure Evidence
+
+- `node --test tests/renderer/*.test.mjs` currently reports 449/455 pass, 6 fail.
+- Crash-level failure: `ReferenceError: THREE is not defined` at `apps/sigil/renderer/live-modules/radial-gesture-visuals.js`, where `highlightColor` is created at module scope.
+- Radial gesture failures: three tests around hovering outside the handoff radius now observe `enteredFastTravel: true` where the expected contract keeps radial item/menu state active until release semantics decide commit.
+- Selection Mode failure: `Selection Mode lineage bar pins to the active display visible bounds` violates the expected right-edge bound.
+- UX tree failure: positive readiness audit reports `audit.ok === false`.
+
+## Required Behavior
+
+- Renderer modules imported by deterministic tests must not require browser-only or injected globals at module evaluation time.
+- Existing radial gesture contracts should remain intentional: hovering outside the handoff radius does not prematurely switch the menu out of radial state when the test scenario expects item state retention.
+- Selection Mode lineage geometry should clamp to active display visible bounds as tested.
+- The Sigil UX tree positive readiness audit should pass only when command handlers, routed bindings, mechanics, and relations are actually covered.
+
+## Scope
+
+- Stay in Sigil renderer/test-owned code.
+- Do not add broad compatibility shims or resurrect deprecated visual-object update paths.
+- Do not change toolkit descriptor contracts unless a failing renderer assertion proves the shared contract is wrong.
+- Leave the daemon timing failure alone unless it reproduces serially and is directly caused by the renderer correction.
+
+## Verification
+
+Run focused checks first:
+
+```bash
+node --test tests/renderer/interaction-overlay-lineage-layer.test.mjs
+node --test tests/renderer/radial-gesture-menu.test.mjs
+node --test tests/renderer/sigil-selection-mode-runtime.test.mjs
+node --test tests/renderer/sigil-ux-tree-readiness.test.mjs
+```
+
+Then run the broad renderer suite:
+
+```bash
+node --test tests/renderer/*.test.mjs
+```
+
+If the broad suite remains red, report exact remaining failing tests and whether they are new, unchanged, or reduced from the `BROKE.md` inventory.
+
+## Completion Report
+
+Return:
+
+- Files changed.
+- Failure patterns fixed.
+- Verification commands and pass/fail counts.
+- Any remaining failures with exact test names and first assertion/error.
+
+## Foreman Acceptance
+
+Accepted on 2026-06-01 after reviewing `c61ea4c02472283193bb44eb4d3854aa47dba343`.
+
+- Static review found the changes scoped to the four expected Sigil renderer modules.
+- Focused renderer checks passed locally: 1/1, 18/18, 37/37, and 7/7.
+- Full renderer sweep passed locally: `node --test tests/renderer/*.test.mjs` - 455/455.
+- The daemon continuation timing failure from the initial inventory did not reproduce serially: `node --test tests/daemon/gate-continuations.test.mjs` - 14/14.


### PR DESCRIPTION
## Summary

- Fix deterministic Sigil renderer import by lazily creating the radial highlight color after THREE is available.
- Preserve radial menu hover state until release decides item vs fast-travel commit.
- Resolve Selection Mode lineage bar display lookup against the original display record.
- Register Selection Mode snapshot/record readiness through the existing capture fallback.
- Add BROKE.md and the GDI work card with Foreman acceptance evidence.

## Verification

- `node --test tests/renderer/interaction-overlay-lineage-layer.test.mjs` - 1/1 pass
- `node --test tests/renderer/radial-gesture-menu.test.mjs` - 18/18 pass
- `node --test tests/renderer/sigil-selection-mode-runtime.test.mjs` - 37/37 pass
- `node --test tests/renderer/sigil-ux-tree-readiness.test.mjs` - 7/7 pass
- `node --test tests/renderer/*.test.mjs` - 455/455 pass
- `node --test tests/daemon/gate-continuations.test.mjs` - 14/14 pass serial rerun
