### PR TITLE
feat(dev-gh): add issue lifecycle editing

### DIFF
--- a/.docks/foreman/dock.json
+++ b/.docks/foreman/dock.json
@@ -30,6 +30,7 @@
     "dev.github.issue_comment",
     "dev.github.issue_create",
     "dev.github.issue_close",
+    "dev.github.issue_edit",
     "dev.github.label_list",
     "dev.github.pr_list",
     "dev.github.pr_view",

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -10,8 +10,9 @@ started" notes. Put reusable guidance in repo docs instead.
 Repo-specific GitHub operations should go through `./aos dev gh`, which shells
 out to the authenticated local `gh` CLI while preserving the repo's workflow
 boundary. Use it for context discovery, issue reads, issue comments, issue
-creation, issue close, label inventory, PR context, PR merge, CI inspection,
-and review-comment reads when GitHub work is explicitly in scope.
+creation, issue close, issue lifecycle edits, label inventory, PR context, PR
+merge, CI inspection, and review-comment reads when GitHub work is explicitly
+in scope.
 
 Do not open or update issues or PRs unless the assigned goal or handoff
 explicitly includes that mutation. When a skill says to publish to the issue

--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -263,6 +263,7 @@ for full-screen capture.
 ./aos dev gh issue comment 298 --body-file /tmp/comment.md
 ./aos dev gh issue create --title "Follow-up tracker" --body-file /tmp/issue.md
 ./aos dev gh issue close 298 --reason completed
+./aos dev gh issue edit 298 --remove-label lane:active --add-label lane:parked
 ./aos dev gh pr merge 410 --merge --match-head-commit abc123
 ./aos dev gh ci inspect --pr 298 --json
 ./aos dev gh review-comments --pr 298 --json
@@ -296,7 +297,7 @@ turning the profile into a rigid executor.
 `gh` executable from `PATH`, the user's existing `gh` authentication, and the
 local git checkout to infer `owner/repo` unless `--repo owner/name` is supplied.
 Direct operations such as `issue list`, `issue view`, `issue comment`,
-`issue create`, `issue close`, `label list`, `pr list`, `pr view`,
+`issue create`, `issue close`, `issue edit`, `label list`, `pr list`, `pr view`,
 `pr checks`, `pr comment`, and `pr merge` forward to `gh` and preserve its exit
 behavior. List operations expose the repo-safe inventory filters Foreman and
 GDI need most often: issue and PR lists support `--state`, `--limit`,
@@ -305,8 +306,11 @@ GDI need most often: issue and PR lists support `--state`, `--limit`,
 support `--limit`, `--search`, `--sort`, and `--order`. Write operations are
 non-interactive: `issue create` requires `--title` and `--body-file`,
 `issue close` requires an issue number and optionally accepts `--reason`, and
-`pr merge` requires a PR number and exactly one of `--squash`, `--merge`, or
-`--rebase`; use `--match-head-commit` when merging a reviewed head. The
+`issue edit` requires an issue number and at least one explicit edit flag:
+`--add-label`, `--remove-label`, `--add-assignee`, `--remove-assignee`,
+`--milestone`, `--title`, or `--body-file`. `pr merge` requires a PR number
+and exactly one of `--squash`, `--merge`, or `--rebase`; use
+`--match-head-commit` when merging a reviewed head. The
 composite helpers cover repo-specific repeated loops:
 `ci inspect` reads PR checks and fetches failed GitHub Actions logs when the
 check links to an Actions run, while `review-comments` uses `gh api graphql` to

--- a/docs/dev/agent-capabilities.json
+++ b/docs/dev/agent-capabilities.json
@@ -340,6 +340,65 @@
       }
     },
     {
+      "id": "dev.github.issue_edit",
+      "label": "GitHub Issue Edit",
+      "summary": "Edit GitHub issue lifecycle metadata through ./aos dev gh with explicit non-interactive flags.",
+      "status": "active",
+      "roles": ["foreman"],
+      "entry_paths": ["aos_developer"],
+      "adapter": {
+        "kind": "aos_cli",
+        "command": ["./aos", "dev", "gh", "issue", "edit"]
+      },
+      "mutability": {
+        "class": "external_write",
+        "side_effects": ["github_issue_edit"],
+        "requires_explicit_assignment": true,
+        "requires_human_approval": false,
+        "requires_body_file": false
+      },
+      "execution": {
+        "cwd_policy": "repo_root",
+        "timeout_seconds": 30,
+        "network": "required",
+        "raw_process": false,
+        "audit": "required"
+      },
+      "inputs": [
+        {
+          "name": "issue_number",
+          "summary": "GitHub issue number.",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        {
+          "name": "metadata",
+          "summary": "One or more explicit --add-label, --remove-label, --add-assignee, --remove-assignee, --milestone, --title, or --body-file edits.",
+          "required": true,
+          "schema": {
+            "type": "object"
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "edit_result",
+          "summary": "Output from gh issue edit.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "failure_policy": {
+        "bubble_up": true,
+        "retry": "none"
+      }
+    },
+    {
       "id": "dev.github.label_list",
       "label": "GitHub Label List",
       "summary": "List GitHub repository labels through ./aos dev gh with bounded read-only filters.",

--- a/scripts/aos-dev-gh.mjs
+++ b/scripts/aos-dev-gh.mjs
@@ -17,6 +17,15 @@ const COMMON_FLAGS = new Set(['--json', '--repo', '--cwd', '--body-file', '--pr'
 const LIST_FLAGS = new Set(['--state', '--limit', '--label', '--author', '--assignee', '--search']);
 const PR_LIST_FLAGS = new Set(['--base', '--head', '--draft']);
 const PR_MERGE_STRATEGY_FLAGS = new Set(['--squash', '--merge', '--rebase']);
+const ISSUE_EDIT_VALUE_FLAGS = new Set([
+  '--add-label',
+  '--remove-label',
+  '--add-assignee',
+  '--remove-assignee',
+  '--milestone',
+  '--title',
+  '--body-file',
+]);
 const ISSUE_VIEW_JSON_FIELDS = 'number,title,state,url,body,labels,comments';
 
 const FLAG_SPECS = {
@@ -31,12 +40,16 @@ const FLAG_SPECS = {
   },
   '--body-file': {
     summary: 'a path',
-    assign: (options, value) => { options.bodyFile = value; },
+    assign: (options, value) => {
+      options.bodyFile = value;
+    },
   },
   '--title': {
     summary: 'an issue title',
-    assign: (options, value) => { options.title = value; },
-    invalid: '--title is only valid for issue create subcommands',
+    assign: (options, value) => {
+      options.title = value;
+    },
+    invalid: '--title is only valid for issue create and edit subcommands',
   },
   '--pr': {
     summary: 'a PR number',
@@ -75,6 +88,16 @@ const FLAG_SPECS = {
     assign: (options, value) => { options.labels.push(value); },
     invalid: '--label is only valid for issue create and issue/PR list subcommands',
   },
+  '--add-label': {
+    summary: 'a label name',
+    assign: () => {},
+    invalid: '--add-label is only valid for issue edit subcommands',
+  },
+  '--remove-label': {
+    summary: 'a label name',
+    assign: () => {},
+    invalid: '--remove-label is only valid for issue edit subcommands',
+  },
   '--author': {
     summary: 'a GitHub login',
     assign: (options, value) => { options.author = value; },
@@ -88,6 +111,16 @@ const FLAG_SPECS = {
     },
     invalid: '--assignee is only valid for issue create and list subcommands',
   },
+  '--add-assignee': {
+    summary: 'a GitHub login or @me',
+    assign: () => {},
+    invalid: '--add-assignee is only valid for issue edit subcommands',
+  },
+  '--remove-assignee': {
+    summary: 'a GitHub login or @me',
+    assign: () => {},
+    invalid: '--remove-assignee is only valid for issue edit subcommands',
+  },
   '--search': {
     summary: 'a search query',
     assign: (options, value) => { options.search = value; },
@@ -95,7 +128,9 @@ const FLAG_SPECS = {
   },
   '--milestone': {
     summary: 'an issue milestone name',
-    assign: (options, value) => { options.milestone = value; },
+    assign: (options, value) => {
+      options.milestone = value;
+    },
   },
   '--base': {
     summary: 'a base branch name',
@@ -139,6 +174,15 @@ const COMMAND_FLAGS = new Map([
   ['issue:list', new Set([...COMMON_FLAGS, ...LIST_FLAGS, '--milestone'])],
   ['issue:create', new Set([...COMMON_FLAGS, '--title', '--label', '--assignee', '--milestone'])],
   ['issue:close', new Set([...COMMON_FLAGS, '--reason'])],
+  ['issue:edit', new Set([
+    ...COMMON_FLAGS,
+    '--add-label',
+    '--remove-label',
+    '--add-assignee',
+    '--remove-assignee',
+    '--milestone',
+    '--title',
+  ])],
   ['label:list', new Set([...COMMON_FLAGS, '--limit', '--search', '--sort', '--order'])],
   ['pr:list', new Set([...COMMON_FLAGS, ...LIST_FLAGS, ...PR_LIST_FLAGS])],
   ['pr:merge', new Set([...COMMON_FLAGS, ...PR_MERGE_STRATEGY_FLAGS, '--match-head-commit'])],
@@ -181,6 +225,7 @@ function parseOptions(args, command = 'common') {
     closeReason: null,
     sort: null,
     order: null,
+    issueEditOperations: [],
     positionals: [],
   };
   const allowedFlags = COMMAND_FLAGS.get(command) ?? COMMAND_FLAGS.get('common');
@@ -201,6 +246,9 @@ function parseOptions(args, command = 'common') {
         const summary = typeof spec.summary === 'function' ? spec.summary(command) : spec.summary;
         const value = requireValueAt(i, arg, summary);
         spec.assign(options, value, command, arg);
+        if (command === 'issue:edit' && ISSUE_EDIT_VALUE_FLAGS.has(arg)) {
+          options.issueEditOperations.push({ flag: arg, value });
+        }
         i += 2;
       } else {
         spec.assign(options, null, command, arg);
@@ -490,9 +538,22 @@ function appendIssueCreateMetadata(args, options) {
   if (options.milestone) args.push('--milestone', options.milestone);
 }
 
+function appendIssueEditMetadata(args, options) {
+  for (const operation of options.issueEditOperations) {
+    if (operation.flag === '--body-file') {
+      const bodyFile = resolveUserPath(operation.value);
+      if (!fs.existsSync(bodyFile)) die(`Missing issue body file: ${bodyFile}`, 'MISSING_BODY_FILE');
+      args.push(operation.flag, bodyFile);
+    } else {
+      args.push(operation.flag, operation.value);
+    }
+  }
+  return options.issueEditOperations.length;
+}
+
 function issueCommand(args) {
   const action = args[0];
-  if (!action) die('dev gh issue requires a subcommand: list, view, create, comment, or close', 'MISSING_SUBCOMMAND');
+  if (!action) die('dev gh issue requires a subcommand: list, view, create, comment, edit, or close', 'MISSING_SUBCOMMAND');
   if (action === 'list') {
     const options = parseOptions(args.slice(1), 'issue:list');
     if (options.positionals.length > 0) die(`Unknown dev gh issue argument: ${options.positionals[0]}`, 'UNKNOWN_ARG');
@@ -552,6 +613,21 @@ function issueCommand(args) {
     const ghArgs = ['issue', 'close', issueNumber];
     appendRepo(ghArgs, repoFullName);
     if (options.closeReason) ghArgs.push('--reason', options.closeReason);
+    runGhAndExit(ghArgs, repoRoot);
+  } else if (action === 'edit') {
+    const options = parseOptions(args.slice(1), 'issue:edit');
+    if (options.positionals.length === 0) die('dev gh issue edit requires exactly one issue number', 'MISSING_ARG');
+    if (options.positionals.length > 1) die(`Unknown dev gh issue argument: ${options.positionals[1]}`, 'UNKNOWN_ARG');
+    const issueNumber = options.positionals[0];
+    if (!/^[0-9]+$/.test(issueNumber)) die(`Issue number must be numeric for edit: ${issueNumber}`, 'INVALID_ISSUE');
+    const repoRoot = repoRootFrom(options);
+    const repoFullName = repositoryFullName(options, repoRoot);
+    const ghArgs = ['issue', 'edit', issueNumber];
+    appendRepo(ghArgs, repoFullName);
+    const editCount = appendIssueEditMetadata(ghArgs, options);
+    if (editCount === 0) {
+      die('dev gh issue edit requires at least one edit flag', 'MISSING_ARG');
+    }
     runGhAndExit(ghArgs, repoRoot);
   } else {
     die(`Unknown dev gh issue subcommand: ${action}`, 'UNKNOWN_SUBCOMMAND');

--- a/scripts/aos-dev-gh.mjs
+++ b/scripts/aos-dev-gh.mjs
@@ -13,7 +13,150 @@ function die(message, code = 'ERROR', exitCode = 1) {
   process.exit(exitCode);
 }
 
-function parseOptions(args, config = {}) {
+const COMMON_FLAGS = new Set(['--json', '--repo', '--cwd', '--body-file', '--pr']);
+const LIST_FLAGS = new Set(['--state', '--limit', '--label', '--author', '--assignee', '--search']);
+const PR_LIST_FLAGS = new Set(['--base', '--head', '--draft']);
+const PR_MERGE_STRATEGY_FLAGS = new Set(['--squash', '--merge', '--rebase']);
+
+const FLAG_SPECS = {
+  '--json': { assign: (options) => { options.json = true; } },
+  '--repo': {
+    summary: 'a GitHub repository in owner/name form',
+    assign: (options, value) => { options.repo = value; },
+  },
+  '--cwd': {
+    summary: 'a local checkout path',
+    assign: (options, value) => { options.cwd = value; },
+  },
+  '--body-file': {
+    summary: 'a path',
+    assign: (options, value) => { options.bodyFile = value; },
+  },
+  '--title': {
+    summary: 'an issue title',
+    assign: (options, value) => { options.title = value; },
+    invalid: '--title is only valid for issue create subcommands',
+  },
+  '--pr': {
+    summary: 'a PR number',
+    assign: (options, value) => { options.prNumber = value; },
+  },
+  '--reason': {
+    summary: 'completed or not planned',
+    assign: (options, value) => { options.closeReason = value; },
+    invalid: '--reason is only valid for issue close subcommands',
+  },
+  '--sort': {
+    summary: 'created or name',
+    assign: (options, value) => { options.sort = value; },
+    invalid: '--sort is only valid for label list subcommands',
+  },
+  '--order': {
+    summary: 'asc or desc',
+    assign: (options, value) => { options.order = value; },
+    invalid: '--order is only valid for label list subcommands',
+  },
+  '--state': {
+    summary: (command) => command === 'pr:list' ? 'open, closed, merged, or all' : 'open, closed, or all',
+    assign: (options, value) => { options.state = value; },
+    invalid: '--state is only valid for list subcommands',
+  },
+  '--limit': {
+    summary: 'a numeric result limit',
+    assign: (options, value) => {
+      if (!/^[0-9]+$/.test(value)) die(`--limit must be numeric: ${value}`, 'INVALID_ARG');
+      options.limit = Number.parseInt(value, 10);
+    },
+    invalid: '--limit is only valid for list subcommands',
+  },
+  '--label': {
+    summary: 'a label name',
+    assign: (options, value) => { options.labels.push(value); },
+    invalid: '--label is only valid for issue create and issue/PR list subcommands',
+  },
+  '--author': {
+    summary: 'a GitHub login',
+    assign: (options, value) => { options.author = value; },
+    invalid: '--author is only valid for list subcommands',
+  },
+  '--assignee': {
+    summary: (command) => command === 'issue:create' ? 'a GitHub login or @me' : 'a GitHub login or @me',
+    assign: (options, value, command) => {
+      if (command === 'issue:create') options.assignees.push(value);
+      else options.assignee = value;
+    },
+    invalid: '--assignee is only valid for issue create and list subcommands',
+  },
+  '--search': {
+    summary: 'a search query',
+    assign: (options, value) => { options.search = value; },
+    invalid: '--search is only valid for list subcommands',
+  },
+  '--milestone': {
+    summary: 'an issue milestone name',
+    assign: (options, value) => { options.milestone = value; },
+  },
+  '--base': {
+    summary: 'a base branch name',
+    assign: (options, value) => { options.base = value; },
+  },
+  '--head': {
+    summary: 'a head branch name',
+    assign: (options, value) => { options.head = value; },
+  },
+  '--draft': { assign: (options) => { options.draft = true; } },
+  '--squash': {
+    assign: (options, _value, _command, flag) => {
+      if (options.mergeStrategy) die('dev gh pr merge accepts exactly one merge strategy', 'INVALID_ARG');
+      options.mergeStrategy = flag;
+    },
+    invalid: '--squash is only valid for PR merge subcommands',
+  },
+  '--merge': {
+    assign: (options, _value, _command, flag) => {
+      if (options.mergeStrategy) die('dev gh pr merge accepts exactly one merge strategy', 'INVALID_ARG');
+      options.mergeStrategy = flag;
+    },
+    invalid: '--merge is only valid for PR merge subcommands',
+  },
+  '--rebase': {
+    assign: (options, _value, _command, flag) => {
+      if (options.mergeStrategy) die('dev gh pr merge accepts exactly one merge strategy', 'INVALID_ARG');
+      options.mergeStrategy = flag;
+    },
+    invalid: '--rebase is only valid for PR merge subcommands',
+  },
+  '--match-head-commit': {
+    summary: 'a commit SHA',
+    assign: (options, value) => { options.matchHeadCommit = value; },
+    invalid: '--match-head-commit is only valid for PR merge subcommands',
+  },
+};
+
+const COMMAND_FLAGS = new Map([
+  ['common', COMMON_FLAGS],
+  ['issue:list', new Set([...COMMON_FLAGS, ...LIST_FLAGS, '--milestone'])],
+  ['issue:create', new Set([...COMMON_FLAGS, '--title', '--label', '--assignee', '--milestone'])],
+  ['issue:close', new Set([...COMMON_FLAGS, '--reason'])],
+  ['label:list', new Set([...COMMON_FLAGS, '--limit', '--search', '--sort', '--order'])],
+  ['pr:list', new Set([...COMMON_FLAGS, ...LIST_FLAGS, ...PR_LIST_FLAGS])],
+  ['pr:merge', new Set([...COMMON_FLAGS, ...PR_MERGE_STRATEGY_FLAGS, '--match-head-commit'])],
+]);
+
+function flagErrorMessage(flag, command, allowedFlags) {
+  const spec = FLAG_SPECS[flag];
+  if (!spec) return null;
+  if (allowedFlags.has(flag)) return null;
+  if (spec.invalid && !allowedFlags.has(flag)) return spec.invalid;
+  if (LIST_FLAGS.has(flag) && !command.endsWith(':list')) return `${flag} is only valid for list subcommands`;
+  if (PR_LIST_FLAGS.has(flag) && !command.endsWith(':list')) return `${flag} is only valid for PR list subcommands`;
+  if ((PR_MERGE_STRATEGY_FLAGS.has(flag) || flag === '--match-head-commit') && command !== 'pr:merge') {
+    return `${flag} is only valid for PR merge subcommands`;
+  }
+  return null;
+}
+
+function parseOptions(args, command = 'common') {
   const options = {
     json: false,
     repo: null,
@@ -39,14 +182,7 @@ function parseOptions(args, config = {}) {
     order: null,
     positionals: [],
   };
-  const listKind = config.listKind ?? null;
-  const issueCreate = config.issueCreate ?? false;
-  const issueClose = config.issueClose ?? false;
-  const prMerge = config.prMerge ?? false;
-  const labelList = listKind === 'label';
-  const commonListOnlyFlags = new Set(['--state', '--limit', '--author', '--search']);
-  const prListFlags = new Set(['--base', '--head', '--draft']);
-  const prMergeStrategyFlags = new Set(['--squash', '--merge', '--rebase']);
+  const allowedFlags = COMMAND_FLAGS.get(command) ?? COMMAND_FLAGS.get('common');
   const requireValueAt = (index, flag, summary) => {
     if (index < 0 || index + 1 >= args.length || args[index + 1].startsWith('--')) {
       die(`${flag} requires ${summary}`, 'MISSING_ARG');
@@ -55,98 +191,20 @@ function parseOptions(args, config = {}) {
   };
   for (let i = 0; i < args.length;) {
     const arg = args[i];
-    if (arg === '--json') {
-      options.json = true;
-      i += 1;
-    } else if (arg === '--repo') {
-      if (i + 1 >= args.length || args[i + 1].startsWith('--')) die('--repo requires a GitHub repository in owner/name form', 'MISSING_ARG');
-      options.repo = args[i + 1];
-      i += 2;
-    } else if (arg === '--cwd') {
-      if (i + 1 >= args.length || args[i + 1].startsWith('--')) die('--cwd requires a local checkout path', 'MISSING_ARG');
-      options.cwd = args[i + 1];
-      i += 2;
-    } else if (arg === '--body-file') {
-      if (i + 1 >= args.length || args[i + 1].startsWith('--')) die('--body-file requires a path', 'MISSING_ARG');
-      options.bodyFile = args[i + 1];
-      i += 2;
-    } else if (arg === '--title' && issueCreate) {
-      options.title = requireValueAt(i, arg, 'an issue title');
-      i += 2;
-    } else if (arg === '--title') {
-      die('--title is only valid for issue create subcommands', 'UNKNOWN_FLAG');
-    } else if (arg === '--pr') {
-      if (i + 1 >= args.length || args[i + 1].startsWith('--')) die('--pr requires a PR number', 'MISSING_ARG');
-      options.prNumber = args[i + 1];
-      i += 2;
-    } else if (arg === '--reason' && issueClose) {
-      options.closeReason = requireValueAt(i, arg, 'completed or not planned');
-      i += 2;
-    } else if (arg === '--reason') {
-      die('--reason is only valid for issue close subcommands', 'UNKNOWN_FLAG');
-    } else if (arg === '--sort' && labelList) {
-      options.sort = requireValueAt(i, arg, 'created or name');
-      i += 2;
-    } else if (arg === '--sort') {
-      die('--sort is only valid for label list subcommands', 'UNKNOWN_FLAG');
-    } else if (arg === '--order' && labelList) {
-      options.order = requireValueAt(i, arg, 'asc or desc');
-      i += 2;
-    } else if (arg === '--order') {
-      die('--order is only valid for label list subcommands', 'UNKNOWN_FLAG');
-    } else if (commonListOnlyFlags.has(arg) && !listKind) {
-      die(`${arg} is only valid for list subcommands`, 'UNKNOWN_FLAG');
-    } else if (prListFlags.has(arg) && !listKind) {
-      die(`${arg} is only valid for PR list subcommands`, 'UNKNOWN_FLAG');
-    } else if ((prMergeStrategyFlags.has(arg) || arg === '--match-head-commit') && !prMerge) {
-      die(`${arg} is only valid for PR merge subcommands`, 'UNKNOWN_FLAG');
-    } else if (arg === '--state' && listKind && !labelList) {
-      const stateSummary = listKind === 'pr' ? 'open, closed, merged, or all' : 'open, closed, or all';
-      options.state = requireValueAt(i, arg, stateSummary);
-      i += 2;
-    } else if (arg === '--limit' && listKind) {
-      const limit = requireValueAt(i, arg, 'a numeric result limit');
-      if (!/^[0-9]+$/.test(limit)) die(`--limit must be numeric: ${limit}`, 'INVALID_ARG');
-      options.limit = Number.parseInt(limit, 10);
-      i += 2;
-    } else if (arg === '--label' && ((listKind && !labelList) || issueCreate)) {
-      options.labels.push(requireValueAt(i, arg, 'a label name'));
-      i += 2;
-    } else if (arg === '--label') {
-      die('--label is only valid for issue create and issue/PR list subcommands', 'UNKNOWN_FLAG');
-    } else if (arg === '--author' && listKind && !labelList) {
-      options.author = requireValueAt(i, arg, 'a GitHub login');
-      i += 2;
-    } else if (arg === '--assignee' && issueCreate) {
-      options.assignees.push(requireValueAt(i, arg, 'a GitHub login or @me'));
-      i += 2;
-    } else if (arg === '--assignee' && listKind && !labelList) {
-      options.assignee = requireValueAt(i, arg, 'a GitHub login or @me');
-      i += 2;
-    } else if (arg === '--assignee') {
-      die('--assignee is only valid for issue create and list subcommands', 'UNKNOWN_FLAG');
-    } else if (arg === '--search' && listKind) {
-      options.search = requireValueAt(i, arg, 'a search query');
-      i += 2;
-    } else if (arg === '--milestone' && (listKind === 'issue' || issueCreate)) {
-      options.milestone = requireValueAt(i, arg, 'an issue milestone name');
-      i += 2;
-    } else if (arg === '--base' && listKind === 'pr') {
-      options.base = requireValueAt(i, arg, 'a base branch name');
-      i += 2;
-    } else if (arg === '--head' && listKind === 'pr') {
-      options.head = requireValueAt(i, arg, 'a head branch name');
-      i += 2;
-    } else if (arg === '--draft' && listKind === 'pr') {
-      options.draft = true;
-      i += 1;
-    } else if (prMergeStrategyFlags.has(arg) && prMerge) {
-      if (options.mergeStrategy) die('dev gh pr merge accepts exactly one merge strategy', 'INVALID_ARG');
-      options.mergeStrategy = arg;
-      i += 1;
-    } else if (arg === '--match-head-commit' && prMerge) {
-      options.matchHeadCommit = requireValueAt(i, arg, 'a commit SHA');
-      i += 2;
+    const spec = FLAG_SPECS[arg];
+    if (spec) {
+      const error = flagErrorMessage(arg, command, allowedFlags);
+      if (error) die(error, 'UNKNOWN_FLAG');
+      if (!allowedFlags.has(arg)) die(`Unknown dev gh flag: ${arg}`, 'UNKNOWN_FLAG');
+      if (spec.summary) {
+        const summary = typeof spec.summary === 'function' ? spec.summary(command) : spec.summary;
+        const value = requireValueAt(i, arg, summary);
+        spec.assign(options, value, command, arg);
+        i += 2;
+      } else {
+        spec.assign(options, null, command, arg);
+        i += 1;
+      }
     } else if (arg.startsWith('--')) {
       die(`Unknown dev gh flag: ${arg}`, 'UNKNOWN_FLAG');
     } else {
@@ -435,7 +493,7 @@ function issueCommand(args) {
   const action = args[0];
   if (!action) die('dev gh issue requires a subcommand: list, view, create, comment, or close', 'MISSING_SUBCOMMAND');
   if (action === 'list') {
-    const options = parseOptions(args.slice(1), { listKind: 'issue' });
+    const options = parseOptions(args.slice(1), 'issue:list');
     if (options.positionals.length > 0) die(`Unknown dev gh issue argument: ${options.positionals[0]}`, 'UNKNOWN_ARG');
     const repoRoot = repoRootFrom(options);
     const repoFullName = repositoryFullName(options, repoRoot);
@@ -468,7 +526,7 @@ function issueCommand(args) {
     ghArgs.push('--body-file', bodyFile);
     runGhAndExit(ghArgs, repoRoot);
   } else if (action === 'create') {
-    const options = parseOptions(args.slice(1), { issueCreate: true });
+    const options = parseOptions(args.slice(1), 'issue:create');
     if (options.positionals.length > 0) die(`Unknown dev gh issue argument: ${options.positionals[0]}`, 'UNKNOWN_ARG');
     if (!options.title) die('dev gh issue create requires --title <title>', 'MISSING_ARG');
     if (!options.bodyFile) die('dev gh issue create requires --body-file <path>', 'MISSING_ARG');
@@ -482,7 +540,7 @@ function issueCommand(args) {
     appendIssueCreateMetadata(ghArgs, options);
     runGhAndExit(ghArgs, repoRoot);
   } else if (action === 'close') {
-    const options = parseOptions(args.slice(1), { issueClose: true });
+    const options = parseOptions(args.slice(1), 'issue:close');
     if (options.positionals.length === 0) die('dev gh issue close requires exactly one issue number', 'MISSING_ARG');
     if (options.positionals.length > 1) die(`Unknown dev gh issue argument: ${options.positionals[1]}`, 'UNKNOWN_ARG');
     if (options.bodyFile) die('dev gh issue close does not accept --body-file; post a separate issue comment first', 'UNKNOWN_FLAG');
@@ -503,7 +561,7 @@ function labelCommand(args) {
   const action = args[0];
   if (!action) die('dev gh label requires a subcommand: list', 'MISSING_SUBCOMMAND');
   if (action === 'list') {
-    const options = parseOptions(args.slice(1), { listKind: 'label' });
+    const options = parseOptions(args.slice(1), 'label:list');
     if (options.positionals.length > 0) die(`Unknown dev gh label argument: ${options.positionals[0]}`, 'UNKNOWN_ARG');
     const repoRoot = repoRootFrom(options);
     const repoFullName = repositoryFullName(options, repoRoot);
@@ -521,7 +579,7 @@ function prCommand(args) {
   const action = args[0];
   if (!action) die('dev gh pr requires a subcommand: list, view, checks, comment, or merge', 'MISSING_SUBCOMMAND');
   if (action === 'list') {
-    const options = parseOptions(args.slice(1), { listKind: 'pr' });
+    const options = parseOptions(args.slice(1), 'pr:list');
     if (options.positionals.length > 0) die(`Unknown dev gh pr argument: ${options.positionals[0]}`, 'UNKNOWN_ARG');
     const repoRoot = repoRootFrom(options);
     const repoFullName = repositoryFullName(options, repoRoot);
@@ -564,7 +622,7 @@ function prCommand(args) {
     ghArgs.push('--body-file', bodyFile);
     runGhAndExit(ghArgs, repoRoot);
   } else if (action === 'merge') {
-    const options = parseOptions(args.slice(1), { prMerge: true });
+    const options = parseOptions(args.slice(1), 'pr:merge');
     if (options.positionals.length === 0) die('dev gh pr merge requires exactly one PR number', 'MISSING_ARG');
     if (options.positionals.length > 1) die(`Unknown dev gh pr argument: ${options.positionals[1]}`, 'UNKNOWN_ARG');
     const prNumber = options.positionals[0];

--- a/scripts/aos-dev-gh.mjs
+++ b/scripts/aos-dev-gh.mjs
@@ -27,6 +27,7 @@ const ISSUE_EDIT_VALUE_FLAGS = new Set([
   '--body-file',
 ]);
 const ISSUE_VIEW_JSON_FIELDS = 'number,title,state,url,body,labels,comments';
+const ISSUE_VIEW_TEMPLATE = '{{printf "#%v %s\\n%s\\n\\n%s\\n" .number .title .url .body}}';
 
 const FLAG_SPECS = {
   '--json': { assign: (options) => { options.json = true; } },
@@ -573,6 +574,7 @@ function issueCommand(args) {
     const ghArgs = ['issue', 'view', options.positionals[0]];
     appendRepo(ghArgs, repoFullName);
     if (options.json) ghArgs.push('--json', ISSUE_VIEW_JSON_FIELDS);
+    else ghArgs.push('--json', ISSUE_VIEW_JSON_FIELDS, '--template', ISSUE_VIEW_TEMPLATE);
     runGhAndExit(ghArgs, repoRoot);
   } else if (action === 'comment') {
     const options = parseOptions(args.slice(1));

--- a/scripts/aos-dev-gh.mjs
+++ b/scripts/aos-dev-gh.mjs
@@ -17,17 +17,12 @@ const COMMON_FLAGS = new Set(['--json', '--repo', '--cwd', '--body-file', '--pr'
 const LIST_FLAGS = new Set(['--state', '--limit', '--label', '--author', '--assignee', '--search']);
 const PR_LIST_FLAGS = new Set(['--base', '--head', '--draft']);
 const PR_MERGE_STRATEGY_FLAGS = new Set(['--squash', '--merge', '--rebase']);
-const ISSUE_EDIT_VALUE_FLAGS = new Set([
-  '--add-label',
-  '--remove-label',
-  '--add-assignee',
-  '--remove-assignee',
-  '--milestone',
-  '--title',
-  '--body-file',
-]);
 const ISSUE_VIEW_JSON_FIELDS = 'number,title,state,url,body,labels,comments';
 const ISSUE_VIEW_TEMPLATE = '{{printf "#%v %s\\n%s\\n\\n%s\\n" .number .title .url .body}}';
+
+function appendOperation(options, value, _command, flag) {
+  options.issueEditOperations.push({ flag, value });
+}
 
 const FLAG_SPECS = {
   '--json': { assign: (options) => { options.json = true; } },
@@ -41,14 +36,16 @@ const FLAG_SPECS = {
   },
   '--body-file': {
     summary: 'a path',
-    assign: (options, value) => {
+    assign: (options, value, command, flag) => {
       options.bodyFile = value;
+      if (command === 'issue:edit') appendOperation(options, value, command, flag);
     },
   },
   '--title': {
     summary: 'an issue title',
-    assign: (options, value) => {
+    assign: (options, value, command, flag) => {
       options.title = value;
+      if (command === 'issue:edit') appendOperation(options, value, command, flag);
     },
     invalid: '--title is only valid for issue create and edit subcommands',
   },
@@ -91,12 +88,12 @@ const FLAG_SPECS = {
   },
   '--add-label': {
     summary: 'a label name',
-    assign: () => {},
+    assign: appendOperation,
     invalid: '--add-label is only valid for issue edit subcommands',
   },
   '--remove-label': {
     summary: 'a label name',
-    assign: () => {},
+    assign: appendOperation,
     invalid: '--remove-label is only valid for issue edit subcommands',
   },
   '--author': {
@@ -105,7 +102,7 @@ const FLAG_SPECS = {
     invalid: '--author is only valid for list subcommands',
   },
   '--assignee': {
-    summary: (command) => command === 'issue:create' ? 'a GitHub login or @me' : 'a GitHub login or @me',
+    summary: 'a GitHub login or @me',
     assign: (options, value, command) => {
       if (command === 'issue:create') options.assignees.push(value);
       else options.assignee = value;
@@ -114,12 +111,12 @@ const FLAG_SPECS = {
   },
   '--add-assignee': {
     summary: 'a GitHub login or @me',
-    assign: () => {},
+    assign: appendOperation,
     invalid: '--add-assignee is only valid for issue edit subcommands',
   },
   '--remove-assignee': {
     summary: 'a GitHub login or @me',
-    assign: () => {},
+    assign: appendOperation,
     invalid: '--remove-assignee is only valid for issue edit subcommands',
   },
   '--search': {
@@ -129,8 +126,9 @@ const FLAG_SPECS = {
   },
   '--milestone': {
     summary: 'an issue milestone name',
-    assign: (options, value) => {
+    assign: (options, value, command, flag) => {
       options.milestone = value;
+      if (command === 'issue:edit') appendOperation(options, value, command, flag);
     },
   },
   '--base': {
@@ -193,7 +191,8 @@ function flagErrorMessage(flag, command, allowedFlags) {
   const spec = FLAG_SPECS[flag];
   if (!spec) return null;
   if (allowedFlags.has(flag)) return null;
-  if (spec.invalid && !allowedFlags.has(flag)) return spec.invalid;
+  if (command === 'label:list' && flag === '--state') return `Unknown dev gh flag: ${flag}`;
+  if (spec.invalid) return spec.invalid;
   if (LIST_FLAGS.has(flag) && !command.endsWith(':list')) return `${flag} is only valid for list subcommands`;
   if (PR_LIST_FLAGS.has(flag) && !command.endsWith(':list')) return `${flag} is only valid for PR list subcommands`;
   if ((PR_MERGE_STRATEGY_FLAGS.has(flag) || flag === '--match-head-commit') && command !== 'pr:merge') {
@@ -247,9 +246,6 @@ function parseOptions(args, command = 'common') {
         const summary = typeof spec.summary === 'function' ? spec.summary(command) : spec.summary;
         const value = requireValueAt(i, arg, summary);
         spec.assign(options, value, command, arg);
-        if (command === 'issue:edit' && ISSUE_EDIT_VALUE_FLAGS.has(arg)) {
-          options.issueEditOperations.push({ flag: arg, value });
-        }
         i += 2;
       } else {
         spec.assign(options, null, command, arg);

--- a/scripts/aos-dev-gh.mjs
+++ b/scripts/aos-dev-gh.mjs
@@ -17,6 +17,7 @@ const COMMON_FLAGS = new Set(['--json', '--repo', '--cwd', '--body-file', '--pr'
 const LIST_FLAGS = new Set(['--state', '--limit', '--label', '--author', '--assignee', '--search']);
 const PR_LIST_FLAGS = new Set(['--base', '--head', '--draft']);
 const PR_MERGE_STRATEGY_FLAGS = new Set(['--squash', '--merge', '--rebase']);
+const ISSUE_VIEW_JSON_FIELDS = 'number,title,state,url,body,labels,comments';
 
 const FLAG_SPECS = {
   '--json': { assign: (options) => { options.json = true; } },
@@ -510,7 +511,7 @@ function issueCommand(args) {
     const repoFullName = repositoryFullName(options, repoRoot);
     const ghArgs = ['issue', 'view', options.positionals[0]];
     appendRepo(ghArgs, repoFullName);
-    if (options.json) ghArgs.push('--json', 'number,title,state,url,body,labels,comments');
+    if (options.json) ghArgs.push('--json', ISSUE_VIEW_JSON_FIELDS);
     runGhAndExit(ghArgs, repoRoot);
   } else if (action === 'comment') {
     const options = parseOptions(args.slice(1));

--- a/tests/dev-workflow-router.sh
+++ b/tests/dev-workflow-router.sh
@@ -485,6 +485,7 @@ assert "dev.github.pr_list" in ids, ids
 assert "dev.github.issue_comment" in ids, ids
 assert "dev.github.issue_create" in ids, ids
 assert "dev.github.issue_close" in ids, ids
+assert "dev.github.issue_edit" in ids, ids
 assert "dev.github.label_list" in ids, ids
 assert "dev.github.pr_comment" in ids, ids
 assert "dev.github.pr_merge" in ids, ids
@@ -579,6 +580,27 @@ else
     fail "dev capabilities explain did not return expected issue close metadata"
 fi
 
+if OUT="$(./aos dev capabilities explain dev.github.issue_edit --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+capability = data["capability"]
+assert capability["id"] == "dev.github.issue_edit", data
+assert capability["adapter"]["kind"] == "aos_cli", data
+assert capability["mutability"]["class"] == "external_write", data
+assert capability["mutability"]["requires_explicit_assignment"] is True, data
+assert capability["mutability"]["requires_human_approval"] is False, data
+assert capability["mutability"]["requires_body_file"] is False, data
+assert capability["execution"]["audit"] == "required", data
+assert capability["execution"]["raw_process"] is False, data
+PY
+then
+    pass "dev capabilities explain returns issue edit metadata"
+else
+    fail "dev capabilities explain did not return expected issue edit metadata"
+fi
+
 if OUT="$(./aos dev capabilities explain dev.github.label_list --json 2>/dev/null)" python3 - <<'PY'
 import json
 import os
@@ -662,6 +684,7 @@ assert "dev.github.pr_list" in ids, ids
 assert "dev.github.issue_comment" in ids, ids
 assert "dev.github.issue_create" in ids, ids
 assert "dev.github.issue_close" in ids, ids
+assert "dev.github.issue_edit" in ids, ids
 assert "dev.github.label_list" in ids, ids
 assert "dev.github.pr_comment" in ids, ids
 assert "dev.github.pr_merge" in ids, ids
@@ -705,6 +728,7 @@ assert "dev.github.pr_checks" in ids, ids
 assert "dev.github.issue_comment" not in ids, ids
 assert "dev.github.issue_create" not in ids, ids
 assert "dev.github.issue_close" not in ids, ids
+assert "dev.github.issue_edit" not in ids, ids
 assert "dev.github.pr_comment" not in ids, ids
 assert "dev.github.pr_merge" not in ids, ids
 assert "dev.build.aos" in ids, ids
@@ -746,6 +770,7 @@ assert "dev.github.ci_inspect" in ids, ids
 assert "dev.github.issue_comment" not in ids, ids
 assert "dev.github.issue_create" not in ids, ids
 assert "dev.github.issue_close" not in ids, ids
+assert "dev.github.issue_edit" not in ids, ids
 assert "dev.github.pr_comment" not in ids, ids
 assert "dev.github.pr_merge" not in ids, ids
 assert all(item["mutability_class"] == "read_only" for item in data["capabilities"]), data
@@ -795,6 +820,10 @@ if [[ "$cmd" == issue\ create\ --repo\ michaelblum/agent-os\ --title\ Strategic\
 fi
 if [[ "$cmd" == "issue close 411 --repo michaelblum/agent-os --reason completed" ]]; then
     echo "✓ Closed issue michaelblum/agent-os#411"
+    exit 0
+fi
+if [[ "$cmd" == issue\ edit\ 407\ --repo\ michaelblum/agent-os\ --remove-label\ lane:active\ --add-label\ lane:parked\ --add-assignee\ @me\ --remove-assignee\ old-owner\ --milestone\ v1\ --title\ Parked\ ledger\ --body-file\ * ]]; then
+    echo "https://github.com/michaelblum/agent-os/issues/407"
     exit 0
 fi
 if [[ "$cmd" == "issue view 298 --repo michaelblum/agent-os --json number,title,state,url,body,labels,comments" ]]; then
@@ -1017,6 +1046,47 @@ elif echo "$ERR" | grep -q -- 'dev gh issue close does not accept --body-file'; 
     pass "dev gh issue close rejects body files"
 else
     fail "dev gh issue close body-file error mismatch: $ERR"
+fi
+
+: > "$GH_ARGS_LOG"
+if OUT="$(./aos dev gh issue edit 407 --remove-label lane:active --add-label lane:parked --add-assignee @me --remove-assignee old-owner --milestone v1 --title "Parked ledger" --body-file "$BODY" 2>/dev/null)" &&
+   grep -q "issue edit 407 --repo michaelblum/agent-os --remove-label lane:active --add-label lane:parked --add-assignee @me --remove-assignee old-owner --milestone v1 --title Parked ledger --body-file $BODY" "$GH_ARGS_LOG" &&
+   echo "$OUT" | grep -q "issues/407"; then
+    pass "dev gh issue edit shells out with explicit lifecycle flags"
+else
+    fail "dev gh issue edit did not shell out through expected gh invocation"
+fi
+
+if ERR="$(./aos dev gh issue edit 2>&1 >/dev/null)"; then
+    fail "dev gh issue edit should require an issue number"
+elif echo "$ERR" | grep -q -- 'dev gh issue edit requires exactly one issue number'; then
+    pass "dev gh issue edit requires an issue number"
+else
+    fail "dev gh issue edit missing issue error mismatch: $ERR"
+fi
+
+if ERR="$(./aos dev gh issue edit current --add-label lane:parked 2>&1 >/dev/null)"; then
+    fail "dev gh issue edit should require a numeric issue"
+elif echo "$ERR" | grep -q -- 'Issue number must be numeric for edit: current'; then
+    pass "dev gh issue edit rejects non-numeric issues"
+else
+    fail "dev gh issue edit non-numeric issue error mismatch: $ERR"
+fi
+
+if ERR="$(./aos dev gh issue edit 407 2>&1 >/dev/null)"; then
+    fail "dev gh issue edit should reject no-op edits"
+elif echo "$ERR" | grep -q -- 'dev gh issue edit requires at least one edit flag'; then
+    pass "dev gh issue edit rejects no-op edits"
+else
+    fail "dev gh issue edit no-op error mismatch: $ERR"
+fi
+
+if ERR="$(./aos dev gh issue edit 407 --body-file "$TMPDIR/missing-issue-edit-body.md" 2>&1 >/dev/null)"; then
+    fail "dev gh issue edit should reject missing body files"
+elif echo "$ERR" | grep -q -- 'Missing issue body file:'; then
+    pass "dev gh issue edit rejects missing body files"
+else
+    fail "dev gh issue edit missing body file error mismatch: $ERR"
 fi
 
 if OUT="$(./aos dev gh label list --limit 10 --search governance --sort name --order desc --json 2>/dev/null)" python3 - <<'PY'

--- a/tests/dev-workflow-router.sh
+++ b/tests/dev-workflow-router.sh
@@ -830,6 +830,15 @@ if [[ "$cmd" == "issue view 298 --repo michaelblum/agent-os --json number,title,
     echo '{"number":298,"title":"Governance ledger","state":"OPEN","url":"https://github.com/michaelblum/agent-os/issues/298","labels":[],"comments":[]}'
     exit 0
 fi
+if [[ "$cmd" == issue\ view\ 298\ --repo\ michaelblum/agent-os\ --json\ number,title,state,url,body,labels,comments\ --template\ * ]]; then
+    echo "#298 Governance ledger"
+    echo "https://github.com/michaelblum/agent-os/issues/298"
+    exit 0
+fi
+if [[ "$cmd" == "issue view 298 --repo michaelblum/agent-os" ]]; then
+    echo "GraphQL: Projects (classic) is being deprecated. (repository.issue.projectCards)" >&2
+    exit 1
+fi
 if [[ "$cmd" == issue\ view\ 298\ --repo\ michaelblum/agent-os\ --json\ *projectCards* ]]; then
     echo "GraphQL: Projects (classic) is being deprecated. (repository.issue.projectCards)" >&2
     exit 1
@@ -907,22 +916,14 @@ else
     fail "dev gh issue view extra positional error mismatch: $ERR"
 fi
 
-if OUT="$(./aos dev gh issue view 298 --json 2>/dev/null)" python3 - <<'PY'
-import json
-import os
-
-data = json.loads(os.environ["OUT"])
-assert data["number"] == 298, data
-assert data["title"] == "Governance ledger", data
-PY
-then
-    if grep -q "projectCards" "$GH_ARGS_LOG"; then
-        fail "dev gh issue view requested deprecated projectCards JSON field"
-    else
-        pass "dev gh issue view avoids deprecated projectCards JSON field"
-    fi
+: > "$GH_ARGS_LOG"
+if OUT="$(./aos dev gh issue view 298 2>/dev/null)" &&
+   echo "$OUT" | grep -q "#298 Governance ledger" &&
+   grep -q "issue view 298 --repo michaelblum/agent-os --json number,title,state,url,body,labels,comments --template" "$GH_ARGS_LOG" &&
+   ! grep -q "projectCards" "$GH_ARGS_LOG"; then
+    pass "dev gh issue view avoids deprecated projectCards on non-json output"
 else
-    fail "dev gh issue view did not return expected JSON"
+    fail "dev gh issue view did not force safe non-json fields"
 fi
 
 if OUT="$(./aos dev gh issue list --state all --limit 20 --label bug --label docs --search "semantic target" --milestone v0 --json 2>/dev/null)" python3 - <<'PY'

--- a/tests/dev-workflow-router.sh
+++ b/tests/dev-workflow-router.sh
@@ -797,6 +797,14 @@ if [[ "$cmd" == "issue close 411 --repo michaelblum/agent-os --reason completed"
     echo "✓ Closed issue michaelblum/agent-os#411"
     exit 0
 fi
+if [[ "$cmd" == "issue view 298 --repo michaelblum/agent-os --json number,title,state,url,body,labels,comments" ]]; then
+    echo '{"number":298,"title":"Governance ledger","state":"OPEN","url":"https://github.com/michaelblum/agent-os/issues/298","labels":[],"comments":[]}'
+    exit 0
+fi
+if [[ "$cmd" == issue\ view\ 298\ --repo\ michaelblum/agent-os\ --json\ *projectCards* ]]; then
+    echo "GraphQL: Projects (classic) is being deprecated. (repository.issue.projectCards)" >&2
+    exit 1
+fi
 if [[ "$cmd" == "issue list --repo michaelblum/agent-os --state all --limit 20 --label bug --label docs --search semantic target --milestone v0 --json number,title,state,url,createdAt,updatedAt,labels,assignees,author" ]]; then
     echo '[{"number":399,"title":"Track semantic target cleanup","state":"CLOSED","url":"https://github.com/michaelblum/agent-os/issues/399"}]'
     exit 0
@@ -868,6 +876,24 @@ elif echo "$ERR" | grep -q 'Unknown dev gh issue argument: extra'; then
     pass "dev gh issue view rejects extra positional args"
 else
     fail "dev gh issue view extra positional error mismatch: $ERR"
+fi
+
+if OUT="$(./aos dev gh issue view 298 --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert data["number"] == 298, data
+assert data["title"] == "Governance ledger", data
+PY
+then
+    if grep -q "projectCards" "$GH_ARGS_LOG"; then
+        fail "dev gh issue view requested deprecated projectCards JSON field"
+    else
+        pass "dev gh issue view avoids deprecated projectCards JSON field"
+    fi
+else
+    fail "dev gh issue view did not return expected JSON"
 fi
 
 if OUT="$(./aos dev gh issue list --state all --limit 20 --label bug --label docs --search "semantic target" --milestone v0 --json 2>/dev/null)" python3 - <<'PY'

--- a/tests/schemas/aos-agent-capability-manifest-v0.test.mjs
+++ b/tests/schemas/aos-agent-capability-manifest-v0.test.mjs
@@ -152,6 +152,7 @@ test('typed AOS GitHub capabilities stay non-raw and explicit for writes', async
     'dev.github.issue_comment',
     'dev.github.issue_create',
     'dev.github.issue_close',
+    'dev.github.issue_edit',
     'dev.github.pr_comment',
     'dev.github.pr_merge',
   ]) {
@@ -166,6 +167,7 @@ test('typed AOS GitHub capabilities stay non-raw and explicit for writes', async
   assert.equal(capabilities.get('dev.github.issue_comment').mutability.requires_body_file, true);
   assert.equal(capabilities.get('dev.github.issue_create').mutability.requires_body_file, true);
   assert.equal(capabilities.get('dev.github.issue_close').mutability.requires_body_file, false);
+  assert.equal(capabilities.get('dev.github.issue_edit').mutability.requires_body_file, false);
   assert.equal(capabilities.get('dev.github.pr_comment').mutability.requires_body_file, true);
   assert.equal(capabilities.get('dev.github.pr_merge').mutability.requires_body_file, false);
 });
@@ -181,6 +183,7 @@ test('canonical manifest includes the initial developer capability set', async (
     'dev.github.issue_comment',
     'dev.github.issue_create',
     'dev.github.issue_close',
+    'dev.github.issue_edit',
     'dev.github.label_list',
     'dev.github.pr_list',
     'dev.github.pr_view',

--- a/tests/schemas/aos-dock-profile-v0.test.mjs
+++ b/tests/schemas/aos-dock-profile-v0.test.mjs
@@ -143,6 +143,9 @@ test('role envelopes preserve the intended coordination boundaries', async () =>
   assert.ok(profiles.get('foreman').allowed_capabilities.includes('dev.github.issue_close'));
   assert.ok(!profiles.get('gdi').allowed_capabilities.includes('dev.github.issue_close'));
   assert.ok(!profiles.get('operator').allowed_capabilities.includes('dev.github.issue_close'));
+  assert.ok(profiles.get('foreman').allowed_capabilities.includes('dev.github.issue_edit'));
+  assert.ok(!profiles.get('gdi').allowed_capabilities.includes('dev.github.issue_edit'));
+  assert.ok(!profiles.get('operator').allowed_capabilities.includes('dev.github.issue_edit'));
   assert.ok(profiles.get('foreman').allowed_capabilities.includes('dev.github.pr_comment'));
   assert.ok(!profiles.get('gdi').allowed_capabilities.includes('dev.github.pr_comment'));
   assert.ok(!profiles.get('operator').allowed_capabilities.includes('dev.github.pr_comment'));


### PR DESCRIPTION
## Summary

- refactor `scripts/aos-dev-gh.mjs` option parsing into subcommand-owned flag specs
- keep issue view off deprecated Projects Classic `projectCards` JSON and add a regression check
- add Foreman-only `./aos dev gh issue edit` for explicit issue lifecycle metadata edits

## Verification

- `bash tests/dev-workflow-router.sh`
- `node --test tests/schemas/aos-agent-capability-manifest-v0.test.mjs`
- `node --test tests/schemas/aos-dock-profile-v0.test.mjs`
- `git diff --check`
- `git show --check --stat --oneline HEAD`

## Notes

Issue view root cause: requesting `projectCards` triggers GitHub GraphQL `repository.issue.projectCards` Projects Classic deprecation failures; the sanctioned view field set stays on issue fields and comments only.

Out of scope for this PR: PR editing, label create/delete, milestone CRUD, project mutations, and comment editing.