### PR TITLE
fix(sigil): bind compact surface descriptors live

### DIFF
--- a/apps/sigil/avatar-editor/model.js
+++ b/apps/sigil/avatar-editor/model.js
@@ -2,10 +2,7 @@ import {
     contextMenuControlDescriptors,
     getContextMenuControlDescriptor,
 } from '../context-menu/descriptors.js';
-import {
-    createVisualObjectDescriptor,
-    VISUAL_OBJECT_DESCRIPTOR_CONTRACT_ID,
-} from '../../../packages/toolkit/workbench/visual-object-contract.js';
+import { toolkitSpecifier } from '../renderer/live-modules/content-roots.js';
 import {
     AVATAR_AURA_OBJECT_ID,
     AVATAR_LIGHTNING_OBJECT_ID,
@@ -19,6 +16,13 @@ import {
     AVATAR_TRAIL_OBJECT_ID,
     AVATAR_TRAVEL_OBJECT_ID,
 } from '../renderer/live-modules/avatar-object-control.js';
+
+const {
+    createVisualObjectDescriptor,
+    VISUAL_OBJECT_DESCRIPTOR_CONTRACT_ID,
+} = await import(toolkitSpecifier('workbench/visual-object-contract.js', {
+    local: '../../../packages/toolkit/workbench/visual-object-contract.js',
+}));
 
 export const SIGIL_AVATAR_SUBJECT_ID = 'sigil.avatar:avatar-main';
 export const SIGIL_AVATAR_SUBJECT_TYPE = 'sigil.avatar';

--- a/apps/sigil/context-menu/descriptors.js
+++ b/apps/sigil/context-menu/descriptors.js
@@ -351,6 +351,7 @@ function syncRenderer(descriptor, value, context) {
         if (hook === 'updateGeometry') context.updateGeometry?.(context.state?.avatar?.shape?.type ?? context.state?.currentGeometryType ?? context.state?.currentType);
         else if (hook === 'updatePrimaryStellation') context.updatePrimaryStellation?.(value);
         else if (hook === 'updatePrimaryAppearance') context.updatePrimaryAppearance?.();
+        else if (hook === 'updatePrimaryTesseronProportion') context.updatePrimaryTesseronProportion?.(value);
         else if (hook === 'updateOmegaGeometry') context.updateOmegaGeometry?.(context.state?.avatar?.effects?.omega?.shape?.type ?? context.state?.omegaGeometryType ?? context.state?.omegaType);
         else if (hook === 'updateAllColors') context.updateAllColors?.();
         else if (hook === 'updatePulsars') context.updatePulsars?.(context.state?.pulsarRayCount);

--- a/apps/sigil/context-menu/menu.js
+++ b/apps/sigil/context-menu/menu.js
@@ -9,9 +9,12 @@ import {
     DEFAULT_FAST_TRAVEL_EFFECT,
     normalizeFastTravelEffect,
 } from '../renderer/transition-registry.js';
+import { syncAvatarAliasesFromGraph } from '../renderer/state.js';
 import { isTesseronSupportedShape, normalizeTesseronConfig } from '../renderer/tesseron.js';
 import {
     applyContextMenuDescriptorUpdate,
+    contextMenuControlDescriptors,
+    getContextMenuControlDescriptor,
 } from './descriptors.js';
 
 let compactSurfaceModulePromise = null;
@@ -39,6 +42,12 @@ function computeBaseScale(base) {
     return (base / REF_BASE) * REF_SCALE * (REF_HEIGHT / viewportHeight);
 }
 
+function statePathText(value) {
+    return (Array.isArray(value) ? value : String(value ?? '').split('.'))
+        .filter((part) => part !== '')
+        .join('.');
+}
+
 function rectContainsPoint(rect, point) {
     return rect
         && Number.isFinite(rect.left)
@@ -49,6 +58,30 @@ function rectContainsPoint(rect, point) {
         && point.y >= rect.top
         && point.x < rect.right
         && point.y < rect.bottom;
+}
+
+function elementContains(parent, child) {
+    if (!parent || !child) return false;
+    if (typeof parent.contains === 'function') return parent.contains(child);
+    for (let cursor = child; cursor; cursor = cursor.parentElement) {
+        if (cursor === parent) return true;
+    }
+    return false;
+}
+
+function closestAny(element, selectors = []) {
+    if (!element) return null;
+    const combinedSelector = selectors.join(', ');
+    const combined = element.closest?.(combinedSelector);
+    if (combined) return combined;
+    for (const selector of selectors) {
+        const match = element.closest?.(selector);
+        if (match) return match;
+    }
+    for (let cursor = element; cursor; cursor = cursor.parentElement) {
+        if (selectors.some((selector) => cursor.matches?.(selector))) return cursor;
+    }
+    return null;
 }
 
 function displayVisibleBoundsForPoint(displays = [], point) {
@@ -151,25 +184,30 @@ export function resolveContextMenuOrigin(point, options = {}) {
 export function findContextMenuElementAt(anchor, point, doc = document) {
     if (!anchor || !point || !Number.isFinite(point.x) || !Number.isFinite(point.y)) return null;
     const viewportHit = doc?.elementFromPoint?.(point.x, point.y);
-    if (viewportHit && anchor.contains(viewportHit)) return viewportHit;
+    if (viewportHit && elementContains(anchor, viewportHit)) return viewportHit;
 
-    const candidates = Array.from(anchor.querySelectorAll(
-        [
-            'button',
-            'input',
-            'select',
-            'textarea',
-            'label',
-            '.sigil-avatar-control-surface',
-            '.aos-form-field',
-            '[data-aos-select-content]',
-            '[data-aos-select-item]',
-            '[data-aos-slider-root]',
-            '[data-aos-slider-control]',
-            '[data-aos-slider-track]',
-            '[data-aos-slider-thumb]',
-        ].join(', ')
-    ));
+    const selectors = [
+        'button',
+        'input',
+        'select',
+        'textarea',
+        'label',
+        '.sigil-avatar-control-surface',
+        '.aos-form-field',
+        '[data-aos-select-content]',
+        '[data-aos-select-item]',
+        '[data-aos-slider-root]',
+        '[data-aos-slider-control]',
+        '[data-aos-slider-track]',
+        '[data-aos-slider-thumb]',
+    ];
+    const combinedSelector = selectors.join(', ');
+    const combinedCandidates = Array.from(anchor.querySelectorAll(combinedSelector) || []);
+    const candidates = combinedCandidates.length
+        ? combinedCandidates
+        : Array.from(new Set(selectors.flatMap((selector) => (
+            Array.from(anchor.querySelectorAll(selector) || [])
+        ))));
     for (let i = candidates.length - 1; i >= 0; i -= 1) {
         const element = candidates[i];
         if (element.hidden) continue;
@@ -220,6 +258,8 @@ export function createSigilContextMenu({
     projectPoint,
     updateGeometry,
     updatePrimaryStellation,
+    updatePrimaryAppearance,
+    updatePrimaryTesseronProportion,
     updateOmegaGeometry,
     updateAllColors,
     updatePulsars,
@@ -240,7 +280,17 @@ export function createSigilContextMenu({
     layer.innerHTML = menuMarkup();
     document.body.appendChild(layer);
 
-    const anchor = layer.querySelector('#sigil-context-menu');
+    let anchor = layer.querySelector('#sigil-context-menu');
+    if (!anchor) {
+        anchor = document.createElement('div');
+        anchor.id = 'sigil-context-menu';
+        anchor.className = 'ctx-anchor sigil-context-menu';
+        anchor.setAttribute('role', 'dialog');
+        anchor.setAttribute('aria-modal', 'false');
+        anchor.setAttribute('aria-label', 'Sigil avatar control surface');
+        anchor.setAttribute('aria-hidden', 'true');
+        layer.appendChild(anchor);
+    }
     let menuState = {
         open: false,
         bounds: null,
@@ -326,6 +376,8 @@ export function createSigilContextMenu({
             liveJs,
             updateGeometry,
             updatePrimaryStellation,
+            updatePrimaryAppearance,
+            updatePrimaryTesseronProportion,
             updateOmegaGeometry,
             updateAllColors,
             updatePulsars,
@@ -351,6 +403,110 @@ export function createSigilContextMenu({
             persisted: result.persisted,
         });
         return result;
+    }
+
+    function compatibilityDescriptorForVisualDescriptor(descriptor = {}) {
+        if (!descriptor) return null;
+        return getContextMenuControlDescriptor(descriptor.id)
+            || getContextMenuControlDescriptor(descriptor.state_path)
+            || getContextMenuControlDescriptor(descriptor.action_id)
+            || contextMenuControlDescriptors.find((entry) => (
+                statePathText(entry.statePath) === statePathText(descriptor.state_path)
+                && (!descriptor.route || entry.route === descriptor.route)
+            ))
+            || null;
+    }
+
+    function applyVisualBindingCompatibility(context = {}) {
+        const { descriptor, mutation } = context;
+        const compatibility = compatibilityDescriptorForVisualDescriptor(descriptor);
+        const value = mutation?.value;
+        if (!state || !compatibility) return;
+
+        if (mutation?.state_path?.startsWith?.('avatar.')) syncAvatarAliasesFromGraph(state);
+
+        if (compatibility.id === 'sigil-menu-shape-select') {
+            state.currentType = value;
+            const supported = isTesseronSupportedShape(value);
+            setControlDisabled('sigil-menu-tesseron', !supported);
+            setControlDisabled('sigil-menu-stellation', supported && !!state.avatar?.shape?.tesseron?.enabled);
+        } else if (compatibility.id === 'sigil-menu-tesseron') {
+            state.avatar.shape.tesseron = normalizeTesseronConfig(state.avatar.shape.tesseron);
+            setControlDisabled('sigil-menu-stellation', value);
+            setControlDisabled('sigil-menu-tesseron-proportion', !value);
+            setControlDisabled('sigil-menu-tesseron-match', !value);
+        } else if (compatibility.id === 'sigil-menu-tesseron-match' && !value) {
+            state.avatar.shape.tesseron = normalizeTesseronConfig(state.avatar.shape.tesseron);
+            state.avatar.shape.tesseron.child.opacity ??= state.avatar.appearance.opacity;
+            state.avatar.shape.tesseron.child.edgeOpacity ??= state.avatar.appearance.edgeOpacity;
+            state.avatar.shape.tesseron.child.maskEnabled ??= state.avatar.appearance.maskEnabled;
+            state.avatar.shape.tesseron.child.interiorEdges ??= state.avatar.appearance.interiorEdges;
+            state.avatar.shape.tesseron.child.specular ??= state.avatar.appearance.specular;
+        } else if (compatibility.id === 'sigil-menu-pulsar' && value && (state.avatar?.effects?.phenomena?.pulsar?.count ?? 0) <= 0) {
+            state.avatar.effects.phenomena.pulsar.count = 1;
+            syncAvatarAliasesFromGraph(state);
+        } else if (compatibility.id === 'sigil-menu-accretion' && value && (state.avatar?.effects?.phenomena?.accretion?.count ?? 0) <= 0) {
+            state.avatar.effects.phenomena.accretion.count = 1;
+            syncAvatarAliasesFromGraph(state);
+        } else if (compatibility.id === 'sigil-menu-gamma' && value && (state.avatar?.effects?.phenomena?.gamma?.count ?? 0) <= 0) {
+            state.avatar.effects.phenomena.gamma.count = 3;
+            syncAvatarAliasesFromGraph(state);
+        } else if (compatibility.id === 'sigil-menu-neutrino' && value && (state.avatar?.effects?.phenomena?.neutrino?.count ?? 0) <= 0) {
+            state.avatar.effects.phenomena.neutrino.count = 1;
+            syncAvatarAliasesFromGraph(state);
+        } else if (compatibility.id === 'sigil-menu-line-interdim') {
+            setControlValue('sigil-menu-line-trail-enabled', null, value);
+        } else if (compatibility.id === 'sigil-menu-omega-shape') {
+            state.omegaType = value;
+            const supported = isTesseronSupportedShape(value);
+            setControlDisabled('sigil-menu-omega-tesseron', !supported);
+            setControlDisabled('sigil-menu-omega-stellation', supported && !!state.avatar?.effects?.omega?.shape?.tesseron?.enabled);
+        } else if (compatibility.id === 'sigil-menu-omega-tesseron') {
+            state.avatar.effects.omega.shape.tesseron = normalizeTesseronConfig(state.avatar.effects.omega.shape.tesseron);
+            setControlDisabled('sigil-menu-omega-stellation', value);
+            setControlDisabled('sigil-menu-omega-tesseron-proportion', !value);
+            setControlDisabled('sigil-menu-omega-tesseron-match', !value);
+        }
+
+        if (compatibility.persistence === 'appearance') {
+            onAppearanceChange?.({ controlId: compatibility.id, value, descriptor: compatibility });
+        }
+        recordTrace('visual-object-binding-update', {
+            descriptorId: descriptor.id,
+            compatibilityId: compatibility.id,
+            route: mutation?.route,
+            value,
+        });
+    }
+
+    function visualObjectRouteHandlers() {
+        const handler = (context) => {
+            applyVisualBindingCompatibility(context);
+            return true;
+        };
+        return {
+            'canvas_object.transform.patch': handler,
+            'canvas_object.effects.patch': handler,
+        };
+    }
+
+    function visualObjectRendererSyncHandlers() {
+        return {
+            updateGeometry: () => updateGeometry?.(state?.avatar?.shape?.type ?? state?.currentGeometryType ?? state?.currentType),
+            updatePrimaryStellation: ({ mutation }) => updatePrimaryStellation?.(mutation.value),
+            updatePrimaryAppearance: () => updatePrimaryAppearance?.(),
+            updatePrimaryTesseronProportion: ({ mutation }) => updatePrimaryTesseronProportion?.(mutation.value),
+            updateOmegaGeometry: () => updateOmegaGeometry?.(state?.avatar?.effects?.omega?.shape?.type ?? state?.omegaGeometryType ?? state?.omegaType),
+            updateAllColors: () => updateAllColors?.(),
+            updatePulsars: () => updatePulsars?.(state?.pulsarRayCount),
+            updateGammaRays: () => updateGammaRays?.(state?.gammaRayCount),
+            updateAccretion: () => updateAccretion?.(state?.accretionDiskCount),
+            updateNeutrinos: () => updateNeutrinos?.(state?.neutrinoJetCount),
+            updateMagneticTentacleCount: ({ mutation }) => updateMagneticTentacleCount?.(mutation.value),
+            avatarScale: ({ mutation }) => {
+                if (state) state.baseScale = computeBaseScale(mutation.value) ?? state.baseScale;
+            },
+        };
     }
 
     function cacheKey(value) {
@@ -423,8 +579,16 @@ export function createSigilContextMenu({
         compactSurface = createSigilAvatarCompactControlSurface(anchor, state || {}, {
             document,
             defaultTab: activeTab || compactSurface?.getActiveTab?.() || undefined,
-            onControlChange(payload = {}) {
-                routeChangedControls(payload.section?.controls || [], payload.values || {});
+            visualObjectBinding: {
+                state,
+                routeHandlers: visualObjectRouteHandlers(),
+                rendererSyncHandlers: visualObjectRendererSyncHandlers(),
+            },
+            onControlChange() {
+                queueMicrotask(() => {
+                    syncFromState();
+                    syncSnapshot();
+                });
             },
             onProjectionChange(payload = {}) {
                 routeChangedControls(payload.controls || [], payload.values || {});
@@ -462,16 +626,16 @@ export function createSigilContextMenu({
     }
 
     function compactFieldRecordForElement(element) {
-        const fieldEl = element?.closest?.('.aos-form-field');
+        const fieldEl = closestAny(element, ['.aos-form-field']);
         const fieldId = fieldEl?.dataset?.aosFieldId;
         if (!fieldId || !compactSurface) return null;
         for (const entry of compactSurface.forms.values()) {
-            if (!entry.el.contains(fieldEl)) continue;
+            if (!elementContains(entry.el, fieldEl)) continue;
             const field = entry.form.getField(fieldId);
             if (field) return { ...field, form: entry.form, section: entry.section, tab: entry.tab };
         }
         for (const form of compactSurface.projectionForms.values()) {
-            if (!form.el.contains(fieldEl)) continue;
+            if (!elementContains(form.el, fieldEl)) continue;
             const field = form.getField(fieldId);
             if (field) return { ...field, form };
         }
@@ -498,7 +662,10 @@ export function createSigilContextMenu({
         const max = Number.isFinite(Number(record.field.max)) ? Number(record.field.max) : 100;
         const ratio = clamp((local.x - rect.left) / rect.width, 0, 1);
         const value = snappedSliderValue(min + ((max - min) * ratio), record.field);
-        record.control.setValue(value, { emit: true });
+        const current = Number(record.control.getValue?.());
+        if (!Number.isFinite(current) || current !== value) {
+            record.control.setValue(value, { emit: true });
+        }
         if (options.commit) record.control.el?.dispatchEvent?.(new Event('commit', { bubbles: true }));
         return true;
     }
@@ -744,7 +911,7 @@ export function createSigilContextMenu({
     function containsDesktopPoint(point) {
         if (!point) return false;
         const target = elementAt(point);
-        if (target && anchor.contains(target)) return true;
+        if (target && elementContains(anchor, target)) return true;
         const b = surfaceBounds() || menuState.bounds;
         return !!(b
             && point.x >= b.x
@@ -765,14 +932,14 @@ export function createSigilContextMenu({
     }
 
     function activeScrollableSurface(target) {
-        return target?.closest?.('.sigil-avatar-control-surface')
+        return closestAny(target, ['.sigil-avatar-control-surface'])
             || anchor.querySelector('.sigil-avatar-control-surface');
     }
 
     function scrollSurfaceAt(point, event = {}) {
         const target = elementAt(point);
         let surface = null;
-        if (target && anchor.contains(target)) {
+        if (target && elementContains(anchor, target)) {
             surface = activeScrollableSurface(target);
         } else {
             const b = surfaceBounds() || menuState.bounds;
@@ -821,11 +988,11 @@ export function createSigilContextMenu({
         if (kind !== 'left_mouse_down' && kind !== 'left_mouse_up') return true;
 
         const target = elementAt(point);
-        if (!target || !anchor.contains(target)) {
+        if (!target || !elementContains(anchor, target)) {
             recordTrace('pointer:no-target', { kind, point, target: describeElement(target) });
             return true;
         }
-        const input = target.closest?.([
+        const input = closestAny(target, [
             'input',
             'button',
             'label',
@@ -835,7 +1002,7 @@ export function createSigilContextMenu({
             '[data-aos-slider-control]',
             '[data-aos-slider-track]',
             '[data-aos-slider-thumb]',
-        ].join(', '));
+        ]);
         recordTrace('pointer:target', {
             kind,
             point,
@@ -844,7 +1011,7 @@ export function createSigilContextMenu({
         });
         if (!input) return true;
 
-        const sliderRoot = input.closest?.('[data-aos-slider-root]');
+        const sliderRoot = closestAny(input, ['[data-aos-slider-root]']);
         if (kind === 'left_mouse_down' && sliderRoot) {
             menuState.activeSlider = { sliderRoot };
             return updateCompactSliderAt(sliderRoot, point);

--- a/apps/sigil/context-menu/menu.js
+++ b/apps/sigil/context-menu/menu.js
@@ -9,13 +9,11 @@ import {
     DEFAULT_FAST_TRAVEL_EFFECT,
     normalizeFastTravelEffect,
 } from '../renderer/transition-registry.js';
-import { syncAvatarAliasesFromGraph } from '../renderer/state.js';
 import { isTesseronSupportedShape, normalizeTesseronConfig } from '../renderer/tesseron.js';
 import {
     applyContextMenuDescriptorUpdate,
-    contextMenuControlDescriptors,
-    getContextMenuControlDescriptor,
 } from './descriptors.js';
+import { createVisualObjectBindingAdapter } from './visual-object-binding.js';
 
 let compactSurfaceModulePromise = null;
 
@@ -40,12 +38,6 @@ function computeBaseScale(base) {
         ? Math.max(1, window.innerHeight)
         : REF_HEIGHT;
     return (base / REF_BASE) * REF_SCALE * (REF_HEIGHT / viewportHeight);
-}
-
-function statePathText(value) {
-    return (Array.isArray(value) ? value : String(value ?? '').split('.'))
-        .filter((part) => part !== '')
-        .join('.');
 }
 
 function rectContainsPoint(rect, point) {
@@ -74,10 +66,6 @@ function closestAny(element, selectors = []) {
     const combinedSelector = selectors.join(', ');
     const combined = element.closest?.(combinedSelector);
     if (combined) return combined;
-    for (const selector of selectors) {
-        const match = element.closest?.(selector);
-        if (match) return match;
-    }
     for (let cursor = element; cursor; cursor = cursor.parentElement) {
         if (selectors.some((selector) => cursor.matches?.(selector))) return cursor;
     }
@@ -274,6 +262,7 @@ export function createSigilContextMenu({
     onBoundsChange,
     onClose,
     trace,
+    allowTestAnchorFallback = false,
 } = {}) {
     const layer = document.createElement('div');
     layer.className = 'sigil-context-menu-layer';
@@ -282,14 +271,19 @@ export function createSigilContextMenu({
 
     let anchor = layer.querySelector('#sigil-context-menu');
     if (!anchor) {
-        anchor = document.createElement('div');
-        anchor.id = 'sigil-context-menu';
-        anchor.className = 'ctx-anchor sigil-context-menu';
-        anchor.setAttribute('role', 'dialog');
-        anchor.setAttribute('aria-modal', 'false');
-        anchor.setAttribute('aria-label', 'Sigil avatar control surface');
-        anchor.setAttribute('aria-hidden', 'true');
-        layer.appendChild(anchor);
+        if (allowTestAnchorFallback) {
+            anchor = document.createElement('div');
+            anchor.id = 'sigil-context-menu';
+            anchor.className = 'ctx-anchor sigil-context-menu';
+            anchor.setAttribute('role', 'dialog');
+            anchor.setAttribute('aria-modal', 'false');
+            anchor.setAttribute('aria-label', 'Sigil avatar control surface');
+            anchor.setAttribute('aria-hidden', 'true');
+            layer.appendChild(anchor);
+        }
+    }
+    if (!anchor) {
+        throw new TypeError('Sigil context menu markup must include #sigil-context-menu.');
     }
     let menuState = {
         open: false,
@@ -405,109 +399,10 @@ export function createSigilContextMenu({
         return result;
     }
 
-    function compatibilityDescriptorForVisualDescriptor(descriptor = {}) {
-        if (!descriptor) return null;
-        return getContextMenuControlDescriptor(descriptor.id)
-            || getContextMenuControlDescriptor(descriptor.state_path)
-            || getContextMenuControlDescriptor(descriptor.action_id)
-            || contextMenuControlDescriptors.find((entry) => (
-                statePathText(entry.statePath) === statePathText(descriptor.state_path)
-                && (!descriptor.route || entry.route === descriptor.route)
-            ))
-            || null;
-    }
-
-    function applyVisualBindingCompatibility(context = {}) {
-        const { descriptor, mutation } = context;
-        const compatibility = compatibilityDescriptorForVisualDescriptor(descriptor);
-        const value = mutation?.value;
-        if (!state || !compatibility) return;
-
-        if (mutation?.state_path?.startsWith?.('avatar.')) syncAvatarAliasesFromGraph(state);
-
-        if (compatibility.id === 'sigil-menu-shape-select') {
-            state.currentType = value;
-            const supported = isTesseronSupportedShape(value);
-            setControlDisabled('sigil-menu-tesseron', !supported);
-            setControlDisabled('sigil-menu-stellation', supported && !!state.avatar?.shape?.tesseron?.enabled);
-        } else if (compatibility.id === 'sigil-menu-tesseron') {
-            state.avatar.shape.tesseron = normalizeTesseronConfig(state.avatar.shape.tesseron);
-            setControlDisabled('sigil-menu-stellation', value);
-            setControlDisabled('sigil-menu-tesseron-proportion', !value);
-            setControlDisabled('sigil-menu-tesseron-match', !value);
-        } else if (compatibility.id === 'sigil-menu-tesseron-match' && !value) {
-            state.avatar.shape.tesseron = normalizeTesseronConfig(state.avatar.shape.tesseron);
-            state.avatar.shape.tesseron.child.opacity ??= state.avatar.appearance.opacity;
-            state.avatar.shape.tesseron.child.edgeOpacity ??= state.avatar.appearance.edgeOpacity;
-            state.avatar.shape.tesseron.child.maskEnabled ??= state.avatar.appearance.maskEnabled;
-            state.avatar.shape.tesseron.child.interiorEdges ??= state.avatar.appearance.interiorEdges;
-            state.avatar.shape.tesseron.child.specular ??= state.avatar.appearance.specular;
-        } else if (compatibility.id === 'sigil-menu-pulsar' && value && (state.avatar?.effects?.phenomena?.pulsar?.count ?? 0) <= 0) {
-            state.avatar.effects.phenomena.pulsar.count = 1;
-            syncAvatarAliasesFromGraph(state);
-        } else if (compatibility.id === 'sigil-menu-accretion' && value && (state.avatar?.effects?.phenomena?.accretion?.count ?? 0) <= 0) {
-            state.avatar.effects.phenomena.accretion.count = 1;
-            syncAvatarAliasesFromGraph(state);
-        } else if (compatibility.id === 'sigil-menu-gamma' && value && (state.avatar?.effects?.phenomena?.gamma?.count ?? 0) <= 0) {
-            state.avatar.effects.phenomena.gamma.count = 3;
-            syncAvatarAliasesFromGraph(state);
-        } else if (compatibility.id === 'sigil-menu-neutrino' && value && (state.avatar?.effects?.phenomena?.neutrino?.count ?? 0) <= 0) {
-            state.avatar.effects.phenomena.neutrino.count = 1;
-            syncAvatarAliasesFromGraph(state);
-        } else if (compatibility.id === 'sigil-menu-line-interdim') {
-            setControlValue('sigil-menu-line-trail-enabled', null, value);
-        } else if (compatibility.id === 'sigil-menu-omega-shape') {
-            state.omegaType = value;
-            const supported = isTesseronSupportedShape(value);
-            setControlDisabled('sigil-menu-omega-tesseron', !supported);
-            setControlDisabled('sigil-menu-omega-stellation', supported && !!state.avatar?.effects?.omega?.shape?.tesseron?.enabled);
-        } else if (compatibility.id === 'sigil-menu-omega-tesseron') {
-            state.avatar.effects.omega.shape.tesseron = normalizeTesseronConfig(state.avatar.effects.omega.shape.tesseron);
-            setControlDisabled('sigil-menu-omega-stellation', value);
-            setControlDisabled('sigil-menu-omega-tesseron-proportion', !value);
-            setControlDisabled('sigil-menu-omega-tesseron-match', !value);
-        }
-
-        if (compatibility.persistence === 'appearance') {
-            onAppearanceChange?.({ controlId: compatibility.id, value, descriptor: compatibility });
-        }
-        recordTrace('visual-object-binding-update', {
-            descriptorId: descriptor.id,
-            compatibilityId: compatibility.id,
-            route: mutation?.route,
-            value,
-        });
-    }
-
-    function visualObjectRouteHandlers() {
-        const handler = (context) => {
-            applyVisualBindingCompatibility(context);
-            return true;
-        };
-        return {
-            'canvas_object.transform.patch': handler,
-            'canvas_object.effects.patch': handler,
-        };
-    }
-
-    function visualObjectRendererSyncHandlers() {
-        return {
-            updateGeometry: () => updateGeometry?.(state?.avatar?.shape?.type ?? state?.currentGeometryType ?? state?.currentType),
-            updatePrimaryStellation: ({ mutation }) => updatePrimaryStellation?.(mutation.value),
-            updatePrimaryAppearance: () => updatePrimaryAppearance?.(),
-            updatePrimaryTesseronProportion: ({ mutation }) => updatePrimaryTesseronProportion?.(mutation.value),
-            updateOmegaGeometry: () => updateOmegaGeometry?.(state?.avatar?.effects?.omega?.shape?.type ?? state?.omegaGeometryType ?? state?.omegaType),
-            updateAllColors: () => updateAllColors?.(),
-            updatePulsars: () => updatePulsars?.(state?.pulsarRayCount),
-            updateGammaRays: () => updateGammaRays?.(state?.gammaRayCount),
-            updateAccretion: () => updateAccretion?.(state?.accretionDiskCount),
-            updateNeutrinos: () => updateNeutrinos?.(state?.neutrinoJetCount),
-            updateMagneticTentacleCount: ({ mutation }) => updateMagneticTentacleCount?.(mutation.value),
-            avatarScale: ({ mutation }) => {
-                if (state) state.baseScale = computeBaseScale(mutation.value) ?? state.baseScale;
-            },
-        };
-    }
+    const visualObjectBinding = createVisualObjectBindingAdapter({
+        descriptorContext,
+        recordTrace,
+    });
 
     function cacheKey(value) {
         if (value === undefined) return 'undefined';
@@ -581,8 +476,8 @@ export function createSigilContextMenu({
             defaultTab: activeTab || compactSurface?.getActiveTab?.() || undefined,
             visualObjectBinding: {
                 state,
-                routeHandlers: visualObjectRouteHandlers(),
-                rendererSyncHandlers: visualObjectRendererSyncHandlers(),
+                routeHandlers: visualObjectBinding.routeHandlers,
+                rendererSyncHandlers: visualObjectBinding.rendererSyncHandlers,
             },
             onControlChange() {
                 queueMicrotask(() => {

--- a/apps/sigil/context-menu/visual-object-binding.js
+++ b/apps/sigil/context-menu/visual-object-binding.js
@@ -1,0 +1,74 @@
+import {
+    applyContextMenuDescriptorUpdate,
+    contextMenuControlDescriptors,
+    getContextMenuControlDescriptor,
+} from './descriptors.js';
+
+function text(value) {
+    return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function statePathText(value) {
+    return (Array.isArray(value) ? value : text(value).split('.'))
+        .filter((part) => part !== '')
+        .join('.');
+}
+
+export function contextMenuDescriptorForVisualObjectDescriptor(descriptor = {}) {
+    if (!descriptor) return null;
+    return getContextMenuControlDescriptor(descriptor.id)
+        || getContextMenuControlDescriptor(descriptor.state_path)
+        || getContextMenuControlDescriptor(descriptor.action_id)
+        || contextMenuControlDescriptors.find((entry) => (
+            statePathText(entry.statePath) === statePathText(descriptor.state_path)
+            && (!descriptor.route || entry.route === descriptor.route)
+        ))
+        || null;
+}
+
+export function createVisualObjectBindingAdapter({
+    descriptorContext,
+    recordTrace,
+} = {}) {
+    const context = typeof descriptorContext === 'function' ? descriptorContext : () => ({});
+
+    function applyVisualObjectDescriptorUpdate(bindingContext = {}) {
+        const { descriptor, mutation } = bindingContext;
+        const compatibility = contextMenuDescriptorForVisualObjectDescriptor(descriptor);
+        if (!compatibility) return false;
+
+        const updateContext = context();
+        const result = applyContextMenuDescriptorUpdate(
+            compatibility.id,
+            mutation?.value,
+            {
+                ...updateContext,
+                onAppearanceChange(event = {}) {
+                    updateContext.onAppearanceChange?.({
+                        ...event,
+                        descriptor,
+                        compatibilityDescriptor: event.descriptor,
+                        descriptorContract: 'aos.visual_object.descriptor.v0',
+                    });
+                },
+            }
+        );
+        if (!result) return false;
+
+        recordTrace?.('visual-object-binding-update', {
+            descriptorId: descriptor.id,
+            compatibilityId: compatibility.id,
+            route: mutation?.route,
+            value: result.value,
+        });
+        return true;
+    }
+
+    return {
+        routeHandlers: {
+            'canvas_object.transform.patch': applyVisualObjectDescriptorUpdate,
+            'canvas_object.effects.patch': applyVisualObjectDescriptorUpdate,
+        },
+        rendererSyncHandlers: {},
+    };
+}

--- a/tests/renderer/context-menu-hit-test.test.mjs
+++ b/tests/renderer/context-menu-hit-test.test.mjs
@@ -1,6 +1,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import {
+  createSigilContextMenu,
   contextMenuSurfaceScrollDelta,
   contextMenuContentProps,
   findContextMenuElementAt,
@@ -12,6 +13,19 @@ import {
   contextMenuControlDescriptors,
   getContextMenuControlDescriptor,
 } from '../../apps/sigil/context-menu/descriptors.js'
+import { createDefaultAvatarState } from '../../apps/sigil/renderer/state.js'
+import { createDocument, patchSpreadSupport } from '../toolkit/zag-adapter-test-utils.mjs'
+
+function createPatchedDocument() {
+  const document = createDocument()
+  const createElement = document.createElement.bind(document)
+  document.createElement = (tagName) => patchSpreadSupport(createElement(tagName))
+  return document
+}
+
+function waitForMicrotasks() {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
 
 function fakeElement(id, rect, selector = '*') {
   return {
@@ -229,6 +243,79 @@ test('context menu descriptors carry toolkit form metadata for compact avatar su
   assert.equal(opacity.step, 0.01)
   assert.ok(fastTravel.options.some((option) => option.value === 'line'))
   assert.deepEqual(grid.options.map((option) => option.value), ['off', 'flat', '3d'])
+})
+
+test('live context menu compact surface routes canonical controls through visual object binding once', async () => {
+  const previousDocument = globalThis.document
+  const previousWindow = globalThis.window
+  const previousEvent = globalThis.Event
+  const document = createPatchedDocument()
+  globalThis.document = document
+  globalThis.window = { innerHeight: 900 }
+  globalThis.Event = document.defaultView.Event
+
+  try {
+    const state = {
+      avatar: createDefaultAvatarState(),
+      currentGeometryType: 12,
+      currentType: 12,
+      avatarBase: 153,
+    }
+    const calls = []
+    const menu = createSigilContextMenu({
+      state,
+      liveJs: {
+        displays: [{ visibleBounds: { x: 0, y: 0, w: 1200, h: 900 } }],
+        avatarPos: { x: 0, y: 0 },
+      },
+      projectPoint: (point) => point,
+      updatePrimaryAppearance() { calls.push(['appearance']) },
+      onAppearanceChange(event) { calls.push(['persist', event.controlId, event.value]) },
+      trace: {
+        record(stage, data) {
+          if (stage === 'context-menu:descriptor-update') calls.push(['legacy-route', data.id])
+          if (stage === 'context-menu:visual-object-binding-update') calls.push(['binding-route', data.compatibilityId])
+        },
+      },
+    })
+
+    menu.openAt({ x: 0, y: 0 })
+    await waitForMicrotasks()
+    await waitForMicrotasks()
+
+    const field = Array.from(document.body.querySelectorAll('.aos-form-field'))
+      .find((element) => element.dataset?.descriptorId === 'sigil-menu-opacity')
+    assert.ok(field)
+    const track = field.querySelector('[data-aos-slider-track]')
+    const slider = field.querySelector('[data-aos-slider-root]')
+    assert.ok(track)
+    assert.ok(slider)
+    const sliderRect = () => ({
+      left: 20,
+      top: 20,
+      right: 120,
+      bottom: 28,
+      width: 100,
+      height: 8,
+    })
+    field.getBoundingClientRect = sliderRect
+    slider.getBoundingClientRect = sliderRect
+    track.getBoundingClientRect = sliderRect
+
+    assert.equal(menu.handlePointerEvent('left_mouse_down', { x: 62, y: 24 }), true)
+    assert.equal(menu.handlePointerEvent('left_mouse_up', { x: 62, y: 24 }), true)
+    await waitForMicrotasks()
+
+    assert.equal(state.avatar.appearance.opacity, 0.42)
+    assert.deepEqual(calls.filter(([kind]) => kind === 'binding-route'), [['binding-route', 'sigil-menu-opacity']])
+    assert.deepEqual(calls.filter(([kind]) => kind === 'legacy-route'), [])
+    assert.deepEqual(calls.filter(([kind]) => kind === 'appearance'), [['appearance']])
+    assert.deepEqual(calls.filter(([kind]) => kind === 'persist'), [['persist', 'sigil-menu-opacity', 0.42]])
+  } finally {
+    globalThis.document = previousDocument
+    globalThis.window = previousWindow
+    globalThis.Event = previousEvent
+  }
 })
 
 test('descriptor routing applies a shape control through geometry sync', () => {

--- a/tests/renderer/context-menu-hit-test.test.mjs
+++ b/tests/renderer/context-menu-hit-test.test.mjs
@@ -461,6 +461,29 @@ test('descriptor routing applies primary stellation through minimal sync hook', 
   assert.deepEqual(calls, [['stellation', 1.25]])
 })
 
+test('descriptor routing applies primary tesseron proportion through minimal sync hook', () => {
+  const calls = []
+  const state = {
+    avatar: {
+      shape: {
+        type: 4,
+        tesseron: { enabled: true, proportion: 0.5, matchMother: true, child: {} },
+      },
+      appearance: {},
+      effects: {},
+    },
+  }
+  const result = applyContextMenuDescriptorUpdate('sigil-menu-tesseron-proportion', '0.68', {
+    state,
+    updateGeometry(value) { calls.push(['geometry', value]) },
+    updatePrimaryTesseronProportion(value) { calls.push(['tesseron-proportion', value]) },
+  })
+
+  assert.equal(result.route, 'canvas_object.transform.patch')
+  assert.equal(state.avatar.shape.tesseron.proportion, 0.68)
+  assert.deepEqual(calls, [['tesseron-proportion', 0.68]])
+})
+
 test('descriptor routing applies primary appearance controls through minimal sync hook', () => {
   for (const [id, rawValue, expectedPath, expectedValue] of [
     ['sigil-menu-opacity', '0.35', ['appearance', 'opacity'], 0.35],

--- a/tests/renderer/context-menu-hit-test.test.mjs
+++ b/tests/renderer/context-menu-hit-test.test.mjs
@@ -1,5 +1,6 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
 import {
   createSigilContextMenu,
   contextMenuSurfaceScrollDelta,
@@ -13,6 +14,9 @@ import {
   contextMenuControlDescriptors,
   getContextMenuControlDescriptor,
 } from '../../apps/sigil/context-menu/descriptors.js'
+import {
+  contextMenuDescriptorForVisualObjectDescriptor,
+} from '../../apps/sigil/context-menu/visual-object-binding.js'
 import { createDefaultAvatarState } from '../../apps/sigil/renderer/state.js'
 import { createDocument, patchSpreadSupport } from '../toolkit/zag-adapter-test-utils.mjs'
 
@@ -270,13 +274,23 @@ test('live context menu compact surface routes canonical controls through visual
       },
       projectPoint: (point) => point,
       updatePrimaryAppearance() { calls.push(['appearance']) },
-      onAppearanceChange(event) { calls.push(['persist', event.controlId, event.value]) },
+      onAppearanceChange(event) {
+        calls.push([
+          'persist',
+          event.controlId,
+          event.value,
+          event.descriptor?.contract,
+          event.descriptor?.id,
+          event.compatibilityDescriptor?.id,
+        ])
+      },
       trace: {
         record(stage, data) {
           if (stage === 'context-menu:descriptor-update') calls.push(['legacy-route', data.id])
           if (stage === 'context-menu:visual-object-binding-update') calls.push(['binding-route', data.compatibilityId])
         },
       },
+      allowTestAnchorFallback: true,
     })
 
     menu.openAt({ x: 0, y: 0 })
@@ -310,12 +324,104 @@ test('live context menu compact surface routes canonical controls through visual
     assert.deepEqual(calls.filter(([kind]) => kind === 'binding-route'), [['binding-route', 'sigil-menu-opacity']])
     assert.deepEqual(calls.filter(([kind]) => kind === 'legacy-route'), [])
     assert.deepEqual(calls.filter(([kind]) => kind === 'appearance'), [['appearance']])
-    assert.deepEqual(calls.filter(([kind]) => kind === 'persist'), [['persist', 'sigil-menu-opacity', 0.42]])
+    assert.deepEqual(calls.filter(([kind]) => kind === 'persist'), [[
+      'persist',
+      'sigil-menu-opacity',
+      0.42,
+      'aos.visual_object.descriptor.v0',
+      'sigil.avatar.primary-polyhedron.avatar.appearance.opacity',
+      'sigil-menu-opacity',
+    ]])
   } finally {
     globalThis.document = previousDocument
     globalThis.window = previousWindow
     globalThis.Event = previousEvent
   }
+})
+
+test('live context menu visual binding suppresses duplicate slider commits', async () => {
+  const previousDocument = globalThis.document
+  const previousWindow = globalThis.window
+  const previousEvent = globalThis.Event
+  const document = createPatchedDocument()
+  globalThis.document = document
+  globalThis.window = { innerHeight: 900 }
+  globalThis.Event = document.defaultView.Event
+
+  try {
+    const state = {
+      avatar: createDefaultAvatarState(),
+      currentGeometryType: 12,
+      currentType: 12,
+      avatarBase: 153,
+    }
+    const calls = []
+    const menu = createSigilContextMenu({
+      state,
+      liveJs: {
+        displays: [{ visibleBounds: { x: 0, y: 0, w: 1200, h: 900 } }],
+        avatarPos: { x: 0, y: 0 },
+      },
+      projectPoint: (point) => point,
+      updatePrimaryAppearance() { calls.push(['appearance']) },
+      onAppearanceChange(event) { calls.push(['persist', event.value]) },
+      trace: {
+        record(stage, data) {
+          if (stage === 'context-menu:visual-object-binding-update') calls.push(['binding-route', data.value])
+        },
+      },
+      allowTestAnchorFallback: true,
+    })
+
+    menu.openAt({ x: 0, y: 0 })
+    await waitForMicrotasks()
+    await waitForMicrotasks()
+
+    const field = Array.from(document.body.querySelectorAll('.aos-form-field'))
+      .find((element) => element.dataset?.descriptorId === 'sigil-menu-opacity')
+    const track = field.querySelector('[data-aos-slider-track]')
+    const slider = field.querySelector('[data-aos-slider-root]')
+    const sliderRect = () => ({
+      left: 20,
+      top: 20,
+      right: 120,
+      bottom: 28,
+      width: 100,
+      height: 8,
+    })
+    field.getBoundingClientRect = sliderRect
+    slider.getBoundingClientRect = sliderRect
+    track.getBoundingClientRect = sliderRect
+
+    assert.equal(menu.handlePointerEvent('left_mouse_down', { x: 62, y: 24 }), true)
+    assert.equal(menu.handlePointerEvent('left_mouse_up', { x: 62, y: 24 }), true)
+    await waitForMicrotasks()
+
+    assert.deepEqual(calls.filter(([kind]) => kind === 'binding-route'), [['binding-route', 0.42]])
+    assert.deepEqual(calls.filter(([kind]) => kind === 'appearance'), [['appearance']])
+    assert.deepEqual(calls.filter(([kind]) => kind === 'persist'), [['persist', 0.42]])
+  } finally {
+    globalThis.document = previousDocument
+    globalThis.window = previousWindow
+    globalThis.Event = previousEvent
+  }
+})
+
+test('visual object binding resolves compatibility descriptors without a copied behavior tree', async () => {
+  assert.equal(
+    contextMenuDescriptorForVisualObjectDescriptor({
+      id: 'compact-control:opacity',
+      state_path: 'avatar.appearance.opacity',
+      route: 'canvas_object.effects.patch',
+    })?.id,
+    'sigil-menu-opacity',
+  )
+
+  const menuSource = await readFile(new URL('../../apps/sigil/context-menu/menu.js', import.meta.url), 'utf8')
+  const adapterSource = await readFile(new URL('../../apps/sigil/context-menu/visual-object-binding.js', import.meta.url), 'utf8')
+  assert.equal(menuSource.includes('function applyVisualBindingCompatibility'), false)
+  assert.equal(menuSource.includes("compatibility.id === 'sigil-menu-shape-select'"), false)
+  assert.equal(adapterSource.includes('applyContextMenuDescriptorUpdate'), true)
 })
 
 test('descriptor routing applies a shape control through geometry sync', () => {


### PR DESCRIPTION
## Summary
- route live Sigil compact-surface canonical controls through `visualObjectBinding`
- preserve Sigil-owned side effects and renderer sync behavior while keeping projection-only controls on the explicit shortcut path
- fix live browser loading for `apps/sigil/avatar-editor/model.js` via `toolkitSpecifier(...)` and add regression coverage for duplicate slider commits

## Verification
- `node --test tests/renderer/sigil-avatar-editor-compact-surface.test.mjs`
- `node --test tests/renderer/sigil-avatar-editor-model.test.mjs`
- `node --test tests/renderer/sigil-avatar-editor-surface-view-model.test.mjs`
- `node --test tests/renderer/sigil-context-menu-input.test.mjs`
- `node --test tests/renderer/sigil-ux-tree-command-registry.test.mjs`
- `node --test tests/renderer/context-menu-hit-test.test.mjs`
- `node --test tests/renderer/*.test.mjs`
- `git diff --check`
- Live AOS smoke: branch-scoped Sigil booted cleanly; right-click opened the compact tabbed surface; opacity slider changed to `0.33`; second right-click closed it; no boot error
