### PR TITLE
feat(perceive): cut over semantic targets to canonical refs

### DIFF
--- a/apps/sigil/renderer/live-modules/main.js
+++ b/apps/sigil/renderer/live-modules/main.js
@@ -2151,6 +2151,8 @@ function annotationReticleSemanticTargetForDesktopWorld(canvasId = '', target = 
         || target.display_bounds
         || target.bounds
         || target.rect
+        || target.provenance?.bounds
+        || target.provenance?.frame
     );
     if (!sourceRect) return target;
 
@@ -2200,10 +2202,17 @@ function annotationReticleHandleCanvasLifecycle(msg = {}) {
 }
 
 function annotationReticleHandleSemanticTargets(payload = {}) {
-    const canvasId = String(payload.canvas_id || payload.surface_id || payload.id || payload.source_canvas_id || '').trim();
     const targets = Array.isArray(payload.semantic_targets)
         ? payload.semantic_targets
         : (Array.isArray(payload.targets) ? payload.targets : []);
+    const canvasId = String(
+        payload.canvas_id
+        || payload.surface_id
+        || payload.id
+        || payload.source_canvas_id
+        || targets.find((target) => target?.provenance?.canvas_id)?.provenance?.canvas_id
+        || ''
+    ).trim();
     if (!canvasId) return;
     clearAnnotationReticleSemanticCandidatesForCanvas(liveJs.annotationReticleTargetEvidence, canvasId);
     if (!targets.length) return;
@@ -2229,18 +2238,19 @@ function annotationReticleHandleSemanticTargets(payload = {}) {
             candidateIds.push(candidate.id);
             continue;
         }
-        const desktopTarget = annotationReticleSemanticTargetForDesktopWorld(canvasId, target);
+        const targetCanvasId = String(target.provenance?.canvas_id || canvasId).trim();
+        const desktopTarget = annotationReticleSemanticTargetForDesktopWorld(targetCanvasId, target);
         const projection = buildSemanticTargetProjectionAdapterResult(desktopTarget, {
-            canvas_id: canvasId,
+            canvas_id: targetCanvasId,
             refreshed_at: desktopTarget.refreshed_at || payload.refreshed_at || new Date().toISOString(),
-            provenance_source_payload_id: desktopTarget.payload_id || payload.payload_id,
+            provenance_source_payload_id: desktopTarget.provenance?.source_payload_id || desktopTarget.payload_id || payload.payload_id,
         });
         const candidate = {
             id: projection.subject_id,
             subject_id: projection.subject_id,
             subject_path: projection.subject_path,
             root_id: projection.root_id,
-            root_label: canvasId,
+            root_label: targetCanvasId,
             root_kind: 'canvas',
             subject_kind: projection.subject_kind,
             label: desktopTarget.name || desktopTarget.label || desktopTarget.role || projection.subject_id,
@@ -2249,7 +2259,7 @@ function annotationReticleHandleSemanticTargets(payload = {}) {
             source_metadata: {
                 ...desktopTarget,
                 adapter_scope: 'sigil_cached_semantic_targets',
-                canvas_id: canvasId,
+                canvas_id: targetCanvasId,
             },
         };
         annotationReticleUpsertCandidate(candidate);

--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -475,11 +475,12 @@ resolve the element explicitly under the cursor.
 not role-whitelist them into an "interactive" vocabulary. For AOS-owned canvas
 captures, `aos see capture --canvas <id> --xray` also runs a fixed semantic
 target probe inside that canvas and returns `semantic_targets`. Those entries
-project standard DOM/AX/ARIA facts plus thin AOS ownership metadata such as
-`canvas_id`, `data-aos-ref`, `data-aos-action`, `data-aos-surface`, and
-`data-semantic-target-id`. Entries with both `canvas_id` and `ref` also include
-`do_target`, the exact `canvas:<canvas-id>/<ref>` string accepted by
-`aos do click`. The probe does not use caller-supplied JavaScript; `show eval`
+use the canonical `agent_ui_target` envelope: top-level `ref`, `surface`,
+`role`, `name`, `kind`, `enabled`, `state`, `actions`, `extension`, and
+`provenance`. The sole top-level identity is `ref` from `data-aos-ref`.
+Local DOM ids, canvas id, parent canvas id, local geometry, and the
+`canvas:<canvas-id>/<ref>` action-routing string live under `provenance` or
+`extension`. The probe does not use caller-supplied JavaScript; `show eval`
 remains a developer diagnostic bridge, not the agent perception contract.
 
 See [`shared/schemas/aos-semantic-targets.md`](../../shared/schemas/aos-semantic-targets.md)
@@ -618,14 +619,14 @@ aos do click canvas:<canvas-id>/<ref> --state-id <id>
 
 Use `canvas:<canvas-id>/<ref>` when a target was discovered in
 `aos see capture --canvas <canvas-id> --xray`. Agents should pass
-`semantic_targets[].do_target` directly when present; `canvas_id` and `ref`
-remain available for structured filtering. The CLI resolves the current
-AOS-owned canvas semantic target through the fixed probe path, rejects missing,
-disabled, ambiguous, suspended, noninteractive, or unsupported segmented
-canvases with machine-readable errors, and then clicks the resolved target
-center in global CG coordinates. V0 does not dereference a historical
-`state_id`; the id is preserved only as correlation metadata for the perception
-the action was chosen from.
+`semantic_targets[].provenance.do_target` directly when present;
+`provenance.canvas_id` and `ref` remain available for structured filtering. The
+CLI resolves the current AOS-owned canvas semantic target through the fixed
+probe path, rejects missing, disabled, ambiguous, suspended, noninteractive, or
+unsupported segmented canvases with machine-readable errors, and then clicks
+the resolved `provenance.center` in global CG coordinates. V0 does not
+dereference a historical `state_id`; the id is preserved only as correlation
+metadata for the perception the action was chosen from.
 
 Coordinate, browser-target, and canvas-ref actions accept `--state-id <id>` when
 the action was chosen from a prior `aos see capture` response. Direct one-shot

--- a/docs/api/toolkit/components.md
+++ b/docs/api/toolkit/components.md
@@ -339,7 +339,8 @@ including `test-console-v0:response-confirm`, `test-console-v0:response-fail`,
 `test-console-v0:evidence:open:<ref>` refs. These refs are stamped through
 `data-aos-ref`, `data-aos-action`, `data-aos-surface`, and
 `data-semantic-target-id` so `aos see capture --canvas <id> --xray` can expose
-`semantic_targets[].do_target` for `aos do click`.
+canonical `semantic_targets[]` records whose `provenance.do_target` values are
+used for `aos do click`.
 
 The v-next direction keeps wiki document Subjects wiki-oriented and represents
 domain concepts through separate domain Subjects plus Subject References. For

--- a/docs/design/fixtures/agent-ui-target-conformance-v0/candidate-agent-ui-target-projections.json
+++ b/docs/design/fixtures/agent-ui-target-conformance-v0/candidate-agent-ui-target-projections.json
@@ -20,9 +20,14 @@
       "refreshed_at": "2026-06-01T00:00:00.000Z",
       "provenance_source_payload_id": "sigil-menu-opacity",
       "source_tree_node_metadata": {
-        "subject_id": "sigil-menu-opacity",
-        "target_id": "sigil.avatar.compact_control_surface:sigil-menu-opacity",
-        "ref": "sigil.avatar.compact_control_surface:sigil-menu-opacity"
+        "ref": "sigil.avatar.compact_control_surface:sigil-menu-opacity",
+        "extension": {
+          "descriptor_id": "sigil-menu-opacity",
+          "field_id": "face.opacity"
+        },
+        "provenance": {
+          "source_payload_id": "sigil-menu-opacity"
+        }
       }
     },
     {

--- a/docs/design/fixtures/agent-ui-target-conformance-v0/candidate-agent-ui-targets.json
+++ b/docs/design/fixtures/agent-ui-target-conformance-v0/candidate-agent-ui-targets.json
@@ -162,6 +162,39 @@
           "dom_id": "decision-17"
         }
       }
+    },
+    {
+      "shape": "native_perceive_canvas_semantic_target",
+      "agent_ui_target": {
+        "ref": "sigil-radial-item-wiki-graph",
+        "surface": "sigil-radial-menu",
+        "role": "button",
+        "name": "Wiki Graph",
+        "kind": "semantic_target",
+        "enabled": true,
+        "state": {
+          "value": null,
+          "current": "true",
+          "pressed": null,
+          "selected": null,
+          "checked": null,
+          "expanded": null
+        },
+        "actions": ["wiki-graph"],
+        "extension": {
+          "dom_id": "wiki-graph",
+          "source": { "path": null, "line_start": null, "line_end": null }
+        },
+        "provenance": {
+          "canvas_id": "sigil-radial-menu",
+          "do_target": "canvas:sigil-radial-menu/sigil-radial-item-wiki-graph",
+          "parent_canvas_id": "avatar-main",
+          "source_payload_id": "wiki-graph",
+          "bounds": { "x": 40, "y": 24, "width": 56, "height": 56 },
+          "frame": { "x": 40, "y": 24, "width": 56, "height": 56 },
+          "center": { "x": 68, "y": 52 }
+        }
+      }
     }
   ]
 }

--- a/docs/design/fixtures/agent-ui-target-conformance-v0/current-source-records.json
+++ b/docs/design/fixtures/agent-ui-target-conformance-v0/current-source-records.json
@@ -158,6 +158,40 @@
           "dom_id": "decision-17"
         }
       }
+    },
+    {
+      "shape": "native_perceive_canvas_semantic_target",
+      "source": "src/perceive/semantic-targets.swift",
+      "record": {
+        "ref": "sigil-radial-item-wiki-graph",
+        "surface": "sigil-radial-menu",
+        "role": "button",
+        "name": "Wiki Graph",
+        "kind": "semantic_target",
+        "enabled": true,
+        "state": {
+          "value": null,
+          "current": "true",
+          "pressed": null,
+          "selected": null,
+          "checked": null,
+          "expanded": null
+        },
+        "actions": ["wiki-graph"],
+        "extension": {
+          "dom_id": "wiki-graph",
+          "source": { "path": null, "line_start": null, "line_end": null }
+        },
+        "provenance": {
+          "canvas_id": "sigil-radial-menu",
+          "do_target": "canvas:sigil-radial-menu/sigil-radial-item-wiki-graph",
+          "parent_canvas_id": "avatar-main",
+          "source_payload_id": "wiki-graph",
+          "bounds": { "x": 40, "y": 24, "width": 56, "height": 56 },
+          "frame": { "x": 40, "y": 24, "width": 56, "height": 56 },
+          "center": { "x": 68, "y": 52 }
+        }
+      }
     }
   ]
 }

--- a/docs/design/fixtures/agent-ui-target-conformance-v0/mapping-table.md
+++ b/docs/design/fixtures/agent-ui-target-conformance-v0/mapping-table.md
@@ -12,7 +12,8 @@ are not copied into the canonical producer identity.
 | Toolkit panel form control | `ref` | Already canonical `agent_ui_target`; form ids land in `extension.descriptor_id` and `extension.field_id` |
 | Sigil compact control/tab | `ref` | Already canonical `agent_ui_target`; tab/section/label fields land in `extension`; local source ids stay provenance-only |
 | HTML workbench source-line target | `ref` | Canonical `ref` remains the producer identity; source path/lines land in `extension.source`; selector and DOM slug land in provenance/extension reveal hints |
-| Annotation/Surface Inspector projection | `subject_id` plus drift-prone source metadata | Projection fixture renames join identity to `ref`; `subject_path`, `root_id`, geometry, render status, blockers, and freshness stay projection-only |
+| Native `aos see` canvas semantic target | `ref` | Canonical `agent_ui_target`; canvas id, `do_target`, parent canvas, local geometry, and local DOM id land in provenance/extension |
+| Annotation/Surface Inspector projection | `subject_id` | Projection fixture renames join identity to `ref`; `subject_path`, `root_id`, geometry, render status, blockers, and freshness stay projection-only |
 
 ## Field Accounting
 
@@ -27,14 +28,15 @@ are not copied into the canonical producer identity.
 | Workbench extensions | `extension.annotation_eligible`, `reveal_eligible`, `source.path`, `line_start`, `line_end` | None | Source line identity does not become a producer identity spelling. |
 | Provenance selectors | `provenance.selector` | `source_tree_node_metadata.selector` only as adapter source evidence | Selectors are reveal/provenance hints, never canonical identity. |
 | Local producer frame | `provenance.frame` | `local_space_rect` / `display_space_rect` after projection | Current asserted producer frames are accounted for without making projection fields producer-owned. |
+| Canvas action routing | `provenance.do_target` | None | Derived `canvas:<canvas-id>/<ref>` routing identity for `aos do`; not a top-level producer identity. |
 | Projection fields | Forbidden | Top-level projection fixture fields | Includes `current_render_status`, `display_space_rect`, `refreshed_at`, and `blocker_reasons`. |
 
 ## Drift Exposed
 
-The projection fixtures intentionally include source metadata containing both
-`subject_id` and `target_id` for one record, while the canonical projection join
-key remains `ref`. This exposes today's identity drift without preserving it as
-canonical producer shape.
+The projection fixtures intentionally keep projection identity (`subject_id`,
+`subject_path`, `root_id`) separate from producer identity. The canonical
+projection join key remains `ref`, and legacy producer spellings are no longer
+listed as current sources.
 
 The fixtures also include two projection adapter results for the same
 canonical `ref`: `aos-toolkit-semantic-target` and `aos-canvas-window`. This

--- a/packages/gateway/dist/aos-proxy.d.ts
+++ b/packages/gateway/dist/aos-proxy.d.ts
@@ -1,0 +1,202 @@
+export type NormalizedWindow = {
+    id: string;
+    app: string;
+    title: string;
+    frame: {
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+    };
+    focused: boolean;
+};
+type SemanticTargetRect = {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+};
+export type AOSSemanticTarget = {
+    ref: string;
+    surface?: string;
+    role: string;
+    name?: string;
+    kind: string;
+    enabled: boolean;
+    state?: {
+        value?: string;
+        current?: string;
+        pressed?: boolean;
+        selected?: boolean;
+        checked?: boolean;
+        expanded?: boolean;
+    };
+    actions: string[];
+    extension: {
+        dom_id?: string;
+        source?: {
+            path?: string | null;
+            line_start?: number | null;
+            line_end?: number | null;
+        };
+    };
+    provenance: {
+        canvas_id?: string;
+        do_target?: string;
+        parent_canvas_id?: string;
+        source_payload_id?: string;
+        bounds?: SemanticTargetRect;
+        frame?: SemanticTargetRect;
+        center?: {
+            x: number;
+            y: number;
+        };
+    };
+};
+export type CaptureResult = {
+    status: string;
+    base64?: string;
+    elements?: unknown[];
+    semantic_targets?: AOSSemanticTarget[];
+    path?: string;
+};
+/** Normalize raw CLI window data to match the SDK type contract. */
+export declare function normalizeWindow(raw: any, isFocused?: boolean): NormalizedWindow;
+export declare function getWindows(filter?: {
+    app?: string;
+    title?: string;
+}): Promise<NormalizedWindow[]>;
+export declare function getCursor(): Promise<{
+    x: number;
+    y: number;
+    app?: string;
+    title?: string;
+}>;
+export declare function capture(opts?: {
+    display?: string;
+    canvas?: string;
+    window?: boolean;
+    xray?: boolean;
+    base64?: boolean;
+    format?: 'png' | 'jpg';
+    out?: string;
+}): Promise<CaptureResult>;
+export declare function getDisplays(): Promise<Array<{
+    id: string;
+    width: number;
+    height: number;
+    primary?: boolean;
+}>>;
+export declare function click(target: {
+    x: number;
+    y: number;
+}): Promise<void>;
+export declare function type(text: string): Promise<void>;
+export declare function say(text: string): Promise<void>;
+export declare function createCanvas(opts: {
+    id: string;
+    html?: string;
+    url?: string;
+    at: [number, number, number, number];
+    interactive?: boolean;
+    ttl?: number;
+}): Promise<{
+    status: string;
+    id: string;
+}>;
+export declare function removeCanvas(id: string): Promise<{
+    status: string;
+}>;
+export declare function evalCanvas(id: string, js: string): Promise<{
+    result: unknown;
+}>;
+export declare function updateCanvas(id: string, opts: {
+    html?: string;
+    at?: [number, number, number, number];
+}): Promise<{
+    status: string;
+}>;
+export declare function listCanvases(): Promise<Array<{
+    id: string;
+    at: number[];
+    interactive: boolean;
+    scope: string;
+}>>;
+export declare function doctor(): Promise<unknown>;
+export declare function getConfig(): Promise<unknown>;
+export declare function setConfig(key: string, value: string): Promise<{
+    status: string;
+}>;
+/** Combined situational awareness — windows, cursor, displays in one call. */
+export declare function perceive(): Promise<{
+    focused: NormalizedWindow | null;
+    windows: NormalizedWindow[];
+    cursor: {
+        x: number;
+        y: number;
+    };
+    displays: Array<{
+        id: string;
+        width: number;
+        height: number;
+        primary?: boolean;
+    }>;
+}>;
+/** Find a window by app name, title substring, or both. Returns the best match. */
+export declare function findWindow(query: {
+    app?: string;
+    title?: string;
+}): Promise<{
+    found: boolean;
+    window: NormalizedWindow | null;
+    candidates: string[];
+}>;
+/** Capture the screen, find an element by label, and click it. One call. */
+export declare function clickElement(label: string, opts?: {
+    app?: string;
+    role?: string;
+}): Promise<{
+    clicked: boolean;
+    element?: {
+        label: string;
+        role: string;
+        frame: unknown;
+    };
+    error?: string;
+    candidates?: string[];
+}>;
+/** Poll until a condition is met, then return the match. */
+export declare function waitFor(pattern: {
+    window?: string;
+    canvas?: string;
+}, opts?: {
+    timeout?: number;
+    interval?: number;
+}): Promise<{
+    found: boolean;
+    match?: unknown;
+    elapsed: number;
+}>;
+/** Show a positioned overlay near a target window. Auto-generates HTML from content string. */
+export declare function showOverlay(opts: {
+    content: string;
+    near?: {
+        app?: string;
+        title?: string;
+    };
+    at?: [number, number, number, number];
+    style?: 'status' | 'success' | 'error' | 'warning' | 'info';
+    ttl?: number;
+    id?: string;
+}): Promise<{
+    id: string;
+    at: number[];
+}>;
+/** Update an existing overlay's content and/or style. Uses updateCanvas (fast) instead of recreating. */
+export declare function updateOverlay(id: string, opts: {
+    content?: string;
+    style?: 'status' | 'success' | 'error' | 'warning' | 'info';
+    ttl?: number;
+}): Promise<{
+    id: string;
+}>;

--- a/packages/gateway/sdk/aos-sdk.d.ts
+++ b/packages/gateway/sdk/aos-sdk.d.ts
@@ -30,15 +30,30 @@ declare const aos: {
       role: string; label?: string; value?: string;
       frame: { x: number; y: number; width: number; height: number };
     }>; semantic_targets?: Array<{
-      canvas_id?: string; id?: string; ref?: string;
-      role: string; name?: string; action?: string;
-      surface?: string; parent_canvas?: string; enabled: boolean;
-      bounds: { x: number; y: number; width: number; height: number };
-      center: { x: number; y: number };
+      ref: string;
+      surface?: string;
+      role: string;
+      name?: string;
+      kind: string;
+      enabled: boolean;
       state?: {
         current?: string; pressed?: boolean; selected?: boolean;
-        checked?: boolean; expanded?: boolean; disabled?: boolean;
+        checked?: boolean; expanded?: boolean;
         value?: string;
+      };
+      actions: string[];
+      extension: {
+        dom_id?: string;
+        source?: { path?: string | null; line_start?: number | null; line_end?: number | null };
+      };
+      provenance: {
+        canvas_id?: string;
+        do_target?: string;
+        parent_canvas_id?: string;
+        source_payload_id?: string;
+        bounds?: { x: number; y: number; width: number; height: number };
+        frame?: { x: number; y: number; width: number; height: number };
+        center?: { x: number; y: number };
       };
     }>; path?: string;
   }>;

--- a/packages/gateway/src/aos-proxy.ts
+++ b/packages/gateway/src/aos-proxy.ts
@@ -36,6 +36,47 @@ export type NormalizedWindow = {
   focused: boolean;
 };
 
+type SemanticTargetRect = { x: number; y: number; width: number; height: number };
+
+export type AOSSemanticTarget = {
+  ref: string;
+  surface?: string;
+  role: string;
+  name?: string;
+  kind: string;
+  enabled: boolean;
+  state?: {
+    value?: string;
+    current?: string;
+    pressed?: boolean;
+    selected?: boolean;
+    checked?: boolean;
+    expanded?: boolean;
+  };
+  actions: string[];
+  extension: {
+    dom_id?: string;
+    source?: { path?: string | null; line_start?: number | null; line_end?: number | null };
+  };
+  provenance: {
+    canvas_id?: string;
+    do_target?: string;
+    parent_canvas_id?: string;
+    source_payload_id?: string;
+    bounds?: SemanticTargetRect;
+    frame?: SemanticTargetRect;
+    center?: { x: number; y: number };
+  };
+};
+
+export type CaptureResult = {
+  status: string;
+  base64?: string;
+  elements?: unknown[];
+  semantic_targets?: AOSSemanticTarget[];
+  path?: string;
+};
+
 /** Normalize raw CLI window data to match the SDK type contract. */
 export function normalizeWindow(raw: any, isFocused = false): NormalizedWindow {
   const win = raw.window ?? raw;
@@ -93,7 +134,7 @@ export async function capture(opts?: {
   base64?: boolean;
   format?: 'png' | 'jpg';
   out?: string;
-}): Promise<{ status: string; base64?: string; elements?: unknown[]; semantic_targets?: unknown[]; path?: string }> {
+}): Promise<CaptureResult> {
   const args = ['see', 'capture', opts?.display ?? 'user_active'];
   if (opts?.canvas) args.push('--canvas', opts.canvas);
   if (opts?.window) args.push('--window');

--- a/packages/toolkit/components/html-workbench-expression/index.js
+++ b/packages/toolkit/components/html-workbench-expression/index.js
@@ -82,15 +82,6 @@ function rectPayload(rect = null) {
   return { x, y, w, h }
 }
 
-function targetRef(target = {}) {
-  return text(target.ref || target.id)
-}
-
-function targetDomId(target = {}) {
-  const ref = text(target.ref || target.id)
-  return text(target.provenance?.dom_id || ref.split(':').pop() || ref)
-}
-
 function targetRevealEligible(target = {}) {
   return target.extension?.reveal_eligible ?? target.reveal_eligible
 }
@@ -102,8 +93,8 @@ function cssEscape(value) {
 
 function targetSelectors(target = {}) {
   const selectors = []
-  const ref = targetRef(target)
-  const domId = targetDomId(target)
+  const ref = text(target.ref)
+  const domId = text(target.provenance?.dom_id || target.extension?.dom_id)
   if (target.provenance?.selector) selectors.push(String(target.provenance.selector))
   if (target.selector) selectors.push(String(target.selector))
   if (domId) selectors.push(`[data-semantic-target-id="${cssEscape(domId)}"]`)
@@ -131,7 +122,7 @@ export function revealHtmlWorkbenchSemanticTarget(state, target = {}, {
     .map((value) => String(value ?? '').trim())
     .filter(Boolean)
   const metadataTarget = state.metadata?.semantic_targets?.find?.((item) => {
-    const id = targetRef(item)
+    const id = text(item.ref)
     return id && candidateIds.includes(String(id))
   }) || target.source_tree_node_metadata || target
   const element = resolveTargetElement(document_, metadataTarget)
@@ -139,7 +130,7 @@ export function revealHtmlWorkbenchSemanticTarget(state, target = {}, {
     return {
       status: 'target_absent',
       adapter_id: 'aos-toolkit-semantic-target',
-      subject_id: target.subject_id || target.ref || target.id || targetRef(metadataTarget),
+      subject_id: target.subject_id || target.ref || text(metadataTarget.ref),
       blocker_reason: 'semantic_target_not_found',
       completed_at: now,
     }
@@ -164,7 +155,7 @@ export function revealHtmlWorkbenchSemanticTarget(state, target = {}, {
   return {
     status: alreadyVisible ? 'already_visible' : (visible ? 'revealed' : 'blocked'),
     adapter_id: 'aos-toolkit-semantic-target',
-    subject_id: target.subject_id || target.ref || target.id || targetRef(metadataTarget),
+    subject_id: target.subject_id || target.ref || text(metadataTarget.ref),
     blocker_reason: visible ? '' : 'scroll_into_view_did_not_make_target_visible',
     completed_at: now,
     projection: {
@@ -195,11 +186,11 @@ export function buildHtmlWorkbenchSemanticTargetsPayload(state, {
         ? rect.x + rect.w >= viewportRect.x && rect.y + rect.h >= viewportRect.y && rect.x <= viewportRect.x + viewportRect.w && rect.y <= viewportRect.y + viewportRect.h
         : rect.x + rect.w >= 0 && rect.y + rect.h >= 0
     ))
-    const ref = targetRef(target)
-    const canReveal = targetRevealEligible(target) !== false && Boolean(element || target.provenance?.selector || target.selector || targetDomId(target) || ref)
+    const ref = text(target.ref)
+    const domId = text(target.provenance?.dom_id || target.extension?.dom_id)
+    const canReveal = targetRevealEligible(target) !== false && Boolean(element || target.provenance?.selector || target.selector || domId || ref)
     return {
       ...target,
-      id: ref,
       canvas_id: HTML_WORKBENCH_EXPRESSION_SURFACE,
       surface: HTML_WORKBENCH_EXPRESSION_SURFACE,
       name: target.name || target.label || ref,

--- a/packages/toolkit/components/surface-inspector/index.js
+++ b/packages/toolkit/components/surface-inspector/index.js
@@ -233,11 +233,6 @@ function semanticTargetIdentifier(target = {}) {
   return String(
     target.ref
       || target.id
-      // Removal gate: old target identity spellings remain for non-workbench producers until https://github.com/michaelblum/agent-os/issues/399.
-      || target.target_id
-      || target.semantic_target_id
-      || target.do_target
-      || target.data_aos_ref
       || '',
   ).trim()
 }
@@ -266,15 +261,9 @@ export function buildRevealPayloadForSurfaceInspectorPin(pin = {}) {
     subject_path: Array.isArray(pin.subject_path) ? [...pin.subject_path] : [],
     root_id: pin.root_id,
     root_path: Array.isArray(pin.projection?.root_path) ? [...pin.projection.root_path] : [],
-    owner_canvas_id: pin.root_id || sourceMetadata.canvas_id || sourceMetadata.surface,
-    canvas_id: sourceMetadata.canvas_id || pin.root_id,
+    owner_canvas_id: pin.root_id || sourceMetadata.provenance?.canvas_id || sourceMetadata.canvas_id || sourceMetadata.surface,
+    canvas_id: sourceMetadata.provenance?.canvas_id || sourceMetadata.canvas_id || pin.root_id,
     id: sourceMetadata.id,
-    // Removal gate: old target identity spellings remain for non-workbench producers until https://github.com/michaelblum/agent-os/issues/399.
-    target_id: sourceMetadata.target_id,
-    semantic_target_id: sourceMetadata.semantic_target_id,
-    data_aos_ref: sourceMetadata.data_aos_ref,
-    aos_ref: sourceMetadata.aos_ref,
-    do_target: sourceMetadata.do_target,
     selector: sourceMetadata.provenance?.selector || sourceMetadata.selector,
     selector_candidates: Array.isArray(sourceMetadata.selector_candidates) ? [...sourceMetadata.selector_candidates] : [],
     source_path: sourceMetadata.extension?.source?.path || sourceMetadata.source_path,
@@ -912,15 +901,9 @@ function buildRevealTargetEvalScript(target = {}) {
         target.ref ? '[data-aos-ref="' + CSS.escape(target.ref) + '"]' : '',
         target.subject_id ? '[data-semantic-target-id="' + CSS.escape(target.subject_id) + '"]' : '',
         target.subject_id ? '[data-aos-ref="' + CSS.escape(target.subject_id) + '"]' : '',
-        // Removal gate: old target identity spellings remain for non-workbench producers until https://github.com/michaelblum/agent-os/issues/399.
-        target.source_tree_node_metadata?.target_id ? '[data-semantic-target-id="' + CSS.escape(target.source_tree_node_metadata.target_id) + '"]' : '',
-        target.source_tree_node_metadata?.data_aos_ref ? '[data-aos-ref="' + CSS.escape(target.source_tree_node_metadata.data_aos_ref) + '"]' : '',
-        target.source_tree_node_metadata?.aos_ref ? '[data-aos-ref="' + CSS.escape(target.source_tree_node_metadata.aos_ref) + '"]' : '',
         target.source_tree_node_metadata?.selector || '',
         target.source_tree_node_metadata?.preferred_selector || '',
         ...(Array.isArray(target.source_tree_node_metadata?.selector_candidates) ? target.source_tree_node_metadata.selector_candidates : []),
-        target.do_target ? '[data-aos-ref="' + CSS.escape(target.do_target) + '"]' : '',
-        target.do_target ? '[data-aos-action="' + CSS.escape(target.do_target) + '"]' : '',
         target.subject_id ? '[data-aos-action="' + CSS.escape(target.subject_id) + '"]' : ''
       ].filter(Boolean).join(',')
       const element = selector ? document.querySelector(selector) : null
@@ -1585,15 +1568,20 @@ export default function CanvasInspector() {
   }
 
   function normalizeSemanticTargetsPayload(payload = {}) {
-    const canvasId = payload.canvas_id || payload.surface || payload.id
     const targets = Array.isArray(payload.semantic_targets)
       ? payload.semantic_targets
       : (Array.isArray(payload.targets) ? payload.targets : [])
+    const canvasId = payload.canvas_id
+      || payload.surface
+      || payload.id
+      || targets.find((target) => target?.provenance?.canvas_id)?.provenance?.canvas_id
     if (!canvasId) return
     semanticTargetsByCanvas.set(canvasId, targets.map((target) => ({
       ...target,
-      id: semanticTargetId(target) || target.id,
-      canvas_id: target.canvas_id || canvasId,
+      provenance: {
+        ...(target.provenance && typeof target.provenance === 'object' ? target.provenance : {}),
+        canvas_id: target.provenance?.canvas_id || canvasId,
+      },
     })))
   }
 
@@ -2044,7 +2032,7 @@ export default function CanvasInspector() {
       rerender()
       return
     }
-    const canvasId = pin.root_id || pin.source_tree_node_metadata?.canvas_id || pin.source_tree_node_metadata?.surface
+    const canvasId = pin.root_id || pin.source_tree_node_metadata?.provenance?.canvas_id || pin.source_tree_node_metadata?.canvas_id || pin.source_tree_node_metadata?.surface
     if (!canvasId || canvasId === SELF_ID) {
       annotationState = applySurfaceInspectorRevealResult(annotationState, pin.id, {
         status: 'unsupported',

--- a/packages/toolkit/workbench/annotation-perception-verification.js
+++ b/packages/toolkit/workbench/annotation-perception-verification.js
@@ -39,8 +39,11 @@ function firstRect(value) {
 }
 
 function targetBounds(target = {}) {
+  const provenance = target.provenance && typeof target.provenance === 'object' ? target.provenance : {}
   return normalizeRect(
     target.perceived_bounds
+      ?? provenance.bounds
+      ?? provenance.frame
       ?? target.bounds?.viewport_local
       ?? target.bounds?.parent_local
       ?? target.bounds?.desktop_world
@@ -63,18 +66,19 @@ export function boundsOverlapRatio(a, b) {
 
 function normalizeTarget(target = {}) {
   const bounds = targetBounds(target)
+  const provenance = target.provenance && typeof target.provenance === 'object' ? target.provenance : {}
   return {
-    id: text(target.id ?? target.target_id ?? target.path, 'unknown-target'),
-    path: text(target.path ?? target.target_path ?? target.id, 'unknown-target'),
+    id: text(target.ref ?? target.path, 'unknown-target'),
+    path: text(target.path ?? target.target_path ?? target.ref, 'unknown-target'),
     kind: text(target.kind, 'region'),
     label: text(target.label ?? target.name, 'Target'),
     source_ids: {
-      canvas_id: text(target.source_ids?.canvas_id ?? target.canvas_id) || null,
+      canvas_id: text(target.source_ids?.canvas_id ?? provenance.canvas_id) || null,
       surface_id: text(target.source_ids?.surface_id ?? target.surface_id ?? target.surface) || null,
       window_id: text(target.source_ids?.window_id ?? target.window_id) || null,
       display_id: text(target.source_ids?.display_id ?? target.display_id) || null,
-      subject_id: text(target.source_ids?.subject_id ?? target.subject_id ?? target.id) || null,
-      adapter_subject_id: text(target.source_ids?.adapter_subject_id ?? target.ref ?? target.do_target) || null,
+      subject_id: text(target.source_ids?.subject_id ?? target.subject_id ?? target.ref) || null,
+      adapter_subject_id: text(target.source_ids?.adapter_subject_id ?? target.ref ?? provenance.do_target) || null,
     },
     perceived_bounds: bounds,
     role: text(target.role) || null,

--- a/packages/toolkit/workbench/annotation-projection.js
+++ b/packages/toolkit/workbench/annotation-projection.js
@@ -450,17 +450,26 @@ export function buildBrowserContentSeamAdapterResult(record = {}, context = {}) 
 export function buildSemanticTargetProjectionAdapterResult(target = {}, owner = {}) {
   const targetId = text(
     target.ref
-      || target.id
-      // Removal gate: old target identity spellings remain for non-workbench producers until https://github.com/michaelblum/agent-os/issues/399.
-      || target.target_id
-      || target.semantic_target_id
-      || target.do_target
-      || target.data_aos_ref,
+      || target.id,
     'target',
   );
-  const sourceBounds = normalizeRect(target.display_space_rect || target.display_bounds || target.bounds || target.rect);
+  const sourceBounds = normalizeRect(
+    target.display_space_rect
+      || target.display_bounds
+      || target.bounds
+      || target.rect
+      || target.provenance?.bounds
+      || target.provenance?.frame,
+  );
   const bounds = clipAnnotationDisplayRectToVisibleChain(sourceBounds, target.ancestor_viewport_clip_chain || target.clip_chain);
-  const local = normalizeRect(target.local_space_rect || target.local_bounds || target.bounds || target.rect);
+  const local = normalizeRect(
+    target.local_space_rect
+      || target.local_bounds
+      || target.bounds
+      || target.rect
+      || target.provenance?.bounds
+      || target.provenance?.frame,
+  );
   const scrollable = Boolean(target.scrollable_ancestor_chain?.length || target.offscreen_scrollable || target.can_scroll);
   const hasStructuredReveal = target.can_reveal !== false
     && target.reveal_eligible !== false
@@ -472,12 +481,7 @@ export function buildSemanticTargetProjectionAdapterResult(target = {}, owner = 
         || target.extension?.reveal_eligible
         || target.provenance?.selector
         || target.selector
-        || target.ref
-        // Removal gate: old target identity spellings remain for non-workbench producers until https://github.com/michaelblum/agent-os/issues/399.
-        || target.data_aos_ref
-        || target.aos_ref
-        || target.target_id
-        || target.semantic_target_id,
+        || target.ref,
     );
   const visible = target.visible !== false && bounds;
   const coordinateSpace = text(

--- a/packages/toolkit/workbench/spatial-subject-tree.js
+++ b/packages/toolkit/workbench/spatial-subject-tree.js
@@ -310,7 +310,11 @@ export function buildSpatialSubjectTree({
 
   const targetSurfaces = surfaces.length > 0
     ? surfaces
-    : [...new Set(semantic_targets.map((target) => target.surface ?? target.canvas_id).filter(Boolean))].map((id) => ({ id, canvas_id: semantic_targets.find((target) => (target.surface ?? target.canvas_id) === id)?.canvas_id }))
+    : [...new Set(semantic_targets.map((target) => target.surface ?? target.provenance?.canvas_id).filter(Boolean))]
+      .map((id) => ({
+        id,
+        canvas_id: semantic_targets.find((target) => (target.surface ?? target.provenance?.canvas_id) === id)?.provenance?.canvas_id,
+      }))
 
   for (const [surfaceIndex, surface] of targetSurfaces.entries()) {
     const surfaceId = asId(surface.id ?? surface.surface_id, surfaceIndex)
@@ -338,26 +342,38 @@ export function buildSpatialSubjectTree({
   }
 
   for (const [targetIndex, target] of semantic_targets.entries()) {
-    const surfaceId = asId(target.surface ?? target.canvas_id, target.canvas_id)
-    const parentId = surfaceParentById.get(surfaceId) ?? (target.canvas_id ? `canvas:${target.canvas_id}` : rootId)
-    const targetId = asId(target.id ?? target.ref, targetIndex)
+    const provenance = target.provenance && typeof target.provenance === 'object' ? target.provenance : {}
+    const extension = target.extension && typeof target.extension === 'object' ? target.extension : {}
+    const canvasId = asId(provenance.canvas_id, null)
+    const surfaceId = asId(target.surface ?? canvasId, canvasId)
+    const parentId = surfaceParentById.get(surfaceId) ?? (canvasId ? `canvas:${canvasId}` : rootId)
+    const targetId = asId(target.ref, targetIndex)
+    const bounds = provenance.bounds ?? provenance.frame ?? null
+    const actions = Array.isArray(target.actions) ? target.actions : []
+    const doTarget = provenance.do_target ?? null
     nodes.push({
       id: `target:${targetId}`,
       parent_id: parentId,
       kind: 'semantic_target',
       label: target.name ?? target.label ?? target.role ?? targetId,
       source: {
-        canvas_id: target.canvas_id ?? null,
+        canvas_id: canvasId,
         surface_id: surfaceId,
         subject_id: targetId,
-        adapter_subject_id: target.ref ?? target.do_target ?? null,
+        adapter_subject_id: doTarget ?? targetId,
       },
-      bounds: { parent_local: target.bounds },
+      bounds: { parent_local: bounds },
       sibling_order: targetIndex,
       state: target.enabled === false ? 'hidden' : 'visible',
       adapter: { id: 'aos-semantic-targets', type: 'aos_canvas', confidence: 0.85, freshness: 'snapshot', child_discovery: 'complete' },
-      capabilities: { hit_test: true, annotate: true, action: Boolean(target.do_target || target.action), capture: true, inspect_children: false },
-      metadata: { role: target.role ?? null, action: target.action ?? null, state: target.state ?? null },
+      capabilities: { hit_test: true, annotate: true, action: actions.length > 0 || Boolean(doTarget), capture: true, inspect_children: false },
+      metadata: {
+        role: target.role ?? null,
+        actions,
+        dom_id: extension.dom_id ?? null,
+        do_target: doTarget,
+        state: target.state ?? null,
+      },
     })
   }
 

--- a/shared/schemas/aos-semantic-targets.md
+++ b/shared/schemas/aos-semantic-targets.md
@@ -13,8 +13,8 @@ canvas already owns:
 
 - role, name, state, and disabled/value semantics from standard AX/ARIA/native
   controls
-- bounds and center from the element's DOM frame in the capture image's local
-  coordinate space
+- local geometry in `provenance` from the element's DOM frame in the capture
+  image's local coordinate space
 - AOS ownership metadata from `data-aos-ref`, `data-aos-action`,
   `data-aos-surface`, `data-semantic-target-id`, and `data-aos-parent-canvas`
 
@@ -28,19 +28,27 @@ diagnostics.
 {
   "semantic_targets": [
     {
-      "canvas_id": "sigil-radial-menu",
-      "id": "wiki-graph",
       "ref": "sigil-radial-item-wiki-graph",
-      "do_target": "canvas:sigil-radial-menu/sigil-radial-item-wiki-graph",
+      "surface": "sigil-radial-menu",
       "role": "button",
       "name": "Wiki Graph",
-      "action": "wiki-graph",
-      "surface": "sigil-radial-menu",
-      "parent_canvas": "avatar-main",
+      "kind": "semantic_target",
       "enabled": true,
-      "bounds": { "x": 40, "y": 24, "width": 56, "height": 56 },
-      "center": { "x": 68, "y": 52 },
-      "state": { "current": "true" }
+      "state": { "current": "true" },
+      "actions": ["wiki-graph"],
+      "extension": {
+        "dom_id": "wiki-graph",
+        "source": { "path": null, "line_start": null, "line_end": null }
+      },
+      "provenance": {
+        "canvas_id": "sigil-radial-menu",
+        "do_target": "canvas:sigil-radial-menu/sigil-radial-item-wiki-graph",
+        "parent_canvas_id": "avatar-main",
+        "source_payload_id": "wiki-graph",
+        "bounds": { "x": 40, "y": 24, "width": 56, "height": 56 },
+        "frame": { "x": 40, "y": 24, "width": 56, "height": 56 },
+        "center": { "x": 68, "y": 52 }
+      }
     }
   ]
 }
@@ -48,31 +56,30 @@ diagnostics.
 
 ## Field Notes
 
-`canvas_id` is the canvas requested by `--canvas`.
-
-`id` is the stable local target id, normally `data-semantic-target-id` or the DOM
-id.
-
 `ref` is the canonical AOS object reference from `data-aos-ref`.
 
-`do_target` is the canonical target-with-ref string accepted by
-`aos do click`. It is emitted only when both `canvas_id` and `ref` are present,
-and agents may pass it directly to `aos do click` without reconstructing the
-target string. `canvas_id` and `ref` remain present for structured querying and
-filtering.
+`provenance.canvas_id` is the canvas requested by `--canvas`.
+
+`provenance.do_target` is the target-with-ref string accepted by `aos do click`.
+It is emitted only when both `provenance.canvas_id` and `ref` are present, and
+agents may pass it directly to `aos do click` without reconstructing the target
+string. `provenance.canvas_id` and `ref` remain present for structured querying
+and filtering.
 
 `role` is the explicit DOM role when present, otherwise the closest native
 control role.
 
 `name` is the accessible name, usually `aria-label`, not an implementation id.
 
-`action` is the AOS action id from `data-aos-action`.
+`actions` is the list of AOS action ids. The producer converts
+`data-aos-action` to a one-item list when present.
 
-`surface` and `parent_canvas` identify the AOS surface relationship without
-polluting the accessible name.
+`surface` and `provenance.parent_canvas_id` identify the AOS surface
+relationship without polluting the accessible name.
 
-`bounds` and `center` use the same local image coordinate space as capture/xray
-output for that canvas.
+`provenance.bounds`, `provenance.frame`, and `provenance.center` use the same
+local image coordinate space as capture/xray output for that canvas.
 
 `state` is present only when the control exposes state such as `current`,
-`pressed`, `selected`, `checked`, `expanded`, `disabled`, or `value`.
+`pressed`, `selected`, `checked`, `expanded`, or `value`. Disabled state is
+reported as top-level `enabled: false`.

--- a/src/act/canvas-ref-targeting.swift
+++ b/src/act/canvas-ref-targeting.swift
@@ -17,12 +17,12 @@ struct CanvasRefClickTargetInfo: Encodable {
     let target_dialect: String
     let canvas_id: String
     let ref: String
-    let target_id: String?
     let role: String
     let name: String?
-    let action: String?
+    let actions: [String]
     let surface: String?
-    let parent_canvas: String?
+    let parent_canvas_id: String?
+    let do_target: String?
     let enabled: Bool
     let bounds: BoundsJSON
     let local_center: CursorJSON
@@ -90,7 +90,7 @@ func resolveCanvasRefClickTarget(_ rawTarget: String) -> CanvasRefClickResolutio
     }
 
     let matches = targets.filter { target in
-        target.canvas_id == parsed.canvasID && target.ref == parsed.ref
+        target.provenance.canvas_id == parsed.canvasID && target.ref == parsed.ref
     }
     guard !matches.isEmpty else {
         exitError("Ref '\(parsed.ref)' not found on canvas '\(parsed.canvasID)'", code: "REF_NOT_FOUND")
@@ -101,12 +101,19 @@ func resolveCanvasRefClickTarget(_ rawTarget: String) -> CanvasRefClickResolutio
             code: "TARGET_AMBIGUOUS"
         )
     }
-    guard target.enabled, target.state?.disabled != true else {
+    guard target.enabled else {
         exitError("Ref '\(parsed.ref)' on canvas '\(parsed.canvasID)' is disabled", code: "TARGET_DISABLED")
     }
 
-    let globalX = canvasBounds.origin.x + CGFloat(Double(target.center.x) / captureScale)
-    let globalY = canvasBounds.origin.y + CGFloat(Double(target.center.y) / captureScale)
+    guard let center = target.provenance.center else {
+        exitError("Ref '\(parsed.ref)' on canvas '\(parsed.canvasID)' has no center", code: "TARGET_GEOMETRY_UNAVAILABLE")
+    }
+    guard let bounds = target.provenance.bounds ?? target.provenance.frame else {
+        exitError("Ref '\(parsed.ref)' on canvas '\(parsed.canvasID)' has no bounds", code: "TARGET_GEOMETRY_UNAVAILABLE")
+    }
+
+    let globalX = canvasBounds.origin.x + CGFloat(Double(center.x) / captureScale)
+    let globalY = canvasBounds.origin.y + CGFloat(Double(center.y) / captureScale)
     let point = CGPoint(x: globalX, y: globalY)
 
     return CanvasRefClickResolution(
@@ -114,15 +121,15 @@ func resolveCanvasRefClickTarget(_ rawTarget: String) -> CanvasRefClickResolutio
             target_dialect: "canvas",
             canvas_id: parsed.canvasID,
             ref: parsed.ref,
-            target_id: target.id,
             role: target.role,
             name: target.name,
-            action: target.action,
+            actions: target.actions,
             surface: target.surface,
-            parent_canvas: target.parent_canvas,
+            parent_canvas_id: target.provenance.parent_canvas_id,
+            do_target: target.provenance.do_target,
             enabled: target.enabled,
-            bounds: target.bounds,
-            local_center: target.center,
+            bounds: bounds,
+            local_center: center,
             click: CanvasRefClickPoint(x: Double(point.x), y: Double(point.y)),
             coordinate_space: "global_cg",
             capture_scale_factor: captureScale,

--- a/src/perceive/models.swift
+++ b/src/perceive/models.swift
@@ -250,29 +250,46 @@ struct AXElementJSON: Encodable {
 // MARK: - AOS-owned Canvas Semantic Target Output
 
 struct AOSSemanticTargetStateJSON: Codable {
+    let value: String?
     let current: String?
     let pressed: Bool?
     let selected: Bool?
     let checked: Bool?
     let expanded: Bool?
-    let disabled: Bool?
-    let value: String?
+}
+
+struct AOSSemanticTargetExtensionSourceJSON: Codable {
+    let path: String?
+    let line_start: Int?
+    let line_end: Int?
+}
+
+struct AOSSemanticTargetExtensionJSON: Codable {
+    let dom_id: String?
+    let source: AOSSemanticTargetExtensionSourceJSON?
+}
+
+struct AOSSemanticTargetProvenanceJSON: Codable {
+    let canvas_id: String?
+    let do_target: String?
+    let parent_canvas_id: String?
+    let source_payload_id: String?
+    let bounds: BoundsJSON?
+    let frame: BoundsJSON?
+    let center: CursorJSON?
 }
 
 struct AOSSemanticTargetJSON: Codable {
-    let canvas_id: String?
-    let id: String?
-    let ref: String?
-    let do_target: String?
+    let ref: String
+    let surface: String?
     let role: String
     let name: String?
-    let action: String?
-    let surface: String?
-    let parent_canvas: String?
+    let kind: String
     let enabled: Bool
-    let bounds: BoundsJSON
-    let center: CursorJSON
     let state: AOSSemanticTargetStateJSON?
+    let actions: [String]
+    let `extension`: AOSSemanticTargetExtensionJSON
+    let provenance: AOSSemanticTargetProvenanceJSON
 }
 
 // MARK: - Annotation Output Model (annotation.schema.json v0.1.0)

--- a/src/perceive/semantic-targets.swift
+++ b/src/perceive/semantic-targets.swift
@@ -60,17 +60,16 @@ private func semanticTargetProbeJS(canvasID: String, scaleFactor: Double) -> Str
         || id
         || ref
       );
-      const stateFor = (el, disabled) => {
+      const stateFor = (el) => {
         const state = {};
+        const value = attr(el, 'aria-valuetext') || attr(el, 'aria-valuenow') || (el.value !== undefined ? clean(el.value) : '');
+        if (value) state.value = value;
         const current = attr(el, 'aria-current');
         if (current && current !== 'false') state.current = current;
         for (const key of ['pressed', 'selected', 'checked', 'expanded']) {
           const value = boolAttr(el, `aria-${key}`);
           if (value !== null) state[key] = value;
         }
-        const value = attr(el, 'aria-valuetext') || attr(el, 'aria-valuenow') || (el.value !== undefined ? clean(el.value) : '');
-        if (value) state.value = value;
-        if (disabled) state.disabled = true;
         return Object.keys(state).length ? state : null;
       };
 
@@ -79,6 +78,7 @@ private func semanticTargetProbeJS(canvasID: String, scaleFactor: Double) -> Str
         if (!Number.isFinite(rect.width) || !Number.isFinite(rect.height) || rect.width <= 0 || rect.height <= 0) return null;
         const id = data(el, 'semanticTargetId') || attr(el, 'data-semantic-target-id') || attr(el, 'id');
         const ref = data(el, 'aosRef') || attr(el, 'data-aos-ref');
+        if (!ref) return null;
         const doTarget = canvasId && ref ? `canvas:${canvasId}/${ref}` : null;
         const disabled = el.matches?.(':disabled') || attr(el, 'aria-disabled') === 'true';
         const bounds = {
@@ -87,23 +87,33 @@ private func semanticTargetProbeJS(canvasID: String, scaleFactor: Double) -> Str
           width: Math.max(1, Math.round(rect.width * scale)),
           height: Math.max(1, Math.round(rect.height * scale)),
         };
+        const action = data(el, 'aosAction') || attr(el, 'data-aos-action') || '';
+        const parentCanvasId = data(el, 'aosParentCanvas') || attr(el, 'data-aos-parent-canvas') || null;
         return {
-          canvas_id: canvasId,
-          id: id || null,
-          ref: ref || null,
-          do_target: doTarget,
+          ref,
+          surface: data(el, 'aosSurface') || attr(el, 'data-aos-surface') || null,
           role: attr(el, 'role') || nativeRole(el),
           name: targetName(el, id, ref) || null,
-          action: data(el, 'aosAction') || attr(el, 'data-aos-action') || null,
-          surface: data(el, 'aosSurface') || attr(el, 'data-aos-surface') || null,
-          parent_canvas: data(el, 'aosParentCanvas') || attr(el, 'data-aos-parent-canvas') || null,
+          kind: 'semantic_target',
           enabled: !disabled,
-          bounds,
-          center: {
-            x: Math.round(bounds.x + bounds.width / 2),
-            y: Math.round(bounds.y + bounds.height / 2),
+          state: stateFor(el),
+          actions: action ? [action] : [],
+          extension: {
+            dom_id: id || null,
+            source: { path: null, line_start: null, line_end: null },
           },
-          state: stateFor(el, disabled),
+          provenance: {
+            canvas_id: canvasId,
+            do_target: doTarget,
+            parent_canvas_id: parentCanvasId,
+            source_payload_id: id || ref,
+            bounds,
+            frame: bounds,
+            center: {
+              x: Math.round(bounds.x + bounds.width / 2),
+              y: Math.round(bounds.y + bounds.height / 2),
+            },
+          },
         };
       }).filter(Boolean));
     })()

--- a/tests/aos-canvas-ref-click.sh
+++ b/tests/aos-canvas-ref-click.sh
@@ -73,18 +73,32 @@ STATE_ID="$(printf '%s' "$CAPTURE" | jq -r '.state_id')"
 printf '%s' "$CAPTURE" | jq -e --arg canvas "$CANVAS_ID" '
   .semantic_targets
   | map(select(
-      .canvas_id == $canvas
+      .provenance.canvas_id == $canvas
       and .ref == "contract.primary"
-      and .do_target == ("canvas:" + $canvas + "/contract.primary")
+      and .provenance.do_target == ("canvas:" + $canvas + "/contract.primary")
       and .enabled == true
+      and (.actions | index("commit"))
+      and .extension.dom_id == "primary"
+      and (.provenance.bounds.width | type == "number")
+      and (.provenance.center.x | type == "number")
+      and (has("id") | not)
+      and (has("canvas_id") | not)
+      and (has("do_target") | not)
+      and (has("action") | not)
+      and (has("parent_canvas") | not)
+      and (has("bounds") | not)
+      and (has("center") | not)
+      and (has("target_id") | not)
+      and (has("aos_ref") | not)
+      and (has("data_aos_ref") | not)
     ))
   | length == 1
 ' >/dev/null
 
 DO_TARGET="$(printf '%s' "$CAPTURE" | jq -r --arg canvas "$CANVAS_ID" '
   .semantic_targets
-  | map(select(.canvas_id == $canvas and .ref == "contract.primary" and .enabled == true))
-  | if length == 1 then .[0].do_target else empty end
+  | map(select(.provenance.canvas_id == $canvas and .ref == "contract.primary" and .enabled == true))
+  | if length == 1 then .[0].provenance.do_target else empty end
 ')"
 if [ "$DO_TARGET" != "canvas:${CANVAS_ID}/contract.primary" ]; then
   echo "FAIL: expected do_target canvas:${CANVAS_ID}/contract.primary, got '$DO_TARGET'" >&2
@@ -134,6 +148,8 @@ else
   printf '%s' "$ERR" | jq -e '.code == "UNSUPPORTED_SURFACE"' >/dev/null
 fi
 
+./aos show update --id "$CANVAS_ID" --focus >/dev/null
+sleep 0.1
 ./aos do click "$DO_TARGET" --state-id "$STATE_ID" >/dev/null
 sleep 0.2
 

--- a/tests/aos-semantic-targets-xray-retry.sh
+++ b/tests/aos-semantic-targets-xray-retry.sh
@@ -34,15 +34,28 @@ OUT="$(./aos see capture --canvas "$CANVAS_ID" --xray --out "/tmp/${CANVAS_ID}.p
 echo "$OUT" | jq -e --arg canvas "$CANVAS_ID" '
   .semantic_targets
   | map(select(
-      .canvas_id == $canvas
-      and .id == "retry"
+      .provenance.canvas_id == $canvas
       and .ref == "contract.retry"
-      and .do_target == ("canvas:" + $canvas + "/contract.retry")
+      and .extension.dom_id == "retry"
+      and .provenance.do_target == ("canvas:" + $canvas + "/contract.retry")
       and .role == "button"
       and .name == "Retry Action"
-      and .action == "retry"
+      and (.actions | index("retry"))
       and .surface == "contract.surface"
       and .enabled == true
+      and (.provenance.bounds.width | type == "number")
+      and (.provenance.frame.width | type == "number")
+      and (.provenance.center.x | type == "number")
+      and (has("id") | not)
+      and (has("canvas_id") | not)
+      and (has("do_target") | not)
+      and (has("action") | not)
+      and (has("parent_canvas") | not)
+      and (has("bounds") | not)
+      and (has("center") | not)
+      and (has("target_id") | not)
+      and (has("aos_ref") | not)
+      and (has("data_aos_ref") | not)
     ))
   | length == 1
 ' >/dev/null || {

--- a/tests/aos-semantic-targets-xray.sh
+++ b/tests/aos-semantic-targets-xray.sh
@@ -34,20 +34,31 @@ OUT="$(./aos see capture --canvas "$CANVAS_ID" --xray --out "/tmp/${CANVAS_ID}.p
 echo "$OUT" | jq -e --arg canvas "$CANVAS_ID" '
   .semantic_targets
   | map(select(
-      .canvas_id == $canvas
-      and .id == "primary"
+      .provenance.canvas_id == $canvas
       and .ref == "contract.primary"
-      and .do_target == ("canvas:" + $canvas + "/contract.primary")
+      and .extension.dom_id == "primary"
+      and .provenance.do_target == ("canvas:" + $canvas + "/contract.primary")
       and .role == "button"
       and .name == "Primary Action"
-      and .action == "commit"
+      and (.actions | index("commit"))
       and .surface == "contract.surface"
-      and .parent_canvas == "contract-parent"
+      and .provenance.parent_canvas_id == "contract-parent"
       and .enabled == true
       and .state.pressed == true
-      and (.bounds.width | type == "number")
-      and .bounds.width > 0
-      and (.center.x | type == "number")
+      and (.provenance.bounds.width | type == "number")
+      and .provenance.bounds.width > 0
+      and (.provenance.frame.width | type == "number")
+      and (.provenance.center.x | type == "number")
+      and (has("id") | not)
+      and (has("canvas_id") | not)
+      and (has("do_target") | not)
+      and (has("action") | not)
+      and (has("parent_canvas") | not)
+      and (has("bounds") | not)
+      and (has("center") | not)
+      and (has("target_id") | not)
+      and (has("aos_ref") | not)
+      and (has("data_aos_ref") | not)
     ))
   | length == 1
 ' >/dev/null || {

--- a/tests/toolkit/agent-ui-target-conformance.test.mjs
+++ b/tests/toolkit/agent-ui-target-conformance.test.mjs
@@ -181,6 +181,7 @@ test('current producer fixtures map losslessly to candidate agent_ui_target reco
 
   assert.deepEqual([...sources.keys()].sort(), [
     'html_workbench_source_line_target',
+    'native_perceive_canvas_semantic_target',
     'sigil_compact_surface_control',
     'sigil_compact_surface_tab',
     'toolkit_panel_form_control',
@@ -234,18 +235,13 @@ test('blocked projection fixtures preserve explicit blockers instead of selector
   assert.notEqual(blocked.ref, blocked.source_tree_node_metadata.selector)
 })
 
-test('projection fixture exposes current subject_id and target_id drift as source evidence only', async () => {
+test('projection fixtures do not preserve legacy producer identity spellings', async () => {
   const projectionFixture = await readJson('candidate-agent-ui-target-projections.json')
-  const drift = projectionFixture.records.find((record) => (
-    record.source_tree_node_metadata?.subject_id
-    && record.source_tree_node_metadata?.target_id
-    && record.source_tree_node_metadata.subject_id !== record.source_tree_node_metadata.target_id
-  ))
-
-  assert.ok(drift, 'fixture should expose current subject_id/target_id drift')
-  assert.equal(drift.ref, 'sigil.avatar.compact_control_surface:sigil-menu-opacity')
-  assert.equal(drift.source_tree_node_metadata.subject_id, 'sigil-menu-opacity')
-  assert.equal(drift.source_tree_node_metadata.target_id, 'sigil.avatar.compact_control_surface:sigil-menu-opacity')
+  for (const projection of projectionFixture.records) {
+    walkKeys(projection.source_tree_node_metadata || {}, (key) => {
+      assert.ok(!['target_id', 'semantic_target_id', 'data_aos_ref', 'aos_ref'].includes(key), `legacy producer key remained in projection fixture: ${key}`)
+    })
+  }
 })
 
 test('current semantic target core still requires ids and does not invent action defaults', () => {

--- a/tests/toolkit/html-workbench-expression.test.mjs
+++ b/tests/toolkit/html-workbench-expression.test.mjs
@@ -208,7 +208,7 @@ test('HTML expression surface payload exposes revealable live semantic targets',
 
   assert.equal(payload.type, 'canvas_inspector.semantic_targets');
   assert.equal(payload.canvas_id, 'html-workbench-expression');
-  assert.equal(payload.semantic_targets[0].id, 'html-workbench-expression:goal');
+  assert.equal(payload.semantic_targets[0].ref, 'html-workbench-expression:goal');
   assert.equal(payload.semantic_targets[0].current_render_status, 'visible');
   assert.equal(payload.semantic_targets[0].can_reveal, true);
   assert.deepEqual(payload.semantic_targets[0].display_space_rect, { x: 20, y: 40, w: 300, h: 60 });
@@ -375,7 +375,7 @@ test('HTML expression surface replays current semantic targets when Surface Insp
     assert.equal(sent[0].payload.target, 'surface-inspector');
     assert.equal(sent[0].payload.message.type, 'canvas_inspector.semantic_targets');
     assert.equal(sent[0].payload.message.replay_reason, 'surface_inspector_bootstrap');
-    assert.equal(sent[0].payload.message.semantic_targets[0].id, 'html-workbench-expression:goal');
+    assert.equal(sent[0].payload.message.semantic_targets[0].ref, 'html-workbench-expression:goal');
     assert.equal(sent[0].payload.message.semantic_targets[0].can_reveal, true);
     assert.deepEqual(sent[0].payload.message.semantic_targets[0].display_space_rect, { x: 20, y: 40, w: 300, h: 60 });
   } finally {

--- a/tests/toolkit/spatial-subject-tree.test.mjs
+++ b/tests/toolkit/spatial-subject-tree.test.mjs
@@ -114,22 +114,37 @@ test('buildSpatialSubjectTree maps topology, canvas, targets, and projections in
     ],
     semantic_targets: [
       {
-        canvas_id: 'brand-audit',
         surface: 'comparative-audit',
-        id: 'primary-cta',
         ref: 'button-primary-cta',
         role: 'button',
         name: 'Primary CTA',
-        do_target: 'canvas:brand-audit/button-primary-cta',
-        bounds: { x: 48, y: 80, width: 160, height: 36 },
+        kind: 'control',
+        enabled: true,
+        actions: ['commit'],
+        extension: {
+          dom_id: 'primary-cta',
+        },
+        provenance: {
+          canvas_id: 'brand-audit',
+          do_target: 'canvas:brand-audit/button-primary-cta',
+          bounds: { x: 48, y: 80, width: 160, height: 36 },
+        },
       },
       {
-        canvas_id: 'brand-audit',
         surface: 'comparative-audit',
-        id: 'evidence-card',
+        ref: 'evidence-card-ref',
         role: 'region',
         name: 'Evidence Card',
-        bounds: { x: 48, y: 148, width: 360, height: 180 },
+        kind: 'region',
+        enabled: true,
+        actions: [],
+        extension: {
+          dom_id: 'evidence-card',
+        },
+        provenance: {
+          canvas_id: 'brand-audit',
+          frame: { x: 48, y: 148, width: 360, height: 180 },
+        },
       },
     ],
     annotation_projections: [
@@ -145,16 +160,20 @@ test('buildSpatialSubjectTree maps topology, canvas, targets, and projections in
   })
 
   assertSpatialSubjectTreeShape(tree)
-  const target = tree.nodes.find((node) => node.id === 'target:primary-cta')
+  const target = tree.nodes.find((node) => node.id === 'target:button-primary-cta')
   const projection = tree.nodes.find((node) => node.id === 'annotation:ann-cta-copy')
 
   assert.equal(target.parent_id, 'surface:comparative-audit')
   assert.equal(
     target.path,
-    'desktop-world/display:1/window:1001/canvas:brand-audit/surface:comparative-audit/target:primary-cta',
+    'desktop-world/display:1/window:1001/canvas:brand-audit/surface:comparative-audit/target:button-primary-cta',
   )
   assert.deepEqual(target.bounds.desktop_world, { x: 172, y: 204, width: 160, height: 36 })
   assert.equal(target.capabilities.action, true)
+  assert.equal(target.source.canvas_id, 'brand-audit')
+  assert.equal(target.source.subject_id, 'button-primary-cta')
+  assert.equal(target.source.adapter_subject_id, 'canvas:brand-audit/button-primary-cta')
+  assert.equal(target.metadata.dom_id, 'primary-cta')
   assert.deepEqual(projection.bounds.viewport_local, { x: 48, y: 80, width: 160, height: 36 })
   assert.equal(projection.adapter.child_discovery, 'unsupported')
 })


### PR DESCRIPTION
## Summary
- Cuts native `aos see` semantic targets over to the canonical `agent_ui_target` envelope with top-level `ref`, `actions[]`, `extension`, and `provenance`.
- Moves canvas routing/geometry into `provenance` (`do_target`, `canvas_id`, `bounds`, `frame`, `center`) while preserving `aos do click canvas:<id>/<ref>` routing.
- Updates Swift act resolution, gateway SDK/API docs, Sigil consumer reads, toolkit projection/reveal consumers, conformance fixtures, and live smoke tests.
- Removes the #399 old-spelling fallback paths from Surface Inspector / annotation projection and updates remaining tests to assert absence of old top-level aliases.

Closes #399

## Verification
GDI reported passing:
- `git diff --check`
- `./aos dev build`
- `./aos ready`
- `node --test tests/toolkit/spatial-subject-tree.test.mjs`
- `node --test tests/toolkit/annotation-projection.test.mjs tests/toolkit/surface-inspector.test.mjs`
- `node --test tests/toolkit/agent-ui-target-conformance.test.mjs`
- `node --test tests/toolkit/runtime-semantic-targets.test.mjs tests/toolkit/html-workbench-expression.test.mjs`
- `tests/aos-semantic-targets-xray.sh`
- `tests/aos-semantic-targets-xray-retry.sh`
- `tests/aos-canvas-ref-click.sh`

Foreman spot-checks also passed:
- `git diff --check origin/main..origin/gdi/perceive-semantic-target-canonical-cutover-v0`
- `node --test tests/toolkit/spatial-subject-tree.test.mjs`
- `node --test tests/toolkit/annotation-projection.test.mjs tests/toolkit/surface-inspector.test.mjs`
- `node --test tests/toolkit/agent-ui-target-conformance.test.mjs`
- `node --test tests/toolkit/runtime-semantic-targets.test.mjs tests/toolkit/html-workbench-expression.test.mjs`
- `./aos ready`

Drift search reviewed: remaining matches are provenance `do_target` routing/docs, negative assertions, unrelated employer-brand planning contracts, work-record evidence, generic AX bounds, or annotation/object target contracts rather than semantic-target producer old-spelling fallbacks.