### PR TITLE
feat(dev): expose GitHub issue and PR inventory

### DIFF
--- a/.docks/AGENTS.md
+++ b/.docks/AGENTS.md
@@ -88,6 +88,9 @@ Keep GitHub operations thin and intentional:
 
 - use `./aos dev gh context --json` once when local branch, repo, auth, or PR
   context is unclear;
+- use `./aos dev gh issue list --state <state> --limit <n> --json` and
+  `./aos dev gh pr list --state <state> --limit <n> --json` for read-only
+  issue and PR inventory;
 - use body files for issue and PR comments instead of inline shell strings;
 - use `./aos dev gh ci inspect --pr <n> --json` when a PR check fails and you
   need failed GitHub Actions logs;

--- a/.docks/foreman/dock.json
+++ b/.docks/foreman/dock.json
@@ -25,7 +25,11 @@
   ],
   "allowed_capabilities": [
     "dev.github.context",
+    "dev.github.issue_list",
+    "dev.github.issue_view",
     "dev.github.issue_comment",
+    "dev.github.pr_list",
+    "dev.github.pr_view",
     "dev.github.ci_inspect",
     "dev.github.review_comments",
     "dev.build.aos",

--- a/.docks/gdi/dock.json
+++ b/.docks/gdi/dock.json
@@ -24,6 +24,10 @@
   ],
   "allowed_capabilities": [
     "dev.github.context",
+    "dev.github.issue_list",
+    "dev.github.issue_view",
+    "dev.github.pr_list",
+    "dev.github.pr_view",
     "dev.github.ci_inspect",
     "dev.github.review_comments",
     "dev.build.aos",

--- a/.docks/operator/dock.json
+++ b/.docks/operator/dock.json
@@ -21,6 +21,10 @@
   ],
   "allowed_capabilities": [
     "dev.github.context",
+    "dev.github.issue_list",
+    "dev.github.issue_view",
+    "dev.github.pr_list",
+    "dev.github.pr_view",
     "dev.github.ci_inspect",
     "dev.github.review_comments"
   ],

--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -257,6 +257,8 @@ for full-screen capture.
 ./aos dev build
 ./aos dev build-checkpoint --json
 ./aos dev gh context --json
+./aos dev gh issue list --state open --limit 50 --json
+./aos dev gh pr list --state all --limit 30 --json
 ./aos dev gh issue comment 298 --body-file /tmp/comment.md
 ./aos dev gh ci inspect --pr 298 --json
 ./aos dev gh review-comments --pr 298 --json
@@ -296,11 +298,15 @@ turning the profile into a rigid executor.
 `dev gh` is the repo GitHub control surface. It deliberately uses the real
 `gh` executable from `PATH`, the user's existing `gh` authentication, and the
 local git checkout to infer `owner/repo` unless `--repo owner/name` is supplied.
-Direct operations such as `issue view`, `issue comment`, `pr view`, `pr checks`,
-and `pr comment` forward to `gh` and preserve its exit behavior. The composite
-helpers cover repo-specific repeated loops: `ci inspect` reads PR checks and
-fetches failed GitHub Actions logs when the check links to an Actions run, while
-`review-comments` uses `gh api graphql` to read review-thread resolution state.
+Direct operations such as `issue list`, `issue view`, `issue comment`,
+`pr list`, `pr view`, `pr checks`, and `pr comment` forward to `gh` and
+preserve its exit behavior. List operations expose the repo-safe inventory
+filters Foreman and GDI need most often: `--state`, `--limit`, `--label`,
+`--author`, `--assignee`, and `--search`, plus PR-specific `--base`, `--head`,
+and `--draft`. The composite helpers cover repo-specific repeated loops:
+`ci inspect` reads PR checks and fetches failed GitHub Actions logs when the
+check links to an Actions run, while `review-comments` uses `gh api graphql` to
+read review-thread resolution state.
 
 ### Wiki Repo Docs Projection
 

--- a/docs/dev/agent-capabilities.json
+++ b/docs/dev/agent-capabilities.json
@@ -51,6 +51,107 @@
       }
     },
     {
+      "id": "dev.github.issue_list",
+      "label": "GitHub Issue List",
+      "summary": "List GitHub issues through ./aos dev gh with bounded read-only inventory filters.",
+      "status": "active",
+      "roles": ["foreman", "gdi", "operator"],
+      "entry_paths": ["aos_developer"],
+      "adapter": {
+        "kind": "aos_cli",
+        "command": ["./aos", "dev", "gh", "issue", "list"]
+      },
+      "mutability": {
+        "class": "read_only",
+        "side_effects": [],
+        "requires_explicit_assignment": true,
+        "requires_human_approval": false,
+        "requires_body_file": false
+      },
+      "execution": {
+        "cwd_policy": "repo_root",
+        "timeout_seconds": 30,
+        "network": "required",
+        "raw_process": false,
+        "audit": "recommended"
+      },
+      "inputs": [
+        {
+          "name": "filters",
+          "summary": "Optional --state, --limit, --label, --author, --assignee, and --search filters.",
+          "required": false,
+          "schema": {
+            "type": "object"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "issues_json",
+          "summary": "Issue inventory records from gh issue list.",
+          "required": true,
+          "schema": {
+            "type": "array"
+          }
+        }
+      ],
+      "failure_policy": {
+        "bubble_up": true,
+        "retry": "none"
+      }
+    },
+    {
+      "id": "dev.github.issue_view",
+      "label": "GitHub Issue View",
+      "summary": "Read one GitHub issue through ./aos dev gh.",
+      "status": "active",
+      "roles": ["foreman", "gdi", "operator"],
+      "entry_paths": ["aos_developer"],
+      "adapter": {
+        "kind": "aos_cli",
+        "command": ["./aos", "dev", "gh", "issue", "view"]
+      },
+      "mutability": {
+        "class": "read_only",
+        "side_effects": [],
+        "requires_explicit_assignment": true,
+        "requires_human_approval": false,
+        "requires_body_file": false
+      },
+      "execution": {
+        "cwd_policy": "repo_root",
+        "timeout_seconds": 30,
+        "network": "required",
+        "raw_process": false,
+        "audit": "recommended"
+      },
+      "inputs": [
+        {
+          "name": "issue_number",
+          "summary": "GitHub issue number.",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "issue_json",
+          "summary": "Issue title, state, body, labels, and comments.",
+          "required": true,
+          "schema": {
+            "type": "object"
+          }
+        }
+      ],
+      "failure_policy": {
+        "bubble_up": true,
+        "retry": "none"
+      }
+    },
+    {
       "id": "dev.github.issue_comment",
       "label": "GitHub Issue Comment",
       "summary": "Write a GitHub issue comment through a body file using ./aos dev gh.",
@@ -102,6 +203,107 @@
           "required": true,
           "schema": {
             "type": "string"
+          }
+        }
+      ],
+      "failure_policy": {
+        "bubble_up": true,
+        "retry": "none"
+      }
+    },
+    {
+      "id": "dev.github.pr_list",
+      "label": "GitHub PR List",
+      "summary": "List GitHub pull requests through ./aos dev gh with bounded read-only inventory filters.",
+      "status": "active",
+      "roles": ["foreman", "gdi", "operator"],
+      "entry_paths": ["aos_developer"],
+      "adapter": {
+        "kind": "aos_cli",
+        "command": ["./aos", "dev", "gh", "pr", "list"]
+      },
+      "mutability": {
+        "class": "read_only",
+        "side_effects": [],
+        "requires_explicit_assignment": true,
+        "requires_human_approval": false,
+        "requires_body_file": false
+      },
+      "execution": {
+        "cwd_policy": "repo_root",
+        "timeout_seconds": 30,
+        "network": "required",
+        "raw_process": false,
+        "audit": "recommended"
+      },
+      "inputs": [
+        {
+          "name": "filters",
+          "summary": "Optional --state, --limit, --label, --author, --assignee, --search, --base, --head, and --draft filters.",
+          "required": false,
+          "schema": {
+            "type": "object"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "pull_requests_json",
+          "summary": "Pull request inventory records from gh pr list.",
+          "required": true,
+          "schema": {
+            "type": "array"
+          }
+        }
+      ],
+      "failure_policy": {
+        "bubble_up": true,
+        "retry": "none"
+      }
+    },
+    {
+      "id": "dev.github.pr_view",
+      "label": "GitHub PR View",
+      "summary": "Read one GitHub pull request through ./aos dev gh.",
+      "status": "active",
+      "roles": ["foreman", "gdi", "operator"],
+      "entry_paths": ["aos_developer"],
+      "adapter": {
+        "kind": "aos_cli",
+        "command": ["./aos", "dev", "gh", "pr", "view"]
+      },
+      "mutability": {
+        "class": "read_only",
+        "side_effects": [],
+        "requires_explicit_assignment": true,
+        "requires_human_approval": false,
+        "requires_body_file": false
+      },
+      "execution": {
+        "cwd_policy": "repo_root",
+        "timeout_seconds": 30,
+        "network": "required",
+        "raw_process": false,
+        "audit": "recommended"
+      },
+      "inputs": [
+        {
+          "name": "pr_number",
+          "summary": "Optional GitHub PR number; omitted value lets gh infer the current branch PR.",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "pull_request_json",
+          "summary": "Pull request title, state, refs, body, comments, and reviews.",
+          "required": true,
+          "schema": {
+            "type": "object"
           }
         }
       ],

--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -6633,6 +6633,78 @@
               "value_type" : "string"
             },
             {
+              "id" : "state",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Issue or PR list state filter: open, closed, merged, or all",
+              "token" : "--state",
+              "value_type" : "string"
+            },
+            {
+              "id" : "limit",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Maximum issue or PR list result count",
+              "token" : "--limit",
+              "value_type" : "int"
+            },
+            {
+              "id" : "label",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Issue or PR list label filter; repeat for multiple labels",
+              "token" : "--label",
+              "value_type" : "string"
+            },
+            {
+              "id" : "author",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Issue or PR list author login filter",
+              "token" : "--author",
+              "value_type" : "string"
+            },
+            {
+              "id" : "assignee",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Issue or PR list assignee login filter",
+              "token" : "--assignee",
+              "value_type" : "string"
+            },
+            {
+              "id" : "search",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Issue or PR list search query",
+              "token" : "--search",
+              "value_type" : "string"
+            },
+            {
+              "id" : "base",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "PR list base branch filter",
+              "token" : "--base",
+              "value_type" : "string"
+            },
+            {
+              "id" : "head",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "PR list head branch filter",
+              "token" : "--head",
+              "value_type" : "string"
+            },
+            {
+              "id" : "draft",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "PR list draft filter",
+              "token" : "--draft",
+              "value_type" : "bool"
+            },
+            {
               "id" : "arg",
               "kind" : "positional",
               "required" : false,
@@ -6643,8 +6715,10 @@
           ],
           "examples" : [
             "aos dev gh context --json",
+            "aos dev gh issue list --state open --limit 50 --json",
             "aos dev gh issue view 298 --json",
             "aos dev gh issue comment 298 --body-file \/tmp\/comment.md",
+            "aos dev gh pr list --state all --limit 30 --json",
             "aos dev gh ci inspect --pr 298 --json",
             "aos dev gh review-comments --pr 298 --json"
           ],
@@ -6664,7 +6738,7 @@
             "streaming" : false,
             "supports_json_flag" : true
           },
-          "usage" : "aos dev gh <context|issue|pr|ci|review-comments> [--repo owner\/name] [--cwd <path>] [--json] [--body-file <path>] [--pr n]"
+          "usage" : "aos dev gh <context|issue|pr|ci|review-comments> [--repo owner\/name] [--cwd <path>] [--json] [--body-file <path>] [--pr n] [--state <state>] [--limit n] [--label <name>] [--author <login>] [--assignee <login>] [--search <query>] [--base <branch>] [--head <branch>] [--draft]"
         }
       ],
       "path" : [

--- a/scripts/aos-dev-gh.mjs
+++ b/scripts/aos-dev-gh.mjs
@@ -13,14 +13,30 @@ function die(message, code = 'ERROR', exitCode = 1) {
   process.exit(exitCode);
 }
 
-function parseOptions(args) {
+function parseOptions(args, config = {}) {
   const options = {
     json: false,
     repo: null,
     cwd: null,
     bodyFile: null,
     prNumber: null,
+    state: null,
+    limit: null,
+    labels: [],
+    author: null,
+    assignee: null,
+    search: null,
+    base: null,
+    head: null,
+    draft: false,
     positionals: [],
+  };
+  const listKind = config.listKind ?? null;
+  const requireValue = (index, flag, summary) => {
+    if (index < 0 || index + 1 >= args.length || args[index + 1].startsWith('--')) {
+      die(`${flag} requires ${summary}`, 'MISSING_ARG');
+    }
+    return args[index + 1];
   };
   for (let i = 0; i < args.length;) {
     const arg = args[i];
@@ -43,6 +59,35 @@ function parseOptions(args) {
       if (i + 1 >= args.length || args[i + 1].startsWith('--')) die('--pr requires a PR number', 'MISSING_ARG');
       options.prNumber = args[i + 1];
       i += 2;
+    } else if (arg === '--state' && listKind) {
+      const stateSummary = listKind === 'pr' ? 'open, closed, merged, or all' : 'open, closed, or all';
+      options.state = requireValue(i, arg, stateSummary);
+      i += 2;
+    } else if (arg === '--limit' && listKind) {
+      options.limit = requireValue(i, arg, 'a numeric result limit');
+      if (!/^[0-9]+$/.test(options.limit)) die(`--limit must be numeric: ${options.limit}`, 'INVALID_ARG');
+      i += 2;
+    } else if (arg === '--label' && listKind) {
+      options.labels.push(requireValue(i, arg, 'a label name'));
+      i += 2;
+    } else if (arg === '--author' && listKind) {
+      options.author = requireValue(i, arg, 'a GitHub login');
+      i += 2;
+    } else if (arg === '--assignee' && listKind) {
+      options.assignee = requireValue(i, arg, 'a GitHub login or @me');
+      i += 2;
+    } else if (arg === '--search' && listKind) {
+      options.search = requireValue(i, arg, 'a search query');
+      i += 2;
+    } else if (arg === '--base' && listKind === 'pr') {
+      options.base = requireValue(i, arg, 'a base branch name');
+      i += 2;
+    } else if (arg === '--head' && listKind === 'pr') {
+      options.head = requireValue(i, arg, 'a head branch name');
+      i += 2;
+    } else if (arg === '--draft' && listKind === 'pr') {
+      options.draft = true;
+      i += 1;
     } else if (arg.startsWith('--')) {
       die(`Unknown dev gh flag: ${arg}`, 'UNKNOWN_FLAG');
     } else {
@@ -156,6 +201,20 @@ function normalizeRepoTail(tail) {
 
 function appendRepo(args, repoFullName) {
   if (repoFullName) args.push('--repo', repoFullName);
+}
+
+function appendListFilters(args, options, kind) {
+  if (options.state) args.push('--state', options.state);
+  if (options.limit) args.push('--limit', options.limit);
+  for (const label of options.labels) args.push('--label', label);
+  if (options.author) args.push('--author', options.author);
+  if (options.assignee) args.push('--assignee', options.assignee);
+  if (options.search) args.push('--search', options.search);
+  if (kind === 'pr') {
+    if (options.base) args.push('--base', options.base);
+    if (options.head) args.push('--head', options.head);
+    if (options.draft) args.push('--draft');
+  }
 }
 
 function repositoryInfo(repoFullName, repoRoot) {
@@ -301,21 +360,34 @@ function contextCommand(args) {
 
 function issueCommand(args) {
   const action = args[0];
-  if (!action) die('dev gh issue requires a subcommand: view or comment', 'MISSING_SUBCOMMAND');
-  const options = parseOptions(args.slice(1));
-  const repoRoot = repoRootFrom(options);
-  const repoFullName = repositoryFullName(options, repoRoot);
-  if (action === 'view') {
+  if (!action) die('dev gh issue requires a subcommand: list, view, or comment', 'MISSING_SUBCOMMAND');
+  if (action === 'list') {
+    const options = parseOptions(args.slice(1), { listKind: 'issue' });
+    if (options.positionals.length > 0) die(`Unknown dev gh issue argument: ${options.positionals[0]}`, 'UNKNOWN_ARG');
+    const repoRoot = repoRootFrom(options);
+    const repoFullName = repositoryFullName(options, repoRoot);
+    const ghArgs = ['issue', 'list'];
+    appendRepo(ghArgs, repoFullName);
+    appendListFilters(ghArgs, options, 'issue');
+    if (options.json) ghArgs.push('--json', 'number,title,state,url,createdAt,updatedAt,labels,assignees,author');
+    runGhAndExit(ghArgs, repoRoot);
+  } else if (action === 'view') {
+    const options = parseOptions(args.slice(1));
     if (options.positionals.length === 0) die('dev gh issue view requires exactly one issue number', 'MISSING_ARG');
     if (options.positionals.length > 1) die(`Unknown dev gh issue argument: ${options.positionals[1]}`, 'UNKNOWN_ARG');
+    const repoRoot = repoRootFrom(options);
+    const repoFullName = repositoryFullName(options, repoRoot);
     const ghArgs = ['issue', 'view', options.positionals[0]];
     appendRepo(ghArgs, repoFullName);
     if (options.json) ghArgs.push('--json', 'number,title,state,url,body,labels,comments');
     runGhAndExit(ghArgs, repoRoot);
   } else if (action === 'comment') {
+    const options = parseOptions(args.slice(1));
     if (options.positionals.length === 0) die('dev gh issue comment requires exactly one issue number', 'MISSING_ARG');
     if (options.positionals.length > 1) die(`Unknown dev gh issue argument: ${options.positionals[1]}`, 'UNKNOWN_ARG');
     if (!options.bodyFile) die('dev gh issue comment requires --body-file <path>', 'MISSING_ARG');
+    const repoRoot = repoRootFrom(options);
+    const repoFullName = repositoryFullName(options, repoRoot);
     const bodyFile = resolveUserPath(options.bodyFile);
     if (!fs.existsSync(bodyFile)) die(`Missing issue comment body file: ${bodyFile}`, 'MISSING_BODY_FILE');
     const ghArgs = ['issue', 'comment', options.positionals[0]];
@@ -329,28 +401,44 @@ function issueCommand(args) {
 
 function prCommand(args) {
   const action = args[0];
-  if (!action) die('dev gh pr requires a subcommand: view, checks, or comment', 'MISSING_SUBCOMMAND');
-  const options = parseOptions(args.slice(1));
-  const repoRoot = repoRootFrom(options);
-  const repoFullName = repositoryFullName(options, repoRoot);
-  if (action === 'view') {
+  if (!action) die('dev gh pr requires a subcommand: list, view, checks, or comment', 'MISSING_SUBCOMMAND');
+  if (action === 'list') {
+    const options = parseOptions(args.slice(1), { listKind: 'pr' });
+    if (options.positionals.length > 0) die(`Unknown dev gh pr argument: ${options.positionals[0]}`, 'UNKNOWN_ARG');
+    const repoRoot = repoRootFrom(options);
+    const repoFullName = repositoryFullName(options, repoRoot);
+    const ghArgs = ['pr', 'list'];
+    appendRepo(ghArgs, repoFullName);
+    appendListFilters(ghArgs, options, 'pr');
+    if (options.json) ghArgs.push('--json', 'number,title,state,url,createdAt,updatedAt,headRefName,baseRefName,isDraft,labels,author');
+    runGhAndExit(ghArgs, repoRoot);
+  } else if (action === 'view') {
+    const options = parseOptions(args.slice(1));
     if (options.positionals.length > 1) die('dev gh pr view accepts at most one PR number', 'UNKNOWN_ARG');
+    const repoRoot = repoRootFrom(options);
+    const repoFullName = repositoryFullName(options, repoRoot);
     const ghArgs = ['pr', 'view'];
     if (options.positionals[0]) ghArgs.push(options.positionals[0]);
     appendRepo(ghArgs, repoFullName);
     if (options.json) ghArgs.push('--json', 'number,title,state,url,headRefName,baseRefName,isDraft,body,comments,reviews');
     runGhAndExit(ghArgs, repoRoot);
   } else if (action === 'checks') {
+    const options = parseOptions(args.slice(1));
     if (options.positionals.length > 1) die('dev gh pr checks accepts at most one PR number', 'UNKNOWN_ARG');
+    const repoRoot = repoRootFrom(options);
+    const repoFullName = repositoryFullName(options, repoRoot);
     const ghArgs = ['pr', 'checks'];
     if (options.positionals[0]) ghArgs.push(options.positionals[0]);
     appendRepo(ghArgs, repoFullName);
     if (options.json) ghArgs.push('--json', 'name,state,bucket,link,startedAt,completedAt,workflow');
     runGhAndExit(ghArgs, repoRoot);
   } else if (action === 'comment') {
+    const options = parseOptions(args.slice(1));
     if (options.positionals.length === 0) die('dev gh pr comment requires exactly one PR number', 'MISSING_ARG');
     if (options.positionals.length > 1) die(`Unknown dev gh pr argument: ${options.positionals[1]}`, 'UNKNOWN_ARG');
     if (!options.bodyFile) die('dev gh pr comment requires --body-file <path>', 'MISSING_ARG');
+    const repoRoot = repoRootFrom(options);
+    const repoFullName = repositoryFullName(options, repoRoot);
     const bodyFile = resolveUserPath(options.bodyFile);
     if (!fs.existsSync(bodyFile)) die(`Missing PR comment body file: ${bodyFile}`, 'MISSING_BODY_FILE');
     const ghArgs = ['pr', 'comment', options.positionals[0]];

--- a/tests/dev-workflow-router.sh
+++ b/tests/dev-workflow-router.sh
@@ -480,6 +480,8 @@ data = json.loads(os.environ["OUT"])
 ids = {item["id"] for item in data["capabilities"]}
 assert data["status"] == "success", data
 assert data["manifest"] == "docs/dev/agent-capabilities.json", data
+assert "dev.github.issue_list" in ids, ids
+assert "dev.github.pr_list" in ids, ids
 assert "dev.github.issue_comment" in ids, ids
 assert "dev.build.aos" in ids, ids
 assert "dev.test.schema_node" in ids, ids
@@ -559,6 +561,8 @@ data = json.loads(os.environ["OUT"])
 ids = {item["id"] for item in data["capabilities"]}
 assert data["dock"] == "foreman", data
 assert data["active_entry_path"] == "aos_developer", data
+assert "dev.github.issue_list" in ids, ids
+assert "dev.github.pr_list" in ids, ids
 assert "dev.github.issue_comment" in ids, ids
 assert "dev.build.aos" in ids, ids
 PY
@@ -592,6 +596,8 @@ import os
 
 data = json.loads(os.environ["OUT"])
 ids = {item["id"] for item in data["capabilities"]}
+assert "dev.github.issue_list" in ids, ids
+assert "dev.github.pr_list" in ids, ids
 assert "dev.github.issue_comment" not in ids, ids
 assert "dev.build.aos" in ids, ids
 assert "dev.test.schema_node" in ids, ids
@@ -624,6 +630,8 @@ import os
 data = json.loads(os.environ["OUT"])
 ids = {item["id"] for item in data["capabilities"]}
 assert "dev.github.context" in ids, ids
+assert "dev.github.issue_list" in ids, ids
+assert "dev.github.pr_list" in ids, ids
 assert "dev.github.ci_inspect" in ids, ids
 assert "dev.github.issue_comment" not in ids, ids
 assert all(item["mutability_class"] == "read_only" for item in data["capabilities"]), data
@@ -665,6 +673,14 @@ if [[ "$cmd" == "pr view --repo michaelblum/agent-os --json number,url,headRefNa
 fi
 if [[ "$cmd" == issue\ comment\ 298\ --repo\ michaelblum/agent-os\ --body-file\ * ]]; then
     echo "https://github.com/michaelblum/agent-os/issues/298#issuecomment-test"
+    exit 0
+fi
+if [[ "$cmd" == "issue list --repo michaelblum/agent-os --state all --limit 20 --label bug --label docs --search semantic target --json number,title,state,url,createdAt,updatedAt,labels,assignees,author" ]]; then
+    echo '[{"number":399,"title":"Track semantic target cleanup","state":"CLOSED","url":"https://github.com/michaelblum/agent-os/issues/399"}]'
+    exit 0
+fi
+if [[ "$cmd" == "pr list --repo michaelblum/agent-os --state all --limit 30 --author michaelblum --base main --head gdi/example --draft --json number,title,state,url,createdAt,updatedAt,headRefName,baseRefName,isDraft,labels,author" ]]; then
+    echo '[{"number":404,"title":"Reuse semantic target primitives","state":"MERGED","headRefName":"gdi/example","baseRefName":"main","isDraft":true}]'
     exit 0
 fi
 if [[ "$cmd" == "pr checks 298 --repo michaelblum/agent-os --json name,state,bucket,link,startedAt,completedAt,workflow" ]]; then
@@ -720,6 +736,28 @@ else
     fail "dev gh issue view extra positional error mismatch: $ERR"
 fi
 
+if OUT="$(./aos dev gh issue list --state all --limit 20 --label bug --label docs --search "semantic target" --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert data[0]["number"] == 399, data
+assert data[0]["state"] == "CLOSED", data
+PY
+then
+    pass "dev gh issue list forwards filtered inventory queries"
+else
+    fail "dev gh issue list did not forward expected filtered query"
+fi
+
+if ERR="$(./aos dev gh issue list --limit --json 2>&1 >/dev/null)"; then
+    fail "dev gh issue list should reject missing --limit values before a flag"
+elif echo "$ERR" | grep -q -- '--limit requires a numeric result limit'; then
+    pass "dev gh issue list treats flag-after---limit as missing value"
+else
+    fail "dev gh issue list missing --limit error mismatch: $ERR"
+fi
+
 BODY="$TMPDIR/comment.md"
 printf 'accepted state\n' > "$BODY"
 : > "$GH_ARGS_LOG"
@@ -753,6 +791,29 @@ elif echo "$ERR" | grep -q 'Unknown dev gh pr argument: extra'; then
     pass "dev gh pr comment rejects extra positional args"
 else
     fail "dev gh pr comment extra positional error mismatch: $ERR"
+fi
+
+if OUT="$(./aos dev gh pr list --state all --limit 30 --author michaelblum --base main --head gdi/example --draft --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert data[0]["number"] == 404, data
+assert data[0]["headRefName"] == "gdi/example", data
+assert data[0]["isDraft"] is True, data
+PY
+then
+    pass "dev gh pr list forwards filtered PR inventory queries"
+else
+    fail "dev gh pr list did not forward expected filtered query"
+fi
+
+if ERR="$(./aos dev gh pr list --base --json 2>&1 >/dev/null)"; then
+    fail "dev gh pr list should reject missing --base values before a flag"
+elif echo "$ERR" | grep -q -- '--base requires a base branch name'; then
+    pass "dev gh pr list treats flag-after---base as missing value"
+else
+    fail "dev gh pr list missing --base error mismatch: $ERR"
 fi
 
 if OUT="$(./aos dev gh ci inspect --json 2>/dev/null)"; then

--- a/tests/schemas/aos-agent-capability-manifest-v0.test.mjs
+++ b/tests/schemas/aos-agent-capability-manifest-v0.test.mjs
@@ -133,6 +133,19 @@ test('typed AOS GitHub capabilities stay non-raw and body-file backed for writes
   assert.equal(context.execution.raw_process, false);
   assert.equal(context.mutability.class, 'read_only');
 
+  for (const id of [
+    'dev.github.issue_list',
+    'dev.github.issue_view',
+    'dev.github.pr_list',
+    'dev.github.pr_view',
+  ]) {
+    const capability = capabilities.get(id);
+    assert.equal(capability.adapter.kind, 'aos_cli');
+    assert.equal(capability.execution.raw_process, false);
+    assert.equal(capability.mutability.class, 'read_only');
+    assert.equal(capability.failure_policy.bubble_up, true);
+  }
+
   const comment = capabilities.get('dev.github.issue_comment');
   assert.equal(comment.adapter.kind, 'aos_cli');
   assert.equal(comment.execution.raw_process, false);
@@ -147,7 +160,11 @@ test('canonical manifest includes the initial developer capability set', async (
 
   for (const id of [
     'dev.github.context',
+    'dev.github.issue_list',
+    'dev.github.issue_view',
     'dev.github.issue_comment',
+    'dev.github.pr_list',
+    'dev.github.pr_view',
     'dev.github.ci_inspect',
     'dev.github.review_comments',
     'dev.build.aos',

--- a/tests/schemas/aos-dock-profile-v0.test.mjs
+++ b/tests/schemas/aos-dock-profile-v0.test.mjs
@@ -138,6 +138,14 @@ test('role envelopes preserve the intended coordination boundaries', async () =>
   assert.ok(!profiles.get('gdi').allowed_capabilities.includes('dev.github.issue_comment'));
   assert.ok(!profiles.get('operator').allowed_capabilities.includes('dev.github.issue_comment'));
 
+  for (const profileName of ['foreman', 'gdi', 'operator']) {
+    const allowed = profiles.get(profileName).allowed_capabilities;
+    assert.ok(allowed.includes('dev.github.issue_list'), `${profileName} should allow issue inventory`);
+    assert.ok(allowed.includes('dev.github.issue_view'), `${profileName} should allow issue reads`);
+    assert.ok(allowed.includes('dev.github.pr_list'), `${profileName} should allow PR inventory`);
+    assert.ok(allowed.includes('dev.github.pr_view'), `${profileName} should allow PR reads`);
+  }
+
   assert.equal(profiles.get('operator').default_entry_path, 'agent_harness');
   assert.ok(!profiles.get('operator').allowed_capability_classes.includes('external_write'));
   assert.ok(!profiles.get('operator').allowed_capability_classes.includes('host_write'));


### PR DESCRIPTION
## Summary
- Add `./aos dev gh issue list` and `./aos dev gh pr list` as bounded read-only inventory wrappers over `gh`.
- Add typed capabilities for issue/pr list/view and expose read-only GitHub inventory to Foreman, GDI, and Operator dock profiles.
- Update command registry, AOS API docs, and router/schema tests for the expanded `dev gh` surface.

## Verification
- `node --check scripts/aos-dev-gh.mjs`
- `bash tests/dev-workflow-router.sh`
- `node --test tests/schemas/aos-agent-capability-manifest-v0.test.mjs tests/schemas/aos-dock-profile-v0.test.mjs`
- `node --test tests/schemas/aos-external-command-manifest-v0.test.mjs`
- `bash tests/external-command-dispatch.sh`
- `bash tests/external-parser-flags.sh`
- `bash tests/help-contract.sh`
- `node --test tests/schemas/dev-workflow-rules.test.mjs tests/schemas/dev-active-profile.test.mjs tests/schemas/dev-workflow-profiles.test.mjs`
- `bash tests/dev-audit.sh`
- `git diff --cached --check`
- `./aos dev gh issue list --state open --limit 3 --json`
- `./aos dev gh pr list --state all --limit 3 --json`
- `./aos dev capabilities explain dev.github.issue_list --json`
- `./aos dev docks capabilities gdi --json`

## Notes
- Draft PR for review and feedback.
- No native `./aos` rebuild included.
- Existing unrelated untracked local docs/reports and `tests/lib/__pycache__/` are intentionally not part of this branch.