### PR TITLE
test(toolkit): reuse semantic target primitives

### DIFF
--- a/apps/sigil/avatar-editor/compact-surface.js
+++ b/apps/sigil/avatar-editor/compact-surface.js
@@ -442,30 +442,28 @@ export function createSigilAvatarCompactControlSurface(container, input = {}, op
         const triggerEl = triggerEls.get(tabKey);
         const selected = triggerEl?.getAttribute?.('aria-selected') === 'true'
           || activeTabFromTabsAdapter(tabsAdapter) === tabKey;
-        records.push({
-          ...normalizeAgentUiTarget({
-            id: tabKey,
-            role: 'AXTab',
-            name: text(tab.label, tabKey),
+        records.push(normalizeAgentUiTarget({
+          id: tabKey,
+          role: 'AXTab',
+          name: text(tab.label, tabKey),
+          value: tabKey,
+          selected,
+          current: selected,
+          enabled: !triggerEl?.disabled,
+          frame: triggerEl,
+          surface: COMPACT_SURFACE_ID,
+          metadata: {
             value: tabKey,
-            selected,
-            current: selected,
-            enabled: !triggerEl?.disabled,
-            frame: triggerEl,
-            surface: COMPACT_SURFACE_ID,
-            metadata: {
-              value: tabKey,
-              ...(triggerEl?.dataset ? { ...triggerEl.dataset } : {}),
-            },
-          }, {
-            kind: 'tab',
-            actions: triggerEl?.hidden ? [] : ['select'],
-            extension: {
-              label: text(tab.label, tabKey),
-              hidden: !!triggerEl?.hidden,
-            },
-          }),
-        });
+            ...(triggerEl?.dataset ? { ...triggerEl.dataset } : {}),
+          },
+        }, {
+          kind: 'tab',
+          actions: triggerEl?.hidden ? [] : ['select'],
+          extension: {
+            label: text(tab.label, tabKey),
+            hidden: !!triggerEl?.hidden,
+          },
+        }));
       }
       for (const { tab, section, form } of forms.values()) {
         records.push(...form.getControlRecords().map((record) => ({

--- a/packages/toolkit/runtime/index.js
+++ b/packages/toolkit/runtime/index.js
@@ -40,8 +40,11 @@ export {
   resolveDesktopWorldHitRegionOwnerCanvasId,
 } from './desktop-world-hit-region.js'
 export {
+  actionList,
   applySemanticTargetAttributes,
+  compactObject,
   createSemanticTargetElement,
+  extensionSource,
   normalizeAgentUiTarget,
   normalizeSemanticTarget,
   normalizeSemanticTargets,

--- a/packages/toolkit/runtime/semantic-targets.js
+++ b/packages/toolkit/runtime/semantic-targets.js
@@ -182,11 +182,12 @@ export function normalizeSemanticTargets(targets = [], options = {}) {
   return targets.map((target) => normalizeSemanticTarget(target, options))
 }
 
-function compactObject(value) {
+export function compactObject(value) {
+  // Assumes JSON-safe input: drops undefined/functions and throws on cycles.
   return JSON.parse(JSON.stringify(value ?? null))
 }
 
-function extensionSource(record = {}) {
+export function extensionSource(record = {}) {
   return {
     path: record.source_path ?? null,
     line_start: record.source_line_start ?? null,
@@ -194,7 +195,7 @@ function extensionSource(record = {}) {
   }
 }
 
-function actionList(target = {}, options = {}) {
+export function actionList(target = {}, options = {}) {
   if (Array.isArray(options.actions)) return [...options.actions]
   if (Array.isArray(target.actions)) return [...target.actions]
   const action = pickAction(target)

--- a/tests/toolkit/agent-ui-target-conformance.test.mjs
+++ b/tests/toolkit/agent-ui-target-conformance.test.mjs
@@ -5,6 +5,9 @@ import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'node:path'
 
 import {
+  actionList,
+  compactObject,
+  extensionSource,
   normalizeSemanticTarget,
   normalizeSemanticTargets,
 } from '../../packages/toolkit/runtime/semantic-targets.js'
@@ -46,23 +49,6 @@ function currentRecordsByShape(sourceFixture) {
 
 function canonicalRecordsByShape(candidateFixture) {
   return new Map(candidateFixture.records.map((entry) => [entry.shape, entry.agent_ui_target]))
-}
-
-function compactObject(value) {
-  return JSON.parse(JSON.stringify(value))
-}
-
-function actionList(record) {
-  if (Array.isArray(record.actions)) return [...record.actions]
-  return record.action ? [record.action] : []
-}
-
-function extensionSource(record) {
-  return {
-    path: record.source_path ?? null,
-    line_start: record.source_line_start ?? null,
-    line_end: record.source_line_end ?? null,
-  }
 }
 
 function mapCurrentRecordToCandidate(shape, record) {


### PR DESCRIPTION
## Summary
- Exports `compactObject`, `actionList`, and `extensionSource` from the runtime semantic-target module and re-exports them through the runtime index.
- Imports those primitives in the conformance test, removing copied helper definitions while preserving the existing mapping/assertions.
- Removes the redundant spread around `normalizeAgentUiTarget(...)` in the Sigil avatar compact surface.

## Stack / PR hygiene
- Replaces PR #403, which GitHub auto-closed when the stacked #402 base branch was deleted after merge and could not be reopened after the required rebase.
- This branch is now rebased onto `main` at #402 merge commit `06bdfcf8`.

## Verification
- `git diff --check origin/main..HEAD`
- `node --test tests/toolkit/agent-ui-target-conformance.test.mjs`
- `node --test tests/toolkit/runtime-semantic-targets.test.mjs tests/toolkit/panel-form.test.mjs`
- `node --test tests/renderer/sigil-avatar-editor-compact-surface.test.mjs`
- `rg -n "function compactObject|function actionList|function extensionSource" tests/toolkit/agent-ui-target-conformance.test.mjs` returned no matches.