### PR TITLE
test(aos): cover ready auto repair flow

### DIFF
--- a/scripts/aos-ready.mjs
+++ b/scripts/aos-ready.mjs
@@ -14,6 +14,7 @@ import {
 import { brokerFacts } from './lib/aos-facts.mjs';
 import {
   evaluateReadyForTesting,
+  hasRestartableReadyRuntimeBlocker,
   permissionFixLines,
   permissionResetSafeSequenceLines,
   readyAutoRepairReason,
@@ -22,7 +23,6 @@ import {
   readyNextActions,
   readyNotes,
   readyPhase,
-  readyRepairPlan,
 } from './lib/aos-readiness.mjs';
 
 function parseArgs(args) {
@@ -82,11 +82,9 @@ function runReadyServiceAction(action, mode) {
         `${JSON.stringify({ action, mode })}\n`,
       );
     }
-    const parsedExitCode = Number.parseInt(process.env[`AOS_TEST_READY_SERVICE_${action.toUpperCase()}_EXIT_CODE`] ?? '0', 10);
-    const exitCode = Number.isFinite(parsedExitCode) ? parsedExitCode : 0;
     return {
-      exitCode,
-      stdout: JSON.stringify({ status: exitCode === 0 ? 'ok' : 'degraded', action, mode }),
+      exitCode: 0,
+      stdout: JSON.stringify({ status: 'ok', action, mode }),
       stderr: '',
     };
   }
@@ -268,32 +266,19 @@ if (!options.repair && process.env.AOS_TEST_SKIP_READY_SERVICE_START !== '1') {
 }
 
 if (options.repair && !response.ready) {
-  let cleaned = false;
-  let restarted = false;
-  let handedOff = false;
-  while (!response.ready) {
-    const plan = readyRepairPlan(response);
-    if (plan.clean && !cleaned) {
-      cleaned = true;
-      response = runReadyCleanRepair(decision.startup, response.action_trace, mode, prefix);
-      continue;
-    }
-    if (plan.runtimeRestart && !restarted) {
-      restarted = true;
-      response = runReadyRuntimeRepair(decision.startup, response.action_trace, mode, prefix, 20_000, null);
-      continue;
-    }
-    if (plan.humanPermissionHandoff && !handedOff) {
-      handedOff = true;
-      const trace = [...response.action_trace, {
-        step: 'runtime_tcc_reset_handoff',
-        result: 'human_required',
-        detail: `${prefix} permissions reset-runtime --mode ${mode}`,
-      }];
-      response = buildReadyResponse(decision.startup, trace, mode, prefix);
-      continue;
-    }
-    break;
+  if (response.blockers.some((blocker) => blocker.id === 'stale_daemons')) {
+    response = runReadyCleanRepair(decision.startup, response.action_trace, mode, prefix);
+  }
+  if (hasRestartableReadyRuntimeBlocker(response)) {
+    response = runReadyRuntimeRepair(decision.startup, response.action_trace, mode, prefix, 20_000, null);
+  }
+  if (!response.ready && response.blockers.some((blocker) => blocker.kind === 'permission')) {
+    const trace = [...response.action_trace, {
+      step: 'runtime_tcc_reset_handoff',
+      result: 'human_required',
+      detail: `${prefix} permissions reset-runtime --mode ${mode}`,
+    }];
+    response = buildReadyResponse(decision.startup, trace, mode, prefix);
   }
 }
 

--- a/scripts/aos-ready.mjs
+++ b/scripts/aos-ready.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import fs from 'node:fs';
+
 import {
   compactProcessDetail,
   currentMode,
@@ -12,14 +14,15 @@ import {
 import { brokerFacts } from './lib/aos-facts.mjs';
 import {
   evaluateReadyForTesting,
-  isRepairableRuntimeBlockerID,
   permissionFixLines,
   permissionResetSafeSequenceLines,
+  readyAutoRepairReason,
   readyBlockers,
   readyDiagnosis,
   readyNextActions,
   readyNotes,
   readyPhase,
+  readyRepairPlan,
 } from './lib/aos-readiness.mjs';
 
 function parseArgs(args) {
@@ -71,6 +74,25 @@ function serviceCommandString(mode, prefix, action) {
   return `${prefix} service ${action} --mode ${mode} --json`;
 }
 
+function runReadyServiceAction(action, mode) {
+  if (process.env.AOS_TEST_READY_MOCK_SERVICE_ACTIONS === '1') {
+    if (process.env.AOS_TEST_READY_SERVICE_ACTION_LOG) {
+      fs.appendFileSync(
+        process.env.AOS_TEST_READY_SERVICE_ACTION_LOG,
+        `${JSON.stringify({ action, mode })}\n`,
+      );
+    }
+    const parsedExitCode = Number.parseInt(process.env[`AOS_TEST_READY_SERVICE_${action.toUpperCase()}_EXIT_CODE`] ?? '0', 10);
+    const exitCode = Number.isFinite(parsedExitCode) ? parsedExitCode : 0;
+    return {
+      exitCode,
+      stdout: JSON.stringify({ status: exitCode === 0 ? 'ok' : 'degraded', action, mode }),
+      stderr: '',
+    };
+  }
+  return runNodeScript('scripts/aos-service.mjs', [action, '--mode', mode, '--json']);
+}
+
 function decideReadyStartup({ repair, mode, prefix }) {
   const skipServiceStart = process.env.AOS_TEST_SKIP_READY_SERVICE_START === '1';
   const skippedStartup = {
@@ -94,18 +116,20 @@ function decideReadyStartup({ repair, mode, prefix }) {
   if (!repair) {
     const preflight = buildReadyResponse(skippedStartup, [], mode, prefix);
     if (preflight.ready) {
+      const actionTrace = [{
+        step: 'ready_preflight',
+        result: 'ready',
+        detail: 'managed daemon is already reachable, owned by the expected runtime, and input tap is active',
+      }];
       return {
         startup: skippedStartup,
-        actionTrace: [{
-          step: 'ready_preflight',
-          result: 'ready',
-          detail: 'managed daemon is already reachable, owned by the expected runtime, and input tap is active',
-        }],
+        actionTrace,
+        readyResponse: { ...preflight, action_trace: actionTrace },
       };
     }
   }
 
-  const result = runNodeScript('scripts/aos-service.mjs', ['start', '--mode', mode, '--json']);
+  const result = runReadyServiceAction('start', mode);
   return {
     startup: {
       attempted: true,
@@ -121,7 +145,7 @@ function decideReadyStartup({ repair, mode, prefix }) {
   };
 }
 
-function waitForReadyResponse(startup, actionTrace, mode, prefix, budgetMs) {
+function waitForReadyResponse(startup, actionTrace, mode, prefix, budgetMs, pollMs = 500) {
   const deadline = Date.now() + budgetMs;
   while (Date.now() < deadline) {
     const response = buildReadyResponse(startup, actionTrace, mode, prefix);
@@ -133,7 +157,7 @@ function waitForReadyResponse(startup, actionTrace, mode, prefix, budgetMs) {
       }];
       return buildReadyResponse(startup, trace, mode, prefix);
     }
-    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 500);
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, pollMs);
   }
   const trace = [...actionTrace, {
     step: 'wait_for_recovery',
@@ -143,27 +167,24 @@ function waitForReadyResponse(startup, actionTrace, mode, prefix, budgetMs) {
   return buildReadyResponse(startup, trace, mode, prefix);
 }
 
-function readyAutoRepairReason(response, postPermission) {
-  if (response.ready) return null;
-  const blockerIDs = new Set(response.blockers.map((blocker) => blocker.id));
-  const hasRepairableRuntimeBlocker = response.blockers.some((blocker) => isRepairableRuntimeBlockerID(blocker.id));
-  if (blockerIDs.has('stale_daemons')) return null;
-  if (blockerIDs.has('daemon_unmanaged')) return null;
-  if (postPermission && hasRepairableRuntimeBlocker) return 'post-permission bounded daemon restart/recheck';
-  if (blockerIDs.has('daemon_ownership_mismatch')) return 'automatic after daemon ownership mismatch';
-  if (blockerIDs.has('input_tap_not_active')) return 'automatic after input tap inactive';
-  return null;
-}
-
 function runReadyRuntimeRepair(startup, actionTrace, mode, prefix, budgetMs, reason) {
-  const result = runNodeScript('scripts/aos-service.mjs', ['restart', '--mode', mode, '--json']);
+  const result = runReadyServiceAction('restart', mode);
   const detail = [reason, compactProcessDetail(result)].filter(Boolean).join('\n');
   const trace = [...actionTrace, {
     step: 'service_restart',
     result: result.exitCode === 0 ? 'ok' : 'degraded',
     detail: detail || undefined,
   }];
-  return waitForReadyResponse(startup, trace, mode, prefix, budgetMs);
+  const testBudget = Number.parseInt(process.env.AOS_TEST_READY_WAIT_BUDGET_MS ?? '', 10);
+  const testPoll = Number.parseInt(process.env.AOS_TEST_READY_WAIT_POLL_MS ?? '', 10);
+  return waitForReadyResponse(
+    startup,
+    trace,
+    mode,
+    prefix,
+    Number.isFinite(testBudget) ? testBudget : budgetMs,
+    Number.isFinite(testPoll) ? testPoll : 500,
+  );
 }
 
 function runReadyCleanRepair(startup, actionTrace, mode, prefix) {
@@ -230,10 +251,10 @@ const options = parseArgs(process.argv.slice(2));
 const mode = currentMode();
 const prefix = invocationName();
 const decision = decideReadyStartup({ repair: options.repair, mode, prefix });
-let response = buildReadyResponse(decision.startup, decision.actionTrace, mode, prefix);
+let response = decision.readyResponse ?? buildReadyResponse(decision.startup, decision.actionTrace, mode, prefix);
 
 if (!options.repair && process.env.AOS_TEST_SKIP_READY_SERVICE_START !== '1') {
-  const reason = readyAutoRepairReason(response, options.postPermission);
+  const reason = readyAutoRepairReason(response, { postPermission: options.postPermission });
   if (reason) {
     response = runReadyRuntimeRepair(
       decision.startup,
@@ -247,22 +268,33 @@ if (!options.repair && process.env.AOS_TEST_SKIP_READY_SERVICE_START !== '1') {
 }
 
 if (options.repair && !response.ready) {
-  if (response.blockers.some((blocker) => blocker.id === 'stale_daemons')) {
-    response = runReadyCleanRepair(decision.startup, response.action_trace, mode, prefix);
+  let cleaned = false;
+  let restarted = false;
+  let handedOff = false;
+  while (!response.ready) {
+    const plan = readyRepairPlan(response);
+    if (plan.clean && !cleaned) {
+      cleaned = true;
+      response = runReadyCleanRepair(decision.startup, response.action_trace, mode, prefix);
+      continue;
+    }
+    if (plan.runtimeRestart && !restarted) {
+      restarted = true;
+      response = runReadyRuntimeRepair(decision.startup, response.action_trace, mode, prefix, 20_000, null);
+      continue;
+    }
+    if (plan.humanPermissionHandoff && !handedOff) {
+      handedOff = true;
+      const trace = [...response.action_trace, {
+        step: 'runtime_tcc_reset_handoff',
+        result: 'human_required',
+        detail: `${prefix} permissions reset-runtime --mode ${mode}`,
+      }];
+      response = buildReadyResponse(decision.startup, trace, mode, prefix);
+      continue;
+    }
+    break;
   }
-  if (response.blockers.some((blocker) => isRepairableRuntimeBlockerID(blocker.id))) {
-    response = runReadyRuntimeRepair(decision.startup, response.action_trace, mode, prefix, 20_000, null);
-  }
-  if (!response.ready && response.blockers.some((blocker) => blocker.kind === 'permission')) {
-    const trace = [...response.action_trace, {
-      step: 'runtime_tcc_reset_handoff',
-      result: 'human_required',
-      detail: `${prefix} permissions reset-runtime --mode ${mode}`,
-    }];
-    response = buildReadyResponse(decision.startup, trace, mode, prefix);
-  }
-} else if (!options.repair) {
-  response = buildReadyResponse(decision.startup, response.action_trace, mode, prefix);
 }
 
 if (options.json) printJSON(response);

--- a/scripts/aos-status.mjs
+++ b/scripts/aos-status.mjs
@@ -8,11 +8,9 @@ import {
   exitError,
   expectedBinaryPath,
   invocationName,
-  parseJSONOutput,
   printJSON,
   repoRoot,
   run,
-  runAOS,
 } from './lib/aos-cli.mjs';
 import {
   brokerFacts,
@@ -32,13 +30,6 @@ function parseArgs(args) {
     else exitError(`Unknown flag: ${arg}. Usage: ${invocationName()} status [--json]`, 'UNKNOWN_FLAG');
   }
   return options;
-}
-
-function parsePrimitive(result, label) {
-  return parseJSONOutput(result, label, {
-    failureCode: 'STATUS_PRIMITIVE_FAILED',
-    jsonCode: 'STATUS_PRIMITIVE_JSON_INVALID',
-  });
 }
 
 function gitStatus() {
@@ -163,7 +154,7 @@ async function buildStatusResponse() {
     jsonCode: 'STATUS_PRIMITIVE_JSON_INVALID',
     includeRuntime: true,
   });
-  const runtime = facts.runtime ?? parsePrimitive(runAOS(['__runtime', 'status-facts', '--json']), '__runtime status-facts');
+  const runtime = facts.runtime;
   const clean = cleanReport();
   const snapshot = await daemonSnapshot(runtime.socket_path);
   const notes = statusNotes({

--- a/scripts/lib/aos-readiness.mjs
+++ b/scripts/lib/aos-readiness.mjs
@@ -317,16 +317,10 @@ export function readyAutoRepairReason(response, { postPermission = false } = {})
   return null;
 }
 
-export function readyRepairPlan(response) {
-  if (response.ready) return { branch: 'none', clean: false, runtimeRestart: false, humanPermissionHandoff: false };
+export function hasRestartableReadyRuntimeBlocker(response) {
   const blockers = response.blockers ?? [];
-  const hasStaleDaemons = blockers.some((blocker) => blocker.id === 'stale_daemons');
-  const hasRepairableRuntimeBlocker = blockers.some((blocker) => isRepairableRuntimeBlockerID(blocker.id));
-  const hasPermissionBlocker = blockers.some((blocker) => blocker.kind === 'permission');
-  if (hasStaleDaemons) return { branch: 'clean', clean: true, runtimeRestart: false, humanPermissionHandoff: false };
-  if (hasRepairableRuntimeBlocker) return { branch: 'restart', clean: false, runtimeRestart: true, humanPermissionHandoff: false };
-  if (hasPermissionBlocker) return { branch: 'permission_handoff', clean: false, runtimeRestart: false, humanPermissionHandoff: true };
-  return { branch: 'none', clean: false, runtimeRestart: false, humanPermissionHandoff: false };
+  if (blockers.some((blocker) => blocker.id === 'stale_daemons')) return false;
+  return blockers.some((blocker) => isRepairableRuntimeBlockerID(blocker.id));
 }
 
 export function readyPhase(ready, blockers) {

--- a/scripts/lib/aos-readiness.mjs
+++ b/scripts/lib/aos-readiness.mjs
@@ -304,6 +304,31 @@ export function isRepairableRuntimeBlockerID(id) {
     || id === 'input_tap_not_active';
 }
 
+export function readyAutoRepairReason(response, { postPermission = false } = {}) {
+  if (response.ready) return null;
+  const blockerIDs = new Set((response.blockers ?? []).map((blocker) => blocker.id));
+  const hasRepairableRuntimeBlocker = (response.blockers ?? [])
+    .some((blocker) => isRepairableRuntimeBlockerID(blocker.id));
+  if (blockerIDs.has('stale_daemons')) return null;
+  if (blockerIDs.has('daemon_unmanaged')) return null;
+  if (postPermission && hasRepairableRuntimeBlocker) return 'post-permission bounded daemon restart/recheck';
+  if (blockerIDs.has('daemon_ownership_mismatch')) return 'automatic after daemon ownership mismatch';
+  if (blockerIDs.has('input_tap_not_active')) return 'automatic after input tap inactive';
+  return null;
+}
+
+export function readyRepairPlan(response) {
+  if (response.ready) return { branch: 'none', clean: false, runtimeRestart: false, humanPermissionHandoff: false };
+  const blockers = response.blockers ?? [];
+  const hasStaleDaemons = blockers.some((blocker) => blocker.id === 'stale_daemons');
+  const hasRepairableRuntimeBlocker = blockers.some((blocker) => isRepairableRuntimeBlockerID(blocker.id));
+  const hasPermissionBlocker = blockers.some((blocker) => blocker.kind === 'permission');
+  if (hasStaleDaemons) return { branch: 'clean', clean: true, runtimeRestart: false, humanPermissionHandoff: false };
+  if (hasRepairableRuntimeBlocker) return { branch: 'restart', clean: false, runtimeRestart: true, humanPermissionHandoff: false };
+  if (hasPermissionBlocker) return { branch: 'permission_handoff', clean: false, runtimeRestart: false, humanPermissionHandoff: true };
+  return { branch: 'none', clean: false, runtimeRestart: false, humanPermissionHandoff: false };
+}
+
 export function readyPhase(ready, blockers) {
   if (ready) return 'ready';
   if (blockers.some((b) => b.id === 'daemon_unreachable')) return 'runtime_blocked';

--- a/tests/aos-readiness-composition.test.mjs
+++ b/tests/aos-readiness-composition.test.mjs
@@ -9,9 +9,11 @@ import {
   missingPermissionIDsFor,
   permissionRequirements,
   planPermissionSetup,
+  readyAutoRepairReason,
   readyBlockers,
   readyEvaluationSnake,
   readyNextActions,
+  readyRepairPlan,
   runSetupPromptPlan,
 } from '../scripts/lib/aos-readiness.mjs';
 
@@ -281,4 +283,46 @@ test('setup planner preserves already-granted skip branch', () => {
 test('input monitoring guidance accepts daemon camelCase and runtime snake_case tap facts', () => {
   assert.match(inputMonitoringSubGuidance({ listenAccess: false, postAccess: true }, '/repo/aos'), /listen=false, post=true/);
   assert.match(inputMonitoringSubGuidance({ listen_access: true, post_access: false }, '/repo/aos'), /listen=true, post=false/);
+});
+
+test('ready auto-repair reason stays null for ready, stale, and unmanaged states', () => {
+  assert.equal(readyAutoRepairReason({ ready: true, blockers: [] }), null);
+  assert.equal(readyAutoRepairReason({ ready: false, blockers: [{ id: 'stale_daemons', kind: 'runtime' }] }), null);
+  assert.equal(readyAutoRepairReason({ ready: false, blockers: [{ id: 'daemon_unmanaged', kind: 'runtime' }] }), null);
+});
+
+test('ready auto-repair reason is deterministic for ownership and input-tap blockers', () => {
+  assert.equal(
+    readyAutoRepairReason({ ready: false, blockers: [{ id: 'daemon_ownership_mismatch', kind: 'runtime' }] }),
+    'automatic after daemon ownership mismatch',
+  );
+  assert.equal(
+    readyAutoRepairReason({ ready: false, blockers: [{ id: 'input_tap_not_active', kind: 'runtime' }] }),
+    'automatic after input tap inactive',
+  );
+});
+
+test('post-permission readiness enables bounded restart for repairable runtime blockers', () => {
+  assert.equal(
+    readyAutoRepairReason(
+      { ready: false, blockers: [{ id: 'daemon_unreachable', kind: 'runtime' }] },
+      { postPermission: true },
+    ),
+    'post-permission bounded daemon restart/recheck',
+  );
+});
+
+test('explicit repair branch plan chooses clean, restart, then permission handoff', () => {
+  assert.deepEqual(
+    readyRepairPlan({ ready: false, blockers: [{ id: 'stale_daemons', kind: 'runtime' }] }),
+    { branch: 'clean', clean: true, runtimeRestart: false, humanPermissionHandoff: false },
+  );
+  assert.deepEqual(
+    readyRepairPlan({ ready: false, blockers: [{ id: 'input_tap_not_active', kind: 'runtime' }] }),
+    { branch: 'restart', clean: false, runtimeRestart: true, humanPermissionHandoff: false },
+  );
+  assert.deepEqual(
+    readyRepairPlan({ ready: false, blockers: [{ id: 'accessibility', kind: 'permission' }] }),
+    { branch: 'permission_handoff', clean: false, runtimeRestart: false, humanPermissionHandoff: true },
+  );
 });

--- a/tests/aos-readiness-composition.test.mjs
+++ b/tests/aos-readiness-composition.test.mjs
@@ -5,6 +5,7 @@ import { setupState } from '../scripts/lib/aos-facts.mjs';
 import {
   disagreementFor,
   evaluateReadyForTesting,
+  hasRestartableReadyRuntimeBlocker,
   inputMonitoringSubGuidance,
   missingPermissionIDsFor,
   permissionRequirements,
@@ -13,7 +14,6 @@ import {
   readyBlockers,
   readyEvaluationSnake,
   readyNextActions,
-  readyRepairPlan,
   runSetupPromptPlan,
 } from '../scripts/lib/aos-readiness.mjs';
 
@@ -312,17 +312,23 @@ test('post-permission readiness enables bounded restart for repairable runtime b
   );
 });
 
-test('explicit repair branch plan chooses clean, restart, then permission handoff', () => {
-  assert.deepEqual(
-    readyRepairPlan({ ready: false, blockers: [{ id: 'stale_daemons', kind: 'runtime' }] }),
-    { branch: 'clean', clean: true, runtimeRestart: false, humanPermissionHandoff: false },
+test('ready restart predicate is explicit and excludes stale daemon cleanup', () => {
+  assert.equal(
+    hasRestartableReadyRuntimeBlocker({ ready: false, blockers: [{ id: 'input_tap_not_active', kind: 'runtime' }] }),
+    true,
   );
-  assert.deepEqual(
-    readyRepairPlan({ ready: false, blockers: [{ id: 'input_tap_not_active', kind: 'runtime' }] }),
-    { branch: 'restart', clean: false, runtimeRestart: true, humanPermissionHandoff: false },
+  assert.equal(
+    hasRestartableReadyRuntimeBlocker({ ready: false, blockers: [{ id: 'stale_daemons', kind: 'runtime' }] }),
+    false,
   );
-  assert.deepEqual(
-    readyRepairPlan({ ready: false, blockers: [{ id: 'accessibility', kind: 'permission' }] }),
-    { branch: 'permission_handoff', clean: false, runtimeRestart: false, humanPermissionHandoff: true },
+  assert.equal(
+    hasRestartableReadyRuntimeBlocker({
+      ready: false,
+      blockers: [
+        { id: 'stale_daemons', kind: 'runtime' },
+        { id: 'input_tap_not_active', kind: 'runtime' },
+      ],
+    }),
+    false,
   );
 });

--- a/tests/lib/mock-daemon.py
+++ b/tests/lib/mock-daemon.py
@@ -26,7 +26,18 @@ def parse_bool(value: str) -> bool:
     return value.lower() in ("1", "true", "yes")
 
 
+def current_tap_status(args: argparse.Namespace) -> str:
+    if args.ready_after_pings <= 0:
+        return args.tap_status
+    with args.ping_lock:
+        args.ping_count += 1
+        if args.ping_count >= args.ready_after_pings:
+            return "active"
+        return args.tap_status
+
+
 def build_ping_payload(args: argparse.Namespace) -> dict[str, Any]:
+    tap_status = current_tap_status(args)
     payload: dict[str, Any] = {
         "status": "ok",
         "uptime": 1.0,
@@ -39,16 +50,16 @@ def build_ping_payload(args: argparse.Namespace) -> dict[str, Any]:
         # Legacy flat fields. A pre-input-tap-readiness-contract daemon emitted
         # only these — newer daemons emit them alongside the structured blocks
         # for compatibility (CONTRACT-GOVERNANCE rule 4).
-        "input_tap_status": args.tap_status,
+        "input_tap_status": tap_status,
         "input_tap_attempts": args.attempts,
     }
     if not args.legacy:
         payload["input_tap"] = {
-            "status": args.tap_status,
+            "status": tap_status,
             "attempts": args.attempts,
             "listen_access": parse_bool(args.listen_access),
             "post_access": parse_bool(args.post_access),
-            "last_error_at": None if args.tap_status == "active" else "2026-04-24T00:00:00Z",
+            "last_error_at": None if tap_status == "active" else "2026-04-24T00:00:00Z",
         }
         payload["permissions"] = {
             "accessibility": parse_bool(args.accessibility),
@@ -125,6 +136,8 @@ def main() -> None:
     parser.add_argument("--mode", default="repo", choices=("repo", "installed"))
     parser.add_argument("--tap-status", default="active",
                         choices=("active", "retrying", "unavailable"))
+    parser.add_argument("--ready-after-pings", type=int, default=0,
+                        help="After this many system.ping calls, report an active input tap.")
     parser.add_argument("--attempts", type=int, default=1)
     parser.add_argument("--listen-access", default="true")
     parser.add_argument("--post-access", default="true")
@@ -134,6 +147,8 @@ def main() -> None:
                              "input_tap/permissions blocks (simulates a "
                              "pre-readiness-contract daemon binary).")
     args = parser.parse_args()
+    args.ping_count = 0
+    args.ping_lock = threading.Lock()
 
     if os.path.exists(args.socket):
         os.unlink(args.socket)

--- a/tests/ready-auto-repair-flow.sh
+++ b/tests/ready-auto-repair-flow.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT"
+
+PREFIX="aos-ready-auto-repair-flow"
+
+run_case() {
+  local name="$1"
+  local ready_after="$2"
+  local expect_ready="$3"
+
+  local state_root
+  state_root="$(mktemp -d "${TMPDIR:-/tmp}/${PREFIX}-${name}.XXXXXX")"
+  local sock="$state_root/repo/sock"
+  local marker="$state_root/repo/permissions-onboarding.json"
+  local action_log="$state_root/actions.jsonl"
+  local out="$state_root/ready.json"
+  local mock_pid=""
+
+  cleanup_case() {
+    if [[ -n "$mock_pid" ]] && kill -0 "$mock_pid" 2>/dev/null; then
+      kill "$mock_pid" 2>/dev/null || true
+      wait "$mock_pid" 2>/dev/null || true
+    fi
+    rm -rf "$state_root"
+  }
+  trap cleanup_case RETURN
+
+  mkdir -p "$(dirname "$sock")"
+  python3 - "$marker" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+path.write_text(json.dumps({"completed_at": "2026-05-25T00:00:00Z"}), encoding="utf-8")
+PY
+
+  if [[ "$ready_after" != "never" ]]; then
+    python3 tests/lib/mock-daemon.py \
+        --socket "$sock" \
+        --tap-status retrying \
+        --listen-access true \
+        --post-access true \
+        --accessibility true \
+        --ready-after-pings "$ready_after" \
+        >"$state_root/mock.stdout" 2>"$state_root/mock.stderr" &
+  else
+    python3 tests/lib/mock-daemon.py \
+        --socket "$sock" \
+        --tap-status retrying \
+        --listen-access true \
+        --post-access true \
+        --accessibility true \
+        >"$state_root/mock.stdout" 2>"$state_root/mock.stderr" &
+  fi
+  mock_pid=$!
+
+  for _ in $(seq 1 20); do
+    if [[ -S "$sock" ]]; then break; fi
+    sleep 0.1
+  done
+  if ! [[ -S "$sock" ]]; then
+    echo "FAIL: mock daemon did not bind socket $sock"
+    exit 1
+  fi
+
+  set +e
+  AOS_STATE_ROOT="$state_root" \
+    AOS_TEST_ASSUME_PERMISSIONS_GRANTED=1 \
+    AOS_TEST_READY_MOCK_SERVICE_ACTIONS=1 \
+    AOS_TEST_READY_SERVICE_ACTION_LOG="$action_log" \
+    AOS_TEST_READY_WAIT_BUDGET_MS=400 \
+    AOS_TEST_READY_WAIT_POLL_MS=20 \
+    ./aos ready --json >"$out"
+  local rc=$?
+  set -e
+
+  python3 - "$out" "$action_log" "$expect_ready" "$rc" <<'PY'
+import json
+import pathlib
+import sys
+
+response = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+actions = [
+    json.loads(line)
+    for line in pathlib.Path(sys.argv[2]).read_text(encoding="utf-8").splitlines()
+    if line.strip()
+]
+expect_ready = sys.argv[3] == "ready"
+rc = int(sys.argv[4])
+trace = response.get("action_trace", [])
+steps = [(item.get("step"), item.get("result")) for item in trace]
+
+assert any(action == {"action": "restart", "mode": "repo"} for action in actions), actions
+assert all(action["action"] in {"start", "restart"} for action in actions), actions
+assert ("service_restart", "ok") in steps, trace
+
+if expect_ready:
+    assert rc == 0, response
+    assert response.get("ready") is True, response
+    assert ("wait_for_recovery", "ready") in steps, trace
+else:
+    assert rc != 0, response
+    assert response.get("ready") is False, response
+    assert ("wait_for_recovery", "timed_out") in steps, trace
+PY
+
+  trap - RETURN
+  cleanup_case
+}
+
+run_case recovery 4 ready
+run_case timeout never timed_out
+
+echo "PASS"

--- a/tests/ready-auto-repair-flow.sh
+++ b/tests/ready-auto-repair-flow.sh
@@ -4,12 +4,17 @@ set -euo pipefail
 ROOT="$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel 2>/dev/null || pwd)"
 cd "$ROOT"
 
-PREFIX="aos-ready-auto-repair-flow"
+PREFIX="aos-ready-repair"
 
 run_case() {
   local name="$1"
   local ready_after="$2"
   local expect_ready="$3"
+  shift 3
+  local ready_command=(./aos ready)
+  if [[ "$#" -gt 0 ]]; then
+    ready_command+=("$@")
+  fi
 
   local state_root
   state_root="$(mktemp -d "${TMPDIR:-/tmp}/${PREFIX}-${name}.XXXXXX")"
@@ -74,7 +79,7 @@ PY
     AOS_TEST_READY_SERVICE_ACTION_LOG="$action_log" \
     AOS_TEST_READY_WAIT_BUDGET_MS=400 \
     AOS_TEST_READY_WAIT_POLL_MS=20 \
-    ./aos ready --json >"$out"
+    "${ready_command[@]}" --json >"$out"
   local rc=$?
   set -e
 
@@ -114,5 +119,125 @@ PY
 
 run_case recovery 4 ready
 run_case timeout never timed_out
+run_case repair-recovery 2 ready --repair
+
+run_stale_repair_case() {
+  local state_root stale_root
+  state_root="$(mktemp -d "${TMPDIR:-/tmp}/${PREFIX}-stale.XXXXXX")"
+  stale_root="$(mktemp -d "${TMPDIR:-/tmp}/${PREFIX}-stale-daemon.XXXXXX")"
+  local sock="$state_root/repo/sock"
+  local marker="$state_root/repo/permissions-onboarding.json"
+  local action_log="$state_root/actions.jsonl"
+  local out="$state_root/ready.json"
+  local mock_pid=""
+  local stale_pid=""
+
+  cleanup_stale_case() {
+    if [[ -n "$mock_pid" ]] && kill -0 "$mock_pid" 2>/dev/null; then
+      kill "$mock_pid" 2>/dev/null || true
+      wait "$mock_pid" 2>/dev/null || true
+    fi
+    if [[ -n "$stale_pid" ]] && kill -0 "$stale_pid" 2>/dev/null; then
+      kill -9 "$stale_pid" 2>/dev/null || true
+      wait "$stale_pid" 2>/dev/null || true
+    fi
+    rm -rf "$state_root" "$stale_root"
+  }
+  trap cleanup_stale_case RETURN
+
+  mkdir -p "$(dirname "$sock")"
+  printf '{"completed_at":"2026-05-25T00:00:00Z"}\n' >"$marker"
+
+  python3 tests/lib/mock-daemon.py \
+      --socket "$sock" \
+      --tap-status active \
+      --listen-access true \
+      --post-access true \
+      --accessibility true \
+      >"$state_root/mock.stdout" 2>"$state_root/mock.stderr" &
+  mock_pid=$!
+
+  for _ in $(seq 1 20); do
+    if [[ -S "$sock" ]]; then break; fi
+    sleep 0.1
+  done
+  if ! [[ -S "$sock" ]]; then
+    echo "FAIL: mock daemon did not bind socket $sock"
+    exit 1
+  fi
+
+  cat >"$stale_root/aos" <<'SH'
+#!/usr/bin/env bash
+trap '' TERM
+while true; do
+  sleep 10
+done
+SH
+  chmod +x "$stale_root/aos"
+  "$stale_root/aos" serve --idle-timeout 5m \
+    >"$stale_root/stale.stdout" 2>"$stale_root/stale.stderr" &
+  stale_pid=$!
+
+  local found_stale=0
+  for _ in $(seq 1 20); do
+    if AOS_STATE_ROOT="$state_root" ./aos clean --dry-run --json | STALE_PID="$stale_pid" python3 -c '
+import json
+import os
+import sys
+
+payload = json.loads(sys.stdin.read())
+pid = int(os.environ["STALE_PID"])
+raise SystemExit(0 if any(item.get("pid") == pid for item in payload.get("stale_daemons", [])) else 1)
+'; then
+      found_stale=1
+      break
+    fi
+    sleep 0.1
+  done
+  if [[ "$found_stale" -ne 1 ]]; then
+    echo "FAIL: clean dry-run did not detect stale daemon pid=$stale_pid"
+    exit 1
+  fi
+
+  set +e
+  AOS_STATE_ROOT="$state_root" \
+    AOS_TEST_ASSUME_PERMISSIONS_GRANTED=1 \
+    AOS_TEST_READY_MOCK_SERVICE_ACTIONS=1 \
+    AOS_TEST_READY_SERVICE_ACTION_LOG="$action_log" \
+    ./aos ready --repair --json >"$out"
+  local rc=$?
+  set -e
+
+  python3 - "$out" "$action_log" "$stale_pid" "$rc" <<'PY'
+import json
+import pathlib
+import sys
+
+response = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+actions = [
+    json.loads(line)
+    for line in pathlib.Path(sys.argv[2]).read_text(encoding="utf-8").splitlines()
+    if line.strip()
+]
+stale_pid = int(sys.argv[3])
+rc = int(sys.argv[4])
+trace = response.get("action_trace", [])
+steps = [(item.get("step"), item.get("result")) for item in trace]
+blockers = response.get("blockers", [])
+
+assert rc != 0, response
+assert response.get("ready") is False, response
+assert response.get("diagnosis") == "stale_daemons", response
+assert any(item.get("id") == "stale_daemons" and str(stale_pid) in item.get("message", "") for item in blockers), response
+assert ("clean", "ok") in steps, trace
+assert not any(step == "service_restart" for step, _ in steps), trace
+assert not any(action.get("action") == "restart" for action in actions), actions
+PY
+
+  trap - RETURN
+  cleanup_stale_case
+}
+
+run_stale_repair_case
 
 echo "PASS"


### PR DESCRIPTION
## Summary

Refs #407. This is a focused settlement PR for the outside-review follow-up after #409 landed.

- moves pure `ready` auto-repair decision helpers into `scripts/lib/aos-readiness.mjs`
- adds deterministic coverage for ready auto-repair reason/plan branches
- adds a mock-daemon flow covering restart trace, recovery-ready, and recovery-timeout paths without real launchctl/TCC/Settings calls
- removes the redundant healthy-path ready fact rebuild and the dead status runtime fallback

## Verification

- `node --test tests/aos-readiness-composition.test.mjs` -> 17/17 pass
- `node --test tests/schemas/aos-external-command-manifest-v0.test.mjs` -> 27/27 pass
- `bash tests/ready-auto-repair-flow.sh` -> pass
- `bash tests/ready-fast-healthy-path.sh` -> pass
- `bash tests/ready-ownership-mismatch.sh` -> pass
- `bash tests/external-command-dispatch.sh` -> pass
- `bash tests/external-parser-flags.sh` -> pass
- `bash tests/help-contract.sh` -> pass
- `git diff --check HEAD` -> pass
- `git show --check --stat --oneline HEAD` -> pass
- `./aos dev recommend --json --paths ...` -> hot-swappable; no Swift build; not TCC identity sensitive
- `./aos ready --json` -> ready=true, phase=ready, input tap active, permissions granted

## Notes

No Swift edits, no native rebuild, no TCC reset/setup, and no Sigil status-item repair are included. The local checkout still has unrelated untracked coordination/report artifacts; they are not part of this PR.
