### PR TITLE
Define AOS target descriptors and clean identity drift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ node_modules/
 # Local scratch outputs
 clipboard.txt
 .aos-test-tmp/
+.playwright-cli/
 
 # Local gateway secrets
 packages/gateway/.env

--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -497,8 +497,10 @@ action handle. Durable machine identity lives in `target.target_id` scoped by
 id, parent canvas id, local geometry, metadata, and the
 `canvas:<canvas-id>/<ref>` action-routing string are presentation,
 provenance/current-address, or hint fields. They are not durable identity. The
-probe does not use caller-supplied JavaScript; `show eval` remains a developer
-diagnostic bridge, not the agent perception contract.
+current V0 producer emits or consumes descriptor fields when it can derive them;
+older or partial AOS-owned surfaces may omit some fields until their producers
+migrate. The probe does not use caller-supplied JavaScript; `show eval` remains
+a developer diagnostic bridge, not the agent perception contract.
 
 See [`shared/schemas/aos-semantic-targets.md`](../../shared/schemas/aos-semantic-targets.md)
 for the response shape.

--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -489,13 +489,16 @@ resolve the element explicitly under the cursor.
 not role-whitelist them into an "interactive" vocabulary. For AOS-owned canvas
 captures, `aos see capture --canvas <id> --xray` also runs a fixed semantic
 target probe inside that canvas and returns `semantic_targets`. Those entries
-use the canonical `agent_ui_target` envelope: top-level `ref`, `surface`,
-`role`, `name`, `kind`, `enabled`, `state`, `actions`, `extension`, and
-`provenance`. The sole top-level identity is `ref` from `data-aos-ref`.
-Local DOM ids, canvas id, parent canvas id, local geometry, metadata, and the
-`canvas:<canvas-id>/<ref>` action-routing string live under `provenance` or
-`extension`. The probe does not use caller-supplied JavaScript; `show eval`
-remains a developer diagnostic bridge, not the agent perception contract.
+use the canonical `agent_ui_target` envelope: top-level `ref`, `state_id`,
+`surface`, `role`, `name`, `kind`, `enabled`, `target`, `state`, `actions`,
+`extension`, `provenance`, and `reacquisition`. `ref` is the state-scoped
+action handle. Durable machine identity lives in `target.target_id` scoped by
+`target.owner_namespace`; human labels, accessible text, local DOM ids, canvas
+id, parent canvas id, local geometry, metadata, and the
+`canvas:<canvas-id>/<ref>` action-routing string are presentation,
+provenance/current-address, or hint fields. They are not durable identity. The
+probe does not use caller-supplied JavaScript; `show eval` remains a developer
+diagnostic bridge, not the agent perception contract.
 
 See [`shared/schemas/aos-semantic-targets.md`](../../shared/schemas/aos-semantic-targets.md)
 for the response shape.
@@ -634,13 +637,16 @@ aos do click canvas:<canvas-id>/<ref> --state-id <id>
 Use `canvas:<canvas-id>/<ref>` when a target was discovered in
 `aos see capture --canvas <canvas-id> --xray`. Agents should pass
 `semantic_targets[].provenance.do_target` directly when present;
-`provenance.canvas_id` and `ref` remain available for structured filtering. The
-CLI resolves the current AOS-owned canvas semantic target through the fixed
-probe path, rejects missing, disabled, ambiguous, suspended, noninteractive, or
-unsupported segmented canvases with machine-readable errors, and then clicks
-the resolved `provenance.center` in global CG coordinates. V0 does not
-dereference a historical `state_id`; the id is preserved only as correlation
-metadata for the perception the action was chosen from.
+`provenance.canvas_id` and `ref` remain available for structured filtering.
+When the originating descriptor also has `state_id`, pass `--state-id <id>` so
+the actuator can detect stale state when that check is available. The CLI
+resolves the current AOS-owned canvas semantic target through the fixed probe
+path, rejects missing, disabled, stale, ambiguous, suspended, noninteractive,
+or unsupported segmented canvases with machine-readable errors, and then
+clicks the resolved `provenance.center` in global CG coordinates. V0 preserves
+historical `state_id` as correlation metadata; the descriptor contract already
+defines stale-ref status so future producers can reject a stale state/ref pair
+without changing target vocabulary.
 
 Coordinate, browser-target, and canvas-ref actions accept `--state-id <id>` when
 the action was chosen from a prior `aos see capture` response. Direct one-shot
@@ -695,7 +701,18 @@ target center and uses CGEvent as a visible playback implementation detail.
 Target-addressed responses include the action, backend, playback mode,
 `execution.strategy`, `execution.backend`, `execution.fallback_used`, the
 correlation `state_id` when supplied, resolved target details, and post-action
-semantic state when the target can be collected after execution.
+semantic state when the target can be collected after execution. Stale
+state/ref pairs report a machine-readable `stale_ref` status. Descriptor-based
+reacquisition may report `reacquired` only after one current target is found
+through machine facts first; same-label matches without a unique machine
+fingerprint report `ambiguous` with candidates instead of selecting one.
+
+Gesture frames and Work Recording references should carry the same descriptor
+vocabulary: the state-scoped `ref`/`state_id`, durable
+`target.target_id` scoped by `target.owner_namespace`, primitive `actions`,
+current `state`, `provenance` for the current address, and `reacquisition`
+fingerprints for repair. They should not promote labels or coordinates into
+durable target identity.
 
 ## `aos graph`
 

--- a/docs/api/toolkit/controls.md
+++ b/docs/api/toolkit/controls.md
@@ -99,18 +99,23 @@ stepping and returns `{ dispose() }`.
 ## AOS Semantic Control Targets
 
 Toolkit sliders stamp the actionable `[data-aos-slider-control]` part with a
-stable semantic target. The target includes `role="slider"`, `data-aos-ref`,
-`data-semantic-target-id`, `data-aos-actions`, `aria-valuemin`,
-`aria-valuemax`, `aria-valuenow`, `aria-orientation`, `data-aos-values`,
-`data-aos-min`, `data-aos-max`, `data-aos-step`, and
-`data-aos-thumb-count`.
+target descriptor. `data-aos-ref` is the state-scoped ref used by immediate
+`aos do` calls. `data-semantic-target-id` is the local durable
+`target.target_id` inside the slider's owner namespace. ARIA fields remain
+accessibility and current-state presentation, not identity. The stamped target
+includes `role="slider"`, `data-aos-ref`, `data-semantic-target-id`,
+`data-aos-actions`, `aria-valuemin`, `aria-valuemax`, `aria-valuenow`,
+`aria-orientation`, `data-aos-values`, `data-aos-min`, `data-aos-max`,
+`data-aos-step`, and `data-aos-thumb-count`.
 
 Single-thumb sliders advertise `data-aos-actions="drag set-value"` and handle
 the internal `aos:semantic-action` event used by target-addressed
 `aos do set-value canvas:<canvas-id>/<ref>` and
 `aos do drag canvas:<canvas-id>/<ref> --to-value <value>`. Multi-thumb sliders
 advertise `drag` only until thumb-specific semantic refs exist; they must not be
-treated as safe single-value targets.
+treated as safe single-value targets. Reacquisition should use the descriptor's
+machine facts, range shape, owner namespace, and primitive capabilities first;
+labels and accessible text are hints only.
 
 ## Styling
 

--- a/docs/api/toolkit/workbench.md
+++ b/docs/api/toolkit/workbench.md
@@ -450,9 +450,12 @@ The metadata contract records `schema`, `version`, `expression_id`, source kind
 and path, source content hash, generated timestamp, artifact kind, generated
 HTML path, semantic targets, source map entries, Mermaid block records,
 annotation/checkpoint/export capability flags, security policy, and resume
-behavior. Each semantic target has an id, `data-aos-ref`, kind, accessible
-label, source line range, selector, annotation eligibility, and reveal
-eligibility.
+behavior. Each semantic target records the descriptor-facing split: a
+state-scoped `data-aos-ref`, local `target.target_id` from
+`data-semantic-target-id`, owner/source metadata for namespace and provenance,
+kind, accessible label, source line range, selector, annotation eligibility,
+and reveal eligibility. Accessible labels and selectors help humans and
+reacquisition; they are not durable target identity.
 
 The AOS-hosted surface lives at
 `packages/toolkit/components/html-workbench-expression/`. It receives

--- a/docs/design/aos-shared-gesture-spine-v0.md
+++ b/docs/design/aos-shared-gesture-spine-v0.md
@@ -38,8 +38,12 @@ Each frame carries:
   `native`, and `desktop_world`.
 - `origin`, `previous`, `current`, `delta`, and `total_delta` points.
 - `constraints`, `bounds`, and `axis` metadata when the adapter knows them.
-- `semantic_target` and `semantic_action` for target/action identity such as a
-  slider `set-value` drag.
+- `semantic_target` and `semantic_action` for the AOS target descriptor and
+  primitive action, such as a slider `set-value` drag. The descriptor carries
+  state-scoped `ref`/`state_id`, durable `target.target_id` scoped by
+  `target.owner_namespace`, current `state`, provenance/current address, and
+  reacquisition hints. Human-facing labels and coordinates may be recorded as
+  hints or observations, but not as target identity.
 - `timing`: timestamp `t` and `frame_index`.
 - `raw_event_type`: the source event type used to create the frame.
 

--- a/docs/design/aos-work-records-and-self-healing-recipes.md
+++ b/docs/design/aos-work-records-and-self-healing-recipes.md
@@ -138,13 +138,14 @@ Examples:
 ```text
 browser:<session>/<ref>
 ax:<pid>/<ref>
-canvas:<canvas-id>/<object-ref>
+canvas:<canvas-id>/<state-scoped-ref>
 screen:<state-id>/<x,y>
 ```
 
 The exact grammar can harden later. The important point is that target strings
-are compact handles while the execution map can carry richer candidates,
-metadata, and stale-ref repair hints.
+are compact current-address handles while the execution map can carry richer
+target descriptors: owner namespace, durable target id, primitive actions,
+state, provenance, and machine-first stale-ref repair hints.
 
 ## Playwright And Codegen
 

--- a/docs/design/aos-work-records-and-self-healing-recipes.md
+++ b/docs/design/aos-work-records-and-self-healing-recipes.md
@@ -111,7 +111,12 @@ carry those fields as correlation metadata between the natural-language spine,
 the structured execution map, and immutable evidence.
 
 Coordinates can be recorded, but they are fallback material. When semantic
-targets exist, prefer them.
+targets exist, prefer the AOS target descriptor vocabulary: state-scoped `ref`
+and `state_id` for the immediate action, durable `target.target_id` scoped by
+`target.owner_namespace`, primitive `actions`, current `state`, `provenance`
+for the current address, and `reacquisition` fingerprints for repair. Labels
+and accessibility text can help repair as hints, but they are not durable
+target identity.
 
 The first AOS action capture slice is intentionally saved-evidence only. A
 single source records before perception, the AOS `do` result, and after

--- a/docs/design/fixtures/aos-target-descriptor-v0/ambiguous-reacquisition.json
+++ b/docs/design/fixtures/aos-target-descriptor-v0/ambiguous-reacquisition.json
@@ -1,0 +1,62 @@
+{
+  "schema": "aos.target-descriptor.fixture.v0",
+  "case": "ambiguous_same_label_reacquisition",
+  "previous": {
+    "ref": "td3",
+    "state_id": "see_targetdescriptor010",
+    "role": "button",
+    "name": "Open",
+    "reacquisition": {
+      "machine_fingerprint": {
+        "role": "button",
+        "capabilities": ["click", "open"]
+      },
+      "hint_fingerprint": {
+        "label_hints": ["Open"]
+      }
+    }
+  },
+  "current_state_id": "see_targetdescriptor011",
+  "candidates": [
+    {
+      "ref": "td11",
+      "role": "button",
+      "name": "Open",
+      "target": {
+        "target_id": "command:open",
+        "owner_namespace": {
+          "app_id": "sigil",
+          "canvas_id": "file-menu-canvas",
+          "surface_id": "file-menu",
+          "component_family": "menu",
+          "structural_owner": ["menu-bar", "file"]
+        }
+      },
+      "actions": ["click", "open"]
+    },
+    {
+      "ref": "td12",
+      "role": "button",
+      "name": "Open",
+      "target": {
+        "target_id": "command:open",
+        "owner_namespace": {
+          "app_id": "sigil",
+          "canvas_id": "project-card-canvas",
+          "surface_id": "project-card",
+          "component_family": "card",
+          "structural_owner": ["recent-projects", "project-42"]
+        }
+      },
+      "actions": ["click", "open"]
+    }
+  ],
+  "resolution": {
+    "status": "ambiguous",
+    "reason": "machine_fingerprint_not_unique",
+    "action_blocked": true,
+    "selected_ref": null,
+    "candidate_refs": ["td11", "td12"],
+    "labels_used_as_hints_only": true
+  }
+}

--- a/docs/design/fixtures/aos-target-descriptor-v0/manifest.json
+++ b/docs/design/fixtures/aos-target-descriptor-v0/manifest.json
@@ -1,0 +1,10 @@
+{
+  "schema": "aos.target-descriptor.fixture-pack.v0",
+  "description": "Deterministic fixture pack for the AOS target descriptor V0 contract.",
+  "fixtures": [
+    "same-label-namespaces.json",
+    "stale-ref.json",
+    "reacquisition-success.json",
+    "ambiguous-reacquisition.json"
+  ]
+}

--- a/docs/design/fixtures/aos-target-descriptor-v0/reacquisition-success.json
+++ b/docs/design/fixtures/aos-target-descriptor-v0/reacquisition-success.json
@@ -1,0 +1,70 @@
+{
+  "schema": "aos.target-descriptor.fixture.v0",
+  "case": "descriptor_based_reacquisition_success",
+  "previous": {
+    "ref": "td1",
+    "state_id": "see_targetdescriptor001",
+    "target": {
+      "target_id": "control:opacity",
+      "owner_namespace": {
+        "app_id": "sigil",
+        "canvas_id": "avatar-panel-canvas",
+        "surface_id": "avatar-appearance-panel",
+        "component_family": "toolkit.panel.form",
+        "structural_owner": ["avatar-editor", "appearance"]
+      }
+    },
+    "reacquisition": {
+      "machine_fingerprint": {
+        "role": "slider",
+        "structural_path": ["avatar-editor", "appearance", "field:opacity"],
+        "capabilities": ["drag", "set-value", "focus"],
+        "nearby_group": "Appearance",
+        "range_shape": { "min": 0, "max": 1, "step": 0.01 }
+      },
+      "hint_fingerprint": {
+        "label_hints": ["Opacity"],
+        "source_hints": { "field_id": "opacity" }
+      }
+    }
+  },
+  "current_state_id": "see_targetdescriptor002",
+  "candidates": [
+    {
+      "ref": "td9",
+      "state_id": "see_targetdescriptor002",
+      "role": "slider",
+      "name": "Opacity",
+      "target": {
+        "target_id": "control:opacity",
+        "owner_namespace": {
+          "app_id": "sigil",
+          "canvas_id": "avatar-panel-canvas",
+          "surface_id": "avatar-appearance-panel",
+          "component_family": "toolkit.panel.form",
+          "structural_owner": ["avatar-editor", "appearance"]
+        }
+      },
+      "actions": ["drag", "set-value", "focus"],
+      "state": { "value": 0.6, "min": 0, "max": 1, "step": 0.01 },
+      "provenance": {
+        "canvas_id": "avatar-panel-canvas",
+        "do_target": "canvas:avatar-panel-canvas/td9",
+        "center": { "x": 126, "y": 96 }
+      }
+    }
+  ],
+  "resolution": {
+    "status": "reacquired",
+    "selected_ref": "td9",
+    "matched_by": [
+      "owner_namespace",
+      "target_id",
+      "role",
+      "structural_path",
+      "capabilities",
+      "range_shape"
+    ],
+    "labels_used_as_hints_only": true
+  }
+}

--- a/docs/design/fixtures/aos-target-descriptor-v0/same-label-namespaces.json
+++ b/docs/design/fixtures/aos-target-descriptor-v0/same-label-namespaces.json
@@ -1,0 +1,119 @@
+{
+  "schema": "aos.target-descriptor.fixture.v0",
+  "case": "same_label_namespaced_targets",
+  "state_id": "see_targetdescriptor001",
+  "semantic_targets": [
+    {
+      "ref": "td1",
+      "state_id": "see_targetdescriptor001",
+      "surface": "avatar-appearance-panel",
+      "role": "slider",
+      "name": "Opacity",
+      "kind": "slider",
+      "enabled": true,
+      "target": {
+        "target_id": "control:opacity",
+        "owner_namespace": {
+          "app_id": "sigil",
+          "canvas_id": "avatar-panel-canvas",
+          "surface_id": "avatar-appearance-panel",
+          "component_family": "toolkit.panel.form",
+          "structural_owner": ["avatar-editor", "appearance"]
+        }
+      },
+      "state": {
+        "value": 0.55,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "enabled": true
+      },
+      "actions": ["drag", "set-value", "focus"],
+      "extension": {
+        "field_id": "opacity"
+      },
+      "provenance": {
+        "canvas_id": "avatar-panel-canvas",
+        "parent_canvas_id": "avatar-main",
+        "do_target": "canvas:avatar-panel-canvas/td1",
+        "source_payload_id": "appearance.opacity",
+        "bounds": { "x": 24, "y": 80, "width": 180, "height": 32 },
+        "frame": { "x": 24, "y": 80, "width": 180, "height": 32 },
+        "center": { "x": 114, "y": 96 }
+      },
+      "reacquisition": {
+        "strategy": "owner-structural-fingerprint",
+        "machine_fingerprint": {
+          "role": "slider",
+          "structural_path": ["avatar-editor", "appearance", "field:opacity"],
+          "capabilities": ["drag", "set-value", "focus"],
+          "nearby_group": "Appearance",
+          "range_shape": { "min": 0, "max": 1, "step": 0.01 }
+        },
+        "hint_fingerprint": {
+          "label_hints": ["Opacity"],
+          "source_hints": { "field_id": "opacity" }
+        }
+      }
+    },
+    {
+      "ref": "td2",
+      "state_id": "see_targetdescriptor001",
+      "surface": "layer-appearance-panel",
+      "role": "slider",
+      "name": "Opacity",
+      "kind": "slider",
+      "enabled": true,
+      "target": {
+        "target_id": "control:opacity",
+        "owner_namespace": {
+          "app_id": "sigil",
+          "canvas_id": "layer-panel-canvas",
+          "surface_id": "layer-appearance-panel",
+          "component_family": "toolkit.panel.form",
+          "structural_owner": ["layer-editor", "appearance"]
+        }
+      },
+      "state": {
+        "value": 0.72,
+        "min": 0,
+        "max": 1,
+        "step": 0.01,
+        "enabled": true
+      },
+      "actions": ["drag", "set-value", "focus"],
+      "extension": {
+        "field_id": "opacity"
+      },
+      "provenance": {
+        "canvas_id": "layer-panel-canvas",
+        "parent_canvas_id": "layer-main",
+        "do_target": "canvas:layer-panel-canvas/td2",
+        "source_payload_id": "appearance.opacity",
+        "bounds": { "x": 24, "y": 80, "width": 180, "height": 32 },
+        "frame": { "x": 24, "y": 80, "width": 180, "height": 32 },
+        "center": { "x": 114, "y": 96 }
+      },
+      "reacquisition": {
+        "strategy": "owner-structural-fingerprint",
+        "machine_fingerprint": {
+          "role": "slider",
+          "structural_path": ["layer-editor", "appearance", "field:opacity"],
+          "capabilities": ["drag", "set-value", "focus"],
+          "nearby_group": "Appearance",
+          "range_shape": { "min": 0, "max": 1, "step": 0.01 }
+        },
+        "hint_fingerprint": {
+          "label_hints": ["Opacity"],
+          "source_hints": { "field_id": "opacity" }
+        }
+      }
+    }
+  ],
+  "expectation": {
+    "same_label": "Opacity",
+    "same_local_target_id": "control:opacity",
+    "identity_basis": "owner_namespace + target_id",
+    "status": "distinct_targets"
+  }
+}

--- a/docs/design/fixtures/aos-target-descriptor-v0/stale-ref.json
+++ b/docs/design/fixtures/aos-target-descriptor-v0/stale-ref.json
@@ -1,0 +1,38 @@
+{
+  "schema": "aos.target-descriptor.fixture.v0",
+  "case": "stale_state_scoped_ref",
+  "action": {
+    "verb": "set-value",
+    "target": "canvas:avatar-panel-canvas/td1",
+    "ref": "td1",
+    "state_id": "see_targetdescriptor001",
+    "value": 0.8
+  },
+  "current_state_id": "see_targetdescriptor002",
+  "resolution": {
+    "status": "stale_ref",
+    "reason": "state_id_mismatch",
+    "supplied_state_id": "see_targetdescriptor001",
+    "current_state_id": "see_targetdescriptor002",
+    "supplied_ref": "td1",
+    "action_blocked": true,
+    "reacquisition": {
+      "available": true,
+      "requires_explicit_retry": true,
+      "fingerprint": {
+        "target_id": "control:opacity",
+        "owner_namespace": {
+          "app_id": "sigil",
+          "canvas_id": "avatar-panel-canvas",
+          "surface_id": "avatar-appearance-panel",
+          "component_family": "toolkit.panel.form",
+          "structural_owner": ["avatar-editor", "appearance"]
+        },
+        "role": "slider",
+        "structural_path": ["avatar-editor", "appearance", "field:opacity"],
+        "capabilities": ["drag", "set-value", "focus"],
+        "label_hints": ["Opacity"]
+      }
+    }
+  }
+}

--- a/docs/design/work-cards/gdi-agent-ui-target-conformance-fixtures-v0.md
+++ b/docs/design/work-cards/gdi-agent-ui-target-conformance-fixtures-v0.md
@@ -1,5 +1,13 @@
 # Agent UI Target Conformance Fixtures V0
 
+## Historical Status
+
+This card is historical for target identity guidance. It predates the accepted
+#429 target descriptor contract and #432 drift cleanup. Current work should use
+`shared/schemas/aos-semantic-targets.md` for target identity: state-scoped refs
+plus `target.target_id` scoped by `target.owner_namespace`, with labels and
+accessible names only as presentation or reacquisition hints.
+
 ## Recipient
 
 GDI audit and fixture round.

--- a/docs/design/work-cards/gdi-aos-target-addressed-action-ergonomics-v0.md
+++ b/docs/design/work-cards/gdi-aos-target-addressed-action-ergonomics-v0.md
@@ -1,5 +1,15 @@
 # GDI Work Card: AOS Target-Addressed Action Ergonomics V0
 
+## Historical Status
+
+This card is historical for target identity guidance. It predates the accepted
+#429 target descriptor contract and #432 drift cleanup. Current target-addressed
+action docs should use `shared/schemas/aos-semantic-targets.md`: state-scoped
+refs for immediate actions, durable `target.target_id` scoped by
+`target.owner_namespace`, primitive `actions`, current `state`, `provenance`,
+and machine-first `reacquisition` hints. Labels and accessible names are not
+identity.
+
 ## Routing Status
 
 Ready to dispatch after Foreman checkpoints this card.

--- a/docs/design/work-cards/gdi-aos-target-descriptor-contract-v0.md
+++ b/docs/design/work-cards/gdi-aos-target-descriptor-contract-v0.md
@@ -1,0 +1,244 @@
+# AOS Target Descriptor Contract V0
+
+## Recipient
+
+GDI implementation and fixture round.
+
+## Branch / Base
+
+- branch_from: local `main` containing this work card.
+- required_start_ref: local `main` containing this work card.
+- expected output branch: `gdi/aos-target-descriptor-contract-v0`
+
+Do not reset to `origin/main` for this round. Local `main` is intentionally ahead
+of `origin/main` with Foreman coordination state.
+
+## Source Artifact
+
+- GitHub issue #429:
+  https://github.com/michaelblum/agent-os/issues/429
+- Related but downstream ledgers: #430, #432, #428, #427, #164.
+- Current contract surfaces:
+  - `shared/schemas/aos-semantic-targets.md`
+  - `docs/api/aos.md`
+  - `packages/toolkit/runtime/semantic-targets.js`
+  - `tests/toolkit/runtime-semantic-targets.test.mjs`
+  - `tests/toolkit/agent-ui-target-conformance.test.mjs`
+  - `docs/design/aos-shared-gesture-spine-v0.md`
+  - `docs/design/aos-work-records-and-self-healing-recipes.md`
+
+## Fresh Context Contract
+
+GDI starts from a fresh context window. Do not assume branch, checkout, daemon,
+canvas, issue, or prior implementation state. Read and rediscover before
+editing.
+
+## Goal
+
+Define and prove the first AOS target descriptor contract so agents can act
+through state-scoped refs backed by collision-resistant machine descriptors,
+without treating human names or labels as target identity.
+
+## Read First
+
+- `AGENTS.md`
+- `packages/toolkit/runtime/AGENTS.md`
+- `shared/schemas/aos-semantic-targets.md`
+- `docs/api/aos.md` sections for `aos see` semantic targets and `aos do`
+  target-addressed actions.
+- `packages/toolkit/runtime/semantic-targets.js`
+- `tests/toolkit/runtime-semantic-targets.test.mjs`
+- `tests/toolkit/agent-ui-target-conformance.test.mjs`
+- `docs/design/aos-shared-gesture-spine-v0.md`
+- `docs/design/aos-work-records-and-self-healing-recipes.md`
+
+## Rediscover State
+
+```bash
+git status --short --branch
+git rev-parse HEAD origin/main
+./aos service status --mode repo --json
+./aos dev gh issue view 429 --json
+rg -n "semantic_targets|normalizeAgentUiTarget|normalizeSemanticTarget|refForTarget|pickName|target_id|state_id|stateId|reacqui|settings\\.opacity|avatar\\.controls\\.scale" shared docs packages tests
+```
+
+Live AOS is intentionally paused for this workstream. Do not run `./aos ready`,
+`./aos status`, `./aos clean`, service start/restart, or live smoke unless
+Michael explicitly approves it in a new instruction. This slice is
+deterministic-only.
+
+## Existing Code To Inspect
+
+- `shared/schemas/aos-semantic-targets.md` - current semantic-target contract;
+  it still needs the state-scoped ref / durable descriptor split.
+- `docs/api/aos.md` - public `aos see` and `aos do` semantics that must align
+  with descriptor-backed target resolution.
+- `packages/toolkit/runtime/semantic-targets.js` - current toolkit normalizers;
+  watch for any path where `name`, `label`, or accessible text can feed machine
+  identity.
+- `tests/toolkit/runtime-semantic-targets.test.mjs` - focused runtime contract
+  tests.
+- `tests/toolkit/agent-ui-target-conformance.test.mjs` and
+  `docs/design/fixtures/agent-ui-target-conformance-v0/` - adjacent fixture
+  pack proving older target-shape drift.
+- `packages/toolkit/runtime/gesture-stream.js` and
+  `docs/design/aos-shared-gesture-spine-v0.md` - gesture frame vocabulary that
+  should point at descriptors instead of nice-name examples.
+- `shared/schemas/aos-work-record-v0.schema.json`,
+  `tests/toolkit/work-record-*.test.mjs`, and
+  `docs/design/aos-work-records-and-self-healing-recipes.md` - recording
+  vocabulary that will later consume the descriptor contract.
+
+## Required Behavior
+
+### Contract Shape
+
+Add or update the schema/design contract so a target descriptor separates these
+concepts:
+
+- `ref`: a state-scoped, model-facing action handle from the current perception
+  state. It is convenient for immediate `aos do` calls and may become stale.
+- `state_id`: the perception state that scoped the ref, when available.
+- `target_id` or equivalent durable machine identity, scoped by an explicit
+  owner namespace. This identity must not be derived from display/window/app
+  geometry or human-facing labels.
+- `owner_namespace`: the app, canvas, surface, component/schema family, and
+  structural owner facts needed to avoid cross-surface collisions.
+- `capabilities` / `actions`: primitive operations such as `click`, `drag`,
+  `set-value`, `focus`, `select`, `toggle`, and `open`.
+- `state`: current value, selected/expanded/checked/pressed/current state,
+  enabled/disabled state, range metadata, and similar action-relevant facts.
+- `provenance` / current address: canvas id, parent canvas id, do target,
+  frame/bounds/center, display/window capture facts, source payload id, and
+  current routing data. These fields are observations, not durable identity.
+- `reacquisition` / fingerprint: role, structural path, capabilities, nearby
+  group, range shape, source hints, and label/accessibility text as hints only.
+
+Use `/Users/Michael/Code/pi-computer-use` only as pattern inspiration:
+state-scoped refs, stale state ids, richer descriptors behind refs, and
+reacquisition by role/label/capability/position. Do not copy Pi's `@e` / `@w`
+syntax or make it the AOS canonical grammar.
+
+### Identity Rules
+
+- Human-facing labels, accessible names, UI copy, and "nice" examples such as
+  `settings.opacity` or `avatar.controls.scale` are not durable identity.
+- Labels may remain presentation/accessibility fields and reacquisition hints.
+- Same-label controls in different owner namespaces or surfaces must not
+  collide.
+- Geometry and display/window/canvas coordinates must not be part of durable
+  identity; keep them in provenance/current address fields.
+- Owned repo callers should move toward one canonical vocabulary. Do not add
+  broad aliases or compatibility shims unless the card names an external
+  non-updatable consumer and a removal gate.
+
+### Stale Ref And Reacquisition Shape
+
+Define the deterministic stale-ref behavior at the contract level:
+
+- an action carrying a stale `state_id` / ref pair must reject or mark the ref
+  stale with machine-readable status;
+- a descriptor may include a reacquisition plan/fingerprint that says how a
+  current target can be searched for again;
+- reacquisition must use machine facts first and labels only as hints;
+- ambiguous reacquisition must stay explicit instead of silently picking the
+  first same-label target.
+
+This round does not need live `aos do` stale-ref execution. It must define the
+shape and prove it with deterministic fixtures/tests.
+
+## Required Outputs
+
+Produce a tight contract slice. Prefer the narrowest code/doc/test set that
+makes #429's acceptance shape true.
+
+Expected outputs:
+
+- Update `shared/schemas/aos-semantic-targets.md` or add a clearly-linked
+  schema/design draft that defines the descriptor vocabulary above.
+- Update the relevant `docs/api/aos.md` target sections enough that `aos see`
+  output, `aos do` target input, gesture frames, and Work Recording can point at
+  the same descriptor vocabulary.
+- Add deterministic fixtures, likely under
+  `docs/design/fixtures/aos-target-descriptor-v0/`, for:
+  - two same-label controls in different namespaces/surfaces;
+  - a stale state-scoped ref;
+  - descriptor-based reacquisition with role/capability/position/label hints;
+  - an ambiguous same-label reacquisition case that stays rejected/ambiguous.
+- Add a focused Node test, likely
+  `tests/toolkit/aos-target-descriptor-contract.test.mjs`, that validates the
+  fixture pack and fails if labels/names become identity.
+- Update `packages/toolkit/runtime/semantic-targets.js` and existing runtime
+  tests only as needed to stop helper behavior from deriving identity from
+  labels/names when the descriptor contract requires stricter input.
+
+## Scope
+
+Schema/design contract, deterministic fixtures, focused Node tests, and the
+smallest toolkit runtime helper changes needed for those tests.
+
+## Hard Boundaries / Non-Goals
+
+- Do not do the broad #432 drift cleanup sweep in this round. Touch only docs
+  required to define and prove #429.
+- Do not implement #430's full interaction record family yet; only leave the
+  target vocabulary usable by #430.
+- Do not start #431's input-event-v2 hard cutover.
+- Do not restart live AOS or require live canvas/input evidence.
+- Do not introduce Pi's `@e` / `@w` syntax as AOS canonical syntax.
+- Do not make human-readable target names prettier at the expense of machine
+  robustness.
+- Do not add compatibility aliases for owned in-repo callers without an
+  explicit external consumer and removal gate.
+
+## Stop Conditions
+
+Stop with a clear report instead of continuing if:
+
+- a single descriptor contract cannot represent `aos see`, `aos do`, gesture
+  frames, and Work Recording references without conflating labels with identity;
+- making the fixture pass requires a broad producer/consumer migration better
+  owned by #432 or #430;
+- an external consumer requires a compatibility window;
+- live AOS evidence becomes necessary to proceed.
+
+## Suggested Implementation Areas
+
+- `shared/schemas/aos-semantic-targets.md`
+- `docs/api/aos.md`
+- `packages/toolkit/runtime/semantic-targets.js`
+- `tests/toolkit/runtime-semantic-targets.test.mjs`
+- new `docs/design/fixtures/aos-target-descriptor-v0/`
+- new `tests/toolkit/aos-target-descriptor-contract.test.mjs`
+
+## Verification
+
+Run deterministic checks only:
+
+```bash
+git diff --check
+node --test tests/toolkit/runtime-semantic-targets.test.mjs
+node --test tests/toolkit/agent-ui-target-conformance.test.mjs
+node --test tests/toolkit/aos-target-descriptor-contract.test.mjs
+rg -n "human-readable name exposed to AOS perception|name as id|target id from label|label.*identity|name.*identity|settings\\.opacity|avatar\\.controls\\.scale" shared/schemas docs/api docs/design packages/toolkit/runtime tests/toolkit
+```
+
+The final `rg` may return historical or explicitly rejected examples, but the
+completion report must classify every remaining hit as current contract,
+historical/superseded, fixture-negative, or a #432 cleanup follow-up.
+
+## Completion Report
+
+Include:
+
+- branch and head SHA;
+- changed paths;
+- exact descriptor fields added or changed;
+- how the contract separates state-scoped refs, durable target identity,
+  labels, provenance/current address, capabilities, state, and reacquisition;
+- how same-label collision resistance is proved;
+- how stale-ref/state-id and ambiguous reacquisition are represented;
+- which current helpers stopped deriving identity from labels/names, if any;
+- exact verification commands and pass/fail results;
+- remaining #432 cleanup targets, if the round intentionally leaves stale prose
+  outside #429's narrow contract.

--- a/docs/design/work-cards/gdi-semantic-target-drift-cleanup-v0.md
+++ b/docs/design/work-cards/gdi-semantic-target-drift-cleanup-v0.md
@@ -1,0 +1,271 @@
+# Semantic Target Drift Cleanup V0
+
+## Recipient
+
+GDI implementation and cleanup round.
+
+## Transfer Kind
+
+GDI round.
+
+## Branch / Base
+
+- branch_from: local `main` containing the accepted #429 descriptor contract and
+  this work card.
+- required_start_ref: local `main` containing this work card.
+- expected output branch: `gdi/semantic-target-drift-cleanup-v0`
+
+Do not reset to `origin/main` for this round. Local `main` is intentionally ahead
+of `origin/main` with Foreman coordination commits and the accepted #429
+descriptor contract.
+
+## Source Artifact
+
+- GitHub issue #432:
+  https://github.com/michaelblum/agent-os/issues/432
+- Accepted #429 descriptor contract commit:
+  `186eeb6561d1a9b99339bf4831a44514e6f695c5`
+- Canonical descriptor contract:
+  - `shared/schemas/aos-semantic-targets.md`
+  - `docs/api/aos.md`
+  - `docs/design/fixtures/aos-target-descriptor-v0/`
+  - `tests/toolkit/aos-target-descriptor-contract.test.mjs`
+- Adjacent ledgers:
+  - #429 owns the target descriptor contract.
+  - #430 owns the broader interaction grammar and should wait on this cleanup.
+  - #431 remains separate input-event-v2 hard-cutover debt.
+
+## Fresh Context Contract
+
+GDI starts from a fresh context window. Do not assume branch, checkout, daemon,
+canvas, issue, or prior implementation state. Read and rediscover before
+editing.
+
+## Goal
+
+Remove or clearly quarantine stale semantic-target guidance so current docs,
+tests, and helper names teach agent-first target descriptors: state-scoped refs
+plus descriptor-backed machine identity, with labels/names only as
+presentation, accessibility, or reacquisition hints.
+
+## Read First
+
+- `AGENTS.md`
+- `shared/schemas/aos-semantic-targets.md`
+- `docs/api/aos.md`
+- `packages/toolkit/runtime/semantic-targets.js`
+- `tests/toolkit/aos-target-descriptor-contract.test.mjs`
+- `tests/toolkit/runtime-semantic-targets.test.mjs`
+- `tests/toolkit/agent-ui-target-conformance.test.mjs`
+- `docs/guides/aos-app-accessibility-surfaces.md`
+- `docs/api/toolkit/controls.md`
+- `docs/api/toolkit/workbench.md`
+- `docs/design/aos-shared-gesture-spine-v0.md`
+- `docs/design/aos-work-records-and-self-healing-recipes.md`
+- `docs/design/work-cards/gdi-agent-ui-target-conformance-fixtures-v0.md`
+- `docs/design/work-cards/surface-inspector-semantic-target-late-attach-replay-v0.md`
+- `docs/design/work-cards/gdi-aos-target-addressed-action-ergonomics-v0.md`
+
+## Rediscover State
+
+Run before editing:
+
+```bash
+git status --short --branch
+git rev-parse HEAD origin/main
+./aos service status --mode repo --json
+./aos dev gh issue view 432 --json
+rg -n "human-readable name exposed to AOS perception|name as id|target id from label|label.*identity|name.*identity|settings\\.opacity|avatar\\.controls\\.scale|semantic_target\\.id|target\\.id|pickName|display name|accessible name" shared/schemas docs/api docs/guides docs/design packages/toolkit/runtime tests/toolkit --glob "*.md" --glob "*.js" --glob "*.mjs" --glob "*.json"
+rg -n "semantic_targets|semantic target|target descriptor|target_id|state_id|reacqui|data-semantic-target-id|data-aos-ref|data-aos-action" src/perceive shared/schemas docs/api docs/guides docs/design packages/toolkit/runtime tests/toolkit --glob "*.swift" --glob "*.md" --glob "*.js" --glob "*.mjs" --glob "*.json"
+```
+
+Live AOS is intentionally paused for this workstream. Do not run `./aos ready`,
+`./aos status`, `./aos clean`, service start/restart, or live smoke unless
+Michael explicitly approves it in a new instruction. This slice is
+deterministic-only.
+
+## Existing Code To Inspect
+
+- `src/perceive/semantic-targets.swift` - current native producer surface. It
+  may not yet emit every #429 descriptor field, so public docs must not imply
+  every current `aos see` result already contains fields the producer cannot
+  emit.
+- `shared/schemas/aos-semantic-targets.md` - canonical descriptor vocabulary.
+- `docs/api/aos.md` - public command contract; keep it aligned with descriptor
+  vocabulary while being honest about current V0 producer behavior.
+- `packages/toolkit/runtime/semantic-targets.js` - helper naming and behavior
+  around refs, accessible names, descriptor identity, provenance, and
+  reacquisition.
+- `docs/guides/aos-app-accessibility-surfaces.md` - likely stale wording around
+  "stable" semantic names and identity metadata.
+- `docs/api/toolkit/controls.md` and `docs/api/toolkit/workbench.md` - toolkit
+  docs that should distinguish state-scoped refs, durable descriptor identity,
+  action metadata, and presentation labels.
+- Historical work cards under `docs/design/work-cards/` that future searches
+  could mistake for current target identity guidance.
+
+## Required Behavior
+
+### Drift Classification
+
+Classify remaining drift hits before editing. Use these buckets in the
+completion report:
+
+- current canonical descriptor guidance;
+- current docs that need update;
+- historical or superseded work cards that need a visible status note;
+- fixture-negative/test assertions that intentionally prove labels are not
+  identity;
+- unrelated local test object identity, such as annotation `target.id`, that is
+  not AOS target descriptor identity;
+- deferred #430 interaction grammar work.
+
+Do not mechanically edit every `target.id` or `accessible name` hit. Edit where
+a future agent could reasonably infer that human names, labels, DOM ids, or nice
+examples are durable AOS target identity.
+
+### Current Docs
+
+Update current docs so they teach the accepted descriptor split:
+
+- `ref` is state-scoped and model-facing.
+- `state_id` scopes a perceived state and may become stale.
+- durable machine identity is `target.target_id` scoped by
+  `target.owner_namespace`.
+- `actions` name primitive capabilities.
+- current `state` is action-relevant but not identity.
+- `provenance` is the current address, routing, and geometry evidence.
+- `reacquisition` uses machine facts first, with labels/accessibility text only
+  as hints.
+
+Specific cleanup expectations:
+
+- `docs/guides/aos-app-accessibility-surfaces.md` should keep AX/ARIA names as
+  human/accessibility presentation, not identity. AOS metadata should point to
+  refs, target descriptors, owner namespaces, and action metadata.
+- `docs/api/toolkit/controls.md` should describe slider semantic target stamping
+  in descriptor terms instead of letting `data-aos-ref`,
+  `data-semantic-target-id`, or `aria-*` fields blur together.
+- `docs/api/toolkit/workbench.md` should not leave semantic target references
+  as an old one-field id/ref dialect when it is describing current AOS-owned
+  canvas behavior.
+- `docs/api/aos.md` should remain public API documentation, but if current
+  native producer coverage lags the descriptor contract, phrase the new fields
+  as descriptor vocabulary emitted or consumed when present instead of
+  promising every current producer result has all fields.
+- `docs/design/aos-shared-gesture-spine-v0.md` and
+  `docs/design/aos-work-records-and-self-healing-recipes.md` should continue to
+  point at the descriptor vocabulary and should not retain `semantic_target.id`
+  or nice-name examples as durable ids.
+
+### Historical And Superseded Cards
+
+For old work cards or design notes, prefer a concise status note near the top
+over rewriting completed historical instructions. The note should say the card
+is historical/superseded for target identity and point to #429/#432 plus
+`shared/schemas/aos-semantic-targets.md`.
+
+Likely targets include:
+
+- `docs/design/work-cards/gdi-agent-ui-target-conformance-fixtures-v0.md`
+- `docs/design/work-cards/surface-inspector-semantic-target-late-attach-replay-v0.md`
+- `docs/design/work-cards/gdi-aos-target-addressed-action-ergonomics-v0.md`
+- older nearby semantic-target, visual-object, or work-record cards discovered
+  by the rediscovery searches.
+
+Do not delete historical cards.
+
+### Helper Names And Tests
+
+If `packages/toolkit/runtime/semantic-targets.js` still uses helper names or
+comments that imply names are identity, make the smallest current-contract edit.
+For example, an accessible-name helper may remain if it is clearly presentation
+or hint extraction, but it should not be easy to confuse with identity
+construction. Update focused tests when helper behavior or names change.
+
+Do not add compatibility aliases for owned in-repo callers unless an external
+non-updatable consumer is identified with an explicit removal gate.
+
+### GitHub Ledger Drafts
+
+Do not mutate GitHub issues in this GDI round. Instead, draft exact short
+comment bodies for #164 and #428 in the completion report if the cleanup makes
+those ledger comments ready. Foreman will post or revise them after acceptance.
+
+## Scope
+
+Allowed:
+
+- docs under `docs/`;
+- descriptor/schema docs under `shared/schemas/`;
+- focused tests under `tests/toolkit/`;
+- tiny helper/comment cleanup under `packages/toolkit/runtime/`;
+- passive inspection of `src/perceive/semantic-targets.swift`.
+
+Expected likely output is mostly docs and test assertion updates. Native
+producer migration is not expected in this round.
+
+## Hard Boundaries / Non-Goals
+
+- Do not restart live AOS or require live canvas/input evidence.
+- Do not run `./aos ready`, `./aos status`, `./aos clean`, service
+  start/restart, or live smoke.
+- Do not migrate the native Swift producer unless Foreman routes a separate
+  #429 producer-migration card.
+- Do not implement #430's full interaction record family.
+- Do not start #431's input-event-v2 hard cutover.
+- Do not introduce Pi's `@e` / `@w` syntax as AOS canonical syntax.
+- Do not optimize for pretty human names at the expense of machine robustness.
+- Do not delete historical work cards or archives.
+- Do not push, open PRs, or mutate GitHub issues.
+
+## Stop Conditions
+
+Stop with a clear report instead of continuing if:
+
+- public docs cannot be made honest without changing native producer behavior;
+- cleanup requires choosing #430 grammar details not decided by #429/#432;
+- an external consumer requires a compatibility window;
+- deterministic tests reveal label/name identity behavior outside this slice's
+  safe scope;
+- live AOS evidence becomes necessary to proceed.
+
+## Verification
+
+Run deterministic checks:
+
+```bash
+git diff --check
+node --test tests/toolkit/runtime-semantic-targets.test.mjs
+node --test tests/toolkit/agent-ui-target-conformance.test.mjs
+node --test tests/toolkit/aos-target-descriptor-contract.test.mjs
+node --test tests/toolkit/runtime-gesture-stream.test.mjs tests/toolkit/zag-adapter-slider.test.mjs
+rg -n "human-readable name exposed to AOS perception|name as id|target id from label|label.*identity|name.*identity|settings\\.opacity|avatar\\.controls\\.scale|semantic_target\\.id|target\\.id|pickName|display name|accessible name" shared/schemas docs/api docs/guides docs/design packages/toolkit/runtime tests/toolkit --glob "*.md" --glob "*.js" --glob "*.mjs" --glob "*.json"
+```
+
+For remaining `rg` hits, classify them in the completion report as current
+canonical guidance, historical/superseded and visibly marked, fixture-negative,
+unrelated local test identity, retained limit, or deferred #430 work.
+
+If no runtime/test files change, still run the Node tests above because they are
+the accepted #429 contract guardrails.
+
+## Completion Report
+
+Return a path-scoped report with:
+
+- branch and head SHA;
+- base SHA;
+- files changed;
+- which current docs were updated;
+- which historical cards were marked superseded/historical;
+- any helper names/comments changed and why;
+- exact verification commands and pass/fail results;
+- remaining drift-scan hits and their classification;
+- whether `docs/api/aos.md` now distinguishes descriptor contract vocabulary
+  from current native producer coverage;
+- draft #164 and #428 ledger comment bodies, or a reason they should wait;
+- confirmation that live AOS was not restarted;
+- local-only state, including dirty/untracked files and known ignored
+  artifacts;
+- recommended next slice only if the cleanup reveals one concrete follow-up.

--- a/docs/design/work-cards/surface-inspector-semantic-target-late-attach-replay-v0.md
+++ b/docs/design/work-cards/surface-inspector-semantic-target-late-attach-replay-v0.md
@@ -1,5 +1,14 @@
 # Surface Inspector Semantic Target Late-Attach Replay V0
 
+## Historical Status
+
+This card is historical for target identity guidance. It predates the accepted
+#429 target descriptor contract and #432 drift cleanup. Replay/request behavior
+should preserve the current descriptor split in
+`shared/schemas/aos-semantic-targets.md`: state-scoped `ref`/`state_id`,
+durable `target.target_id` scoped by `target.owner_namespace`, current `state`,
+`actions`, `provenance`, and machine-first `reacquisition` hints.
+
 ## Tracker
 
 - Parent epic: https://github.com/michaelblum/agent-os/issues/295

--- a/docs/guides/aos-app-accessibility-surfaces.md
+++ b/docs/guides/aos-app-accessibility-surfaces.md
@@ -34,18 +34,19 @@ For AOS-owned canvases, `aos see capture --canvas <id> --xray` also exposes a
 `semantic_targets` array. Treat that as a projection of the same standard facts,
 not a separate agent language: role and name come from AX/ARIA, bounds come from
 the DOM frame, state comes from ARIA/native disabled/value state, and AOS
-metadata supplies ownership and routing identity.
+metadata supplies state-scoped refs, descriptor identity, provenance, and
+primitive action metadata.
 
 ## Labels And Names
 
 Keep visible labels and semantic names separate.
 
-A visible label is part of the visual design. A semantic AX name is the stable
-human-readable name exposed to accessibility clients and AOS perception. When a
-control already has meaningful visible text, the semantic name can usually
-match it. When the control is icon-only, gesture-driven, or rendered inside a
-canvas, provide the semantic name through the accessibility layer instead of
-painting duplicate text into the UI.
+A visible label is part of the visual design. A semantic AX name is the
+human-readable presentation name exposed to accessibility clients and AOS
+perception. When a control already has meaningful visible text, the semantic
+name can usually match it. When the control is icon-only, gesture-driven, or
+rendered inside a canvas, provide the semantic name through the accessibility
+layer instead of painting duplicate text into the UI.
 
 Do not use visible text as an agent marker. Do not stuff identifiers, action
 ids, routing hints, or debug state into accessible names. Names should read like
@@ -53,26 +54,34 @@ Mac controls, for example `Open radial menu`, `Brush size`, or `Submit`, not
 `sigil.radial.action.open.primary`.
 
 Use descriptions or help text only for user-facing clarification. Use AOS
-metadata for identity and routing.
+metadata for state-scoped refs, descriptor identity, routing, and reacquisition
+hints.
 
 ## AOS Identity Metadata
 
-AOS-specific identity belongs in stable metadata, not in labels.
+AOS-specific identity belongs in descriptor metadata, not in labels.
 
 Use metadata channels to answer "which app object is this?" while keeping the
-AX name human-readable:
+AX name human-readable. The current descriptor split is:
 
-- DOM `id` for stable document identity
-- `data-aos-ref` for the canonical AOS object reference
-- `data-aos-action` for the daemon or app action id
-- canvas id for the owning AOS canvas or child surface
-- context groups for local scope such as menu, toolbar, panel, scene, or mode
-- marks for non-DOM canvas objects that need spatial identity
+- `data-aos-ref` contributes the state-scoped model-facing ref. It is useful
+  for immediate `aos do` calls and may become stale.
+- `data-semantic-target-id` contributes `target.target_id`, the durable machine
+  identity within an owner namespace; it is not derived from the AX name.
+- canvas, surface, app, component-family, and structural-owner metadata form
+  `target.owner_namespace`, the collision domain for durable identity.
+- `data-aos-action` and `data-aos-actions` name daemon/app action ids and
+  primitive capabilities.
+- DOM `id`, selectors, bounds, source paths, and parent canvas ids are
+  provenance/current-address evidence or reacquisition hints, not identity by
+  themselves.
+- context groups and marks can help build structural owner facts for non-DOM
+  canvas objects that need spatial identity.
 
 Context groups should usually be represented both structurally and
 semantically. For example, a radial menu can be an `AXMenu` or `AXGroup` with
-`AXMenuItem` children, while `data-aos-ref`, `data-aos-action`, canvas id, and
-marks carry the exact AOS routing identity.
+`AXMenuItem` children, while `data-aos-ref`, `data-semantic-target-id`,
+`data-aos-action`, canvas id, and marks carry AOS routing and descriptor facts.
 
 This lets `aos see --xray`, traces, tests, and future structured perception
 join semantic controls back to app state without label pollution.
@@ -116,8 +125,9 @@ before claiming runtime verification. In installed mode, use the installed
 For representative controls, verify:
 
 - `./aos see --xray` exposes raw role/name/value/frame/action evidence. For
-  AOS-owned canvases, check `semantic_targets` for stable refs, surface id,
-  parent canvas id, and action id.
+  AOS-owned canvases, check `semantic_targets` for state-scoped refs,
+  `target.target_id`, owner namespace, primitive actions, provenance, current
+  state, and reacquisition hints.
 - `./aos do` can operate the control through the daemon/AOS route, not only
   through app-local JavaScript or a synthetic unit test.
 - Screenshots show the intended visual design, with no duplicate agent labels
@@ -135,9 +145,11 @@ AX discovery, or daemon-routed actions.
 
 1. Pick the standard AX role before designing custom metadata.
 2. Give every meaningful control a concise semantic name.
-3. Keep visible text, semantic names, and AOS identity metadata distinct.
-4. Put AOS routing identity in `data-aos-ref`, `data-aos-action`, canvas ids,
-   context groups, and marks.
+3. Keep visible text, semantic names, state-scoped refs, and AOS descriptor
+   identity distinct.
+4. Put AOS routing and descriptor facts in `data-aos-ref`,
+   `data-semantic-target-id`, owner namespace metadata, `data-aos-action`,
+   `data-aos-actions`, context groups, and marks.
 5. Add a semantic companion layer for canvas/WebGL/Three.js controls.
 6. Route companion actions through the same command path as visible input.
 7. Verify with `./aos ready`, `./aos see --xray`, `./aos do`, screenshots, and

--- a/packages/toolkit/runtime/gesture-stream.js
+++ b/packages/toolkit/runtime/gesture-stream.js
@@ -105,9 +105,16 @@ function sourceIdentity(raw = {}, options = {}) {
 function semanticIdentity(raw = {}, options = {}) {
   const semantic = typeof options.semantic === 'function' ? options.semantic(raw) : options.semantic
   const target = raw?.currentTarget || raw?.target || options.element || null
+  const descriptor = semantic?.target_descriptor || semantic?.targetDescriptor || semantic?.target
+  if (descriptor && typeof descriptor === 'object') {
+    return {
+      target: compactObject(descriptor),
+      action: semantic?.action || semantic?.semanticAction || target?.dataset?.aosActions?.split?.(/\s+/)?.find((item) => item === 'set-value' || item === 'drag') || null,
+    }
+  }
   return {
     target: compactObject({
-      id: semantic?.targetId || semantic?.target_id || target?.dataset?.semanticTargetId || target?.dataset?.aosRef || null,
+      target_id: semantic?.targetId || semantic?.target_id || target?.dataset?.semanticTargetId || null,
       ref: semantic?.ref || target?.dataset?.aosRef || null,
       kind: semantic?.kind || target?.dataset?.aosTargetKind || null,
     }),

--- a/packages/toolkit/runtime/semantic-targets.js
+++ b/packages/toolkit/runtime/semantic-targets.js
@@ -149,13 +149,14 @@ function roleTag(role) {
 export function refForTarget(target = {}, options = {}) {
   if (target.ref) return text(target.ref)
   const surface = text(target.surface ?? target.surfaceId ?? options.surface ?? options.surfaceId, '')
-  const id = safeId(target.id ?? target.name)
+  const id = safeId(target.id, '')
+  if (!id) throw new Error('semantic target ref requires id or explicit ref')
   return surface ? `${surface}:${id}` : id
 }
 
 export function normalizeSemanticTarget(target = {}, options = {}) {
   if (!target || typeof target !== 'object') throw new Error('semantic target must be an object')
-  const id = text(target.id ?? target.ref ?? target.name, '')
+  const id = text(target.id ?? target.ref, '')
   if (!id) throw new Error('semantic target requires id')
   const role = normalizeRole(target.role ?? options.role ?? 'button')
   const name = pickName(target)

--- a/packages/toolkit/runtime/semantic-targets.js
+++ b/packages/toolkit/runtime/semantic-targets.js
@@ -1,8 +1,9 @@
-// semantic-targets.js — accessibility metadata and companion DOM helpers.
+// semantic-targets.js — target descriptor metadata and companion DOM helpers.
 //
-// This module keeps semantic names, AOS routing identity, and visual rendering
-// separate. It is intentionally small: apps own layout/behavior, while toolkit
-// normalizes the target contract and stamps standard metadata consistently.
+// This module keeps accessible labels, state-scoped refs, descriptor identity,
+// and visual rendering separate. It is intentionally small: apps own
+// layout/behavior, while toolkit normalizes the target contract and stamps
+// standard metadata consistently.
 
 const AX_ROLE_ALIASES = {
   AXButton: 'button',
@@ -59,8 +60,8 @@ function safeId(value, fallback = 'target') {
   return text(value, fallback).replace(/[^a-zA-Z0-9_-]/g, '-')
 }
 
-function pickName(target = {}) {
-  return text(target.name ?? target.ariaLabel ?? target.label ?? target.title ?? target.id, 'Target')
+function pickAccessibleName(target = {}) {
+  return text(target.name ?? target.ariaLabel ?? target.label ?? target.title, 'Target')
 }
 
 function pickAction(target = {}) {
@@ -156,15 +157,15 @@ export function refForTarget(target = {}, options = {}) {
 
 export function normalizeSemanticTarget(target = {}, options = {}) {
   if (!target || typeof target !== 'object') throw new Error('semantic target must be an object')
-  const id = text(target.id ?? target.ref, '')
-  if (!id) throw new Error('semantic target requires id')
+  const sourceId = text(target.id, '')
+  if (!sourceId) throw new Error('semantic target requires id')
   const role = normalizeRole(target.role ?? options.role ?? 'button')
-  const name = pickName(target)
+  const name = pickAccessibleName(target)
   const action = pickAction(target)
   const surface = text(target.surface ?? target.surfaceId ?? options.surface ?? options.surfaceId, '')
   const frame = normalizeFrame(target.frame ?? target.rect ?? target.bounds, options.frame)
   const normalized = {
-    id,
+    id: sourceId,
     role,
     name,
     action,
@@ -178,7 +179,7 @@ export function normalizeSemanticTarget(target = {}, options = {}) {
     value: target.value ?? null,
     surface,
     parent_canvas_id: text(target.parent_canvas_id ?? options.parent_canvas_id, ''),
-    ref: refForTarget({ ...target, id, surface }, options),
+    ref: refForTarget({ ...target, id: sourceId, surface }, options),
     metadata: {
       ...(target.metadata && typeof target.metadata === 'object' ? target.metadata : {}),
     },

--- a/shared/schemas/aos-semantic-targets.md
+++ b/shared/schemas/aos-semantic-targets.md
@@ -1,6 +1,6 @@
-# AOS Semantic Targets
+# AOS Semantic Targets And Target Descriptors
 
-Version: `0.1.0`
+Version: `0.2.0`
 
 `semantic_targets` is the AOS-owned canvas target projection emitted by:
 
@@ -23,6 +23,12 @@ The CLI gathers this data through a fixed internal probe. Agents should prefer
 this field for AOS-owned canvases and reserve `show eval` for developer
 diagnostics.
 
+Each entry is also a V0 target descriptor. The descriptor separates the
+state-scoped model-facing action handle from durable machine identity,
+presentation labels, current address/provenance, state, capabilities, and
+reacquisition hints. Human-facing names, labels, accessible text, UI copy, DOM
+ids, and geometry are not durable target identity.
+
 ## Shape
 
 ```json
@@ -30,11 +36,22 @@ diagnostics.
   "semantic_targets": [
     {
       "ref": "sigil-radial-item-wiki-graph",
+      "state_id": "see_abc123def456",
       "surface": "sigil-radial-menu",
       "role": "button",
       "name": "Wiki Graph",
       "kind": "semantic_target",
       "enabled": true,
+      "target": {
+        "target_id": "radial-item:wiki-graph",
+        "owner_namespace": {
+          "app_id": "sigil",
+          "canvas_id": "sigil-radial-menu",
+          "surface_id": "sigil-radial-menu",
+          "component_family": "sigil.radial-menu",
+          "structural_owner": ["avatar-main", "radial-menu"]
+        }
+      },
       "state": { "current": "true" },
       "actions": ["wiki-graph"],
       "extension": {
@@ -49,6 +66,19 @@ diagnostics.
         "bounds": { "x": 40, "y": 24, "width": 56, "height": 56 },
         "frame": { "x": 40, "y": 24, "width": 56, "height": 56 },
         "center": { "x": 68, "y": 52 }
+      },
+      "reacquisition": {
+        "strategy": "owner-structural-fingerprint",
+        "machine_fingerprint": {
+          "role": "button",
+          "structural_path": ["radial-menu", "item:wiki-graph"],
+          "capabilities": ["click", "open"],
+          "nearby_group": "Sigil radial menu"
+        },
+        "hint_fingerprint": {
+          "label_hints": ["Wiki Graph"],
+          "source_hints": { "dom_id": "wiki-graph" }
+        }
       }
     }
   ]
@@ -57,7 +87,24 @@ diagnostics.
 
 ## Field Notes
 
-`ref` is the canonical AOS object reference from `data-aos-ref`.
+`ref` is the state-scoped model-facing action handle from the current
+perception state. It is convenient for immediate `aos do` calls and may become
+stale after the surface changes. It is not durable identity.
+
+`state_id` is the perception state that scoped the `ref`, when available. An
+action that carries a stale `state_id`/`ref` pair must reject or report
+machine-readable stale status instead of silently acting on a different target.
+
+`target.target_id` is a durable machine identity within
+`target.owner_namespace`. The durable identity key is the pair
+`owner_namespace` + `target_id`; callers must not derive it from `name`,
+`label`, accessible text, DOM ids, display/window geometry, or canvas
+coordinates.
+
+`target.owner_namespace` is the explicit collision domain for the target. It
+contains app, canvas, surface, component/schema family, and structural owner
+facts needed to distinguish same-label or same-local-id controls on different
+surfaces. Geometry and current address facts do not belong here.
 
 `provenance.canvas_id` is the canvas requested by `--canvas`.
 
@@ -71,6 +118,8 @@ and filtering.
 control role.
 
 `name` is the accessible name, usually `aria-label`, not an implementation id.
+It may be displayed to humans and may appear in reacquisition hints, but it is
+not machine identity.
 
 `actions` is the canonical primitive action list for the target. It names what
 `aos do` can attempt, such as `click`, `drag`, `set-value`, `focus`, `select`,
@@ -82,6 +131,8 @@ relationship without polluting the accessible name.
 
 `provenance.bounds`, `provenance.frame`, and `provenance.center` use the same
 local image coordinate space as capture/xray output for that canvas.
+Coordinates are observations and current action-routing aids; they are not
+durable identity.
 
 `geometry` is optional control-specific actionable geometry. Toolkit sliders
 may include `control_bounds`, `track_bounds`, and `thumb_bounds` in the same
@@ -97,3 +148,31 @@ may additionally expose `values`, `min`, `max`, `step`, `orientation`, and
 
 `metadata` is optional JSON metadata copied from `data-aos-metadata` for
 debugging and higher-level routing. It is not required for target resolution.
+
+`reacquisition` is a bounded fingerprint for searching for a current target
+after a stale ref. Reacquisition must use machine facts first:
+`owner_namespace`, `target_id`, `role`, structural path, capabilities, source
+payload ids, range shape, and nearby groups. Label/accessibility text belongs
+only in hint fields. If the fingerprint matches more than one current target,
+the result must stay explicit with an `ambiguous` status and candidate list;
+callers must not pick the first same-label target.
+
+## Stale Ref And Reacquisition Status
+
+Target-addressed actions that carry both `ref` and `state_id` compare the
+supplied state with the current perception state when that check is available.
+The deterministic statuses are:
+
+- `resolved`: the supplied `state_id`/`ref` pair is current and resolves to one
+  enabled target.
+- `stale_ref`: the supplied `state_id` is no longer current or the old `ref`
+  is absent from the current state.
+- `reacquired`: a stale descriptor fingerprint resolved to exactly one current
+  target through machine facts, with labels used only as hints.
+- `ambiguous`: reacquisition found more than one plausible current target.
+- `missing`: neither the ref nor the descriptor fingerprint found a candidate.
+- `unsupported`: the target or surface cannot perform the requested action.
+
+Stale and ambiguous outcomes are action blockers. They should return
+machine-readable `status`, `reason`, supplied/current state ids when known,
+and candidate descriptors when ambiguity must be shown to the agent or a human.

--- a/tests/toolkit/aos-target-descriptor-contract.test.mjs
+++ b/tests/toolkit/aos-target-descriptor-contract.test.mjs
@@ -1,0 +1,160 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+import {
+  normalizeSemanticTarget,
+  refForTarget,
+} from '../../packages/toolkit/runtime/semantic-targets.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const fixtureDir = resolve(__dirname, '../../docs/design/fixtures/aos-target-descriptor-v0')
+
+async function readJson(name) {
+  return JSON.parse(await readFile(resolve(fixtureDir, name), 'utf8'))
+}
+
+function namespaceKey(namespace = {}) {
+  return JSON.stringify({
+    app_id: namespace.app_id,
+    canvas_id: namespace.canvas_id,
+    surface_id: namespace.surface_id,
+    component_family: namespace.component_family,
+    structural_owner: namespace.structural_owner,
+  })
+}
+
+function durableIdentityKey(descriptor = {}) {
+  return `${namespaceKey(descriptor.target?.owner_namespace)}\u0000${descriptor.target?.target_id}`
+}
+
+function walk(value, visit, path = []) {
+  if (!value || typeof value !== 'object') return
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => walk(item, visit, [...path, String(index)]))
+    return
+  }
+  visit(value, path)
+  for (const [key, child] of Object.entries(value)) {
+    walk(child, visit, [...path, key])
+  }
+}
+
+function assertDescriptorShape(descriptor) {
+  assert.ok(descriptor.ref, 'descriptor requires state-scoped ref')
+  assert.ok(descriptor.state_id, `${descriptor.ref} requires state_id`)
+  assert.ok(descriptor.target?.target_id, `${descriptor.ref} requires target.target_id`)
+  assert.ok(descriptor.target?.owner_namespace?.app_id, `${descriptor.ref} requires owner namespace app_id`)
+  assert.ok(descriptor.target?.owner_namespace?.canvas_id, `${descriptor.ref} requires owner namespace canvas_id`)
+  assert.ok(Array.isArray(descriptor.actions), `${descriptor.ref} requires actions`)
+  assert.ok(descriptor.state && typeof descriptor.state === 'object', `${descriptor.ref} requires state object`)
+  assert.ok(descriptor.provenance?.canvas_id, `${descriptor.ref} requires provenance canvas_id`)
+  assert.ok(descriptor.reacquisition?.machine_fingerprint, `${descriptor.ref} requires machine reacquisition fingerprint`)
+  assert.ok(descriptor.reacquisition?.hint_fingerprint, `${descriptor.ref} requires hint reacquisition fingerprint`)
+}
+
+function assertNoLabelIdentity(descriptor) {
+  const identityText = JSON.stringify({
+    target_id: descriptor.target?.target_id,
+    owner_namespace: descriptor.target?.owner_namespace,
+  })
+  const label = descriptor.name || descriptor.label
+  assert.ok(label, `${descriptor.ref} needs a label for this fixture`)
+  assert.notEqual(identityText, label)
+  assert.ok(!identityText.includes(`"${label}"`), `${descriptor.ref} must not embed display label in durable identity`)
+}
+
+test('fixture manifest lists the descriptor contract cases', async () => {
+  const manifest = await readJson('manifest.json')
+
+  assert.deepEqual(manifest.fixtures.sort(), [
+    'ambiguous-reacquisition.json',
+    'reacquisition-success.json',
+    'same-label-namespaces.json',
+    'stale-ref.json',
+  ])
+})
+
+test('same-label controls stay distinct through owner namespace plus target id', async () => {
+  const fixture = await readJson('same-label-namespaces.json')
+  const targets = fixture.semantic_targets
+
+  assert.equal(targets.length, 2)
+  targets.forEach(assertDescriptorShape)
+  targets.forEach(assertNoLabelIdentity)
+  assert.equal(targets[0].name, targets[1].name)
+  assert.equal(targets[0].target.target_id, targets[1].target.target_id)
+  assert.notEqual(namespaceKey(targets[0].target.owner_namespace), namespaceKey(targets[1].target.owner_namespace))
+  assert.notEqual(durableIdentityKey(targets[0]), durableIdentityKey(targets[1]))
+  assert.equal(fixture.expectation.status, 'distinct_targets')
+})
+
+test('stale state-scoped refs reject instead of silently acting', async () => {
+  const fixture = await readJson('stale-ref.json')
+
+  assert.equal(fixture.resolution.status, 'stale_ref')
+  assert.equal(fixture.resolution.action_blocked, true)
+  assert.equal(fixture.resolution.supplied_state_id, fixture.action.state_id)
+  assert.notEqual(fixture.resolution.supplied_state_id, fixture.resolution.current_state_id)
+  assert.equal(fixture.resolution.reacquisition.available, true)
+  assert.equal(fixture.resolution.reacquisition.requires_explicit_retry, true)
+})
+
+test('descriptor reacquisition uses machine facts first and labels only as hints', async () => {
+  const fixture = await readJson('reacquisition-success.json')
+  const selected = fixture.candidates.find((candidate) => candidate.ref === fixture.resolution.selected_ref)
+
+  assert.equal(fixture.resolution.status, 'reacquired')
+  assert.ok(selected)
+  assert.equal(durableIdentityKey(selected), durableIdentityKey(fixture.previous))
+  assert.deepEqual(fixture.resolution.matched_by, [
+    'owner_namespace',
+    'target_id',
+    'role',
+    'structural_path',
+    'capabilities',
+    'range_shape',
+  ])
+  assert.equal(fixture.resolution.labels_used_as_hints_only, true)
+  assert.ok(fixture.previous.reacquisition.hint_fingerprint.label_hints.includes(selected.name))
+})
+
+test('ambiguous same-label reacquisition remains blocked', async () => {
+  const fixture = await readJson('ambiguous-reacquisition.json')
+
+  assert.equal(fixture.resolution.status, 'ambiguous')
+  assert.equal(fixture.resolution.action_blocked, true)
+  assert.equal(fixture.resolution.selected_ref, null)
+  assert.equal(fixture.resolution.candidate_refs.length, 2)
+  assert.deepEqual(
+    fixture.candidates.map((candidate) => candidate.name),
+    ['Open', 'Open'],
+  )
+  assert.equal(fixture.resolution.labels_used_as_hints_only, true)
+})
+
+test('runtime helpers reject label/name-only machine identity', () => {
+  assert.throws(
+    () => normalizeSemanticTarget({ name: 'Opacity', label: 'Opacity' }),
+    /semantic target requires id/,
+  )
+  assert.throws(
+    () => refForTarget({ name: 'Opacity', surface: 'settings' }),
+    /semantic target ref requires id or explicit ref/,
+  )
+})
+
+test('fixture identity fields do not depend on provenance geometry', async () => {
+  const fixture = await readJson('same-label-namespaces.json')
+
+  for (const target of fixture.semantic_targets) {
+    const identityText = JSON.stringify(target.target)
+    walk(target.provenance, (node, path) => {
+      if (path.includes('bounds') || path.includes('frame') || path.includes('center')) {
+        assert.equal(identityText.includes(JSON.stringify(node)), false, `${target.ref} copied geometry into identity`)
+      }
+    })
+  }
+})

--- a/tests/toolkit/aos-target-descriptor-contract.test.mjs
+++ b/tests/toolkit/aos-target-descriptor-contract.test.mjs
@@ -141,6 +141,10 @@ test('runtime helpers reject label/name-only machine identity', () => {
     /semantic target requires id/,
   )
   assert.throws(
+    () => normalizeSemanticTarget({ ref: 'settings:opacity', name: 'Opacity' }),
+    /semantic target requires id/,
+  )
+  assert.throws(
     () => refForTarget({ name: 'Opacity', surface: 'settings' }),
     /semantic target ref requires id or explicit ref/,
   )

--- a/tests/toolkit/runtime-gesture-stream.test.mjs
+++ b/tests/toolkit/runtime-gesture-stream.test.mjs
@@ -54,7 +54,8 @@ test('createPointerGestureStream normalizes canvas input into drag gesture frame
   assert.equal(frames[0].source.source_canvas_id, 'avatar-hit')
   assert.deepEqual(frames[1].delta, { x: 20, y: 5 })
   assert.deepEqual(frames[2].total_delta, { x: 40, y: 0 })
-  assert.equal(frames[2].semantic_target.id, 'slider:scale')
+  assert.equal(frames[2].semantic_target.target_id, 'slider:scale')
+  assert.equal(Object.hasOwn(frames[2].semantic_target, 'ref'), false)
   assert.equal(frames[2].semantic_action, 'set-value')
   assert.equal(stream.snapshot().active, null)
 })
@@ -180,7 +181,7 @@ test('bindDomPointerGesture owns DOM capture, document listeners, and cleanup', 
   assert.deepEqual(released, [7])
   assert.deepEqual(frames.map((frame) => frame.phase), ['start', 'move', 'end'])
   assert.deepEqual(frames[1].coordinates.dom_client, { x: 30, y: 20 })
-  assert.equal(frames[0].semantic_target.id, 'opacity')
+  assert.equal(frames[0].semantic_target.target_id, 'opacity')
   assert.equal(frames[0].source.origin, 'dom')
 })
 

--- a/tests/toolkit/runtime-semantic-targets.test.mjs
+++ b/tests/toolkit/runtime-semantic-targets.test.mjs
@@ -103,6 +103,10 @@ test('normalizeSemanticTargets rejects targets without stable ids', () => {
     () => normalizeSemanticTargets([{ label: '' }]),
     /semantic target requires id/
   )
+  assert.throws(
+    () => normalizeSemanticTarget({ ref: 'state-scoped-ref', name: 'State Scoped Ref' }),
+    /semantic target requires id/
+  )
 })
 
 test('refForTarget uses explicit refs before generated surface refs', () => {

--- a/tests/toolkit/zag-adapter-slider.test.mjs
+++ b/tests/toolkit/zag-adapter-slider.test.mjs
@@ -104,8 +104,8 @@ test('pointer drag emits shared gesture frames while preserving preview and comm
   });
   const control = patchSpreadSupport(document.createElement('div'));
   control.dataset.aosSliderControl = '';
-  control.dataset.semanticTargetId = 'settings.opacity';
-  control.dataset.aosRef = 'panel:settings.opacity';
+  control.dataset.semanticTargetId = 'control-opacity';
+  control.dataset.aosRef = 'panel:control-opacity';
   control.dataset.aosActions = 'drag set-value';
   control.getBoundingClientRect = () => ({ left: 10, top: 0, width: 200, height: 24 });
   document.body.appendChild(control);
@@ -120,7 +120,8 @@ test('pointer drag emits shared gesture frames while preserving preview and comm
     'gesture.drag.move',
     'gesture.drag.end',
   ]);
-  assert.equal(frames[0].semantic_target.id, 'settings.opacity');
+  assert.equal(frames[0].semantic_target.target_id, 'control-opacity');
+  assert.equal(frames[0].semantic_target.ref, 'panel:control-opacity');
   assert.equal(frames[0].semantic_action, 'set-value');
   assert.deepEqual(changes, [
     { value: [50], type: 'gesture.drag.move' },


### PR DESCRIPTION
## Summary

- define the AOS target descriptor contract for state-scoped refs, durable target identity, provenance, state, actions, and reacquisition
- add descriptor fixtures and deterministic toolkit tests covering same-label collision resistance, stale refs, and ambiguous reacquisition
- clean current docs and historical cards so labels/accessibility names are presentation or reacquisition hints, not durable identity
- tighten toolkit semantic-target helpers so accessible names do not fall back to ids and normalized target ids cannot be derived from state-scoped refs

## Verification

```bash
git diff --check
node --test tests/toolkit/runtime-semantic-targets.test.mjs
node --test tests/toolkit/agent-ui-target-conformance.test.mjs
node --test tests/toolkit/aos-target-descriptor-contract.test.mjs
node --test tests/toolkit/runtime-gesture-stream.test.mjs tests/toolkit/zag-adapter-slider.test.mjs
```

Live AOS was intentionally paused for this stack; only passive `./aos service status --mode repo --json` was used.

## Ledgers

- #429 target descriptor contract
- #432 semantic target drift cleanup
- #430 is the likely next interaction grammar lane after this stack is accepted
