### PR TITLE
Fix dev gh help discovery parity

### DIFF
--- a/docs/dev/workflow-rules.json
+++ b/docs/dev/workflow-rules.json
@@ -141,6 +141,7 @@
         "manifests/commands/*.json",
         "shared/schemas/aos-external-command-manifest-v0.schema.json",
         "tests/schemas/aos-external-command-manifest-v0.test.mjs",
+        "tests/aos-dev-gh-help-parity.test.mjs",
         "tests/external-command-dispatch.sh",
         "tests/help-contract.sh"
       ],
@@ -165,6 +166,11 @@
           "id": "external-command-dispatch",
           "command": "bash tests/external-command-dispatch.sh",
           "reason": "Manifest-backed command routes must still dispatch through external modules."
+        },
+        {
+          "id": "dev-gh-help-parity",
+          "command": "node --test tests/aos-dev-gh-help-parity.test.mjs",
+          "reason": "Script-owned dev gh subcommands must stay dispatchable and discoverable through real ./aos help."
         },
         {
           "id": "help-contract",
@@ -206,6 +212,11 @@
           "id": "external-parser-flags",
           "command": "bash tests/external-parser-flags.sh",
           "reason": "External command wrappers should reject malformed flags and arguments before falling through to Swift primitives."
+        },
+        {
+          "id": "dev-gh-help-parity",
+          "command": "node --test tests/aos-dev-gh-help-parity.test.mjs",
+          "reason": "Script-owned dev gh subcommands must stay dispatchable and discoverable through real ./aos help."
         },
         {
           "id": "help-contract",

--- a/manifests/commands/aos-external-commands.json
+++ b/manifests/commands/aos-external-commands.json
@@ -528,6 +528,7 @@
       "summary": "Run GitHub workflow helpers through the external dev gh command.",
       "executable": "/usr/bin/env",
       "argv_prefix": ["node", "scripts/aos-dev-gh.mjs"],
+      "help_passthrough": true,
       "cwd": "repo",
       "env": {
         "REPO_ROOT": "$REPO_ROOT"

--- a/scripts/aos-dev-gh-spec.mjs
+++ b/scripts/aos-dev-gh-spec.mjs
@@ -1,200 +1,19 @@
-const COMMON_OPTIONS = [
-  { name: '--repo', summary: 'GitHub repository in owner/name form' },
-  { name: '--cwd', summary: 'Local checkout path used for git context and gh execution' },
-];
-
-const JSON_OPTION = { name: '--json', summary: 'Emit machine-readable output where supported' };
-const BODY_FILE_OPTION = { name: '--body-file', summary: 'Markdown body file path' };
-const ISSUE_NUMBER_ARG = { name: '<issue-number>', summary: 'GitHub issue number', required: true };
-const PR_NUMBER_ARG = { name: '<pr-number>', summary: 'GitHub pull request number', required: true };
-
-const ISSUE_LIST_OPTIONS = [
-  { name: '--state', summary: 'Issue state filter: open, closed, or all' },
-  { name: '--limit', summary: 'Maximum result count' },
-  { name: '--label', summary: 'Issue label filter; repeat for multiple labels' },
-  { name: '--author', summary: 'Author login filter' },
-  { name: '--assignee', summary: 'Assignee login filter' },
-  { name: '--search', summary: 'Issue search query' },
-  { name: '--milestone', summary: 'Issue milestone filter' },
-];
-
-const PR_LIST_OPTIONS = [
-  { name: '--state', summary: 'Pull request state filter: open, closed, merged, or all' },
-  { name: '--limit', summary: 'Maximum result count' },
-  { name: '--label', summary: 'Pull request label filter; repeat for multiple labels' },
-  { name: '--author', summary: 'Author login filter' },
-  { name: '--assignee', summary: 'Assignee login filter' },
-  { name: '--search', summary: 'Pull request search query' },
-  { name: '--base', summary: 'Base branch filter' },
-  { name: '--head', summary: 'Head branch filter' },
-  { name: '--draft', summary: 'Filter draft pull requests' },
-];
-
-export const DEV_GH_ROOT_SUMMARY = 'GitHub workflow helpers through local gh';
-
-export const DEV_GH_COMMAND_SPECS = [
-  {
-    path: ['context'],
-    handler: 'context',
-    summary: 'Inspect local GitHub CLI, repository, branch, PR, and dirty checkout context.',
-    usage: './aos dev gh context [--repo owner/name] [--cwd <path>] [--json]',
-    args: [...COMMON_OPTIONS, JSON_OPTION],
-    examples: ['./aos dev gh context --json'],
-  },
-  {
-    path: ['issue', 'list'],
-    handler: 'issue:list',
-    summary: 'List GitHub issues with bounded inventory filters.',
-    usage: './aos dev gh issue list [--state <state>] [--limit <n>] [--label <name>] [--author <login>] [--assignee <login>] [--search <query>] [--milestone <name>] [--repo owner/name] [--cwd <path>] [--json]',
-    args: [...ISSUE_LIST_OPTIONS, ...COMMON_OPTIONS, JSON_OPTION],
-    examples: ['./aos dev gh issue list --state open --limit 50 --json'],
-  },
-  {
-    path: ['issue', 'view'],
-    handler: 'issue:view',
-    summary: 'Read one GitHub issue.',
-    usage: './aos dev gh issue view <issue-number> [--repo owner/name] [--cwd <path>] [--json]',
-    args: [ISSUE_NUMBER_ARG, ...COMMON_OPTIONS, JSON_OPTION],
-    examples: ['./aos dev gh issue view 416 --json'],
-  },
-  {
-    path: ['issue', 'comment'],
-    handler: 'issue:comment',
-    summary: 'Write a GitHub issue comment from a body file.',
-    usage: './aos dev gh issue comment <issue-number> --body-file <path> [--repo owner/name] [--cwd <path>]',
-    args: [ISSUE_NUMBER_ARG, { ...BODY_FILE_OPTION, required: true }, ...COMMON_OPTIONS],
-    examples: ['./aos dev gh issue comment 416 --body-file /tmp/comment.md'],
-  },
-  {
-    path: ['issue', 'create'],
-    handler: 'issue:create',
-    summary: 'Create a GitHub issue from an explicit title and body file.',
-    usage: './aos dev gh issue create --title <title> --body-file <path> [--label <name>] [--assignee <login>] [--milestone <name>] [--repo owner/name] [--cwd <path>]',
-    args: [
-      { name: '--title', summary: 'Issue title', required: true },
-      { ...BODY_FILE_OPTION, required: true },
-      { name: '--label', summary: 'Issue label; repeat for multiple labels' },
-      { name: '--assignee', summary: 'Assignee login or @me; repeat for multiple assignees' },
-      { name: '--milestone', summary: 'Issue milestone' },
-      ...COMMON_OPTIONS,
-    ],
-    examples: ['./aos dev gh issue create --title "Follow-up" --body-file /tmp/issue.md'],
-  },
-  {
-    path: ['issue', 'close'],
-    handler: 'issue:close',
-    summary: 'Close a GitHub issue with an optional close reason.',
-    usage: './aos dev gh issue close <issue-number> [--reason <completed|not planned>] [--repo owner/name] [--cwd <path>]',
-    args: [ISSUE_NUMBER_ARG, { name: '--reason', summary: 'Close reason: completed or not planned' }, ...COMMON_OPTIONS],
-    examples: ['./aos dev gh issue close 416 --reason completed'],
-  },
-  {
-    path: ['issue', 'edit'],
-    handler: 'issue:edit',
-    summary: 'Edit GitHub issue lifecycle metadata with explicit non-interactive flags.',
-    usage: './aos dev gh issue edit <issue-number> (--add-label <name>|--remove-label <name>|--add-assignee <login>|--remove-assignee <login>|--milestone <name>|--title <title>|--body-file <path>) [--repo owner/name] [--cwd <path>]',
-    args: [
-      ISSUE_NUMBER_ARG,
-      { name: '--add-label', summary: 'Label to add; repeat for multiple labels' },
-      { name: '--remove-label', summary: 'Label to remove; repeat for multiple labels' },
-      { name: '--add-assignee', summary: 'Assignee login or @me to add' },
-      { name: '--remove-assignee', summary: 'Assignee login or @me to remove' },
-      { name: '--milestone', summary: 'Issue milestone' },
-      { name: '--title', summary: 'Replacement issue title' },
-      BODY_FILE_OPTION,
-      ...COMMON_OPTIONS,
-    ],
-    examples: ['./aos dev gh issue edit 416 --add-label lane:active'],
-  },
-  {
-    path: ['label', 'list'],
-    handler: 'label:list',
-    summary: 'List GitHub repository labels with bounded inventory filters.',
-    usage: './aos dev gh label list [--limit <n>] [--search <query>] [--sort <created|name>] [--order <asc|desc>] [--repo owner/name] [--cwd <path>] [--json]',
-    args: [
-      { name: '--limit', summary: 'Maximum result count' },
-      { name: '--search', summary: 'Label search query' },
-      { name: '--sort', summary: 'Sort field: created or name' },
-      { name: '--order', summary: 'Sort direction: asc or desc' },
-      ...COMMON_OPTIONS,
-      JSON_OPTION,
-    ],
-    examples: ['./aos dev gh label list --limit 100 --json'],
-  },
-  {
-    path: ['pr', 'list'],
-    handler: 'pr:list',
-    summary: 'List GitHub pull requests with bounded inventory filters.',
-    usage: './aos dev gh pr list [--state <state>] [--limit <n>] [--label <name>] [--author <login>] [--assignee <login>] [--search <query>] [--base <branch>] [--head <branch>] [--draft] [--repo owner/name] [--cwd <path>] [--json]',
-    args: [...PR_LIST_OPTIONS, ...COMMON_OPTIONS, JSON_OPTION],
-    examples: ['./aos dev gh pr list --state all --limit 30 --json'],
-  },
-  {
-    path: ['pr', 'view'],
-    handler: 'pr:view',
-    summary: 'Read one GitHub pull request, or infer the current PR when omitted.',
-    usage: './aos dev gh pr view [<pr-number>] [--repo owner/name] [--cwd <path>] [--json]',
-    args: [{ ...PR_NUMBER_ARG, required: false }, ...COMMON_OPTIONS, JSON_OPTION],
-    examples: ['./aos dev gh pr view 415 --json'],
-  },
-  {
-    path: ['pr', 'checks'],
-    handler: 'pr:checks',
-    summary: 'Read GitHub pull request check status.',
-    usage: './aos dev gh pr checks [<pr-number>] [--repo owner/name] [--cwd <path>] [--json]',
-    args: [{ ...PR_NUMBER_ARG, required: false }, ...COMMON_OPTIONS, JSON_OPTION],
-    examples: ['./aos dev gh pr checks 415 --json'],
-  },
-  {
-    path: ['pr', 'comment'],
-    handler: 'pr:comment',
-    summary: 'Write a GitHub pull request comment from a body file.',
-    usage: './aos dev gh pr comment <pr-number> --body-file <path> [--repo owner/name] [--cwd <path>]',
-    args: [PR_NUMBER_ARG, { ...BODY_FILE_OPTION, required: true }, ...COMMON_OPTIONS],
-    examples: ['./aos dev gh pr comment 415 --body-file /tmp/comment.md'],
-  },
-  {
-    path: ['pr', 'merge'],
-    handler: 'pr:merge',
-    summary: 'Merge a GitHub pull request through an explicit strategy.',
-    usage: './aos dev gh pr merge <pr-number> (--squash|--merge|--rebase) [--match-head-commit <sha>] [--body-file <path>] [--repo owner/name] [--cwd <path>]',
-    args: [
-      PR_NUMBER_ARG,
-      { name: '--squash', summary: 'Use squash merge strategy' },
-      { name: '--merge', summary: 'Use merge commit strategy' },
-      { name: '--rebase', summary: 'Use rebase merge strategy' },
-      { name: '--match-head-commit', summary: 'Only merge if the PR head matches this commit SHA' },
-      BODY_FILE_OPTION,
-      ...COMMON_OPTIONS,
-    ],
-    examples: ['./aos dev gh pr merge 415 --squash --match-head-commit <sha>'],
-  },
-  {
-    path: ['ci', 'inspect'],
-    handler: 'ci:inspect',
-    summary: 'Inspect PR checks and retrieve failed GitHub Actions logs.',
-    usage: './aos dev gh ci inspect [<pr-number>|--pr <number>] [--repo owner/name] [--cwd <path>] [--json]',
-    args: [
-      { ...PR_NUMBER_ARG, required: false },
-      { name: '--pr', summary: 'PR number to inspect' },
-      ...COMMON_OPTIONS,
-      JSON_OPTION,
-    ],
-    examples: ['./aos dev gh ci inspect --pr 415 --json'],
-  },
-  {
-    path: ['review-comments'],
-    handler: 'review-comments',
-    summary: 'Read thread-level PR review comment state through gh GraphQL.',
-    usage: './aos dev gh review-comments [<pr-number>|--pr <number>] [--repo owner/name] [--cwd <path>] [--json]',
-    args: [
-      { ...PR_NUMBER_ARG, required: false },
-      { name: '--pr', summary: 'PR number whose review threads should be read' },
-      ...COMMON_OPTIONS,
-      JSON_OPTION,
-    ],
-    examples: ['./aos dev gh review-comments --pr 415 --json'],
-  },
+export const DEV_GH_COMMAND_PATHS = [
+  ['context'],
+  ['issue', 'list'],
+  ['issue', 'view'],
+  ['issue', 'comment'],
+  ['issue', 'create'],
+  ['issue', 'close'],
+  ['issue', 'edit'],
+  ['label', 'list'],
+  ['pr', 'list'],
+  ['pr', 'view'],
+  ['pr', 'checks'],
+  ['pr', 'comment'],
+  ['pr', 'merge'],
+  ['ci', 'inspect'],
+  ['review-comments'],
 ];
 
 export function devGhPathKey(pathParts) {
@@ -202,91 +21,70 @@ export function devGhPathKey(pathParts) {
 }
 
 export function dispatchableDevGhCommandPaths() {
-  return DEV_GH_COMMAND_SPECS
-    .filter((spec) => spec.handler)
-    .map((spec) => spec.path);
-}
-
-export function exposedDevGhCommandPaths() {
-  return DEV_GH_COMMAND_SPECS
-    .filter((spec) => spec.usage)
-    .map((spec) => spec.path);
+  return DEV_GH_COMMAND_PATHS.map((pathParts) => [...pathParts]);
 }
 
 export function findDevGhCommandSpec(pathParts) {
   const key = devGhPathKey(pathParts);
-  return DEV_GH_COMMAND_SPECS.find((spec) => devGhPathKey(spec.path) === key) ?? null;
+  const path = DEV_GH_COMMAND_PATHS.find((candidate) => devGhPathKey(candidate) === key);
+  return path ? { path } : null;
 }
 
 export function devGhGroups() {
-  return [...new Set(DEV_GH_COMMAND_SPECS.map((spec) => spec.path[0]))];
+  return [...new Set(DEV_GH_COMMAND_PATHS.map((pathParts) => pathParts[0]))];
 }
 
 export function devGhSubcommandsFor(group) {
-  return DEV_GH_COMMAND_SPECS
-    .filter((spec) => spec.path[0] === group && spec.path.length > 1)
-    .map((spec) => spec.path.slice(1).join(' '));
+  return DEV_GH_COMMAND_PATHS
+    .filter((pathParts) => pathParts[0] === group && pathParts.length > 1)
+    .map((pathParts) => pathParts.slice(1).join(' '));
 }
 
-export function formatDevGhHelp(pathParts = [], options = {}) {
+export function formatDevGhHelp(_pathParts = [], options = {}) {
   const invocation = options.invocation ?? './aos';
-  if (pathParts.length === 0) return formatDevGhRootHelp(invocation);
-
-  const spec = findDevGhCommandSpec(pathParts);
-  if (!spec) return null;
-  return formatDevGhCommandHelp(spec, invocation);
-}
-
-function formatDevGhRootHelp(invocation) {
   const commandLabel = `${invocation} dev gh`;
-  const commandNames = dispatchableDevGhCommandPaths().map((pathParts) => pathParts.join(' '));
+  const commandNames = DEV_GH_COMMAND_PATHS.map(devGhPathKey);
   const width = Math.max(...commandNames.map((name) => name.length));
   const lines = [
-    `${commandLabel} — ${DEV_GH_ROOT_SUMMARY}`,
+    `${commandLabel} — sanctioned GitHub workflow subset`,
     '',
     `  ${commandLabel} <subcommand> [options]`,
     '',
-    '  Subcommands:',
+    '  Allowed subcommands:',
   ];
 
-  for (const spec of DEV_GH_COMMAND_SPECS) {
-    const name = spec.path.join(' ');
-    lines.push(`    ${name.padEnd(width, ' ')}  ${spec.summary}`);
+  for (const commandName of commandNames) {
+    lines.push(`    ${commandName.padEnd(width, ' ')}  ${deltaSummary(commandName)}`);
   }
 
-  lines.push('');
-  lines.push(`Run '${commandLabel} <subcommand> --help' for details on a specific command.`);
-  return `${lines.join('\n')}\n`;
-}
-
-function formatDevGhCommandHelp(spec, invocation) {
-  const commandLabel = `${invocation} dev gh ${spec.path.join(' ')}`;
-  const lines = [
-    `${commandLabel} — ${spec.summary}`,
+  lines.push(
     '',
-    `  ${renderInvocation(spec.usage, invocation)}`,
-  ];
-
-  if (spec.args?.length) {
-    lines.push('');
-    for (const arg of spec.args) {
-      const required = arg.required ? ' (required)' : '';
-      lines.push(`    ${arg.name}\t${arg.summary}${required}`);
-    }
-  }
-
-  if (spec.examples?.length) {
-    lines.push('', '  Examples:');
-    for (const example of spec.examples) {
-      lines.push(`    ${renderInvocation(example, invocation)}`);
-    }
-  }
+    '  Delta from gh:',
+    '    Non-interactive only: commands fail instead of prompting.',
+    '    Body-writing commands use --body-file; issue create/comment and pr comment require it.',
+    '    pr merge requires exactly one explicit strategy: --squash, --merge, or --rebase.',
+    '    List commands take bounded --limit values for inventory scans.',
+    '',
+    '  AOS-only helpers:',
+    '    context          Reports local gh auth, repository, branch, current PR, and dirty checkout state.',
+    '    ci inspect       Reads PR checks and failed GitHub Actions logs for review triage.',
+    '    review-comments  Reads PR review thread state through gh GraphQL.',
+    '',
+    'This surface intentionally exposes a constrained allowlist, not every gh command.',
+  );
 
   return `${lines.join('\n')}\n`;
 }
 
-function renderInvocation(value, invocation) {
-  return String(value)
-    .replace(/^\.\/aos\b/, invocation)
-    .replace(/^aos\b/, invocation);
+function deltaSummary(commandName) {
+  switch (commandName) {
+    case 'context':
+      return 'AOS helper: local GitHub/repo context.';
+    case 'ci inspect':
+      return 'AOS helper: PR checks plus failed Actions logs.';
+    case 'review-comments':
+      return 'AOS helper: PR review thread state.';
+    default:
+      return 'Wrapped gh command.';
+  }
 }

--- a/scripts/aos-dev-gh-spec.mjs
+++ b/scripts/aos-dev-gh-spec.mjs
@@ -1,0 +1,292 @@
+const COMMON_OPTIONS = [
+  { name: '--repo', summary: 'GitHub repository in owner/name form' },
+  { name: '--cwd', summary: 'Local checkout path used for git context and gh execution' },
+];
+
+const JSON_OPTION = { name: '--json', summary: 'Emit machine-readable output where supported' };
+const BODY_FILE_OPTION = { name: '--body-file', summary: 'Markdown body file path' };
+const ISSUE_NUMBER_ARG = { name: '<issue-number>', summary: 'GitHub issue number', required: true };
+const PR_NUMBER_ARG = { name: '<pr-number>', summary: 'GitHub pull request number', required: true };
+
+const ISSUE_LIST_OPTIONS = [
+  { name: '--state', summary: 'Issue state filter: open, closed, or all' },
+  { name: '--limit', summary: 'Maximum result count' },
+  { name: '--label', summary: 'Issue label filter; repeat for multiple labels' },
+  { name: '--author', summary: 'Author login filter' },
+  { name: '--assignee', summary: 'Assignee login filter' },
+  { name: '--search', summary: 'Issue search query' },
+  { name: '--milestone', summary: 'Issue milestone filter' },
+];
+
+const PR_LIST_OPTIONS = [
+  { name: '--state', summary: 'Pull request state filter: open, closed, merged, or all' },
+  { name: '--limit', summary: 'Maximum result count' },
+  { name: '--label', summary: 'Pull request label filter; repeat for multiple labels' },
+  { name: '--author', summary: 'Author login filter' },
+  { name: '--assignee', summary: 'Assignee login filter' },
+  { name: '--search', summary: 'Pull request search query' },
+  { name: '--base', summary: 'Base branch filter' },
+  { name: '--head', summary: 'Head branch filter' },
+  { name: '--draft', summary: 'Filter draft pull requests' },
+];
+
+export const DEV_GH_ROOT_SUMMARY = 'GitHub workflow helpers through local gh';
+
+export const DEV_GH_COMMAND_SPECS = [
+  {
+    path: ['context'],
+    handler: 'context',
+    summary: 'Inspect local GitHub CLI, repository, branch, PR, and dirty checkout context.',
+    usage: './aos dev gh context [--repo owner/name] [--cwd <path>] [--json]',
+    args: [...COMMON_OPTIONS, JSON_OPTION],
+    examples: ['./aos dev gh context --json'],
+  },
+  {
+    path: ['issue', 'list'],
+    handler: 'issue:list',
+    summary: 'List GitHub issues with bounded inventory filters.',
+    usage: './aos dev gh issue list [--state <state>] [--limit <n>] [--label <name>] [--author <login>] [--assignee <login>] [--search <query>] [--milestone <name>] [--repo owner/name] [--cwd <path>] [--json]',
+    args: [...ISSUE_LIST_OPTIONS, ...COMMON_OPTIONS, JSON_OPTION],
+    examples: ['./aos dev gh issue list --state open --limit 50 --json'],
+  },
+  {
+    path: ['issue', 'view'],
+    handler: 'issue:view',
+    summary: 'Read one GitHub issue.',
+    usage: './aos dev gh issue view <issue-number> [--repo owner/name] [--cwd <path>] [--json]',
+    args: [ISSUE_NUMBER_ARG, ...COMMON_OPTIONS, JSON_OPTION],
+    examples: ['./aos dev gh issue view 416 --json'],
+  },
+  {
+    path: ['issue', 'comment'],
+    handler: 'issue:comment',
+    summary: 'Write a GitHub issue comment from a body file.',
+    usage: './aos dev gh issue comment <issue-number> --body-file <path> [--repo owner/name] [--cwd <path>]',
+    args: [ISSUE_NUMBER_ARG, { ...BODY_FILE_OPTION, required: true }, ...COMMON_OPTIONS],
+    examples: ['./aos dev gh issue comment 416 --body-file /tmp/comment.md'],
+  },
+  {
+    path: ['issue', 'create'],
+    handler: 'issue:create',
+    summary: 'Create a GitHub issue from an explicit title and body file.',
+    usage: './aos dev gh issue create --title <title> --body-file <path> [--label <name>] [--assignee <login>] [--milestone <name>] [--repo owner/name] [--cwd <path>]',
+    args: [
+      { name: '--title', summary: 'Issue title', required: true },
+      { ...BODY_FILE_OPTION, required: true },
+      { name: '--label', summary: 'Issue label; repeat for multiple labels' },
+      { name: '--assignee', summary: 'Assignee login or @me; repeat for multiple assignees' },
+      { name: '--milestone', summary: 'Issue milestone' },
+      ...COMMON_OPTIONS,
+    ],
+    examples: ['./aos dev gh issue create --title "Follow-up" --body-file /tmp/issue.md'],
+  },
+  {
+    path: ['issue', 'close'],
+    handler: 'issue:close',
+    summary: 'Close a GitHub issue with an optional close reason.',
+    usage: './aos dev gh issue close <issue-number> [--reason <completed|not planned>] [--repo owner/name] [--cwd <path>]',
+    args: [ISSUE_NUMBER_ARG, { name: '--reason', summary: 'Close reason: completed or not planned' }, ...COMMON_OPTIONS],
+    examples: ['./aos dev gh issue close 416 --reason completed'],
+  },
+  {
+    path: ['issue', 'edit'],
+    handler: 'issue:edit',
+    summary: 'Edit GitHub issue lifecycle metadata with explicit non-interactive flags.',
+    usage: './aos dev gh issue edit <issue-number> (--add-label <name>|--remove-label <name>|--add-assignee <login>|--remove-assignee <login>|--milestone <name>|--title <title>|--body-file <path>) [--repo owner/name] [--cwd <path>]',
+    args: [
+      ISSUE_NUMBER_ARG,
+      { name: '--add-label', summary: 'Label to add; repeat for multiple labels' },
+      { name: '--remove-label', summary: 'Label to remove; repeat for multiple labels' },
+      { name: '--add-assignee', summary: 'Assignee login or @me to add' },
+      { name: '--remove-assignee', summary: 'Assignee login or @me to remove' },
+      { name: '--milestone', summary: 'Issue milestone' },
+      { name: '--title', summary: 'Replacement issue title' },
+      BODY_FILE_OPTION,
+      ...COMMON_OPTIONS,
+    ],
+    examples: ['./aos dev gh issue edit 416 --add-label lane:active'],
+  },
+  {
+    path: ['label', 'list'],
+    handler: 'label:list',
+    summary: 'List GitHub repository labels with bounded inventory filters.',
+    usage: './aos dev gh label list [--limit <n>] [--search <query>] [--sort <created|name>] [--order <asc|desc>] [--repo owner/name] [--cwd <path>] [--json]',
+    args: [
+      { name: '--limit', summary: 'Maximum result count' },
+      { name: '--search', summary: 'Label search query' },
+      { name: '--sort', summary: 'Sort field: created or name' },
+      { name: '--order', summary: 'Sort direction: asc or desc' },
+      ...COMMON_OPTIONS,
+      JSON_OPTION,
+    ],
+    examples: ['./aos dev gh label list --limit 100 --json'],
+  },
+  {
+    path: ['pr', 'list'],
+    handler: 'pr:list',
+    summary: 'List GitHub pull requests with bounded inventory filters.',
+    usage: './aos dev gh pr list [--state <state>] [--limit <n>] [--label <name>] [--author <login>] [--assignee <login>] [--search <query>] [--base <branch>] [--head <branch>] [--draft] [--repo owner/name] [--cwd <path>] [--json]',
+    args: [...PR_LIST_OPTIONS, ...COMMON_OPTIONS, JSON_OPTION],
+    examples: ['./aos dev gh pr list --state all --limit 30 --json'],
+  },
+  {
+    path: ['pr', 'view'],
+    handler: 'pr:view',
+    summary: 'Read one GitHub pull request, or infer the current PR when omitted.',
+    usage: './aos dev gh pr view [<pr-number>] [--repo owner/name] [--cwd <path>] [--json]',
+    args: [{ ...PR_NUMBER_ARG, required: false }, ...COMMON_OPTIONS, JSON_OPTION],
+    examples: ['./aos dev gh pr view 415 --json'],
+  },
+  {
+    path: ['pr', 'checks'],
+    handler: 'pr:checks',
+    summary: 'Read GitHub pull request check status.',
+    usage: './aos dev gh pr checks [<pr-number>] [--repo owner/name] [--cwd <path>] [--json]',
+    args: [{ ...PR_NUMBER_ARG, required: false }, ...COMMON_OPTIONS, JSON_OPTION],
+    examples: ['./aos dev gh pr checks 415 --json'],
+  },
+  {
+    path: ['pr', 'comment'],
+    handler: 'pr:comment',
+    summary: 'Write a GitHub pull request comment from a body file.',
+    usage: './aos dev gh pr comment <pr-number> --body-file <path> [--repo owner/name] [--cwd <path>]',
+    args: [PR_NUMBER_ARG, { ...BODY_FILE_OPTION, required: true }, ...COMMON_OPTIONS],
+    examples: ['./aos dev gh pr comment 415 --body-file /tmp/comment.md'],
+  },
+  {
+    path: ['pr', 'merge'],
+    handler: 'pr:merge',
+    summary: 'Merge a GitHub pull request through an explicit strategy.',
+    usage: './aos dev gh pr merge <pr-number> (--squash|--merge|--rebase) [--match-head-commit <sha>] [--body-file <path>] [--repo owner/name] [--cwd <path>]',
+    args: [
+      PR_NUMBER_ARG,
+      { name: '--squash', summary: 'Use squash merge strategy' },
+      { name: '--merge', summary: 'Use merge commit strategy' },
+      { name: '--rebase', summary: 'Use rebase merge strategy' },
+      { name: '--match-head-commit', summary: 'Only merge if the PR head matches this commit SHA' },
+      BODY_FILE_OPTION,
+      ...COMMON_OPTIONS,
+    ],
+    examples: ['./aos dev gh pr merge 415 --squash --match-head-commit <sha>'],
+  },
+  {
+    path: ['ci', 'inspect'],
+    handler: 'ci:inspect',
+    summary: 'Inspect PR checks and retrieve failed GitHub Actions logs.',
+    usage: './aos dev gh ci inspect [<pr-number>|--pr <number>] [--repo owner/name] [--cwd <path>] [--json]',
+    args: [
+      { ...PR_NUMBER_ARG, required: false },
+      { name: '--pr', summary: 'PR number to inspect' },
+      ...COMMON_OPTIONS,
+      JSON_OPTION,
+    ],
+    examples: ['./aos dev gh ci inspect --pr 415 --json'],
+  },
+  {
+    path: ['review-comments'],
+    handler: 'review-comments',
+    summary: 'Read thread-level PR review comment state through gh GraphQL.',
+    usage: './aos dev gh review-comments [<pr-number>|--pr <number>] [--repo owner/name] [--cwd <path>] [--json]',
+    args: [
+      { ...PR_NUMBER_ARG, required: false },
+      { name: '--pr', summary: 'PR number whose review threads should be read' },
+      ...COMMON_OPTIONS,
+      JSON_OPTION,
+    ],
+    examples: ['./aos dev gh review-comments --pr 415 --json'],
+  },
+];
+
+export function devGhPathKey(pathParts) {
+  return pathParts.join(' ');
+}
+
+export function dispatchableDevGhCommandPaths() {
+  return DEV_GH_COMMAND_SPECS
+    .filter((spec) => spec.handler)
+    .map((spec) => spec.path);
+}
+
+export function exposedDevGhCommandPaths() {
+  return DEV_GH_COMMAND_SPECS
+    .filter((spec) => spec.usage)
+    .map((spec) => spec.path);
+}
+
+export function findDevGhCommandSpec(pathParts) {
+  const key = devGhPathKey(pathParts);
+  return DEV_GH_COMMAND_SPECS.find((spec) => devGhPathKey(spec.path) === key) ?? null;
+}
+
+export function devGhGroups() {
+  return [...new Set(DEV_GH_COMMAND_SPECS.map((spec) => spec.path[0]))];
+}
+
+export function devGhSubcommandsFor(group) {
+  return DEV_GH_COMMAND_SPECS
+    .filter((spec) => spec.path[0] === group && spec.path.length > 1)
+    .map((spec) => spec.path.slice(1).join(' '));
+}
+
+export function formatDevGhHelp(pathParts = [], options = {}) {
+  const invocation = options.invocation ?? './aos';
+  if (pathParts.length === 0) return formatDevGhRootHelp(invocation);
+
+  const spec = findDevGhCommandSpec(pathParts);
+  if (!spec) return null;
+  return formatDevGhCommandHelp(spec, invocation);
+}
+
+function formatDevGhRootHelp(invocation) {
+  const commandLabel = `${invocation} dev gh`;
+  const commandNames = dispatchableDevGhCommandPaths().map((pathParts) => pathParts.join(' '));
+  const width = Math.max(...commandNames.map((name) => name.length));
+  const lines = [
+    `${commandLabel} — ${DEV_GH_ROOT_SUMMARY}`,
+    '',
+    `  ${commandLabel} <subcommand> [options]`,
+    '',
+    '  Subcommands:',
+  ];
+
+  for (const spec of DEV_GH_COMMAND_SPECS) {
+    const name = spec.path.join(' ');
+    lines.push(`    ${name.padEnd(width, ' ')}  ${spec.summary}`);
+  }
+
+  lines.push('');
+  lines.push(`Run '${commandLabel} <subcommand> --help' for details on a specific command.`);
+  return `${lines.join('\n')}\n`;
+}
+
+function formatDevGhCommandHelp(spec, invocation) {
+  const commandLabel = `${invocation} dev gh ${spec.path.join(' ')}`;
+  const lines = [
+    `${commandLabel} — ${spec.summary}`,
+    '',
+    `  ${renderInvocation(spec.usage, invocation)}`,
+  ];
+
+  if (spec.args?.length) {
+    lines.push('');
+    for (const arg of spec.args) {
+      const required = arg.required ? ' (required)' : '';
+      lines.push(`    ${arg.name}\t${arg.summary}${required}`);
+    }
+  }
+
+  if (spec.examples?.length) {
+    lines.push('', '  Examples:');
+    for (const example of spec.examples) {
+      lines.push(`    ${renderInvocation(example, invocation)}`);
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function renderInvocation(value, invocation) {
+  return String(value)
+    .replace(/^\.\/aos\b/, invocation)
+    .replace(/^aos\b/, invocation);
+}

--- a/scripts/aos-dev-gh.mjs
+++ b/scripts/aos-dev-gh.mjs
@@ -25,13 +25,12 @@ function invocationDisplayName() {
 
 function printHelpAndExit(pathParts) {
   const help = formatDevGhHelp(pathParts, { invocation: invocationDisplayName() });
-  if (!help) die(`Unknown dev gh command: ${pathParts.join(' ')}`, 'UNKNOWN_SUBCOMMAND');
   process.stdout.write(help);
   process.exit(0);
 }
 
 function pathIsDispatchable(pathParts) {
-  return findDevGhCommandSpec(pathParts)?.handler != null;
+  return findDevGhCommandSpec(pathParts) != null;
 }
 
 function requireDispatchable(pathParts) {

--- a/scripts/aos-dev-gh.mjs
+++ b/scripts/aos-dev-gh.mjs
@@ -3,6 +3,12 @@
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import {
+  devGhGroups,
+  devGhSubcommandsFor,
+  findDevGhCommandSpec,
+  formatDevGhHelp,
+} from './aos-dev-gh-spec.mjs';
 
 function printJSON(value) {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
@@ -11,6 +17,27 @@ function printJSON(value) {
 function die(message, code = 'ERROR', exitCode = 1) {
   process.stderr.write(`error: ${message}\n`);
   process.exit(exitCode);
+}
+
+function invocationDisplayName() {
+  return process.env.AOS_INVOCATION_DISPLAY_NAME || './aos';
+}
+
+function printHelpAndExit(pathParts) {
+  const help = formatDevGhHelp(pathParts, { invocation: invocationDisplayName() });
+  if (!help) die(`Unknown dev gh command: ${pathParts.join(' ')}`, 'UNKNOWN_SUBCOMMAND');
+  process.stdout.write(help);
+  process.exit(0);
+}
+
+function pathIsDispatchable(pathParts) {
+  return findDevGhCommandSpec(pathParts)?.handler != null;
+}
+
+function requireDispatchable(pathParts) {
+  if (!pathIsDispatchable(pathParts)) {
+    die(`Unknown dev gh command: ${pathParts.join(' ')}`, 'UNKNOWN_SUBCOMMAND');
+  }
 }
 
 const COMMON_FLAGS = new Set(['--json', '--repo', '--cwd', '--body-file', '--pr']);
@@ -550,7 +577,8 @@ function appendIssueEditMetadata(args, options) {
 
 function issueCommand(args) {
   const action = args[0];
-  if (!action) die('dev gh issue requires a subcommand: list, view, create, comment, edit, or close', 'MISSING_SUBCOMMAND');
+  if (!action) die(`dev gh issue requires a subcommand: ${devGhSubcommandsFor('issue').join(', ')}`, 'MISSING_SUBCOMMAND');
+  requireDispatchable(['issue', action]);
   if (action === 'list') {
     const options = parseOptions(args.slice(1), 'issue:list');
     if (options.positionals.length > 0) die(`Unknown dev gh issue argument: ${options.positionals[0]}`, 'UNKNOWN_ARG');
@@ -634,7 +662,8 @@ function issueCommand(args) {
 
 function labelCommand(args) {
   const action = args[0];
-  if (!action) die('dev gh label requires a subcommand: list', 'MISSING_SUBCOMMAND');
+  if (!action) die(`dev gh label requires a subcommand: ${devGhSubcommandsFor('label').join(', ')}`, 'MISSING_SUBCOMMAND');
+  requireDispatchable(['label', action]);
   if (action === 'list') {
     const options = parseOptions(args.slice(1), 'label:list');
     if (options.positionals.length > 0) die(`Unknown dev gh label argument: ${options.positionals[0]}`, 'UNKNOWN_ARG');
@@ -652,7 +681,8 @@ function labelCommand(args) {
 
 function prCommand(args) {
   const action = args[0];
-  if (!action) die('dev gh pr requires a subcommand: list, view, checks, comment, or merge', 'MISSING_SUBCOMMAND');
+  if (!action) die(`dev gh pr requires a subcommand: ${devGhSubcommandsFor('pr').join(', ')}`, 'MISSING_SUBCOMMAND');
+  requireDispatchable(['pr', action]);
   if (action === 'list') {
     const options = parseOptions(args.slice(1), 'pr:list');
     if (options.positionals.length > 0) die(`Unknown dev gh pr argument: ${options.positionals[0]}`, 'UNKNOWN_ARG');
@@ -722,7 +752,8 @@ function prCommand(args) {
 
 function ciCommand(args) {
   const action = args[0];
-  if (!action) die('dev gh ci requires a subcommand: inspect', 'MISSING_SUBCOMMAND');
+  if (!action) die(`dev gh ci requires a subcommand: ${devGhSubcommandsFor('ci').join(', ')}`, 'MISSING_SUBCOMMAND');
+  requireDispatchable(['ci', action]);
   if (action !== 'inspect') die(`Unknown dev gh ci subcommand: ${action}`, 'UNKNOWN_SUBCOMMAND');
   const options = parseOptions(args.slice(1));
   if (options.positionals.length > 1) die('dev gh ci inspect accepts at most one PR number', 'UNKNOWN_ARG');
@@ -828,16 +859,26 @@ function reviewCommentsCommand(args) {
   else process.stdout.write(`dev gh review-comments: PR #${prNumber}\n`);
 }
 
-const [group, ...rest] = process.argv.slice(2);
-if (!group) {
-  process.stdout.write('Usage: aos dev gh <context|issue|label|pr|ci|review-comments> ...\n');
-  process.exit(0);
+const cliArgs = process.argv.slice(2);
+if (cliArgs.includes('--help') || cliArgs.includes('-h')) {
+  printHelpAndExit(cliArgs.filter((arg) => arg !== '--help' && arg !== '-h'));
 }
 
-if (group === 'context') contextCommand(rest);
+const [group, ...rest] = cliArgs;
+if (!group) {
+  printHelpAndExit([]);
+}
+
+if (group === 'context') {
+  requireDispatchable(['context']);
+  contextCommand(rest);
+}
 else if (group === 'issue') issueCommand(rest);
 else if (group === 'label') labelCommand(rest);
 else if (group === 'pr') prCommand(rest);
 else if (group === 'ci') ciCommand(rest);
-else if (group === 'review-comments') reviewCommentsCommand(rest);
-else die(`Unknown dev gh group: ${group}`, 'UNKNOWN_SUBCOMMAND');
+else if (group === 'review-comments') {
+  requireDispatchable(['review-comments']);
+  reviewCommentsCommand(rest);
+}
+else die(`Unknown dev gh group: ${group}. Expected one of: ${devGhGroups().join(', ')}`, 'UNKNOWN_SUBCOMMAND');

--- a/scripts/aos-help-proxy.mjs
+++ b/scripts/aos-help-proxy.mjs
@@ -31,6 +31,11 @@ function registryPath() {
   return path.join(repoRootFrom(process.cwd()), 'manifests/commands/aos-commands.json');
 }
 
+function externalManifestPath() {
+  if (process.env.AOS_EXTERNAL_COMMAND_MANIFEST) return process.env.AOS_EXTERNAL_COMMAND_MANIFEST;
+  return path.join(repoRootFrom(process.cwd()), 'manifests/commands/aos-external-commands.json');
+}
+
 function loadRegistry() {
   const file = registryPath();
   try {
@@ -44,6 +49,20 @@ function loadRegistry() {
       error(`Missing command registry manifest. Checked: ${file}`, 'MISSING_COMMAND_REGISTRY');
     }
     error(`Invalid command registry manifest ${file}: ${err.message}`, 'INVALID_COMMAND_REGISTRY');
+  }
+}
+
+function loadExternalManifest() {
+  const file = externalManifestPath();
+  try {
+    const manifest = JSON.parse(fs.readFileSync(file, 'utf8'));
+    if (!Array.isArray(manifest.commands)) {
+      error(`Invalid external command manifest ${file}: missing commands`, 'INVALID_MANIFEST');
+    }
+    return manifest;
+  } catch (err) {
+    if (err?.code === 'ENOENT') return { commands: [] };
+    error(`Invalid external command manifest ${file}: ${err.message}`, 'INVALID_MANIFEST');
   }
 }
 
@@ -95,6 +114,67 @@ function findCommand(commands, pathArgs) {
 
 function arrayEqual(left, right) {
   return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function externalRouteMatches(command, args) {
+  if (args.length < command.path.length) return false;
+  if (!command.path.every((part, index) => args[index] === part)) return false;
+  if (!command.when) return true;
+  const childArgs = args.slice(command.path.length);
+  const childArgIndex = command.when.child_arg_index;
+  if (childArgIndex === undefined) return true;
+  const childArg = childArgs[childArgIndex];
+  if (childArg === undefined) return command.when.child_arg_missing === true;
+  if (command.when.child_arg_missing === true) return false;
+  if (command.when.prefix !== undefined && !childArg.startsWith(command.when.prefix)) return false;
+  if (command.when.excluded_prefixes?.some((prefix) => childArg.startsWith(prefix))) return false;
+  if (command.when.excluded_values?.includes(childArg)) return false;
+  return true;
+}
+
+function findHelpPassthrough(pathArgs) {
+  const manifest = loadExternalManifest();
+  return (manifest.commands || [])
+    .filter((command) => command.help_passthrough === true)
+    .filter((command) => externalRouteMatches(command, pathArgs))
+    .sort((left, right) => right.path.length - left.path.length)[0] ?? null;
+}
+
+function resolveExternalValue(value, repoRoot) {
+  if (value === '$REPO_ROOT') return repoRoot;
+  if (value?.startsWith('$REPO_ROOT/')) return path.join(repoRoot, value.slice('$REPO_ROOT/'.length));
+  if (value === '$AOS_PATH') return process.env.AOS_PATH || './aos';
+  if (value === '$AOS_INVOCATION_DISPLAY_NAME') return invocationDisplayName();
+  if (value === '$AOS_RUNTIME_MODE') return process.env.AOS_RUNTIME_MODE || 'repo';
+  if (value === '$AOS_STATE_ROOT') return process.env.AOS_STATE_ROOT || '';
+  if (value === '$AOS_SESSION_KEY') return process.env.AOS_SESSION_KEY || '';
+  if (value === '$AOS_SESSION_HARNESS') return process.env.AOS_SESSION_HARNESS || '';
+  return value;
+}
+
+function runHelpPassthrough(command, pathArgs) {
+  const repoRoot = repoRootFrom(process.cwd());
+  const childArgs = pathArgs.slice(command.path.length);
+  const executable = resolveExternalValue(command.executable, repoRoot);
+  const argv = (command.argv_prefix || []).map((arg) => resolveExternalValue(arg, repoRoot)).concat(childArgs, '--help');
+  const cwd = command.cwd === 'repo'
+    ? repoRoot
+    : command.cwd
+      ? resolveExternalValue(command.cwd, repoRoot)
+      : process.cwd();
+  const env = { ...process.env };
+  for (const [key, value] of Object.entries(command.env || {})) {
+    env[key] = resolveExternalValue(value, repoRoot);
+  }
+  if (!env.AOS_INVOCATION_DISPLAY_NAME) env.AOS_INVOCATION_DISPLAY_NAME = invocationDisplayName();
+
+  const result = spawnSync(executable, argv, { cwd, env, encoding: 'utf8' });
+  if (result.error) {
+    error(`Help passthrough failed for ${command.path.join(' ')}: ${result.error.message}`, 'HELP_PASSTHROUGH_FAILED');
+  }
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  process.exit(result.status ?? 1);
 }
 
 function printFullRegistryJSON(registry) {
@@ -220,6 +300,11 @@ if (pathArgs.length === 0) {
   if (jsonMode) printFullRegistryJSON(registry);
   else printFullRegistryText(registry);
 } else {
+  if (!jsonMode) {
+    const passthrough = findHelpPassthrough(pathArgs);
+    if (passthrough) runHelpPassthrough(passthrough, pathArgs);
+  }
+
   const command = findCommand(registry.commands, pathArgs);
   if (!command) {
     error(`Unknown command: ${pathArgs.join(' ')}. Run '${invocationDisplayName()} help --json' for full registry.`, 'UNKNOWN_COMMAND');

--- a/shared/schemas/aos-external-command-manifest-v0.schema.json
+++ b/shared/schemas/aos-external-command-manifest-v0.schema.json
@@ -45,6 +45,10 @@
             "minLength": 1
           }
         },
+        "help_passthrough": {
+          "type": "boolean",
+          "description": "When true, the external help proxy may delegate text help for this route and its children to the target command with --help."
+        },
         "cwd": {
           "enum": ["repo"]
         },

--- a/tests/aos-dev-gh-help-parity.test.mjs
+++ b/tests/aos-dev-gh-help-parity.test.mjs
@@ -1,16 +1,17 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   dispatchableDevGhCommandPaths,
   devGhPathKey,
-  exposedDevGhCommandPaths,
 } from '../scripts/aos-dev-gh-spec.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
+const devGhScriptPath = path.join(repoRoot, 'scripts/aos-dev-gh.mjs');
 
 function sortedKeys(paths) {
   return paths.map(devGhPathKey).sort();
@@ -27,46 +28,97 @@ function combinedOutput(result) {
   return `${result.stdout || ''}${result.stderr || ''}`;
 }
 
-test('dev gh command spec keeps dispatch and help exposure in parity', () => {
-  const dispatchable = sortedKeys(dispatchableDevGhCommandPaths());
-  const exposed = sortedKeys(exposedDevGhCommandPaths());
-  const exposedSet = new Set(exposed);
-  const dispatchableSet = new Set(dispatchable);
+test('dev gh allowlist matches the script dispatch branches', async () => {
+  const source = await fs.readFile(devGhScriptPath, 'utf8');
+  const allowlist = sortedKeys(dispatchableDevGhCommandPaths());
+  const dispatched = sortedKeys(actualDispatchPathsFromSource(source));
 
-  const dispatchableOnly = dispatchable.filter((key) => !exposedSet.has(key));
-  const exposedOnly = exposed.filter((key) => !dispatchableSet.has(key));
-
-  assert.deepEqual(dispatchableOnly, [], `dispatchable but not exposed: ${dispatchableOnly.join(', ')}`);
-  assert.deepEqual(exposedOnly, [], `exposed but not dispatchable: ${exposedOnly.join(', ')}`);
-  assert.ok(dispatchableSet.has('label list'), 'label list is the canary for non-pr child discovery');
+  assert.deepEqual(allowlist, dispatched);
+  assert.ok(allowlist.includes('label list'), 'label list is the canary for non-pr child discovery');
 });
 
-test('dev gh root help enumerates the script-owned command subtree', () => {
+test('dev gh root help enumerates the allowlist and documents deltas', () => {
   const result = runAos(['dev', 'gh', '--help']);
   const output = combinedOutput(result);
 
-  assert.equal(result.status, 0, output);
-  assert.doesNotMatch(output, /UNKNOWN_COMMAND/);
-  assert.match(output, /^\.\/aos dev gh — /m);
-  assert.match(output, /^  \.\/aos dev gh <subcommand> \[options\]/m);
-  assert.match(output, /^  Subcommands:/m);
+  assertDeltaDoc(result, output);
+  assert.match(output, /^  Allowed subcommands:/m);
 
   for (const commandPath of sortedKeys(dispatchableDevGhCommandPaths())) {
     assert.match(output, new RegExp(`^    ${escapeRegExp(commandPath)}\\s{2,}`, 'm'));
   }
 });
 
-test('every dispatchable dev gh command path has real ./aos text help', () => {
+test('dev gh catch-all help returns the delta doc for real and unknown paths', () => {
   for (const pathParts of dispatchableDevGhCommandPaths()) {
-    const result = runAos(['dev', 'gh', ...pathParts, '--help']);
-    const output = combinedOutput(result);
     const label = `./aos dev gh ${pathParts.join(' ')} --help`;
+    const result = runAos(['dev', 'gh', ...pathParts, '--help']);
+    assertDeltaDoc(result, combinedOutput(result), label);
 
-    assert.equal(result.status, 0, `${label}\n${output}`);
-    assert.doesNotMatch(output, /UNKNOWN_COMMAND/, label);
-    assert.match(output, new RegExp(`^  ${escapeRegExp(`./aos dev gh ${pathParts.join(' ')}`)}\\b`, 'm'), label);
+    const helpLabel = `./aos help dev gh ${pathParts.join(' ')}`;
+    const helpResult = runAos(['help', 'dev', 'gh', ...pathParts]);
+    assertDeltaDoc(helpResult, combinedOutput(helpResult), helpLabel);
   }
+
+  const unknownResult = runAos(['dev', 'gh', 'pr', 'definitely-not-real', '--help']);
+  assertDeltaDoc(unknownResult, combinedOutput(unknownResult), 'unknown subcommand help');
 });
+
+function assertDeltaDoc(result, output, label = 'dev gh help') {
+  assert.equal(result.status, 0, `${label}\n${output}`);
+  assert.doesNotMatch(output, /UNKNOWN_COMMAND/, label);
+  assert.match(output, /^\.\/aos dev gh — sanctioned GitHub workflow subset/m, label);
+  assert.match(output, /Non-interactive only: commands fail instead of prompting\./, label);
+  assert.match(output, /Body-writing commands use --body-file; issue create\/comment and pr comment require it\./, label);
+  assert.match(output, /pr merge requires exactly one explicit strategy: --squash, --merge, or --rebase\./, label);
+  assert.match(output, /List commands take bounded --limit values for inventory scans\./, label);
+  assert.match(output, /context\s+Reports local gh auth, repository, branch, current PR, and dirty checkout state\./, label);
+  assert.match(output, /ci inspect\s+Reads PR checks and failed GitHub Actions logs for review triage\./, label);
+  assert.match(output, /review-comments\s+Reads PR review thread state through gh GraphQL\./, label);
+}
+
+function actualDispatchPathsFromSource(source) {
+  const paths = [];
+  const groupFunctions = new Map([
+    ['issue', 'issueCommand'],
+    ['label', 'labelCommand'],
+    ['pr', 'prCommand'],
+    ['ci', 'ciCommand'],
+  ]);
+
+  for (const match of source.matchAll(/\bgroup\s*===\s*'([^']+)'/g)) {
+    const group = match[1];
+    if (!groupFunctions.has(group)) paths.push([group]);
+  }
+
+  for (const [group, functionName] of groupFunctions) {
+    const body = functionBody(source, functionName);
+    const actions = new Set(
+      [...body.matchAll(/\baction\s*(?:===|!==)\s*'([^']+)'/g)].map((match) => match[1]),
+    );
+    for (const action of actions) paths.push([group, action]);
+  }
+
+  return paths;
+}
+
+function functionBody(source, functionName) {
+  const start = source.indexOf(`function ${functionName}(`);
+  assert.notEqual(start, -1, `missing function ${functionName}`);
+  const open = source.indexOf('{', start);
+  assert.notEqual(open, -1, `missing function body for ${functionName}`);
+
+  let depth = 0;
+  for (let i = open; i < source.length; i += 1) {
+    const char = source[i];
+    if (char === '{') depth += 1;
+    else if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(open + 1, i);
+    }
+  }
+  throw new Error(`unterminated function body for ${functionName}`);
+}
 
 function escapeRegExp(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/tests/aos-dev-gh-help-parity.test.mjs
+++ b/tests/aos-dev-gh-help-parity.test.mjs
@@ -1,0 +1,73 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  dispatchableDevGhCommandPaths,
+  devGhPathKey,
+  exposedDevGhCommandPaths,
+} from '../scripts/aos-dev-gh-spec.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+function sortedKeys(paths) {
+  return paths.map(devGhPathKey).sort();
+}
+
+function runAos(args) {
+  return spawnSync('./aos', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+}
+
+function combinedOutput(result) {
+  return `${result.stdout || ''}${result.stderr || ''}`;
+}
+
+test('dev gh command spec keeps dispatch and help exposure in parity', () => {
+  const dispatchable = sortedKeys(dispatchableDevGhCommandPaths());
+  const exposed = sortedKeys(exposedDevGhCommandPaths());
+  const exposedSet = new Set(exposed);
+  const dispatchableSet = new Set(dispatchable);
+
+  const dispatchableOnly = dispatchable.filter((key) => !exposedSet.has(key));
+  const exposedOnly = exposed.filter((key) => !dispatchableSet.has(key));
+
+  assert.deepEqual(dispatchableOnly, [], `dispatchable but not exposed: ${dispatchableOnly.join(', ')}`);
+  assert.deepEqual(exposedOnly, [], `exposed but not dispatchable: ${exposedOnly.join(', ')}`);
+  assert.ok(dispatchableSet.has('label list'), 'label list is the canary for non-pr child discovery');
+});
+
+test('dev gh root help enumerates the script-owned command subtree', () => {
+  const result = runAos(['dev', 'gh', '--help']);
+  const output = combinedOutput(result);
+
+  assert.equal(result.status, 0, output);
+  assert.doesNotMatch(output, /UNKNOWN_COMMAND/);
+  assert.match(output, /^\.\/aos dev gh — /m);
+  assert.match(output, /^  \.\/aos dev gh <subcommand> \[options\]/m);
+  assert.match(output, /^  Subcommands:/m);
+
+  for (const commandPath of sortedKeys(dispatchableDevGhCommandPaths())) {
+    assert.match(output, new RegExp(`^    ${escapeRegExp(commandPath)}\\s{2,}`, 'm'));
+  }
+});
+
+test('every dispatchable dev gh command path has real ./aos text help', () => {
+  for (const pathParts of dispatchableDevGhCommandPaths()) {
+    const result = runAos(['dev', 'gh', ...pathParts, '--help']);
+    const output = combinedOutput(result);
+    const label = `./aos dev gh ${pathParts.join(' ')} --help`;
+
+    assert.equal(result.status, 0, `${label}\n${output}`);
+    assert.doesNotMatch(output, /UNKNOWN_COMMAND/, label);
+    assert.match(output, new RegExp(`^  ${escapeRegExp(`./aos dev gh ${pathParts.join(' ')}`)}\\b`, 'm'), label);
+  }
+});
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/tests/schemas/aos-external-command-manifest-v0.test.mjs
+++ b/tests/schemas/aos-external-command-manifest-v0.test.mjs
@@ -140,6 +140,24 @@ test('external command manifest executable targets exist', async () => {
   }
 });
 
+test('external help passthrough routes stay script-owned', async () => {
+  const manifest = await loadJson(manifestPath);
+  const passthroughRoutes = manifest.commands.filter((command) => command.help_passthrough === true);
+
+  assert.ok(
+    passthroughRoutes.some((command) => command.path.join(' ') === 'dev gh'),
+    'dev gh must declare script-owned help passthrough',
+  );
+
+  for (const command of passthroughRoutes) {
+    assert.notEqual(command.executable, '$AOS_PATH', `${command.path.join(' ')} help passthrough must not route to Swift`);
+    assert.ok(
+      (command.argv_prefix || []).some((arg) => arg.startsWith('scripts/') || arg.startsWith('packages/')),
+      `${command.path.join(' ')} help passthrough must name an external script target`,
+    );
+  }
+});
+
 test('external command manifest placeholders are resolved by Swift dispatcher', async () => {
   const manifest = await loadJson(manifestPath);
   const source = await fs.readFile(path.join(repoRoot, 'src/shared/external-command-dispatch.swift'), 'utf8');

--- a/tests/schemas/dev-workflow-rules.test.mjs
+++ b/tests/schemas/dev-workflow-rules.test.mjs
@@ -102,16 +102,19 @@ test('canonical rules preserve the expected V0 routing contracts', async () => {
     [
       'node --test tests/schemas/aos-external-command-manifest-v0.test.mjs',
       'bash tests/external-command-dispatch.sh',
+      'node --test tests/aos-dev-gh-help-parity.test.mjs',
       'bash tests/help-contract.sh',
     ],
   );
   assert.ok(rules.get('command-surface-manifests')?.patterns?.includes('manifests/commands/*.json'));
   assert.ok(rules.get('command-surface-manifests')?.patterns?.includes('shared/schemas/aos-external-command-manifest-v0.schema.json'));
+  assert.ok(rules.get('command-surface-manifests')?.patterns?.includes('tests/aos-dev-gh-help-parity.test.mjs'));
   assert.deepEqual(
     rules.get('command-surface-implementations')?.commands?.map((step) => step.command),
     [
       'bash tests/external-command-dispatch.sh',
       'bash tests/external-parser-flags.sh',
+      'node --test tests/aos-dev-gh-help-parity.test.mjs',
       'bash tests/help-contract.sh',
     ],
   );


### PR DESCRIPTION
## Summary

- Add manifest-declared help passthrough so `./aos dev gh --help` and child help delegate to the external script without Swift command policy.
- Replace per-command `dev gh` help with one curated delta-doc: the allowlist, the differences from raw `gh`, and the three AOS-only helpers.
- Add allowlist parity coverage against the script dispatch branches and black-box real-`./aos` checks for root, real child, and unknown child help.

Fixes #416.

## Verification

- `git diff --check`
- `node --check scripts/aos-help-proxy.mjs && node --check scripts/aos-dev-gh.mjs && node --check scripts/aos-dev-gh-spec.mjs && node --check tests/aos-dev-gh-help-parity.test.mjs`
- `node --test tests/aos-dev-gh-help-parity.test.mjs`
- `node --test tests/schemas/aos-external-command-manifest-v0.test.mjs`
- `node --test tests/schemas/dev-workflow-rules.test.mjs`
- `bash tests/help-contract.sh`
- `bash tests/external-command-dispatch.sh`
- `bash tests/external-parser-flags.sh`
- `bash tests/dev-workflow-router.sh`