### PR TITLE
Add live orientation situation packet

### DIFF
--- a/.docks/AGENTS.md
+++ b/.docks/AGENTS.md
@@ -94,7 +94,10 @@ change permissions.
 
 When asked "where are we," when starting from a cold context, or when current
 execution state matters, orient from live systems before reading narrative
-artifacts:
+artifacts. Start with `./aos dev situation --json`; it aggregates the canonical
+Git, GitHub, and runtime sources below and records per-source command status.
+If a source reports partial failure, query that source directly instead of
+guessing the missing fact:
 
 - Git owns branch, commit, dirty-file, local-branch, remote-branch, and stash
   facts.
@@ -108,6 +111,11 @@ why a lane existed or why a decision was made. They are not authoritative for
 current issue/PR/branch/stash/runtime status. Cite issue and PR numbers by ID
 and query their current JSON instead of paraphrasing their title, labels, or
 state into new prose.
+
+`./aos dev drift-lint --json` is only a heuristic tripwire for unmarked durable
+status prose. A clean lint result does not prove docs are drift-free or current;
+the acceptance gate is reproducing the cold-session orientation from sourced
+live facts.
 
 ## GitHub Control Surface
 

--- a/.docks/foreman/AGENTS.md
+++ b/.docks/foreman/AGENTS.md
@@ -90,7 +90,10 @@ the bypass in the work note, review, or completion report.
 
 When asked to summarize current state, when starting from a cold context, or
 when deciding the next workstream step, query live systems before reading
-narrative artifacts:
+narrative artifacts. Start with `./aos dev situation --json`; it aggregates the
+canonical Git, GitHub, and runtime sources below and records per-source command
+status. If a source reports partial failure, query that source directly instead
+of guessing the missing fact:
 
 - Git for branch, commit, dirty-file, local-branch, remote-branch, and stash
   facts.
@@ -103,6 +106,11 @@ Treat ledgers, work cards, reports, issue bodies, and issue comments as
 historical rationale unless live state confirms the specific fact. Cite issue
 and PR numbers by ID; do not restate their title, labels, state, or lane as
 standing prose.
+
+`./aos dev drift-lint --json` is only a heuristic tripwire for unmarked durable
+status prose. A clean lint result does not prove docs are drift-free or current;
+the acceptance gate is reproducing the cold-session orientation from sourced
+live facts.
 
 ## Evergreen Strict Contracts
 

--- a/docs/design/2026-05-17-platform-debt-map.md
+++ b/docs/design/2026-05-17-platform-debt-map.md
@@ -60,7 +60,8 @@ These remain salient but are not the next two slices:
   parts of `avatar-main` remain transitional. Retire only with confidence
   evidence, telemetry, or a fresh regression proving the fallback is now debt
   rather than resilience.
-- **Test harness organization:** #162 remains valid. The serial live-canvas
+- **Test harness organization:** At the time of writing, #162 remained valid.
+  The serial live-canvas
   contract and test primitive/molecule guidance reduced risk, but broader file
   organization should wait for a cleaner routing window.
 - **Evidence workflow blocks:** #293 remains a useful abstraction gate. Do not

--- a/docs/design/agent-ui-affordance-synthesis-v0.md
+++ b/docs/design/agent-ui-affordance-synthesis-v0.md
@@ -256,8 +256,9 @@ accepted through the pure snapshot projection correction.
 
 - Action: Park the idea against #164 only as "underlying target record needed,"
   not as a commitment to top-level Playwright-style aliases.
-  - Why: #164 is the closest strategic owner, but it contains older dialect
-    language that can regress the current strict `see/do` discipline.
+  - Why: At the time of writing, #164 was the closest strategic owner, but it
+    contained older dialect language that can regress the current strict
+    `see/do` discipline. Query GitHub before treating it as the current owner.
   - Estimated effort: S.
   - Expected impact: medium.
 

--- a/docs/design/aos-work-records-and-self-healing-recipes.md
+++ b/docs/design/aos-work-records-and-self-healing-recipes.md
@@ -271,8 +271,9 @@ subject executable or inspectable. Tracked in #237.
 
 ## Relationship To Existing Work
 
-- #141 is the browser-only steerable-collection V0 projection. It should stay
-  scoped and can adopt work-record vocabulary when stable.
+- At the time of writing, #141 was the browser-only steerable-collection V0
+  projection. It should stay scoped and can adopt work-record vocabulary when
+  stable.
 - #148 should keep replay codegen deferred until #239 defines how codegen
   attaches to AOS work records.
 - #149 supervised runs already wants run control, timelines, evidence packs,

--- a/docs/design/html-workbench-expression-adoption-audit-2026-05-13.md
+++ b/docs/design/html-workbench-expression-adoption-audit-2026-05-13.md
@@ -59,11 +59,12 @@ source maps, semantic targets, Mermaid preservation records, capability flags,
 security policy, and resume/export behavior. It deliberately does not mutate
 source Markdown automatically.
 
-Artifact Bundle Subject V0 is also already integrated, not merely proposed.
-Issue #263 is closed as complete, with a read-only artifact-bundle subject,
-fixture, canonical subject helper, artifact bundle workbench, catalog/browser
-opening path, docs, tests, and live AOS verification evidence. The artifact
-bundle workbench covers gallery, preview, source, exports, provenance,
+Artifact Bundle Subject V0 is also already integrated, not merely proposed. At
+the time of writing, Issue #263 was closed as complete, with a read-only
+artifact-bundle subject, fixture, canonical subject helper, artifact bundle
+workbench, catalog/browser opening path, docs, tests, and live AOS verification
+evidence. The artifact bundle workbench covers gallery, preview, source, exports,
+provenance,
 validation, and linked work-record evidence.
 
 ## Reinforced Design Rule

--- a/docs/design/open-design-workbench-cross-reference.md
+++ b/docs/design/open-design-workbench-cross-reference.md
@@ -7,12 +7,12 @@ Tracking issue: #263.
 
 ## 2026-05-13 Status Update
 
-Issue #263 is closed as integrated. The repo now has a read-only Artifact
-Bundle Subject V0 with fixture, canonical subject helper, artifact bundle
-workbench, catalog/browser opening path, docs, tests, and live AOS verification
-evidence. The analysis in this note remains useful as adaptation rationale, but
-the "Proposed Narrow Path" section is historical. Future work should build from
-the live `aos.artifact_bundle` subject and
+As of 2026-05-13, issue #263 was closed as integrated. The repo had a read-only
+Artifact Bundle Subject V0 with fixture, canonical subject helper, artifact
+bundle workbench, catalog/browser opening path, docs, tests, and live AOS
+verification evidence. The analysis in this note remains useful as adaptation
+rationale, but the "Proposed Narrow Path" section is historical. Future work
+should build from the live `aos.artifact_bundle` subject and
 `aos://toolkit/components/artifact-bundle-workbench/index.html`, not restart the
 proposal.
 

--- a/docs/dev/workflow-rules.json
+++ b/docs/dev/workflow-rules.json
@@ -224,6 +224,8 @@
         "docs/dev/workflow-profiles.json",
         "docs/dev/workflow-profiles/**",
         "scripts/aos-dev-workflow.mjs",
+        "scripts/aos-dev-situation.mjs",
+        "scripts/aos-dev-drift-lint.mjs",
         "manifests/commands/aos-commands.json",
         "shared/schemas/dev-workflow-rules.schema.json",
         "shared/schemas/fixtures/dev-workflow-rules/**",
@@ -233,6 +235,8 @@
         "shared/schemas/fixtures/dev-workflow-profiles/**",
         "tests/dev-workflow-router.sh",
         "tests/dev-audit.sh",
+        "tests/dev-situation.sh",
+        "tests/dev-drift-lint.sh",
         "tests/schemas/dev-workflow-rules.test.mjs",
         "tests/schemas/dev-active-profile.test.mjs",
         "tests/schemas/dev-workflow-profiles.test.mjs"
@@ -271,6 +275,16 @@
           "id": "dev-audit-test",
           "command": "bash tests/dev-audit.sh",
           "reason": "Verify the dev grammar verifier reports evidence-backed pass and fail claims."
+        },
+        {
+          "id": "dev-situation-test",
+          "command": "bash tests/dev-situation.sh",
+          "reason": "Verify live orientation packets preserve per-source status, source traces, and no-synthesis partial failures."
+        },
+        {
+          "id": "dev-drift-lint-test",
+          "command": "bash tests/dev-drift-lint.sh",
+          "reason": "Verify the heuristic durable-status tripwire distinguishes historical blocks from unmarked standing claims."
         }
       ],
       "verification": []

--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -5856,6 +5856,145 @@
         {
           "args" : [
             {
+              "id" : "repo",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Repository root path",
+              "token" : "--repo",
+              "value_type" : "string"
+            },
+            {
+              "id" : "issue-limit",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Maximum open issues to include",
+              "token" : "--issue-limit",
+              "value_type" : "integer"
+            },
+            {
+              "id" : "recent-issue-limit",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Maximum recent issues to include",
+              "token" : "--recent-issue-limit",
+              "value_type" : "integer"
+            },
+            {
+              "id" : "pr-limit",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Maximum open pull requests to include",
+              "token" : "--pr-limit",
+              "value_type" : "integer"
+            },
+            {
+              "id" : "json",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Emit machine-readable sourced orientation packet",
+              "token" : "--json",
+              "value_type" : "bool"
+            }
+          ],
+          "examples" : [
+            "aos dev situation --json",
+            "aos dev situation --issue-limit 20 --pr-limit 20 --json"
+          ],
+          "execution" : {
+            "auto_starts_daemon" : false,
+            "interactive" : false,
+            "mutates_state" : false,
+            "read_only" : true,
+            "requires_permissions" : false,
+            "streaming" : false,
+            "supports_dry_run" : false
+          },
+          "id" : "dev-situation",
+          "output" : {
+            "default_mode" : "text",
+            "error_mode" : "json_stderr",
+            "streaming" : false,
+            "supports_json_flag" : true
+          },
+          "usage" : "aos dev situation [--repo <path>] [--issue-limit <n>] [--recent-issue-limit <n>] [--pr-limit <n>] [--json]"
+        },
+        {
+          "args" : [
+            {
+              "id" : "paths",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Comma-separated markdown paths to lint",
+              "token" : "--paths",
+              "value_type" : "string"
+            },
+            {
+              "id" : "files",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Space-separated markdown paths to lint",
+              "token" : "--files",
+              "value_type" : "string",
+              "variadic" : true
+            },
+            {
+              "id" : "all-markdown",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Include archived work-card markdown in the heuristic scan",
+              "token" : "--all-markdown",
+              "value_type" : "bool"
+            },
+            {
+              "id" : "repo",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Repository root path",
+              "token" : "--repo",
+              "value_type" : "string"
+            },
+            {
+              "id" : "json",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Emit machine-readable heuristic lint findings",
+              "token" : "--json",
+              "value_type" : "bool"
+            },
+            {
+              "id" : "path",
+              "kind" : "positional",
+              "required" : false,
+              "summary" : "Markdown path",
+              "value_type" : "string",
+              "variadic" : true
+            }
+          ],
+          "examples" : [
+            "aos dev drift-lint --json",
+            "aos dev drift-lint --files docs/design/agent-relay-readiness-narrative-ledger-2026-06-04.md --json"
+          ],
+          "execution" : {
+            "auto_starts_daemon" : false,
+            "interactive" : false,
+            "mutates_state" : false,
+            "read_only" : true,
+            "requires_permissions" : false,
+            "streaming" : false,
+            "supports_dry_run" : false
+          },
+          "id" : "dev-drift-lint",
+          "output" : {
+            "default_mode" : "text",
+            "error_mode" : "json_stderr",
+            "streaming" : false,
+            "supports_json_flag" : true
+          },
+          "usage" : "aos dev drift-lint [--paths <path,...> | --files <path...>] [--all-markdown] [--repo <path>] [--json] [path...]"
+        },
+        {
+          "args" : [
+            {
               "id" : "release",
               "kind" : "flag",
               "required" : false,

--- a/manifests/commands/aos-external-commands.json
+++ b/manifests/commands/aos-external-commands.json
@@ -534,6 +534,27 @@
       }
     },
     {
+      "path": ["dev", "situation"],
+      "summary": "Aggregate sourced live orientation facts through the external dev situation command.",
+      "executable": "/usr/bin/env",
+      "argv_prefix": ["node", "scripts/aos-dev-situation.mjs"],
+      "cwd": "repo",
+      "env": {
+        "AOS_PATH": "$AOS_PATH",
+        "REPO_ROOT": "$REPO_ROOT"
+      }
+    },
+    {
+      "path": ["dev", "drift-lint"],
+      "summary": "Run the heuristic durable-status drift tripwire through the external dev drift-lint command.",
+      "executable": "/usr/bin/env",
+      "argv_prefix": ["node", "scripts/aos-dev-drift-lint.mjs"],
+      "cwd": "repo",
+      "env": {
+        "REPO_ROOT": "$REPO_ROOT"
+      }
+    },
+    {
       "path": ["dev", "build"],
       "summary": "Run the AOS build wrapper from the external dev build command.",
       "executable": "/usr/bin/env",

--- a/scripts/aos-dev-drift-lint.mjs
+++ b/scripts/aos-dev-drift-lint.mjs
@@ -18,21 +18,42 @@ const defaultExcludedPrefixes = [
   'docs/dev/work-cards/',
 ];
 
-const markerPattern = /\b(at the time of writing|as of\s+(?:\d{4}-\d{2}-\d{2}|[0-9a-f]{7,40})|observed (?:on|at)\s+\d{4}-\d{2}-\d{2}|historical|former|then-current|at commit\s+[0-9a-f]{7,40}|recorded at write time|snapshot|settlement)\b/i;
-const pastTensePattern = /\b(was merged|was closed|was observed|was created|was reported|was restored|was dropped|was settled|was retargeted|had been|reported|observed|created on|closed on|merged on)\b/i;
+const lifecycleKeywords = [
+  'open',
+  'closed',
+  'merged',
+  'active',
+  'parked',
+  'blocked',
+  'valid',
+  'closable',
+  'ready',
+  'waiting',
+];
+const lifecycleKeywordPattern = lifecycleKeywords.map(escapeRegex).join('|');
+const lifecycleKeywordLookaheads = lifecycleKeywords.map((keyword) => `(?!${escapeRegex(keyword)}\\b)`).join('');
+
+const claimMarkerPattern = /\b(at the time of writing|as of\s+(?:\d{4}-\d{2}-\d{2}|[0-9a-f]{7,40})|observed (?:on|at)\s+\d{4}-\d{2}-\d{2}|historical|former|then-current|at commit\s+[0-9a-f]{7,40}|recorded at write time|snapshot|settlement)\b/i;
+const evidenceHeadingPattern = /\b(\d{4}-\d{2}-\d{2}|as of\s+(?:\d{4}-\d{2}-\d{2}|[0-9a-f]{7,40})|observed (?:on|at)\s+\d{4}-\d{2}-\d{2}|at commit\s+[0-9a-f]{7,40})\b/i;
+const pastTensePattern = /\b(was merged|was closed|was observed|was created|was reported|was restored|was dropped|was removed|was settled|was retargeted|had been|reported|observed|created on|closed on|merged on)\b/i;
 const liveQueryPattern = /\b(Query (?:GitHub|Git|live|`?\.\/aos)|run `?git stash list`?|use `?\.\/aos dev gh|Use `?\.\/aos dev gh|GitHub for current|before assuming|before acting)\b/i;
+const pastTenseLicensedRuleIds = new Set([
+  'lane_label_standing_claim',
+  'stash_lifecycle_standing_claim',
+  'runtime_lifecycle_standing_claim',
+]);
 
 const rules = [
   {
     id: 'issue_lifecycle_standing_claim',
     reason: 'Issue or PR lifecycle status should be dated/historical or queried live.',
-    pattern: /(?:\b(?:issue|pr|pull request)\s+)?#\d+\s+(?:is|are|remains?|stays?|should\s+stay|still)\s+(?:open|closed|merged|active|parked|blocked|valid|closable|ready\b|waiting\b)/i,
+    pattern: new RegExp(String.raw`(?:\b(?:issue|pr|pull request)\s+)?#\d+\s+(?:is|are|remains?|stays?|should\s+stay|still)\s+(?:${lifecycleKeywordPattern})\b`, 'i'),
     suggested_fix: 'Cite the issue or PR number and query live JSON, or move the claim into a dated historical block.',
   },
   {
     id: 'issue_identity_paraphrase',
     reason: 'Issue identity should be cited by number and queried; scope paraphrases become stale.',
-    pattern: /(?:\b(?:issue|pr|pull request)\s+)?#\d+\s+(?:is|are)\s+(?!not\b)(?!the\b)(?!an?\s+older\b)(?!a\s+historical\b)(?!history\b)(?!open\b)(?!closed\b)(?!merged\b)(?!active\b)(?!parked\b)(?!blocked\b)(?!valid\b)(?!closable\b)(?!ready\b)(?!waiting\b)[^.!?\n]{3,}/i,
+    pattern: new RegExp(String.raw`(?:\b(?:issue|pr|pull request)\s+)?#\d+\s+(?:is|are)\s+(?!not\b)(?!an?\s+older\b)(?!a\s+historical\b)(?!history\b)${lifecycleKeywordLookaheads}[^.!?\n]{3,}`, 'i'),
     suggested_fix: 'Cite the number and query its current title, labels, and state instead of paraphrasing scope.',
   },
   {
@@ -62,12 +83,20 @@ const rules = [
 ];
 
 function printJSON(value) {
-  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+  process.stdout.write(formatJSON(value));
+}
+
+function formatJSON(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
 }
 
 function exitError(message, code) {
-  process.stderr.write(`{\n  "code" : "${code}",\n  "error" : "${message}"\n}\n`);
+  process.stderr.write(formatJSON({ code, error: message }));
   process.exit(1);
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function runGit(args, cwd) {
@@ -164,29 +193,58 @@ function headingText(line) {
   return line.replace(/^#{1,6}\s+/, '').trim();
 }
 
-function blockLicensed(text, headings) {
-  const scopeText = [text, ...headings].join('\n');
-  return markerPattern.test(scopeText) || pastTensePattern.test(text) || liveQueryPattern.test(text);
+function hasEvidenceHeading(headings) {
+  return headings.some((heading) => evidenceHeadingPattern.test(heading));
+}
+
+function claimScope(text, start, end) {
+  let scopeStart = 0;
+  for (const match of text.matchAll(/[.!?;\n]/g)) {
+    if (match.index < start) scopeStart = match.index + 1;
+    else break;
+  }
+  let scopeEnd = text.length;
+  for (const match of text.matchAll(/[.!?;\n]/g)) {
+    if (match.index >= end) {
+      scopeEnd = match.index;
+      break;
+    }
+  }
+  return text.slice(scopeStart, scopeEnd).trim();
+}
+
+function claimLicensed(prose, match, headings, rule) {
+  if (hasEvidenceHeading(headings)) return true;
+  const scope = claimScope(prose, match.index, match.index + match.text.length);
+  if (claimMarkerPattern.test(scope) || liveQueryPattern.test(scope)) return true;
+  return pastTenseLicensedRuleIds.has(rule.id) && pastTensePattern.test(scope);
+}
+
+function ruleMatches(rule, prose) {
+  const flags = rule.pattern.flags.includes('g') ? rule.pattern.flags : `${rule.pattern.flags}g`;
+  const pattern = new RegExp(rule.pattern.source, flags);
+  return [...prose.matchAll(pattern)].map((match) => ({
+    text: match[0],
+    index: match.index ?? 0,
+  }));
 }
 
 function checkBlock(block, headings, file, findings) {
-  const blockText = block.map((item) => stripInlineCode(item.text)).join('\n');
-  const licensed = blockLicensed(blockText, headings);
   for (const item of block) {
     const prose = stripInlineCode(item.text);
     if (!prose.trim()) continue;
     for (const rule of rules) {
-      const match = prose.match(rule.pattern);
-      if (!match) continue;
-      if (licensed) continue;
-      findings.push({
-        path: file,
-        line: item.line,
-        token: match[0].trim(),
-        rule_id: rule.id,
-        reason: rule.reason,
-        suggested_fix: rule.suggested_fix,
-      });
+      for (const match of ruleMatches(rule, prose)) {
+        if (claimLicensed(prose, match, headings, rule)) continue;
+        findings.push({
+          path: file,
+          line: item.line,
+          token: match.text.trim(),
+          rule_id: rule.id,
+          reason: rule.reason,
+          suggested_fix: rule.suggested_fix,
+        });
+      }
     }
   }
 }
@@ -256,7 +314,9 @@ function lint(options) {
       proof: false,
       notice: detectorNotice,
       denylist_complete: false,
-      block_scoped_markers: true,
+      block_scoped_markers: false,
+      claim_scoped_markers: true,
+      dated_heading_scoped_markers: true,
       excludes_fenced_code_blocks: true,
       excludes_inline_code_spans: true,
     },

--- a/scripts/aos-dev-drift-lint.mjs
+++ b/scripts/aos-dev-drift-lint.mjs
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const detectorNotice = 'Heuristic tripwire only: passing this lint does not prove durable docs are drift-free or current.';
+
+const defaultIncludePrefixes = [
+  '.docks/',
+  'docs/adr/',
+  'docs/design/',
+  'docs/dev/',
+];
+
+const defaultExcludedPrefixes = [
+  'docs/design/work-cards/',
+  'docs/dev/work-cards/',
+];
+
+const markerPattern = /\b(at the time of writing|as of\s+(?:\d{4}-\d{2}-\d{2}|[0-9a-f]{7,40})|observed (?:on|at)\s+\d{4}-\d{2}-\d{2}|historical|former|then-current|at commit\s+[0-9a-f]{7,40}|recorded at write time|snapshot|settlement)\b/i;
+const pastTensePattern = /\b(was merged|was closed|was observed|was created|was reported|was restored|was dropped|was settled|was retargeted|had been|reported|observed|created on|closed on|merged on)\b/i;
+const liveQueryPattern = /\b(Query (?:GitHub|Git|live|`?\.\/aos)|run `?git stash list`?|use `?\.\/aos dev gh|Use `?\.\/aos dev gh|GitHub for current|before assuming|before acting)\b/i;
+
+const rules = [
+  {
+    id: 'issue_lifecycle_standing_claim',
+    reason: 'Issue or PR lifecycle status should be dated/historical or queried live.',
+    pattern: /(?:\b(?:issue|pr|pull request)\s+)?#\d+\s+(?:is|are|remains?|stays?|should\s+stay|still)\s+(?:open|closed|merged|active|parked|blocked|valid|closable|ready\b|waiting\b)/i,
+    suggested_fix: 'Cite the issue or PR number and query live JSON, or move the claim into a dated historical block.',
+  },
+  {
+    id: 'issue_identity_paraphrase',
+    reason: 'Issue identity should be cited by number and queried; scope paraphrases become stale.',
+    pattern: /(?:\b(?:issue|pr|pull request)\s+)?#\d+\s+(?:is|are)\s+(?!not\b)(?!the\b)(?!an?\s+older\b)(?!a\s+historical\b)(?!history\b)(?!open\b)(?!closed\b)(?!merged\b)(?!active\b)(?!parked\b)(?!blocked\b)(?!valid\b)(?!closable\b)(?!ready\b)(?!waiting\b)[^.!?\n]{3,}/i,
+    suggested_fix: 'Cite the number and query its current title, labels, and state instead of paraphrasing scope.',
+  },
+  {
+    id: 'lane_label_standing_claim',
+    reason: 'Lane labels are live GitHub metadata, not durable standing prose.',
+    pattern: /\blane:(?:active|tech-debt|research|parked)\b/i,
+    suggested_fix: 'Query GitHub for current labels or mark the label reference as historical.',
+  },
+  {
+    id: 'branch_lifecycle_standing_claim',
+    reason: 'Branch lifecycle and ahead/behind state are live Git facts.',
+    pattern: /\b(?:only\s+real\s+branch\s+is|current\s+branch\s+(?:is|remains|stays|points|has|contains)|branch\s+(?:is|remains|stays)\s+(?:ahead|behind|clean|dirty|pushed|merged|open|closed))\b/i,
+    suggested_fix: 'Query Git for current branch state or mark the branch claim as historical.',
+  },
+  {
+    id: 'stash_lifecycle_standing_claim',
+    reason: 'Stash refs are live Git ordering facts unless explicitly historical.',
+    pattern: /\b(?:current\s+)?stash@\{\d+\}/i,
+    suggested_fix: 'Use a dated former-stash block or tell readers to run git stash list.',
+  },
+  {
+    id: 'runtime_lifecycle_standing_claim',
+    reason: 'Runtime readiness/status/tap state must come from ./aos ready/status at read time.',
+    pattern: /\b(?:ready=true|status=degraded|status=ok|tap=active|input[_ -]?tap=active)\b/i,
+    suggested_fix: 'Move runtime output into a dated evidence block or tell readers to run ./aos ready --json and ./aos status --json.',
+  },
+];
+
+function printJSON(value) {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function exitError(message, code) {
+  process.stderr.write(`{\n  "code" : "${code}",\n  "error" : "${message}"\n}\n`);
+  process.exit(1);
+}
+
+function runGit(args, cwd) {
+  const result = spawnSync('/usr/bin/git', args, { cwd, encoding: 'utf8' });
+  return {
+    exitCode: result.status ?? 127,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? (result.error ? `${result.error.message}\n` : ''),
+  };
+}
+
+function resolveRepoRoot(requested) {
+  const start = path.resolve(requested || process.env.REPO_ROOT || process.cwd());
+  const result = runGit(['-C', start, 'rev-parse', '--show-toplevel'], start);
+  if (result.exitCode === 0 && result.stdout.trim()) return path.resolve(result.stdout.trim());
+  return start;
+}
+
+function parseArgs(args) {
+  const options = { json: false, files: [], paths: [] };
+  for (let i = 0; i < args.length;) {
+    const arg = args[i];
+    if (arg === '--json') {
+      options.json = true;
+      i += 1;
+    } else if (arg === '--repo') {
+      if (i + 1 >= args.length || args[i + 1].startsWith('--')) exitError('--repo requires a path', 'MISSING_ARG');
+      options.repo = args[i + 1];
+      i += 2;
+    } else if (arg === '--paths') {
+      if (i + 1 >= args.length || args[i + 1].startsWith('--')) exitError('--paths requires a comma-separated path list', 'MISSING_ARG');
+      options.paths.push(...args[i + 1].split(',').filter(Boolean));
+      i += 2;
+    } else if (arg === '--files') {
+      i += 1;
+      let consumed = false;
+      while (i < args.length && !args[i].startsWith('--')) {
+        options.files.push(args[i]);
+        consumed = true;
+        i += 1;
+      }
+      if (!consumed) exitError('--files requires at least one path', 'MISSING_ARG');
+    } else if (arg === '--all-markdown') {
+      options.allMarkdown = true;
+      i += 1;
+    } else if (arg.startsWith('--')) {
+      exitError(`Unknown dev drift-lint flag: ${arg}`, 'UNKNOWN_FLAG');
+    } else {
+      options.files.push(arg);
+      i += 1;
+    }
+  }
+  return options;
+}
+
+function normalizeRepoRelative(value, repoRoot) {
+  const resolved = path.resolve(value);
+  const root = path.resolve(repoRoot);
+  if (resolved === root) return '.';
+  if (resolved.startsWith(`${root}${path.sep}`)) return resolved.slice(root.length + 1);
+  return value.replace(/^\.\//, '');
+}
+
+function defaultMarkdownFiles(repoRoot, includeArchives) {
+  const result = runGit(['ls-files', '-z', '--', '*.md'], repoRoot);
+  if (result.exitCode !== 0) exitError(`git ls-files failed: ${result.stderr.trim()}`, 'GIT_FAILED');
+  return result.stdout
+    .split('\0')
+    .filter(Boolean)
+    .filter((file) => defaultIncludePrefixes.some((prefix) => file.startsWith(prefix)))
+    .filter((file) => includeArchives || !defaultExcludedPrefixes.some((prefix) => file.startsWith(prefix)));
+}
+
+function selectedFiles(options, repoRoot) {
+  const explicit = [...options.paths, ...options.files];
+  const files = explicit.length ? explicit : defaultMarkdownFiles(repoRoot, options.allMarkdown);
+  return [...new Set(files.map((file) => normalizeRepoRelative(path.isAbsolute(file) ? file : path.join(repoRoot, file), repoRoot)))]
+    .filter((file) => file.endsWith('.md'));
+}
+
+function stripInlineCode(line) {
+  return line.replace(/`[^`]*`/g, '');
+}
+
+function isHeading(line) {
+  return /^(#{1,6})\s+/.test(line);
+}
+
+function headingDepth(line) {
+  return line.match(/^(#{1,6})\s+/)?.[1].length ?? 0;
+}
+
+function headingText(line) {
+  return line.replace(/^#{1,6}\s+/, '').trim();
+}
+
+function blockLicensed(text, headings) {
+  const scopeText = [text, ...headings].join('\n');
+  return markerPattern.test(scopeText) || pastTensePattern.test(text) || liveQueryPattern.test(text);
+}
+
+function checkBlock(block, headings, file, findings) {
+  const blockText = block.map((item) => stripInlineCode(item.text)).join('\n');
+  const licensed = blockLicensed(blockText, headings);
+  for (const item of block) {
+    const prose = stripInlineCode(item.text);
+    if (!prose.trim()) continue;
+    for (const rule of rules) {
+      const match = prose.match(rule.pattern);
+      if (!match) continue;
+      if (licensed) continue;
+      findings.push({
+        path: file,
+        line: item.line,
+        token: match[0].trim(),
+        rule_id: rule.id,
+        reason: rule.reason,
+        suggested_fix: rule.suggested_fix,
+      });
+    }
+  }
+}
+
+function lintMarkdown(file, repoRoot) {
+  const fullPath = path.join(repoRoot, file);
+  let raw;
+  try {
+    raw = fs.readFileSync(fullPath, 'utf8');
+  } catch (err) {
+    return [{
+      path: file,
+      line: 1,
+      token: file,
+      rule_id: 'file_unreadable',
+      reason: `Could not read file: ${err.message}`,
+      suggested_fix: 'Pass an existing markdown file path.',
+    }];
+  }
+
+  const findings = [];
+  const headings = [];
+  let block = [];
+  let fenced = false;
+  const lines = raw.split(/\r?\n/);
+
+  function flush() {
+    if (block.length) checkBlock(block, headings, file, findings);
+    block = [];
+  }
+
+  lines.forEach((line, index) => {
+    const lineNumber = index + 1;
+    if (/^\s*```/.test(line) || /^\s*~~~/.test(line)) {
+      flush();
+      fenced = !fenced;
+      return;
+    }
+    if (fenced) return;
+    if (isHeading(line)) {
+      flush();
+      const depth = headingDepth(line);
+      headings.length = Math.max(0, depth - 1);
+      headings[depth - 1] = headingText(line);
+      return;
+    }
+    if (!line.trim()) {
+      flush();
+      return;
+    }
+    block.push({ line: lineNumber, text: line });
+  });
+  flush();
+  return findings;
+}
+
+function lint(options) {
+  const repoRoot = resolveRepoRoot(options.repo);
+  const files = selectedFiles(options, repoRoot);
+  const findings = files.flatMap((file) => lintMarkdown(file, repoRoot));
+  return {
+    status: findings.length ? 'failed' : 'success',
+    schema_version: 1,
+    subject: 'durable-status-claim-drift-tripwire',
+    detector: {
+      kind: 'heuristic_tripwire',
+      proof: false,
+      notice: detectorNotice,
+      denylist_complete: false,
+      block_scoped_markers: true,
+      excludes_fenced_code_blocks: true,
+      excludes_inline_code_spans: true,
+    },
+    convention: 'Status claims about issues, PRs, branches, stashes, and runtime state must be dated, past-tense, fenced evidence, or instruct readers to query live sources.',
+    repo: repoRoot,
+    scanned_files: files,
+    findings,
+    summary: {
+      scanned_file_count: files.length,
+      finding_count: findings.length,
+    },
+  };
+}
+
+function printText(payload) {
+  process.stdout.write(`dev drift-lint: ${payload.status}\n`);
+  process.stdout.write(`${payload.detector.notice}\n`);
+  process.stdout.write(`Scanned files: ${payload.summary.scanned_file_count}\n`);
+  process.stdout.write(`Findings: ${payload.summary.finding_count}\n`);
+  for (const finding of payload.findings) {
+    process.stdout.write(`${finding.path}:${finding.line}: ${finding.rule_id}: ${finding.token}\n`);
+  }
+}
+
+const options = parseArgs(process.argv.slice(2));
+const payload = lint(options);
+options.json ? printJSON(payload) : printText(payload);
+process.exit(payload.findings.length ? 1 : 0);

--- a/scripts/aos-dev-situation.mjs
+++ b/scripts/aos-dev-situation.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+function printJSON(value) {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function exitError(message, code) {
+  process.stderr.write(`{\n  "code" : "${code}",\n  "error" : "${message}"\n}\n`);
+  process.exit(1);
+}
+
+function parsePositiveInteger(value, flag) {
+  if (!/^[0-9]+$/.test(value)) exitError(`${flag} must be numeric: ${value}`, 'INVALID_ARG');
+  const parsed = Number.parseInt(value, 10);
+  if (parsed < 1) exitError(`${flag} must be greater than zero: ${value}`, 'INVALID_ARG');
+  return parsed;
+}
+
+function parseArgs(args) {
+  const options = {
+    json: false,
+    issueLimit: 50,
+    recentIssueLimit: 20,
+    prLimit: 50,
+  };
+  for (let i = 0; i < args.length;) {
+    const arg = args[i];
+    if (arg === '--json') {
+      options.json = true;
+      i += 1;
+    } else if (arg === '--repo') {
+      if (i + 1 >= args.length || args[i + 1].startsWith('--')) exitError('--repo requires a path', 'MISSING_ARG');
+      options.repo = args[i + 1];
+      i += 2;
+    } else if (arg === '--issue-limit') {
+      if (i + 1 >= args.length || args[i + 1].startsWith('--')) exitError('--issue-limit requires a number', 'MISSING_ARG');
+      options.issueLimit = parsePositiveInteger(args[i + 1], '--issue-limit');
+      i += 2;
+    } else if (arg === '--recent-issue-limit') {
+      if (i + 1 >= args.length || args[i + 1].startsWith('--')) exitError('--recent-issue-limit requires a number', 'MISSING_ARG');
+      options.recentIssueLimit = parsePositiveInteger(args[i + 1], '--recent-issue-limit');
+      i += 2;
+    } else if (arg === '--pr-limit') {
+      if (i + 1 >= args.length || args[i + 1].startsWith('--')) exitError('--pr-limit requires a number', 'MISSING_ARG');
+      options.prLimit = parsePositiveInteger(args[i + 1], '--pr-limit');
+      i += 2;
+    } else if (arg.startsWith('--')) {
+      exitError(`Unknown dev situation flag: ${arg}`, 'UNKNOWN_FLAG');
+    } else {
+      exitError(`Unknown dev situation argument: ${arg}`, 'UNKNOWN_ARG');
+    }
+  }
+  return options;
+}
+
+function run(command, args, cwd) {
+  const result = spawnSync(command, args, { cwd, encoding: 'utf8' });
+  if (result.error) {
+    return {
+      exitCode: 127,
+      stdout: '',
+      stderr: `${result.error.message}\n`,
+    };
+  }
+  return {
+    exitCode: result.status ?? 0,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+function git(args, cwd) {
+  return run('/usr/bin/git', args, cwd);
+}
+
+function resolveRepoRoot(requested) {
+  const start = path.resolve(requested || process.env.REPO_ROOT || process.cwd());
+  const result = git(['-C', start, 'rev-parse', '--show-toplevel'], start);
+  if (result.exitCode === 0 && result.stdout.trim()) return path.resolve(result.stdout.trim());
+  return start;
+}
+
+function clip(text) {
+  const trimmed = String(text || '').trim();
+  if (!trimmed) return undefined;
+  const firstLines = trimmed.split(/\r?\n/).slice(0, 5).join('\n');
+  return firstLines.length > 700 ? `${firstLines.slice(0, 700)}...` : firstLines;
+}
+
+function commandString(executableLabel, args) {
+  return [executableLabel, ...args].join(' ');
+}
+
+function runSource(sources, id, executable, args, cwd, executableLabel = executable) {
+  const result = run(executable, args, cwd);
+  const source = {
+    id,
+    command: commandString(executableLabel, args),
+    status: result.exitCode === 0 ? 'success' : 'failed',
+    exit_code: result.exitCode,
+  };
+  if (source.status === 'failed') source.note = clip(result.stderr || result.stdout) || `exit=${result.exitCode}`;
+  sources.push(source);
+  return { source, result };
+}
+
+function parseJSONSource(source, result) {
+  if (source.status !== 'success') return null;
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    source.status = 'failed';
+    source.note = 'stdout was not valid JSON';
+    return null;
+  }
+}
+
+function outputLines(result) {
+  return result.stdout.split(/\r?\n/).filter(Boolean);
+}
+
+function parseStatus(stdout) {
+  const lines = stdout.split(/\r?\n/).filter(Boolean);
+  const branchLine = lines.find((line) => line.startsWith('## ')) || '';
+  const branchText = branchLine.replace(/^##\s+/, '');
+  const branch = branchText.split(/[ .[]/, 1)[0] || null;
+  return {
+    branch,
+    dirty_files: lines.filter((line) => !line.startsWith('## ')).length,
+    raw: lines,
+  };
+}
+
+function parseAheadBehind(stdout) {
+  const [behindRaw, aheadRaw] = stdout.trim().split(/\s+/);
+  const behind = Number.parseInt(behindRaw, 10);
+  const ahead = Number.parseInt(aheadRaw, 10);
+  return {
+    ahead: Number.isFinite(ahead) ? ahead : null,
+    behind: Number.isFinite(behind) ? behind : null,
+  };
+}
+
+function parseStash(line) {
+  const match = line.match(/^(stash@\{\d+\}):(?:\s+On\s+([^:]+):)?\s*(.*)$/);
+  if (!match) return { ref: null, branch: null, message: line, raw: line };
+  return {
+    ref: match[1],
+    branch: match[2] || null,
+    message: match[3] || '',
+    raw: line,
+  };
+}
+
+function setTrace(trace, key, ids) {
+  trace[key] = ids.filter(Boolean);
+}
+
+function buildSituation(options) {
+  const repoRoot = resolveRepoRoot(options.repo);
+  const sources = [];
+  const trace = {};
+  const aosPath = process.env.AOS_DEV_SITUATION_AOS_PATH || process.env.AOS_PATH || path.join(repoRoot, 'aos');
+  const aosLabel = './aos';
+
+  const gitStatus = runSource(sources, 'git_status', '/usr/bin/git', ['status', '--short', '--branch'], repoRoot, 'git');
+  const gitHead = runSource(sources, 'git_head', '/usr/bin/git', ['rev-parse', 'HEAD'], repoRoot, 'git');
+  const gitOriginMain = runSource(sources, 'git_origin_main', '/usr/bin/git', ['rev-parse', 'origin/main'], repoRoot, 'git');
+  const gitAheadBehind = runSource(sources, 'git_ahead_behind', '/usr/bin/git', ['rev-list', '--left-right', '--count', 'origin/main...HEAD'], repoRoot, 'git');
+  const gitLocalBranches = runSource(sources, 'git_local_branches', '/usr/bin/git', ['for-each-ref', '--format=%(refname:short)', 'refs/heads'], repoRoot, 'git');
+  const gitRemoteBranches = runSource(sources, 'git_remote_branches', '/usr/bin/git', ['for-each-ref', '--format=%(refname:short)', 'refs/remotes'], repoRoot, 'git');
+  const gitStashes = runSource(sources, 'git_stashes', '/usr/bin/git', ['stash', 'list'], repoRoot, 'git');
+
+  const ghContext = runSource(sources, 'github_context', aosPath, ['dev', 'gh', 'context', '--json'], repoRoot, aosLabel);
+  const ghOpenIssues = runSource(sources, 'github_open_issues', aosPath, ['dev', 'gh', 'issue', 'list', '--state', 'open', '--limit', String(options.issueLimit), '--json'], repoRoot, aosLabel);
+  const ghRecentIssues = runSource(sources, 'github_recent_issues', aosPath, ['dev', 'gh', 'issue', 'list', '--state', 'all', '--limit', String(options.recentIssueLimit), '--json'], repoRoot, aosLabel);
+  const ghOpenPRs = runSource(sources, 'github_open_prs', aosPath, ['dev', 'gh', 'pr', 'list', '--state', 'open', '--limit', String(options.prLimit), '--json'], repoRoot, aosLabel);
+  const ready = runSource(sources, 'aos_ready', aosPath, ['ready', '--json'], repoRoot, aosLabel);
+  const status = runSource(sources, 'aos_status', aosPath, ['status', '--json'], repoRoot, aosLabel);
+
+  const statusFacts = gitStatus.source.status === 'success' ? parseStatus(gitStatus.result.stdout) : null;
+  const aheadBehind = gitAheadBehind.source.status === 'success' ? parseAheadBehind(gitAheadBehind.result.stdout) : null;
+  const githubContext = parseJSONSource(ghContext.source, ghContext.result);
+  const openIssues = parseJSONSource(ghOpenIssues.source, ghOpenIssues.result);
+  const recentIssues = parseJSONSource(ghRecentIssues.source, ghRecentIssues.result);
+  const openPRs = parseJSONSource(ghOpenPRs.source, ghOpenPRs.result);
+  const readyJSON = parseJSONSource(ready.source, ready.result);
+  const statusJSON = parseJSONSource(status.source, status.result);
+
+  const gitPayload = {
+    branch: statusFacts?.branch ?? null,
+    head: gitHead.source.status === 'success' ? gitHead.result.stdout.trim() : null,
+    origin_main: gitOriginMain.source.status === 'success' ? gitOriginMain.result.stdout.trim() : null,
+    ahead_of_origin_main: aheadBehind?.ahead ?? null,
+    behind_origin_main: aheadBehind?.behind ?? null,
+    dirty_files: statusFacts?.dirty_files ?? null,
+    local_branches: gitLocalBranches.source.status === 'success' ? outputLines(gitLocalBranches.result) : null,
+    remote_branches: gitRemoteBranches.source.status === 'success' ? outputLines(gitRemoteBranches.result) : null,
+    stashes: gitStashes.source.status === 'success' ? outputLines(gitStashes.result).map(parseStash) : null,
+  };
+  setTrace(trace, 'git.branch', ['git_status']);
+  setTrace(trace, 'git.head', ['git_head']);
+  setTrace(trace, 'git.origin_main', ['git_origin_main']);
+  setTrace(trace, 'git.ahead_of_origin_main', ['git_ahead_behind']);
+  setTrace(trace, 'git.behind_origin_main', ['git_ahead_behind']);
+  setTrace(trace, 'git.dirty_files', ['git_status']);
+  setTrace(trace, 'git.local_branches', ['git_local_branches']);
+  setTrace(trace, 'git.remote_branches', ['git_remote_branches']);
+  setTrace(trace, 'git.stashes', ['git_stashes']);
+
+  const summary = {
+    clean: gitPayload.dirty_files === null ? null : gitPayload.dirty_files === 0,
+    synced_with_origin_main: gitPayload.ahead_of_origin_main === null || gitPayload.behind_origin_main === null
+      ? null
+      : gitPayload.ahead_of_origin_main === 0 && gitPayload.behind_origin_main === 0,
+    open_pr_count: Array.isArray(openPRs) ? openPRs.length : null,
+    open_issue_count: Array.isArray(openIssues) ? openIssues.length : null,
+    stash_count: Array.isArray(gitPayload.stashes) ? gitPayload.stashes.length : null,
+    runtime_ready: readyJSON && typeof readyJSON.ready === 'boolean' ? readyJSON.ready : null,
+  };
+  setTrace(trace, 'summary.clean', ['git_status']);
+  setTrace(trace, 'summary.synced_with_origin_main', ['git_ahead_behind']);
+  setTrace(trace, 'summary.open_pr_count', ['github_open_prs']);
+  setTrace(trace, 'summary.open_issue_count', ['github_open_issues']);
+  setTrace(trace, 'summary.stash_count', ['git_stashes']);
+  setTrace(trace, 'summary.runtime_ready', ['aos_ready']);
+
+  const failedSources = sources.filter((source) => source.status !== 'success');
+  const statusValue = failedSources.length === 0 ? 'success' : failedSources.length === sources.length ? 'failed' : 'partial';
+  return {
+    status: statusValue,
+    schema_version: 1,
+    generated_at: new Date().toISOString(),
+    repo: repoRoot,
+    sources,
+    source_trace: trace,
+    git: gitPayload,
+    github: {
+      context: githubContext,
+      open_issues: Array.isArray(openIssues) ? openIssues : null,
+      recent_issues: Array.isArray(recentIssues) ? recentIssues : null,
+      open_prs: Array.isArray(openPRs) ? openPRs : null,
+    },
+    runtime: {
+      ready: readyJSON,
+      status: statusJSON,
+    },
+    summary,
+  };
+}
+
+function printText(payload) {
+  process.stdout.write(`dev situation: ${payload.status}\n`);
+  process.stdout.write(`Repo: ${payload.repo}\n`);
+  process.stdout.write(`Branch: ${payload.git.branch ?? 'unknown'}\n`);
+  process.stdout.write(`Head: ${payload.git.head ?? 'unknown'}\n`);
+  process.stdout.write(`Clean: ${payload.summary.clean}\n`);
+  process.stdout.write(`Synced with origin/main: ${payload.summary.synced_with_origin_main}\n`);
+  process.stdout.write(`Open PRs: ${payload.summary.open_pr_count ?? 'unknown'}\n`);
+  process.stdout.write(`Open issues: ${payload.summary.open_issue_count ?? 'unknown'}\n`);
+  process.stdout.write(`Stashes: ${payload.summary.stash_count ?? 'unknown'}\n`);
+  process.stdout.write(`Runtime ready: ${payload.summary.runtime_ready ?? 'unknown'}\n`);
+  const failed = payload.sources.filter((source) => source.status !== 'success');
+  for (const source of failed) process.stdout.write(`Source failed: ${source.id} exit=${source.exit_code}${source.note ? ` ${source.note}` : ''}\n`);
+}
+
+const options = parseArgs(process.argv.slice(2));
+const payload = buildSituation(options);
+options.json ? printJSON(payload) : printText(payload);
+process.exit(payload.status === 'failed' ? 1 : 0);

--- a/scripts/aos-dev-situation.mjs
+++ b/scripts/aos-dev-situation.mjs
@@ -4,11 +4,15 @@ import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 
 function printJSON(value) {
-  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+  process.stdout.write(formatJSON(value));
+}
+
+function formatJSON(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
 }
 
 function exitError(message, code) {
-  process.stderr.write(`{\n  "code" : "${code}",\n  "error" : "${message}"\n}\n`);
+  process.stderr.write(formatJSON({ code, error: message }));
   process.exit(1);
 }
 
@@ -159,6 +163,21 @@ function setTrace(trace, key, ids) {
   trace[key] = ids.filter(Boolean);
 }
 
+function limitedCount(value, limit) {
+  if (!Array.isArray(value)) {
+    return {
+      count: null,
+      limit,
+      limitReached: null,
+    };
+  }
+  return {
+    count: value.length,
+    limit,
+    limitReached: value.length >= limit,
+  };
+}
+
 function buildSituation(options) {
   const repoRoot = resolveRepoRoot(options.repo);
   const sources = [];
@@ -211,20 +230,30 @@ function buildSituation(options) {
   setTrace(trace, 'git.remote_branches', ['git_remote_branches']);
   setTrace(trace, 'git.stashes', ['git_stashes']);
 
+  const openIssueCount = limitedCount(openIssues, options.issueLimit);
+  const openPRCount = limitedCount(openPRs, options.prLimit);
   const summary = {
     clean: gitPayload.dirty_files === null ? null : gitPayload.dirty_files === 0,
     synced_with_origin_main: gitPayload.ahead_of_origin_main === null || gitPayload.behind_origin_main === null
       ? null
       : gitPayload.ahead_of_origin_main === 0 && gitPayload.behind_origin_main === 0,
-    open_pr_count: Array.isArray(openPRs) ? openPRs.length : null,
-    open_issue_count: Array.isArray(openIssues) ? openIssues.length : null,
+    open_pr_count: openPRCount.count,
+    open_pr_count_limit: openPRCount.limit,
+    open_pr_count_limit_reached: openPRCount.limitReached,
+    open_issue_count: openIssueCount.count,
+    open_issue_count_limit: openIssueCount.limit,
+    open_issue_count_limit_reached: openIssueCount.limitReached,
     stash_count: Array.isArray(gitPayload.stashes) ? gitPayload.stashes.length : null,
     runtime_ready: readyJSON && typeof readyJSON.ready === 'boolean' ? readyJSON.ready : null,
   };
   setTrace(trace, 'summary.clean', ['git_status']);
   setTrace(trace, 'summary.synced_with_origin_main', ['git_ahead_behind']);
   setTrace(trace, 'summary.open_pr_count', ['github_open_prs']);
+  setTrace(trace, 'summary.open_pr_count_limit', ['github_open_prs']);
+  setTrace(trace, 'summary.open_pr_count_limit_reached', ['github_open_prs']);
   setTrace(trace, 'summary.open_issue_count', ['github_open_issues']);
+  setTrace(trace, 'summary.open_issue_count_limit', ['github_open_issues']);
+  setTrace(trace, 'summary.open_issue_count_limit_reached', ['github_open_issues']);
   setTrace(trace, 'summary.stash_count', ['git_stashes']);
   setTrace(trace, 'summary.runtime_ready', ['aos_ready']);
 
@@ -259,12 +288,17 @@ function printText(payload) {
   process.stdout.write(`Head: ${payload.git.head ?? 'unknown'}\n`);
   process.stdout.write(`Clean: ${payload.summary.clean}\n`);
   process.stdout.write(`Synced with origin/main: ${payload.summary.synced_with_origin_main}\n`);
-  process.stdout.write(`Open PRs: ${payload.summary.open_pr_count ?? 'unknown'}\n`);
-  process.stdout.write(`Open issues: ${payload.summary.open_issue_count ?? 'unknown'}\n`);
+  process.stdout.write(`Open PRs: ${limitedCountText(payload.summary.open_pr_count, payload.summary.open_pr_count_limit, payload.summary.open_pr_count_limit_reached)}\n`);
+  process.stdout.write(`Open issues: ${limitedCountText(payload.summary.open_issue_count, payload.summary.open_issue_count_limit, payload.summary.open_issue_count_limit_reached)}\n`);
   process.stdout.write(`Stashes: ${payload.summary.stash_count ?? 'unknown'}\n`);
   process.stdout.write(`Runtime ready: ${payload.summary.runtime_ready ?? 'unknown'}\n`);
   const failed = payload.sources.filter((source) => source.status !== 'success');
   for (const source of failed) process.stdout.write(`Source failed: ${source.id} exit=${source.exit_code}${source.note ? ` ${source.note}` : ''}\n`);
+}
+
+function limitedCountText(count, limit, limitReached) {
+  if (count === null || count === undefined) return 'unknown';
+  return limitReached ? `${count} (limit ${limit} reached)` : String(count);
 }
 
 const options = parseArgs(process.argv.slice(2));

--- a/scripts/aos-dev-workflow.mjs
+++ b/scripts/aos-dev-workflow.mjs
@@ -554,12 +554,14 @@ function auditRegistryClaims(repoRoot) {
     return [claim('dev-help-registry-present', 'The external help manifest exposes the dev command.', false, 'command path dev', 'missing', ['manifests/commands/aos-commands.json'], 'Register the dev command before trusting parser/help alignment.')];
   }
   const forms = new Map((dev.forms || []).map((form) => [form.id, form]));
-  const expectedForms = ['dev-classify', 'dev-recommend', 'dev-build', 'dev-afk-dry-run', 'dev-afk-launch-attempt', 'dev-afk-session-trigger', 'dev-audit', 'dev-capabilities', 'dev-docks', 'dev-gh'];
+  const expectedForms = ['dev-classify', 'dev-recommend', 'dev-situation', 'dev-drift-lint', 'dev-build', 'dev-afk-dry-run', 'dev-afk-launch-attempt', 'dev-afk-session-trigger', 'dev-audit', 'dev-capabilities', 'dev-docks', 'dev-gh'];
   const observedForms = (dev.forms || []).map((form) => form.id).sort();
   return [
     claim('dev-help-forms', 'External help manifest exposes the complete dev command surface.', expectedForms.every((id) => observedForms.includes(id)), expectedForms.slice().sort().join(','), observedForms.join(','), ['manifests/commands/aos-commands.json', './aos help dev --json'], 'Add the missing dev InvocationForm so agents can discover the command.'),
     auditFormFlagClaim('dev-classify-help-flags', forms.get('dev-classify'), ['--paths', '--files', '--manifest', '--base', '--repo', '--json'], true),
     auditFormFlagClaim('dev-recommend-help-flags', forms.get('dev-recommend'), ['--paths', '--files', '--manifest', '--base', '--repo', '--json'], true),
+    auditFormFlagClaim('dev-situation-help-flags', forms.get('dev-situation'), ['--repo', '--issue-limit', '--recent-issue-limit', '--pr-limit', '--json'], false),
+    auditFormFlagClaim('dev-drift-lint-help-flags', forms.get('dev-drift-lint'), ['--paths', '--files', '--all-markdown', '--repo', '--json'], false),
     auditFormFlagClaim('dev-afk-dry-run-help-flags', forms.get('dev-afk-dry-run'), ['--packet', '--provider', '--dock', '--repo', '--timestamp', '--out', '--json'], false),
     auditFormFlagClaim('dev-afk-launch-attempt-help-flags', forms.get('dev-afk-launch-attempt'), ['--packet', '--provider', '--dock', '--repo', '--timestamp', '--out', '--json', '--duplicate-in-process', '--catalog-fixture', '--bridge-visibility-fixture', '--provider-session-id', '--launch-observed-at', '--codex-home-fixture', '--codex-home'], false),
     auditFormFlagClaim('dev-afk-session-trigger-help-flags', forms.get('dev-afk-session-trigger'), ['--packet', '--afk-work-queue', '--queue-run-fixture', '--afk-authorization', '--sleep-lease', '--provider', '--dock', '--repo', '--timestamp', '--out', '--result-route', '--idempotence-salt', '--existing-receipt', '--replacement-for', '--dry-run', '--supervised-live-launch', '--afk-live-launch', '--sleep-lease-live-launch', '--i-am-present', '--provider-launch-dry-run', '--bridge-visibility-fixture', '--cleanup-proof-fixture', '--provider-session-id', '--launch-observed-at', '--codex-home-fixture', '--codex-home', '--json'], false),
@@ -573,8 +575,8 @@ function auditRegistryClaims(repoRoot) {
 function auditWorkflowManifestClaims(manifest) {
   const rule = (manifest.rules || []).find((item) => item.id === workflowRuleID);
   if (!rule) return [claim('dev-workflow-self-routes', 'The dev workflow manifest routes its own command, registry, and tests.', false, workflowRuleID, 'missing', [workflowDefaultManifest], `Add a ${workflowRuleID} rule to the workflow manifest.`)];
-  const expectedPatterns = ['docs/dev/workflow-rules.json', 'scripts/aos-dev-workflow.mjs', 'manifests/commands/aos-commands.json', 'tests/dev-workflow-router.sh', 'tests/dev-audit.sh', 'tests/schemas/dev-workflow-rules.test.mjs'];
-  const expectedCommands = ['node --test tests/schemas/dev-workflow-rules.test.mjs', 'bash tests/dev-workflow-router.sh', 'bash tests/dev-audit.sh'];
+  const expectedPatterns = ['docs/dev/workflow-rules.json', 'scripts/aos-dev-workflow.mjs', 'scripts/aos-dev-situation.mjs', 'scripts/aos-dev-drift-lint.mjs', 'manifests/commands/aos-commands.json', 'tests/dev-workflow-router.sh', 'tests/dev-audit.sh', 'tests/dev-situation.sh', 'tests/dev-drift-lint.sh', 'tests/schemas/dev-workflow-rules.test.mjs'];
+  const expectedCommands = ['node --test tests/schemas/dev-workflow-rules.test.mjs', 'bash tests/dev-workflow-router.sh', 'bash tests/dev-audit.sh', 'bash tests/dev-situation.sh', 'bash tests/dev-drift-lint.sh'];
   const patterns = rule.patterns || [];
   const commands = (rule.commands || []).map((item) => item.command);
   return [

--- a/tests/dev-audit.sh
+++ b/tests/dev-audit.sh
@@ -21,6 +21,8 @@ expected = {
     "dev-help-forms",
     "dev-classify-help-flags",
     "dev-recommend-help-flags",
+    "dev-situation-help-flags",
+    "dev-drift-lint-help-flags",
     "dev-audit-help-flags",
     "dev-workflow-self-routes",
     "dev-workflow-self-verifies",

--- a/tests/dev-drift-lint.sh
+++ b/tests/dev-drift-lint.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+FAILS=0
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1" >&2; FAILS=$((FAILS + 1)); }
+
+HISTORICAL="tests/fixtures/dev-drift-lint/historical-status.md"
+STANDING="tests/fixtures/dev-drift-lint/standing-status.md"
+IDENTITY="tests/fixtures/dev-drift-lint/identity-paraphrase.md"
+BLOCK_SCOPE="tests/fixtures/dev-drift-lint/block-scope.md"
+CODE_SPANS="tests/fixtures/dev-drift-lint/code-spans.md"
+NARRATIVE="docs/design/agent-relay-readiness-narrative-ledger-2026-06-04.md"
+export NARRATIVE
+
+if OUT="$(./aos dev drift-lint --files "$HISTORICAL" --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert data["status"] == "success", data
+assert data["detector"]["kind"] == "heuristic_tripwire", data
+assert data["detector"]["proof"] is False, data
+assert data["detector"]["denylist_complete"] is False, data
+assert data["summary"]["finding_count"] == 0, data
+assert data["scanned_files"] == ["tests/fixtures/dev-drift-lint/historical-status.md"], data
+PY
+then
+    pass "dev drift-lint permits dated historical status fixture"
+else
+    fail "dev drift-lint over-flagged historical fixture"
+fi
+
+if OUT="$(./aos dev drift-lint --files "$STANDING" --json 2>/dev/null)"; then
+    fail "dev drift-lint should fail unmarked standing status fixture"
+elif OUT="$OUT" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+rules = {finding["rule_id"] for finding in data["findings"]}
+assert data["status"] == "failed", data
+assert "issue_lifecycle_standing_claim" in rules, data
+assert "stash_lifecycle_standing_claim" in rules, data
+assert "runtime_lifecycle_standing_claim" in rules, data
+assert data["summary"]["finding_count"] >= 3, data
+PY
+then
+    pass "dev drift-lint blocks fabricated unmarked standing status claims"
+else
+    fail "dev drift-lint under-flagged standing status fixture"
+fi
+
+if OUT="$(./aos dev drift-lint --files "$IDENTITY" --json 2>/dev/null)"; then
+    fail "dev drift-lint should fail bare issue identity paraphrase fixture"
+elif OUT="$OUT" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert any(item["rule_id"] == "issue_identity_paraphrase" for item in data["findings"]), data
+assert any("Cite the number and query" in item["suggested_fix"] for item in data["findings"]), data
+PY
+then
+    pass "dev drift-lint blocks issue-number scope paraphrases"
+else
+    fail "dev drift-lint did not report issue identity paraphrase"
+fi
+
+if OUT="$(./aos dev drift-lint --files "$BLOCK_SCOPE" --json 2>/dev/null)"; then
+    fail "dev drift-lint should not let a prior historical block license a later standing claim"
+elif OUT="$OUT" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert data["summary"]["finding_count"] == 1, data
+finding = data["findings"][0]
+assert finding["line"] == 5, finding
+assert finding["token"] == "#222 is open", finding
+PY
+then
+    pass "dev drift-lint uses block-scoped markers instead of nearby-marker proximity"
+else
+    fail "dev drift-lint block-scoping behavior drifted"
+fi
+
+if OUT="$(./aos dev drift-lint --files "$CODE_SPANS" --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert data["status"] == "success", data
+assert data["detector"]["excludes_fenced_code_blocks"] is True, data
+assert data["detector"]["excludes_inline_code_spans"] is True, data
+assert data["summary"]["finding_count"] == 0, data
+PY
+then
+    pass "dev drift-lint excludes fenced code blocks and inline code spans"
+else
+    fail "dev drift-lint flagged code-span or fenced evidence text"
+fi
+
+if OUT="$(./aos dev drift-lint --files "$NARRATIVE" --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+data = json.loads(os.environ["OUT"])
+text = Path(os.environ["NARRATIVE"]).read_text(encoding="utf-8")
+assert text.count("stash@{") == 3, text.count("stash@{")
+assert data["status"] == "success", data
+assert data["summary"]["finding_count"] == 0, data
+PY
+then
+    pass "dev drift-lint permits historical stash refs in narrative ledger"
+else
+    fail "dev drift-lint over-flagged narrative ledger historical stash refs"
+fi
+
+if ERR="$(./aos dev drift-lint --bogus 2>&1 >/dev/null)"; then
+    fail "dev drift-lint should reject unknown flags"
+elif echo "$ERR" | grep -q '"code" : "UNKNOWN_FLAG"'; then
+    pass "dev drift-lint rejects unknown flags"
+else
+    fail "dev drift-lint unknown flag error drifted: $ERR"
+fi
+
+echo
+if [[ "$FAILS" -eq 0 ]]; then
+    echo "dev-drift-lint: all checks passed"
+    exit 0
+fi
+
+echo "dev-drift-lint: $FAILS failure(s)"
+exit 1

--- a/tests/dev-drift-lint.sh
+++ b/tests/dev-drift-lint.sh
@@ -13,6 +13,10 @@ STANDING="tests/fixtures/dev-drift-lint/standing-status.md"
 IDENTITY="tests/fixtures/dev-drift-lint/identity-paraphrase.md"
 BLOCK_SCOPE="tests/fixtures/dev-drift-lint/block-scope.md"
 CODE_SPANS="tests/fixtures/dev-drift-lint/code-spans.md"
+DATED_SAMELINE="tests/fixtures/dev-drift-lint/dated-sameline.md"
+SAME_LINE_CONTAMINATION="tests/fixtures/dev-drift-lint/same-line-contamination.md"
+SOFT_HEADING_SCOPE="tests/fixtures/dev-drift-lint/soft-heading-scope.md"
+COMBINED_CONTAMINATION="tests/fixtures/dev-drift-lint/combined-contamination.md"
 NARRATIVE="docs/design/agent-relay-readiness-narrative-ledger-2026-06-04.md"
 export NARRATIVE
 
@@ -25,6 +29,8 @@ assert data["status"] == "success", data
 assert data["detector"]["kind"] == "heuristic_tripwire", data
 assert data["detector"]["proof"] is False, data
 assert data["detector"]["denylist_complete"] is False, data
+assert data["detector"]["block_scoped_markers"] is False, data
+assert data["detector"]["claim_scoped_markers"] is True, data
 assert data["summary"]["finding_count"] == 0, data
 assert data["scanned_files"] == ["tests/fixtures/dev-drift-lint/historical-status.md"], data
 PY
@@ -83,9 +89,87 @@ assert finding["line"] == 5, finding
 assert finding["token"] == "#222 is open", finding
 PY
 then
-    pass "dev drift-lint uses block-scoped markers instead of nearby-marker proximity"
+    pass "dev drift-lint keeps nearby markers from licensing later claims"
 else
-    fail "dev drift-lint block-scoping behavior drifted"
+    fail "dev drift-lint nearby-marker behavior drifted"
+fi
+
+if OUT="$(./aos dev drift-lint --files "$DATED_SAMELINE" --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert data["status"] == "success", data
+assert data["summary"]["finding_count"] == 0, data
+PY
+then
+    pass "dev drift-lint permits same-clause dated status claims"
+else
+    fail "dev drift-lint over-flagged same-clause dated fixture"
+fi
+
+if OUT="$(./aos dev drift-lint --files "$SAME_LINE_CONTAMINATION" --json 2>/dev/null)"; then
+    fail "dev drift-lint should fail same-line two-sentence contamination"
+elif OUT="$OUT" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert data["status"] == "failed", data
+assert data["summary"]["finding_count"] == 1, data
+finding = data["findings"][0]
+assert finding["line"] == 3, finding
+assert finding["token"] == "#407 is open", finding
+assert finding["rule_id"] == "issue_lifecycle_standing_claim", finding
+PY
+then
+    pass "dev drift-lint catches same-line two-sentence contamination"
+else
+    fail "dev drift-lint missed same-line contamination"
+fi
+
+if OUT="$(./aos dev drift-lint --files "$SOFT_HEADING_SCOPE" --json 2>/dev/null)"; then
+    fail "dev drift-lint should fail fresh status under soft historical heading"
+elif OUT="$OUT" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert data["status"] == "failed", data
+assert data["summary"]["finding_count"] == 1, data
+finding = data["findings"][0]
+assert finding["line"] == 5, finding
+assert finding["token"] == "#407 is open", finding
+PY
+then
+    pass "dev drift-lint catches soft-heading scope contamination"
+else
+    fail "dev drift-lint missed soft-heading contamination"
+fi
+
+if OUT="$(./aos dev drift-lint --files "$COMBINED_CONTAMINATION" --json 2>/dev/null)"; then
+    fail "dev drift-lint should fail realistic ledger contamination"
+elif OUT="$OUT" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+tokens = {finding["token"] for finding in data["findings"]}
+rules = {finding["rule_id"] for finding in data["findings"]}
+assert data["status"] == "failed", data
+assert data["summary"]["finding_count"] == 4, data
+assert "#407 is open" in tokens, tokens
+assert "#411 is the parser simplification work" in tokens, tokens
+assert "#415 is closable" in tokens, tokens
+assert "lane:active" in tokens, tokens
+assert "issue_lifecycle_standing_claim" in rules, rules
+assert "issue_identity_paraphrase" in rules, rules
+assert "lane_label_standing_claim" in rules, rules
+PY
+then
+    pass "dev drift-lint catches every claim in realistic ledger contamination"
+else
+    fail "dev drift-lint missed realistic ledger contamination"
 fi
 
 if OUT="$(./aos dev drift-lint --files "$CODE_SPANS" --json 2>/dev/null)" python3 - <<'PY'
@@ -123,7 +207,15 @@ fi
 
 if ERR="$(./aos dev drift-lint --bogus 2>&1 >/dev/null)"; then
     fail "dev drift-lint should reject unknown flags"
-elif echo "$ERR" | grep -q '"code" : "UNKNOWN_FLAG"'; then
+elif ERR="$ERR" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["ERR"])
+assert data["code"] == "UNKNOWN_FLAG", data
+assert "Unknown dev drift-lint flag" in data["error"], data
+PY
+then
     pass "dev drift-lint rejects unknown flags"
 else
     fail "dev drift-lint unknown flag error drifted: $ERR"

--- a/tests/dev-situation.sh
+++ b/tests/dev-situation.sh
@@ -80,7 +80,11 @@ assert data["git"]["behind_origin_main"] == 0, data
 assert data["summary"]["clean"] is True, data
 assert data["summary"]["synced_with_origin_main"] is True, data
 assert data["summary"]["open_issue_count"] == 2, data
+assert data["summary"]["open_issue_count_limit"] == 2, data
+assert data["summary"]["open_issue_count_limit_reached"] is True, data
 assert data["summary"]["open_pr_count"] == 1, data
+assert data["summary"]["open_pr_count_limit"] == 4, data
+assert data["summary"]["open_pr_count_limit_reached"] is False, data
 assert data["summary"]["stash_count"] == 1, data
 assert data["summary"]["runtime_ready"] is True, data
 assert "notes" not in data["summary"], data["summary"]
@@ -90,7 +94,11 @@ for key, source_id in {
     "summary.clean": "git_status",
     "summary.synced_with_origin_main": "git_ahead_behind",
     "summary.open_issue_count": "github_open_issues",
+    "summary.open_issue_count_limit": "github_open_issues",
+    "summary.open_issue_count_limit_reached": "github_open_issues",
     "summary.open_pr_count": "github_open_prs",
+    "summary.open_pr_count_limit": "github_open_prs",
+    "summary.open_pr_count_limit_reached": "github_open_prs",
     "summary.stash_count": "git_stashes",
     "summary.runtime_ready": "aos_ready",
 }.items():
@@ -166,7 +174,15 @@ fi
 
 if ERR="$(./aos dev situation --bogus 2>&1 >/dev/null)"; then
     fail "dev situation should reject unknown flags"
-elif echo "$ERR" | grep -q '"code" : "UNKNOWN_FLAG"'; then
+elif ERR="$ERR" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["ERR"])
+assert data["code"] == "UNKNOWN_FLAG", data
+assert "Unknown dev situation flag" in data["error"], data
+PY
+then
     pass "dev situation rejects unknown flags"
 else
     fail "dev situation unknown flag error drifted: $ERR"

--- a/tests/dev-situation.sh
+++ b/tests/dev-situation.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+FAILS=0
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1" >&2; FAILS=$((FAILS + 1)); }
+
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/aos-dev-situation.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+REPO="$TMPDIR/repo"
+export REPO
+mkdir -p "$REPO"
+git -C "$REPO" init -q
+git -C "$REPO" config user.email "dev-situation@example.invalid"
+git -C "$REPO" config user.name "Dev Situation Test"
+printf 'one\n' > "$REPO/file.txt"
+git -C "$REPO" add file.txt
+git -C "$REPO" commit -q -m "initial"
+git -C "$REPO" branch -M main
+git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+printf 'two\n' >> "$REPO/file.txt"
+git -C "$REPO" stash push -q -m "preserve test stash"
+
+FAKE_AOS="$TMPDIR/aos"
+FAKE_LOG="$TMPDIR/fake-aos.log"
+cat > "$FAKE_AOS" <<SH
+#!/usr/bin/env bash
+set -euo pipefail
+cmd="\$*"
+printf '%s\n' "\$cmd" >> "$FAKE_LOG"
+case "\$cmd" in
+  "dev gh context --json")
+    printf '%s\n' '{"status":"success","authority":"gh_cli","repository":"michaelblum/agent-os","default_branch":"main"}'
+    ;;
+  "dev gh issue list --state open --limit 2 --json")
+    printf '%s\n' '[{"number":414,"state":"OPEN"},{"number":411,"state":"OPEN"}]'
+    ;;
+  "dev gh issue list --state all --limit 3 --json")
+    printf '%s\n' '[{"number":414,"state":"OPEN"},{"number":411,"state":"OPEN"},{"number":407,"state":"CLOSED"}]'
+    ;;
+  "dev gh pr list --state open --limit 4 --json")
+    printf '%s\n' '[{"number":415,"state":"OPEN"}]'
+    ;;
+  "ready --json")
+    printf '%s\n' '{"status":"ok","ready":true,"phase":"ready"}'
+    ;;
+  "status --json")
+    if [[ "\${FAKE_AOS_FAIL_STATUS:-0}" == "1" ]]; then
+      echo "status exploded" >&2
+      exit 7
+    fi
+    printf '%s\n' '{"status":"ok","runtime":{"daemon_running":true}}'
+    ;;
+  *)
+    echo "unexpected fake aos invocation: \$cmd" >&2
+    exit 64
+    ;;
+esac
+SH
+chmod +x "$FAKE_AOS"
+
+if OUT="$(AOS_DEV_SITUATION_AOS_PATH="$FAKE_AOS" node scripts/aos-dev-situation.mjs --repo "$REPO" --issue-limit 2 --recent-issue-limit 3 --pr-limit 4 --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+data = json.loads(os.environ["OUT"])
+sources = {item["id"]: item for item in data["sources"]}
+assert data["status"] == "success", data
+assert data["schema_version"] == 1, data
+assert Path(data["repo"]).resolve() == Path(os.environ["REPO"]).resolve(), data
+assert data["git"]["branch"] == "main", data
+assert data["git"]["head"] == data["git"]["origin_main"], data
+assert data["git"]["ahead_of_origin_main"] == 0, data
+assert data["git"]["behind_origin_main"] == 0, data
+assert data["summary"]["clean"] is True, data
+assert data["summary"]["synced_with_origin_main"] is True, data
+assert data["summary"]["open_issue_count"] == 2, data
+assert data["summary"]["open_pr_count"] == 1, data
+assert data["summary"]["stash_count"] == 1, data
+assert data["summary"]["runtime_ready"] is True, data
+assert "notes" not in data["summary"], data["summary"]
+assert "runtime" in data and "ready" in data["runtime"] and "status" in data["runtime"], data
+assert "ready" not in data["github"] and "status" not in data["github"], data["github"]
+for key, source_id in {
+    "summary.clean": "git_status",
+    "summary.synced_with_origin_main": "git_ahead_behind",
+    "summary.open_issue_count": "github_open_issues",
+    "summary.open_pr_count": "github_open_prs",
+    "summary.stash_count": "git_stashes",
+    "summary.runtime_ready": "aos_ready",
+}.items():
+    assert source_id in data["source_trace"][key], (key, data["source_trace"].get(key))
+for source_id in [
+    "git_status",
+    "git_head",
+    "git_origin_main",
+    "git_ahead_behind",
+    "git_local_branches",
+    "git_remote_branches",
+    "git_stashes",
+    "github_context",
+    "github_open_issues",
+    "github_recent_issues",
+    "github_open_prs",
+    "aos_ready",
+    "aos_status",
+]:
+    assert sources[source_id]["status"] == "success", sources[source_id]
+PY
+then
+    pass "dev situation emits sourced live-orientation packet"
+else
+    fail "dev situation packet shape or summary drifted"
+fi
+
+if OUT="$(./aos help dev situation --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+forms = {form["id"]: form for form in data["forms"]}
+assert set(forms) == {"dev-situation"}, forms
+tokens = {arg.get("token") for arg in forms["dev-situation"]["args"]}
+assert {"--repo", "--issue-limit", "--recent-issue-limit", "--pr-limit", "--json"} <= tokens, tokens
+assert forms["dev-situation"]["execution"]["read_only"] is True, forms["dev-situation"]
+PY
+then
+    pass "dev situation help route exposes sourced orientation form"
+else
+    fail "dev situation help route drifted"
+fi
+
+if grep -q '^dev gh context --json$' "$FAKE_LOG" \
+    && grep -q '^dev gh issue list --state open --limit 2 --json$' "$FAKE_LOG" \
+    && grep -q '^dev gh pr list --state open --limit 4 --json$' "$FAKE_LOG"; then
+    pass "dev situation dogfoods ./aos dev gh source commands"
+else
+    fail "dev situation did not call expected ./aos dev gh source commands"
+fi
+
+if OUT="$(AOS_DEV_SITUATION_AOS_PATH="$FAKE_AOS" FAKE_AOS_FAIL_STATUS=1 node scripts/aos-dev-situation.mjs --repo "$REPO" --issue-limit 2 --recent-issue-limit 3 --pr-limit 4 --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+sources = {item["id"]: item for item in data["sources"]}
+assert data["status"] == "partial", data
+assert sources["aos_status"]["status"] == "failed", sources["aos_status"]
+assert sources["aos_status"]["exit_code"] == 7, sources["aos_status"]
+assert "status exploded" in sources["aos_status"]["note"], sources["aos_status"]
+assert data["runtime"]["status"] is None, data["runtime"]
+assert data["runtime"]["ready"]["ready"] is True, data["runtime"]
+assert data["summary"]["runtime_ready"] is True, data["summary"]
+assert "notes" not in data["summary"], data["summary"]
+PY
+then
+    pass "dev situation marks source failure partial without synthesizing missing runtime facts"
+else
+    fail "dev situation partial-failure behavior drifted"
+fi
+
+if ERR="$(./aos dev situation --bogus 2>&1 >/dev/null)"; then
+    fail "dev situation should reject unknown flags"
+elif echo "$ERR" | grep -q '"code" : "UNKNOWN_FLAG"'; then
+    pass "dev situation rejects unknown flags"
+else
+    fail "dev situation unknown flag error drifted: $ERR"
+fi
+
+echo
+if [[ "$FAILS" -eq 0 ]]; then
+    echo "dev-situation: all checks passed"
+    exit 0
+fi
+
+echo "dev-situation: $FAILS failure(s)"
+exit 1

--- a/tests/fixtures/dev-drift-lint/block-scope.md
+++ b/tests/fixtures/dev-drift-lint/block-scope.md
@@ -1,0 +1,6 @@
+# Block Scope Fixture
+
+As of 2026-06-04, #111 was open.
+
+#222 is open.
+

--- a/tests/fixtures/dev-drift-lint/code-spans.md
+++ b/tests/fixtures/dev-drift-lint/code-spans.md
@@ -1,0 +1,9 @@
+# Code Span Fixture
+
+Inline code should not be prose-linted: `#333 is open` and `ready=true`.
+
+```text
+#444 is open
+ready=true
+```
+

--- a/tests/fixtures/dev-drift-lint/combined-contamination.md
+++ b/tests/fixtures/dev-drift-lint/combined-contamination.md
@@ -1,0 +1,12 @@
+# Combined Contamination Fixture
+
+## Same-block contamination
+
+PR #412 was merged on 2026-06-01. #407 is open and should stay open until the lint lands.
+
+## Historical Ledger
+
+This section records former state observed during cleanup.
+#411 is the parser simplification work. #415 is closable now.
+lane:active governs the situation work.
+

--- a/tests/fixtures/dev-drift-lint/dated-sameline.md
+++ b/tests/fixtures/dev-drift-lint/dated-sameline.md
@@ -1,0 +1,4 @@
+# Dated Same-Line Fixture
+
+As of 2026-06-01: #407 is open.
+

--- a/tests/fixtures/dev-drift-lint/historical-status.md
+++ b/tests/fixtures/dev-drift-lint/historical-status.md
@@ -1,0 +1,12 @@
+# Historical Fixture
+
+## As of 2026-06-04
+
+The following entries are historical examples, not current status:
+
+- Former stash@{0} from 2026-06-04 was restored and dropped.
+- Former stash@{1} from 2026-06-03 was dropped after explicit approval.
+- Former stash@{2} from 2026-06-02 had been preserved for diagnostics.
+- #411 was created for a readiness design question.
+- `ready=true` was reported by the runtime check at the time.
+

--- a/tests/fixtures/dev-drift-lint/identity-paraphrase.md
+++ b/tests/fixtures/dev-drift-lint/identity-paraphrase.md
@@ -1,0 +1,4 @@
+# Identity Paraphrase Fixture
+
+#411 is parser simplification.
+

--- a/tests/fixtures/dev-drift-lint/same-line-contamination.md
+++ b/tests/fixtures/dev-drift-lint/same-line-contamination.md
@@ -1,0 +1,4 @@
+# Same-Line Contamination Fixture
+
+Things were observed. #407 is open.
+

--- a/tests/fixtures/dev-drift-lint/soft-heading-scope.md
+++ b/tests/fixtures/dev-drift-lint/soft-heading-scope.md
@@ -1,0 +1,6 @@
+# Soft Heading Scope Fixture
+
+## Historical notes
+
+#407 is open.
+

--- a/tests/fixtures/dev-drift-lint/standing-status.md
+++ b/tests/fixtures/dev-drift-lint/standing-status.md
@@ -1,0 +1,8 @@
+# Standing Status Fixture
+
+#999 is open.
+
+The current stash@{0} is the active cleanup stash.
+
+ready=true, so the runtime is ready.
+

--- a/tests/schemas/dev-workflow-rules.test.mjs
+++ b/tests/schemas/dev-workflow-rules.test.mjs
@@ -129,10 +129,16 @@ test('canonical rules preserve the expected V0 routing contracts', async () => {
       'node --test tests/schemas/dev-workflow-profiles.test.mjs',
       'bash tests/dev-workflow-router.sh',
       'bash tests/dev-audit.sh',
+      'bash tests/dev-situation.sh',
+      'bash tests/dev-drift-lint.sh',
     ],
   );
   assert.ok(rules.get('dev-workflow-manifest')?.patterns?.includes('scripts/aos-dev-workflow.mjs'));
+  assert.ok(rules.get('dev-workflow-manifest')?.patterns?.includes('scripts/aos-dev-situation.mjs'));
+  assert.ok(rules.get('dev-workflow-manifest')?.patterns?.includes('scripts/aos-dev-drift-lint.mjs'));
   assert.ok(rules.get('dev-workflow-manifest')?.patterns?.includes('manifests/commands/aos-commands.json'));
+  assert.ok(rules.get('dev-workflow-manifest')?.patterns?.includes('tests/dev-situation.sh'));
+  assert.ok(rules.get('dev-workflow-manifest')?.patterns?.includes('tests/dev-drift-lint.sh'));
   assert.ok(rules.get('dev-workflow-manifest')?.patterns?.includes('docs/dev/workflow-profiles.json'));
   assert.ok(rules.get('dev-workflow-manifest')?.patterns?.includes('docs/dev/active-profile.json'));
   assert.ok(rules.get('dev-workflow-manifest')?.patterns?.includes('tests/schemas/dev-active-profile.test.mjs'));


### PR DESCRIPTION
## Summary

- Add `./aos dev situation --json` as a thin sourced orientation packet with per-source status, source traces, partial-failure handling, capped-count signaling, and no editorial `summary.notes`.
- Add `./aos dev drift-lint --json` as an explicitly heuristic durable-status tripwire with claim-scoped licensing, dated evidence-heading scope, code-span/fenced-block exclusions, and regression fixtures.
- Wire both commands into command manifests, dev workflow routing/audit checks, and dock cold-start bootstrap guidance.

## Verification

- `git diff --check`
- `node --check scripts/aos-dev-situation.mjs`
- `node --check scripts/aos-dev-drift-lint.mjs`
- `node --test tests/schemas/dev-workflow-rules.test.mjs`
- `node --test tests/schemas/dev-active-profile.test.mjs`
- `node --test tests/schemas/dev-workflow-profiles.test.mjs`
- `node --test tests/schemas/aos-dock-profile-v0.test.mjs`
- `node --test tests/schemas/aos-external-command-manifest-v0.test.mjs`
- `bash tests/dev-audit.sh`
- `bash tests/dev-situation.sh`
- `bash tests/dev-drift-lint.sh`
- `bash tests/dev-workflow-router.sh`
- `bash tests/help-contract.sh`
- `bash tests/external-command-dispatch.sh`
- `bash tests/external-parser-flags.sh`
- `./aos dev situation --issue-limit 10 --recent-issue-limit 10 --pr-limit 10 --json` shape/source-trace assertion
- `./aos dev drift-lint --json`

## Correction Verification

- `git diff --check`
- `node --check scripts/aos-dev-drift-lint.mjs`
- `node --check scripts/aos-dev-situation.mjs`
- `bash tests/dev-drift-lint.sh`
- `bash tests/dev-situation.sh`
- `bash tests/dev-workflow-router.sh`
- `./aos dev drift-lint --json`
- `./aos dev situation --issue-limit 10 --recent-issue-limit 10 --pr-limit 10 --json`
- JSON assertions over the captured live situation packet and default drift-lint output
