### PR TITLE
refactor(sigil): extract context menu snapshot projection

### DIFF
--- a/apps/sigil/context-menu/menu.js
+++ b/apps/sigil/context-menu/menu.js
@@ -13,6 +13,7 @@ import { isTesseronSupportedShape, normalizeTesseronConfig } from '../renderer/t
 import {
     applyContextMenuDescriptorUpdate,
 } from './descriptors.js';
+import { createContextMenuSnapshotProjection } from './snapshot-projection.js';
 import { createVisualObjectBindingAdapter } from './visual-object-binding.js';
 
 let compactSurfaceModulePromise = null;
@@ -315,29 +316,16 @@ export function createSigilContextMenu({
         };
     }
 
-    function compactControlRecords() {
-        return compactSurface?.getControlRecords?.() || [];
-    }
-
-    function snapshot() {
-        return {
-            open: menuState.open,
-            bounds: menuState.bounds ? { ...menuState.bounds } : null,
-            stack: null,
-            activeTab: compactSurface?.getActiveTab?.() || null,
-            controls: compactControlRecords(),
-        };
-    }
-
-    function syncSnapshot() {
-        menuState.snapshot = {
-            activeTab: compactSurface?.getActiveTab?.() || null,
-            controlCount: compactControlRecords().length,
-        };
-        anchor.setAttribute('aria-hidden', menuState.open ? 'false' : 'true');
-        anchor.setAttribute('data-state', menuState.open ? 'open' : 'closed');
-        if (liveJs) liveJs.contextMenu = snapshot();
-    }
+    const {
+        compactControlRecords,
+        snapshot,
+        syncSnapshot,
+    } = createContextMenuSnapshotProjection({
+        anchor,
+        liveJs,
+        getMenuState: () => menuState,
+        getCompactSurface: () => compactSurface,
+    });
 
     function setControlValue(id, value, checked = null) {
         compactFieldRecordByDescriptorId(id)?.control?.setValue?.(checked !== null ? !!checked : value, { emit: false });

--- a/apps/sigil/context-menu/menu.js
+++ b/apps/sigil/context-menu/menu.js
@@ -13,7 +13,7 @@ import { isTesseronSupportedShape, normalizeTesseronConfig } from '../renderer/t
 import {
     applyContextMenuDescriptorUpdate,
 } from './descriptors.js';
-import { createContextMenuSnapshotProjection } from './snapshot-projection.js';
+import { buildContextMenuSnapshot } from './snapshot-projection.js';
 import { createVisualObjectBindingAdapter } from './visual-object-binding.js';
 
 let compactSurfaceModulePromise = null;
@@ -316,16 +316,24 @@ export function createSigilContextMenu({
         };
     }
 
-    const {
-        compactControlRecords,
-        snapshot,
-        syncSnapshot,
-    } = createContextMenuSnapshotProjection({
-        anchor,
-        liveJs,
-        getMenuState: () => menuState,
-        getCompactSurface: () => compactSurface,
-    });
+    function compactControlRecords() {
+        return compactSurface?.getControlRecords() || [];
+    }
+
+    function snapshot() {
+        return buildContextMenuSnapshot(menuState, compactSurface);
+    }
+
+    function syncSnapshot() {
+        const controls = compactControlRecords();
+        menuState.snapshot = {
+            activeTab: compactSurface?.getActiveTab() || null,
+            controlCount: controls.length,
+        };
+        anchor.setAttribute('aria-hidden', menuState.open ? 'false' : 'true');
+        anchor.setAttribute('data-state', menuState.open ? 'open' : 'closed');
+        if (liveJs) liveJs.contextMenu = snapshot();
+    }
 
     function setControlValue(id, value, checked = null) {
         compactFieldRecordByDescriptorId(id)?.control?.setValue?.(checked !== null ? !!checked : value, { emit: false });

--- a/apps/sigil/context-menu/snapshot-projection.js
+++ b/apps/sigil/context-menu/snapshot-projection.js
@@ -1,0 +1,41 @@
+export function createContextMenuSnapshotProjection({
+    anchor,
+    liveJs,
+    getMenuState,
+    getCompactSurface,
+} = {}) {
+    function compactControlRecords() {
+        return getCompactSurface?.()?.getControlRecords?.() || [];
+    }
+
+    function snapshot() {
+        const menuState = getMenuState?.() || {};
+        const compactSurface = getCompactSurface?.() || null;
+        return {
+            open: !!menuState.open,
+            bounds: menuState.bounds ? { ...menuState.bounds } : null,
+            stack: null,
+            activeTab: compactSurface?.getActiveTab?.() || null,
+            controls: compactControlRecords(),
+        };
+    }
+
+    function syncSnapshot() {
+        const menuState = getMenuState?.();
+        if (!menuState) return;
+        const compactSurface = getCompactSurface?.() || null;
+        menuState.snapshot = {
+            activeTab: compactSurface?.getActiveTab?.() || null,
+            controlCount: compactControlRecords().length,
+        };
+        anchor?.setAttribute?.('aria-hidden', menuState.open ? 'false' : 'true');
+        anchor?.setAttribute?.('data-state', menuState.open ? 'open' : 'closed');
+        if (liveJs) liveJs.contextMenu = snapshot();
+    }
+
+    return {
+        compactControlRecords,
+        snapshot,
+        syncSnapshot,
+    };
+}

--- a/apps/sigil/context-menu/snapshot-projection.js
+++ b/apps/sigil/context-menu/snapshot-projection.js
@@ -1,41 +1,10 @@
-export function createContextMenuSnapshotProjection({
-    anchor,
-    liveJs,
-    getMenuState,
-    getCompactSurface,
-} = {}) {
-    function compactControlRecords() {
-        return getCompactSurface?.()?.getControlRecords?.() || [];
-    }
-
-    function snapshot() {
-        const menuState = getMenuState?.() || {};
-        const compactSurface = getCompactSurface?.() || null;
-        return {
-            open: !!menuState.open,
-            bounds: menuState.bounds ? { ...menuState.bounds } : null,
-            stack: null,
-            activeTab: compactSurface?.getActiveTab?.() || null,
-            controls: compactControlRecords(),
-        };
-    }
-
-    function syncSnapshot() {
-        const menuState = getMenuState?.();
-        if (!menuState) return;
-        const compactSurface = getCompactSurface?.() || null;
-        menuState.snapshot = {
-            activeTab: compactSurface?.getActiveTab?.() || null,
-            controlCount: compactControlRecords().length,
-        };
-        anchor?.setAttribute?.('aria-hidden', menuState.open ? 'false' : 'true');
-        anchor?.setAttribute?.('data-state', menuState.open ? 'open' : 'closed');
-        if (liveJs) liveJs.contextMenu = snapshot();
-    }
-
+export function buildContextMenuSnapshot(menuState, compactSurface) {
+    const controls = compactSurface?.getControlRecords() || [];
     return {
-        compactControlRecords,
-        snapshot,
-        syncSnapshot,
+        open: !!menuState.open,
+        bounds: menuState.bounds ? { ...menuState.bounds } : null,
+        stack: null,
+        activeTab: compactSurface?.getActiveTab() || null,
+        controls,
     };
 }

--- a/tests/renderer/context-menu-snapshot-projection.test.mjs
+++ b/tests/renderer/context-menu-snapshot-projection.test.mjs
@@ -1,0 +1,49 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildContextMenuSnapshot,
+} from '../../apps/sigil/context-menu/snapshot-projection.js';
+
+test('context menu snapshot projection clones bounds and reads compact surface state', () => {
+  const bounds = { x: 24, y: 48, w: 292, h: 448 };
+  const controls = [
+    {
+      id: 'sigil-menu-opacity',
+      descriptor_id: 'sigil-menu-opacity',
+      role: 'slider',
+      value: 0.8,
+    },
+  ];
+  const compactSurface = {
+    getActiveTab() {
+      return 'appearance';
+    },
+    getControlRecords() {
+      return controls;
+    },
+  };
+
+  const snapshot = buildContextMenuSnapshot(
+    { open: true, bounds },
+    compactSurface,
+  );
+
+  assert.deepEqual(snapshot, {
+    open: true,
+    bounds,
+    stack: null,
+    activeTab: 'appearance',
+    controls,
+  });
+  assert.notEqual(snapshot.bounds, bounds);
+});
+
+test('context menu snapshot projection preserves closed null surface shape', () => {
+  assert.deepEqual(buildContextMenuSnapshot({ open: false, bounds: null }, null), {
+    open: false,
+    bounds: null,
+    stack: null,
+    activeTab: null,
+    controls: [],
+  });
+});


### PR DESCRIPTION
## Summary

- Extract context-menu snapshot/control-record projection into `apps/sigil/context-menu/snapshot-projection.js`.
- Keep compact control-record output, `window.liveJs.contextMenu`, and bounds/close snapshot payload behavior stable.
- Reduce `apps/sigil/context-menu/menu.js` to 989 lines.

## Verification

- `git diff --check 2bd233845f3575c1d38bd12f3f84a080ca9f79b1..ec1503dbfa73d5bf1ae3bb0da495fb391733c3a7`
- `node --check apps/sigil/context-menu/menu.js`
- `node --check apps/sigil/context-menu/snapshot-projection.js`
- `node --test tests/renderer/context-menu-hit-test.test.mjs tests/renderer/sigil-avatar-editor-compact-surface.test.mjs` passed 38/38
- `wc -l apps/sigil/context-menu/menu.js` returned 989

## Review Notes

Base is `gdi/post-refactor-real-input-dogfooding-corrections-v0` at `2bd2338`; this PR is intentionally scoped to the extraction delta after the accepted compact control-record corrections.