### PR TITLE
docs(aos): define interaction grammar contract

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -716,6 +716,10 @@ current `state`, `provenance` for the current address, and `reacquisition`
 fingerprints for repair. They should not promote labels or coordinates into
 durable target identity.
 
+For the design split between action intents, execution results, optional
+gesture evidence, state patches, and Work Recording replay plans, see
+[`docs/design/aos-interaction-grammar-v0.md`](../design/aos-interaction-grammar-v0.md).
+
 ## `aos graph`
 
 Primary public verbs:

--- a/docs/design/aos-interaction-grammar-v0.md
+++ b/docs/design/aos-interaction-grammar-v0.md
@@ -1,0 +1,164 @@
+# AOS Interaction Grammar V0
+
+**Status:** contract note for #430 deterministic fixtures
+**Depends on:** #429 target descriptor vocabulary and #427 gesture frames
+
+## Purpose
+
+AOS interaction records are a small family, not one flat event stream. The
+family connects what a target is, what an agent or replay requested, how AOS
+executed it, what input evidence was observed, and what state changed.
+
+Every target-addressed interaction in this contract uses the descriptor
+vocabulary from
+[`shared/schemas/aos-semantic-targets.md`](../../shared/schemas/aos-semantic-targets.md):
+
+- immediate action handles are `ref` scoped by `state_id`;
+- durable identity is `target.target_id` scoped by `target.owner_namespace`;
+- primitive actions are listed in `actions`;
+- current state lives in `state`;
+- current address and geometry live in `provenance`;
+- repair search facts live in `reacquisition.machine_fingerprint`;
+- labels, accessible names, source names, and coordinates are hints or
+  observations, not durable identity.
+
+## Record Family
+
+### `target_descriptor`
+
+`target_descriptor` says what target exists and what can be done to it. It is
+the same shape emitted in `semantic_targets[]` for AOS-owned canvases.
+
+Required target-addressing fields:
+
+- `ref`
+- `state_id`
+- `target.target_id`
+- `target.owner_namespace`
+- `actions`
+- `state`
+- `provenance`
+- `reacquisition`
+
+### `action_intent`
+
+`action_intent` records what an agent, recipe, or replay requested before AOS
+mutates anything.
+
+Required fields:
+
+- `id` and `transaction_id`
+- `action_type`, such as `click`, `drag`, `set-value`, `focus`, or `toggle`
+- `target_ref.ref` and `target_ref.state_id` for the current action attempt
+- `target_ref.target_descriptor` when the action is target-addressed
+- optional `input.value` or `input.vector`
+- `source_state_id`
+- `constraints`
+- `caller` and provenance metadata
+
+An intent that carries a stale `state_id`/`ref` pair must reject before
+execution or report stale status. It must not silently select a same-label
+target.
+
+### `execution_result`
+
+`execution_result` records how `aos do` handled an intent. It is the canonical
+place to preserve the current `aos do` response fields and additive target
+details.
+
+Required fields when present in the `aos do` response:
+
+- `status`
+- `reason`
+- `duration_ms`
+- `execution.backend`
+- `execution.strategy`
+- `execution.fallback_used`
+- `execution.state_id`
+- `target`
+- `resolved_target`
+- `post_action_state`
+
+Rejected stale or ambiguous actions still produce an `execution_result`, but
+`executed` is false and `status`/`reason` explain why no actuator backend ran.
+
+### `observed_input`
+
+`observed_input` stores raw hardware, DOM, canvas, or daemon facts only when
+they are needed for evidence, diagnosis, or visible playback. It is source
+evidence, not the primary semantic recording grammar for AOS-owned surfaces.
+
+For AOS-owned sliders and controls, raw coordinates may describe where playback
+occurred. They must not become the target identity.
+
+### `gesture_frame`
+
+`gesture_frame` is the optional normalized lifecycle stream from
+`aos.gesture-frame`. It is linked to the action transaction through
+`transaction_id` and carries the same target descriptor under
+`semantic_target`.
+
+Gesture frames are required only when human-visible playback or observation
+captured a drag. They are not the whole action intent, execution result, or
+Work Recording model.
+
+### `state_patch` / `evidence`
+
+`state_patch` records what changed. `evidence` records how that change was
+verified. Both point back to the target descriptor and transaction instead of
+repeating label or coordinate identity.
+
+Recommended fields:
+
+- `id`
+- `transaction_id`
+- `target_ref`
+- `before_state`
+- `after_state`
+- `changes`
+- `verified_by`
+- `evidence_refs`
+
+### `recording_replay_plan`
+
+`recording_replay_plan` describes how a Work Recording should attempt the same
+work later:
+
+1. re-perceive the relevant surface;
+2. resolve the descriptor by `owner_namespace`, `target_id`, role,
+   structural path, capabilities, range shape, and other machine facts;
+3. use label/accessibility text only as hints;
+4. block on ambiguous or missing matches;
+5. reissue the semantic `action_intent`;
+6. verify the expected `state_patch` or postcondition.
+
+Blind raw event replay is not the default for AOS-owned surfaces. Raw
+`input_event` / input-event-v2 payloads remain evidence and compatibility debt
+until the input-event-v2 cutover is designed.
+
+## Ownership Boundaries
+
+- `aos do` owns action intent validation, target resolution, stale/ambiguous
+  rejection, execution result fields, backend/strategy/fallback metadata,
+  target details, post-action state, status, reason, and duration.
+- Toolkit gesture stream owns pointer/gesture mechanics, capture lifecycle,
+  frame lifecycle, passive subscribers, and `aos.gesture-frame` publication.
+- Work Recording owns durable intent storage, execution-map storage, evidence,
+  replay plans, health, and repair patches. It records and verifies work; it
+  does not make raw input replay canonical.
+- Raw `input_event` / input-event-v2 is source evidence and compatibility debt.
+  It is not the canonical recording grammar for AOS-owned controls.
+
+## Fixture Cases
+
+The deterministic fixture pack in
+[`docs/design/fixtures/aos-interaction-grammar-v0/`](fixtures/aos-interaction-grammar-v0/)
+proves:
+
+- a single-thumb toolkit slider sequence:
+  `see -> action_intent(set-value) -> execution_result -> gesture.drag.* ->
+  state_patch -> work_record -> replay_plan`;
+- stale `state_id`/`ref` rejection before execution, followed by a
+  machine-first reacquisition replay plan;
+- ambiguous same-label reacquisition that remains blocked.
+

--- a/docs/design/aos-shared-gesture-spine-v0.md
+++ b/docs/design/aos-shared-gesture-spine-v0.md
@@ -47,6 +47,13 @@ Each frame carries:
 - `timing`: timestamp `t` and `frame_index`.
 - `raw_event_type`: the source event type used to create the frame.
 
+Gesture frames are optional interaction evidence and human-visible playback
+frames in the broader
+[`aos-interaction-grammar-v0.md`](aos-interaction-grammar-v0.md) family. They
+link to an action intent/execution transaction through `transaction_id`, but
+they are not the whole action intent, execution result, state patch, or Work
+Recording replay model.
+
 DOM controls should use toolkit gesture lifecycle helpers for pointer capture,
 document-level move/end listeners, end/cancel cleanup, and frame publication.
 Canvas or daemon input consumers should normalize existing `input_event` /

--- a/docs/design/aos-work-records-and-self-healing-recipes.md
+++ b/docs/design/aos-work-records-and-self-healing-recipes.md
@@ -110,6 +110,13 @@ fallback flag, and originating `state_id` when supplied. Work records should
 carry those fields as correlation metadata between the natural-language spine,
 the structured execution map, and immutable evidence.
 
+For AOS-owned target interactions, the current split between durable intent,
+execution result metadata, optional gesture evidence, state patches, and replay
+plans is defined in
+[`aos-interaction-grammar-v0.md`](aos-interaction-grammar-v0.md). Work Records
+store that family in their intent, execution-map, evidence, health, and replay
+policy layers; they do not collapse it into raw input replay.
+
 Coordinates can be recorded, but they are fallback material. When semantic
 targets exist, prefer the AOS target descriptor vocabulary: state-scoped `ref`
 and `state_id` for the immediate action, durable `target.target_id` scoped by

--- a/docs/design/fixtures/aos-interaction-grammar-v0/ambiguous-same-label-reacquisition.json
+++ b/docs/design/fixtures/aos-interaction-grammar-v0/ambiguous-same-label-reacquisition.json
@@ -1,0 +1,207 @@
+{
+  "schema": "aos.interaction-grammar.fixture.v0",
+  "case": "ambiguous_same_label_reacquisition_stays_blocked",
+  "previous_target_descriptor": {
+    "ref": "open-command",
+    "state_id": "see_interaction_menu001",
+    "surface": "recent-projects-menu",
+    "role": "button",
+    "name": "Open",
+    "kind": "semantic_target",
+    "enabled": true,
+    "target": {
+      "target_id": "command:open",
+      "owner_namespace": {
+        "app_id": "sigil",
+        "canvas_id": "recent-projects-menu",
+        "surface_id": "recent-projects-menu",
+        "component_family": "toolkit.menu",
+        "structural_owner": [
+          "recent-projects"
+        ]
+      }
+    },
+    "state": {
+      "current": "true"
+    },
+    "actions": [
+      "click",
+      "open"
+    ],
+    "provenance": {
+      "canvas_id": "recent-projects-menu",
+      "do_target": "canvas:recent-projects-menu/open-command",
+      "center": {
+        "x": 80,
+        "y": 44
+      }
+    },
+    "reacquisition": {
+      "strategy": "owner-structural-fingerprint",
+      "machine_fingerprint": {
+        "role": "button",
+        "structural_path": [
+          "recent-projects",
+          "command"
+        ],
+        "capabilities": [
+          "click",
+          "open"
+        ]
+      },
+      "hint_fingerprint": {
+        "label_hints": [
+          "Open"
+        ]
+      }
+    }
+  },
+  "current_state_id": "see_interaction_menu010",
+  "candidates": [
+    {
+      "ref": "file-open-command",
+      "state_id": "see_interaction_menu010",
+      "surface": "file-menu",
+      "role": "button",
+      "name": "Open",
+      "kind": "semantic_target",
+      "enabled": true,
+      "target": {
+        "target_id": "command:open",
+        "owner_namespace": {
+          "app_id": "sigil",
+          "canvas_id": "file-menu-canvas",
+          "surface_id": "file-menu",
+          "component_family": "toolkit.menu",
+          "structural_owner": [
+            "menu-bar",
+            "file"
+          ]
+        }
+      },
+      "state": {
+        "current": "true"
+      },
+      "actions": [
+        "click",
+        "open"
+      ],
+      "provenance": {
+        "canvas_id": "file-menu-canvas",
+        "do_target": "canvas:file-menu-canvas/file-open-command"
+      },
+      "reacquisition": {
+        "machine_fingerprint": {
+          "role": "button",
+          "structural_path": [
+            "menu-bar",
+            "file",
+            "command"
+          ],
+          "capabilities": [
+            "click",
+            "open"
+          ]
+        },
+        "hint_fingerprint": {
+          "label_hints": [
+            "Open"
+          ]
+        }
+      }
+    },
+    {
+      "ref": "project-open-command",
+      "state_id": "see_interaction_menu010",
+      "surface": "project-card",
+      "role": "button",
+      "name": "Open",
+      "kind": "semantic_target",
+      "enabled": true,
+      "target": {
+        "target_id": "command:open",
+        "owner_namespace": {
+          "app_id": "sigil",
+          "canvas_id": "project-card-canvas",
+          "surface_id": "project-card",
+          "component_family": "toolkit.card",
+          "structural_owner": [
+            "recent-projects",
+            "project-42"
+          ]
+        }
+      },
+      "state": {
+        "current": "true"
+      },
+      "actions": [
+        "click",
+        "open"
+      ],
+      "provenance": {
+        "canvas_id": "project-card-canvas",
+        "do_target": "canvas:project-card-canvas/project-open-command"
+      },
+      "reacquisition": {
+        "machine_fingerprint": {
+          "role": "button",
+          "structural_path": [
+            "recent-projects",
+            "project-42",
+            "command"
+          ],
+          "capabilities": [
+            "click",
+            "open"
+          ]
+        },
+        "hint_fingerprint": {
+          "label_hints": [
+            "Open"
+          ]
+        }
+      }
+    }
+  ],
+  "resolution": {
+    "status": "ambiguous",
+    "reason": "same_label_without_unique_machine_fingerprint",
+    "action_blocked": true,
+    "selected_ref": null,
+    "candidate_refs": [
+      "file-open-command",
+      "project-open-command"
+    ],
+    "labels_used_as_hints_only": true
+  },
+  "recording_replay_plan": {
+    "id": "replay-plan:ambiguous-open",
+    "mode": "semantic_reacquire_then_do",
+    "steps": [
+      {
+        "kind": "re_perceive",
+        "surface": "sigil"
+      },
+      {
+        "kind": "resolve_descriptor",
+        "machine_facts_first": [
+          "target.owner_namespace",
+          "target.target_id",
+          "role",
+          "reacquisition.machine_fingerprint.structural_path",
+          "reacquisition.machine_fingerprint.capabilities"
+        ],
+        "hint_facts_only": [
+          "name",
+          "reacquisition.hint_fingerprint.label_hints"
+        ],
+        "ambiguous_result": "block"
+      },
+      {
+        "kind": "request_repair_patch",
+        "reason": "ambiguous"
+      }
+    ],
+    "raw_input_policy": "do_not_select_by_label_or_coordinates"
+  }
+}

--- a/docs/design/fixtures/aos-interaction-grammar-v0/manifest.json
+++ b/docs/design/fixtures/aos-interaction-grammar-v0/manifest.json
@@ -1,0 +1,10 @@
+{
+  "schema": "aos.interaction-grammar.fixture-pack.v0",
+  "description": "Deterministic fixture pack for the AOS interaction grammar V0 contract.",
+  "contract_note": "../../aos-interaction-grammar-v0.md",
+  "fixtures": [
+    "toolkit-slider-sequence.json",
+    "stale-ref-replay-plan.json",
+    "ambiguous-same-label-reacquisition.json"
+  ]
+}

--- a/docs/design/fixtures/aos-interaction-grammar-v0/stale-ref-replay-plan.json
+++ b/docs/design/fixtures/aos-interaction-grammar-v0/stale-ref-replay-plan.json
@@ -1,0 +1,172 @@
+{
+  "schema": "aos.interaction-grammar.fixture.v0",
+  "case": "stale_ref_rejects_before_execution",
+  "previous_target_descriptor": {
+    "ref": "display-brightness-slider",
+    "state_id": "see_interaction_slider001",
+    "surface": "display-settings-panel",
+    "role": "slider",
+    "name": "Brightness",
+    "kind": "semantic_target",
+    "enabled": true,
+    "target": {
+      "target_id": "control:display-brightness",
+      "owner_namespace": {
+        "app_id": "aos-toolkit-demo",
+        "canvas_id": "display-settings-panel",
+        "surface_id": "display-settings-panel",
+        "component_family": "toolkit.zag.slider",
+        "structural_owner": [
+          "settings-workbench",
+          "display-section"
+        ]
+      }
+    },
+    "state": {
+      "value": 0.4,
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "orientation": "horizontal",
+      "thumb_count": 1
+    },
+    "actions": [
+      "drag",
+      "set-value",
+      "focus"
+    ],
+    "provenance": {
+      "canvas_id": "display-settings-panel",
+      "do_target": "canvas:display-settings-panel/display-brightness-slider",
+      "center": {
+        "x": 120,
+        "y": 88
+      }
+    },
+    "reacquisition": {
+      "strategy": "owner-structural-fingerprint",
+      "machine_fingerprint": {
+        "role": "slider",
+        "structural_path": [
+          "settings-workbench",
+          "display-section",
+          "field:brightness"
+        ],
+        "capabilities": [
+          "drag",
+          "set-value",
+          "focus"
+        ],
+        "range_shape": {
+          "min": 0,
+          "max": 1,
+          "step": 0.05,
+          "orientation": "horizontal",
+          "thumb_count": 1
+        }
+      },
+      "hint_fingerprint": {
+        "label_hints": [
+          "Brightness"
+        ]
+      }
+    }
+  },
+  "action_intent": {
+    "id": "intent:stale-brightness-070",
+    "transaction_id": "txn:stale-brightness-070",
+    "action_type": "set-value",
+    "source_state_id": "see_interaction_slider001",
+    "target_ref": {
+      "ref": "display-brightness-slider",
+      "state_id": "see_interaction_slider001",
+      "target_descriptor": {
+        "$ref": "#/previous_target_descriptor"
+      }
+    },
+    "input": {
+      "kind": "scalar",
+      "value": 0.7
+    },
+    "constraints": {
+      "expected_role": "slider",
+      "allowed_actions": [
+        "set-value"
+      ]
+    },
+    "caller": {
+      "kind": "recording_replay",
+      "id": "work-record:set-brightness-070"
+    }
+  },
+  "current_state_id": "see_interaction_slider009",
+  "execution_result": {
+    "id": "result:stale-brightness-070",
+    "transaction_id": "txn:stale-brightness-070",
+    "action_intent_id": "intent:stale-brightness-070",
+    "action_type": "set-value",
+    "status": "blocked",
+    "reason": "stale_ref",
+    "duration_ms": 6,
+    "executed": false,
+    "execution": {
+      "backend": null,
+      "strategy": "preflight_state_ref_validation",
+      "fallback_used": false,
+      "state_id": "see_interaction_slider001"
+    },
+    "target": {
+      "target_dialect": "canvas",
+      "canvas_id": "display-settings-panel",
+      "ref": "display-brightness-slider",
+      "target_descriptor": {
+        "$ref": "#/previous_target_descriptor"
+      }
+    },
+    "resolved_target": {
+      "status": "stale_ref",
+      "supplied_state_id": "see_interaction_slider001",
+      "current_state_id": "see_interaction_slider009",
+      "ref": "display-brightness-slider",
+      "action_blocked": true
+    },
+    "post_action_state": null
+  },
+  "recording_replay_plan": {
+    "id": "replay-plan:stale-brightness-070",
+    "mode": "semantic_reacquire_then_do",
+    "stale_ref_policy": "reject_before_execution",
+    "steps": [
+      {
+        "kind": "re_perceive",
+        "surface": "display-settings-panel"
+      },
+      {
+        "kind": "resolve_descriptor",
+        "machine_facts_first": [
+          "target.owner_namespace",
+          "target.target_id",
+          "role",
+          "reacquisition.machine_fingerprint.structural_path",
+          "reacquisition.machine_fingerprint.capabilities",
+          "reacquisition.machine_fingerprint.range_shape"
+        ],
+        "hint_facts_only": [
+          "name",
+          "reacquisition.hint_fingerprint.label_hints"
+        ],
+        "ambiguous_result": "block",
+        "missing_result": "block"
+      },
+      {
+        "kind": "issue_action_intent_after_unique_reacquisition",
+        "action_type": "set-value",
+        "input": {
+          "kind": "scalar",
+          "value": 0.7
+        }
+      }
+    ],
+    "raw_input_policy": "do_not_blindly_replay_for_aos_owned_slider"
+  }
+}

--- a/docs/design/fixtures/aos-interaction-grammar-v0/toolkit-slider-sequence.json
+++ b/docs/design/fixtures/aos-interaction-grammar-v0/toolkit-slider-sequence.json
@@ -1,0 +1,384 @@
+{
+  "schema": "aos.interaction-grammar.fixture.v0",
+  "case": "toolkit_single_thumb_slider_sequence",
+  "see": {
+    "command": "./aos see capture --canvas display-settings-panel --xray",
+    "state_id": "see_interaction_slider001",
+    "semantic_targets": [
+      {
+        "ref": "display-brightness-slider",
+        "state_id": "see_interaction_slider001",
+        "surface": "display-settings-panel",
+        "role": "slider",
+        "name": "Brightness",
+        "kind": "semantic_target",
+        "enabled": true,
+        "target": {
+          "target_id": "control:display-brightness",
+          "owner_namespace": {
+            "app_id": "aos-toolkit-demo",
+            "canvas_id": "display-settings-panel",
+            "surface_id": "display-settings-panel",
+            "component_family": "toolkit.zag.slider",
+            "structural_owner": [
+              "settings-workbench",
+              "display-section"
+            ]
+          }
+        },
+        "state": {
+          "value": 0.4,
+          "min": 0,
+          "max": 1,
+          "step": 0.05,
+          "orientation": "horizontal",
+          "thumb_count": 1
+        },
+        "actions": [
+          "drag",
+          "set-value",
+          "focus"
+        ],
+        "provenance": {
+          "canvas_id": "display-settings-panel",
+          "do_target": "canvas:display-settings-panel/display-brightness-slider",
+          "bounds": {
+            "x": 24,
+            "y": 72,
+            "width": 240,
+            "height": 32
+          },
+          "center": {
+            "x": 120,
+            "y": 88
+          },
+          "control_bounds": {
+            "x": 24,
+            "y": 72,
+            "width": 240,
+            "height": 32
+          },
+          "track_bounds": {
+            "x": 36,
+            "y": 84,
+            "width": 216,
+            "height": 4
+          },
+          "thumb_bounds": {
+            "x": 116,
+            "y": 76,
+            "width": 16,
+            "height": 16
+          }
+        },
+        "reacquisition": {
+          "strategy": "owner-structural-fingerprint",
+          "machine_fingerprint": {
+            "role": "slider",
+            "structural_path": [
+              "settings-workbench",
+              "display-section",
+              "field:brightness"
+            ],
+            "capabilities": [
+              "drag",
+              "set-value",
+              "focus"
+            ],
+            "range_shape": {
+              "min": 0,
+              "max": 1,
+              "step": 0.05,
+              "orientation": "horizontal",
+              "thumb_count": 1
+            }
+          },
+          "hint_fingerprint": {
+            "label_hints": [
+              "Brightness"
+            ],
+            "source_hints": {
+              "dom_id": "brightness"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "action_intent": {
+    "id": "intent:set-brightness-070",
+    "transaction_id": "txn:set-brightness-070",
+    "action_type": "set-value",
+    "source_state_id": "see_interaction_slider001",
+    "target_ref": {
+      "ref": "display-brightness-slider",
+      "state_id": "see_interaction_slider001",
+      "target_descriptor": {
+        "$ref": "#/see/semantic_targets/0"
+      }
+    },
+    "input": {
+      "kind": "scalar",
+      "value": 0.7
+    },
+    "constraints": {
+      "expected_role": "slider",
+      "allowed_actions": [
+        "set-value"
+      ],
+      "playback": "human"
+    },
+    "caller": {
+      "kind": "agent",
+      "id": "gdi-fixture",
+      "provenance": "docs/design/fixtures/aos-interaction-grammar-v0/toolkit-slider-sequence.json"
+    }
+  },
+  "execution_result": {
+    "id": "result:set-brightness-070",
+    "transaction_id": "txn:set-brightness-070",
+    "action_intent_id": "intent:set-brightness-070",
+    "action_type": "set-value",
+    "status": "success",
+    "reason": null,
+    "duration_ms": 42,
+    "executed": true,
+    "execution": {
+      "backend": "canvas",
+      "strategy": "canvas_semantic_set_value",
+      "fallback_used": false,
+      "state_id": "see_interaction_slider001"
+    },
+    "target": {
+      "target_dialect": "canvas",
+      "canvas_id": "display-settings-panel",
+      "ref": "display-brightness-slider",
+      "target_descriptor": {
+        "$ref": "#/see/semantic_targets/0"
+      },
+      "local_center": {
+        "x": 120,
+        "y": 88
+      },
+      "global_point": {
+        "x": 1480,
+        "y": 620
+      },
+      "coordinate_space": "canvas_local",
+      "capture_scale": 2
+    },
+    "resolved_target": {
+      "status": "resolved",
+      "ref": "display-brightness-slider",
+      "state_id": "see_interaction_slider001",
+      "target_descriptor": {
+        "$ref": "#/see/semantic_targets/0"
+      }
+    },
+    "post_action_state": {
+      "state_id": "see_interaction_slider002",
+      "state": {
+        "value": 0.7,
+        "min": 0,
+        "max": 1,
+        "step": 0.05,
+        "orientation": "horizontal",
+        "thumb_count": 1
+      }
+    }
+  },
+  "gesture_frames": [
+    {
+      "schema": "aos.gesture-frame",
+      "schema_version": 0,
+      "type": "gesture.drag.start",
+      "phase": "start",
+      "gesture_id": "gesture:brightness-human-playback",
+      "transaction_id": "txn:set-brightness-070",
+      "semantic_target": {
+        "$ref": "#/see/semantic_targets/0"
+      },
+      "semantic_action": "set-value",
+      "coordinates": {
+        "dom_client": {
+          "x": 120,
+          "y": 88
+        }
+      },
+      "timing": {
+        "t": 1000,
+        "frame_index": 0
+      }
+    },
+    {
+      "schema": "aos.gesture-frame",
+      "schema_version": 0,
+      "type": "gesture.drag.move",
+      "phase": "move",
+      "gesture_id": "gesture:brightness-human-playback",
+      "transaction_id": "txn:set-brightness-070",
+      "semantic_target": {
+        "$ref": "#/see/semantic_targets/0"
+      },
+      "semantic_action": "set-value",
+      "coordinates": {
+        "dom_client": {
+          "x": 185,
+          "y": 88
+        }
+      },
+      "timing": {
+        "t": 1016,
+        "frame_index": 1
+      }
+    },
+    {
+      "schema": "aos.gesture-frame",
+      "schema_version": 0,
+      "type": "gesture.drag.end",
+      "phase": "end",
+      "gesture_id": "gesture:brightness-human-playback",
+      "transaction_id": "txn:set-brightness-070",
+      "semantic_target": {
+        "$ref": "#/see/semantic_targets/0"
+      },
+      "semantic_action": "set-value",
+      "coordinates": {
+        "dom_client": {
+          "x": 187,
+          "y": 88
+        }
+      },
+      "timing": {
+        "t": 1032,
+        "frame_index": 2
+      }
+    }
+  ],
+  "state_patch": {
+    "id": "patch:set-brightness-070",
+    "transaction_id": "txn:set-brightness-070",
+    "target_ref": {
+      "ref": "display-brightness-slider",
+      "state_id": "see_interaction_slider001",
+      "target_descriptor": {
+        "$ref": "#/see/semantic_targets/0"
+      }
+    },
+    "before_state": {
+      "value": 0.4
+    },
+    "after_state": {
+      "value": 0.7
+    },
+    "changes": [
+      {
+        "path": [
+          "state",
+          "value"
+        ],
+        "before": 0.4,
+        "after": 0.7
+      }
+    ],
+    "verified_by": {
+      "kind": "after_perception",
+      "state_id": "see_interaction_slider002",
+      "assertion": "target state.value equals 0.7"
+    },
+    "evidence_refs": [
+      "evidence:set-brightness-before-see",
+      "evidence:set-brightness-do",
+      "evidence:set-brightness-after-see"
+    ]
+  },
+  "work_record": {
+    "type": "aos.work_record.interaction-draft",
+    "id": "work-record:set-brightness-070",
+    "intent_ref": "intent:set-brightness-070",
+    "execution_map": {
+      "targets": [
+        {
+          "$ref": "#/see/semantic_targets/0"
+        }
+      ],
+      "action_intents": [
+        {
+          "$ref": "#/action_intent"
+        }
+      ],
+      "execution_results": [
+        {
+          "$ref": "#/execution_result"
+        }
+      ],
+      "state_patches": [
+        {
+          "$ref": "#/state_patch"
+        }
+      ],
+      "replay_policy": {
+        "mode": "semantic_reacquire_then_do",
+        "raw_input_replay": "fallback_evidence_only"
+      }
+    },
+    "evidence": [
+      {
+        "id": "evidence:set-brightness-before-see",
+        "kind": "aos_see_capture",
+        "state_id": "see_interaction_slider001"
+      },
+      {
+        "id": "evidence:set-brightness-do",
+        "kind": "aos_do_action",
+        "execution_result_ref": "result:set-brightness-070"
+      },
+      {
+        "id": "evidence:set-brightness-after-see",
+        "kind": "aos_see_capture",
+        "state_id": "see_interaction_slider002"
+      }
+    ]
+  },
+  "recording_replay_plan": {
+    "id": "replay-plan:set-brightness-070",
+    "mode": "semantic_reacquire_then_do",
+    "steps": [
+      {
+        "kind": "re_perceive",
+        "surface": "display-settings-panel"
+      },
+      {
+        "kind": "resolve_descriptor",
+        "machine_facts_first": [
+          "target.owner_namespace",
+          "target.target_id",
+          "role",
+          "reacquisition.machine_fingerprint.structural_path",
+          "reacquisition.machine_fingerprint.capabilities",
+          "reacquisition.machine_fingerprint.range_shape"
+        ],
+        "hint_facts_only": [
+          "name",
+          "reacquisition.hint_fingerprint.label_hints"
+        ],
+        "ambiguous_result": "block"
+      },
+      {
+        "kind": "issue_action_intent",
+        "action_type": "set-value",
+        "input": {
+          "kind": "scalar",
+          "value": 0.7
+        }
+      },
+      {
+        "kind": "verify_state_patch",
+        "expected_state": {
+          "value": 0.7
+        }
+      }
+    ],
+    "raw_input_policy": "do_not_blindly_replay_for_aos_owned_slider"
+  }
+}

--- a/docs/design/see-do-grammar-trace-connections.md
+++ b/docs/design/see-do-grammar-trace-connections.md
@@ -3,6 +3,14 @@
 **Date:** 2026-05-04
 **Status:** research note / brainstorming
 
+**Status update 2026-06-06:** This is a pre-#429 research note. Current AOS
+target-addressed interaction contracts defer to #429 target descriptors and
+[`aos-interaction-grammar-v0.md`](aos-interaction-grammar-v0.md). Where this
+note says replay should prefer accessible names over coordinates, read that as
+historical shorthand for "prefer semantic descriptors over raw coordinates."
+Accessible names and labels are now hints only; durable identity is
+`target.target_id` scoped by `target.owner_namespace`.
+
 This note connects two threads from an external discussion:
 
 - BNF and grammar-constrained sampling as a way to keep model output inside a

--- a/docs/design/work-cards/gdi-aos-interaction-grammar-contract-v0.md
+++ b/docs/design/work-cards/gdi-aos-interaction-grammar-contract-v0.md
@@ -1,0 +1,271 @@
+# AOS Interaction Grammar Contract V0
+
+## Recipient
+
+GDI contract, fixture, and test round.
+
+## Transfer Kind
+
+GDI round.
+
+## Branch / Base
+
+- branch_from: local `main` containing this work card.
+- required_start_ref: local `main` containing this work card.
+- published prerequisite base: `origin/main` at `143382ac` or later, with PR
+  #433 merged.
+- expected output branch: `gdi/aos-interaction-grammar-contract-v0`
+
+Do not reset to an older `origin/main`. The target descriptor contract and
+semantic-target drift cleanup are published prerequisites.
+
+## Source Artifact
+
+- GitHub issue #430:
+  https://github.com/michaelblum/agent-os/issues/430
+- Published prerequisite PR #433:
+  https://github.com/michaelblum/agent-os/pull/433
+- Prerequisite lanes:
+  - #429 target descriptor contract is published.
+  - #432 semantic-target drift cleanup is closed.
+  - #427 gesture-frame proof is published.
+  - #428 Work Recording remains downstream schema/design work.
+  - #431 input-event-v2 hard cutover remains separate debt.
+
+## Fresh Context Contract
+
+GDI starts from a fresh context window. Do not assume branch, checkout, daemon,
+canvas, issue, or prior implementation state. Read and rediscover before
+editing.
+
+## Goal
+
+Define and prove the first AOS interaction grammar contract so action intents,
+execution results, optional gesture frames, state patches/evidence, and Work
+Recording replay plans all reference the #429 target descriptor vocabulary
+without treating labels or coordinates as durable identity.
+
+## Read First
+
+- `AGENTS.md`
+- `shared/schemas/aos-semantic-targets.md`
+- `docs/api/aos.md`
+- `docs/design/aos-shared-gesture-spine-v0.md`
+- `docs/design/aos-work-records-and-self-healing-recipes.md`
+- `docs/design/see-do-grammar-trace-connections.md`
+- `docs/design/fixtures/aos-target-descriptor-v0/manifest.json`
+- `tests/toolkit/aos-target-descriptor-contract.test.mjs`
+- `packages/toolkit/runtime/gesture-stream.js`
+- `tests/toolkit/runtime-gesture-stream.test.mjs`
+- `shared/schemas/aos-work-record-v0.md`
+- `shared/schemas/aos-work-record-v0.schema.json`
+- `docs/design/fixtures/aos-work-records/canvas-toolkit-control-step.json`
+- `tests/toolkit/work-record-capture.test.mjs`
+- `tests/toolkit/work-record-adapter.test.mjs`
+
+## Rediscover State
+
+Run before editing:
+
+```bash
+git status --short --branch
+git rev-parse HEAD origin/main
+./aos service status --mode repo --json
+./aos dev gh issue view 430 --json
+rg -n "action intent|execution result|gesture frame|state patch|do_step|execution_map|aos\\.gesture-frame|semantic_action|semantic_target|target\\.target_id|state_id|replay" docs/design shared/schemas packages/toolkit tests/toolkit --glob "*.md" --glob "*.json" --glob "*.js" --glob "*.mjs"
+```
+
+Live AOS is intentionally paused for this workstream. Do not run `./aos ready`,
+`./aos status`, `./aos clean`, service start/restart, or live smoke unless
+Michael explicitly approves it in a new instruction. This slice is
+deterministic-only.
+
+## Existing Code And Docs To Inspect
+
+- `shared/schemas/aos-semantic-targets.md` - canonical target descriptor
+  vocabulary that every interaction frame must use.
+- `docs/design/aos-shared-gesture-spine-v0.md` and
+  `packages/toolkit/runtime/gesture-stream.js` - existing `aos.gesture-frame`
+  proof and gesture frame fields.
+- `docs/design/aos-work-records-and-self-healing-recipes.md`,
+  `shared/schemas/aos-work-record-v0.md`, and
+  `shared/schemas/aos-work-record-v0.schema.json` - current work-record
+  vocabulary and replay/repair boundaries.
+- `docs/design/see-do-grammar-trace-connections.md` - older research note that
+  should be reconciled or marked as pre-#429 where it conflicts.
+- `docs/design/fixtures/aos-work-records/canvas-toolkit-control-step.json` -
+  current toolkit control step fixture that can inform the slider example.
+- `tests/toolkit/work-record-*.test.mjs` - existing fixture/test style for
+  Work Record guardrails.
+
+## Required Behavior
+
+### Contract Note
+
+Add a current design note, likely `docs/design/aos-interaction-grammar-v0.md`,
+that defines the V0 interaction record family:
+
+- `target_descriptor`: what target exists and what can be done to it, using the
+  #429 descriptor vocabulary.
+- `action_intent`: what an agent, recipe, or replay requested. It must carry
+  action type, target ref/descriptor, optional input value or vector, source
+  state id, constraints, and caller/provenance metadata.
+- `execution_result`: how AOS performed the intent and whether it fell back,
+  preserving current `aos do` response fields such as backend, strategy,
+  fallback flag, state id, target details, resolved target, post-action state,
+  status, reason, and duration.
+- `observed_input`: raw hardware/canvas facts only when needed for evidence or
+  visible playback; not the primary semantic record for AOS-owned surfaces.
+- `gesture_frame`: optional normalized lifecycle frames from
+  `aos.gesture-frame`, linked to the action intent/execution transaction when
+  playback is human/visible or observation captured a drag.
+- `state_patch` / `evidence`: what changed and how it was verified.
+- `recording_replay_plan`: how a Work Recording should re-perceive, resolve the
+  descriptor, reissue the semantic action, and verify state without blind raw
+  event replay.
+
+The note must name ownership boundaries:
+
+- `aos do` owns action intent validation and execution result fields.
+- toolkit gesture stream owns gesture mechanics and frame lifecycle.
+- Work Recording owns durable intent, execution-map/evidence storage, replay
+  plan, health, and repair patches.
+- raw `input_event` / input-event-v2 is source evidence and compatibility debt,
+  not the new canonical recording grammar.
+
+### Fixture Pack
+
+Add deterministic fixtures, likely under
+`docs/design/fixtures/aos-interaction-grammar-v0/`, with at least:
+
+- `manifest.json`;
+- a toolkit single-thumb slider sequence showing:
+  `see -> action_intent(set-value) -> execution_result -> optional
+  gesture.drag.* frames for human playback -> state_patch -> work_record /
+  replay_plan`;
+- a stale-ref sequence where `state_id`/`ref` rejects before execution and the
+  replay plan attempts machine-first reacquisition;
+- an ambiguous same-label reacquisition sequence that stays blocked.
+
+The slider fixture must use the #429 descriptor vocabulary:
+
+- `ref` and `state_id` for the immediate action;
+- `target.target_id` scoped by `target.owner_namespace`;
+- primitive `actions`;
+- current `state`;
+- `provenance`;
+- `reacquisition` machine facts first, labels only as hints.
+
+Do not use examples such as `avatar.controls.scale` or `settings.opacity` as
+durable ids unless they are explicitly presented as labels/hints and paired
+with descriptor identity.
+
+### Tests
+
+Add a focused Node test, likely
+`tests/toolkit/aos-interaction-grammar-contract.test.mjs`, that validates the
+fixture pack and fails if:
+
+- labels/accessibility names appear in durable target identity;
+- `action_intent`, `execution_result`, gesture frames, state patches, or replay
+  plans point at a target without descriptor identity or state-scoped ref
+  context;
+- an execution result loses current `aos do` fields such as backend, strategy,
+  fallback flag, state id, target details, post-action state, status/reason, or
+  duration when those fields are present;
+- raw coordinates become the primary target identity for the AOS-owned slider
+  case;
+- ambiguous same-label reacquisition silently selects a target.
+
+Prefer fixture validation and small helpers in the test file over broad runtime
+changes unless inspection shows a tiny shared helper belongs in toolkit.
+
+### Existing Docs
+
+Update adjacent current docs only as needed:
+
+- `docs/design/aos-work-records-and-self-healing-recipes.md` should point to
+  the new interaction grammar note for the intent/execution/gesture/patch
+  split.
+- `docs/design/aos-shared-gesture-spine-v0.md` should make clear that gesture
+  frames are optional interaction evidence/playback frames, not the whole
+  action intent or Work Recording model.
+- `docs/design/see-do-grammar-trace-connections.md` may remain a research note,
+  but if it still recommends accessible names over descriptor identity for
+  replay, add a dated status note pointing to #429/#430 and the new grammar
+  note.
+- `docs/api/aos.md` may be updated only if the contract note needs a narrow
+  public cross-reference. Do not overpromise current producer/runtime coverage.
+
+## Scope
+
+Schema/design docs, deterministic fixtures, focused Node tests, and narrow
+current-doc cross-references.
+
+Runtime code changes are optional and should happen only if a tiny helper is
+needed to keep fixture validation honest. Native Swift producer, daemon, live
+runtime, and input-event-v2 hard-cutover work are out of scope.
+
+## Hard Boundaries / Non-Goals
+
+- Do not restart live AOS or require live canvas/input evidence.
+- Do not run `./aos ready`, `./aos status`, `./aos clean`, service
+  start/restart, or live smoke.
+- Do not implement a recorder, replayer, autonomous repair loop, or `aos do`
+  runtime changes.
+- Do not start #431 input-event-v2 hard cutover.
+- Do not change native/Swift or TCC broker code.
+- Do not introduce Pi `@e` / `@w` syntax as canonical AOS syntax.
+- Do not make raw coordinates or human-readable labels primary identity for
+  AOS-owned targets.
+- Do not close #430; Foreman will decide after review.
+- Do not push, open PRs, or mutate GitHub issues.
+
+## Stop Conditions
+
+Stop with a clear report instead of continuing if:
+
+- the interaction family cannot represent current `aos do` result metadata
+  without losing fields;
+- a useful end-to-end fixture requires live AOS evidence or native producer
+  migration;
+- the design requires unresolved #431 input-event-v2 decisions;
+- existing Work Record schemas conflict with the proposed fixture in a way that
+  needs Foreman product/architecture judgment.
+
+## Verification
+
+Run deterministic checks:
+
+```bash
+git diff --check
+node --test tests/toolkit/aos-target-descriptor-contract.test.mjs
+node --test tests/toolkit/runtime-gesture-stream.test.mjs
+node --test tests/toolkit/work-record-capture.test.mjs tests/toolkit/work-record-adapter.test.mjs
+node --test tests/toolkit/aos-interaction-grammar-contract.test.mjs
+rg -n "avatar\\.controls\\.scale|settings\\.opacity|accessible names over coordinates|human-readable.*identity|label.*identity|name.*identity|semantic_target\\.id|target\\.id" docs/design shared/schemas docs/api packages/toolkit tests/toolkit --glob "*.md" --glob "*.json" --glob "*.js" --glob "*.mjs"
+```
+
+For remaining `rg` hits, classify them in the completion report as current
+canonical guidance, historical/research and visibly marked, fixture-negative,
+unrelated local object identity, or deferred #431/#428 work.
+
+## Completion Report
+
+Return a path-scoped report with:
+
+- branch and head SHA;
+- base SHA;
+- files changed;
+- contract note path and summary of the interaction record family;
+- fixture paths and what each proves;
+- test path and exact assertions added;
+- existing docs updated or marked historical;
+- how current `aos do` result metadata is preserved in `execution_result`;
+- how gesture frames link to action intent/execution without becoming the
+  whole Work Recording model;
+- exact verification commands and pass/fail results;
+- remaining drift-scan hits and classification;
+- confirmation that live AOS was not restarted;
+- local-only state, including dirty/untracked files and ignored artifacts;
+- recommended next slice only if the round reveals one concrete follow-up.

--- a/tests/toolkit/aos-interaction-grammar-contract.test.mjs
+++ b/tests/toolkit/aos-interaction-grammar-contract.test.mjs
@@ -1,0 +1,213 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const fixtureDir = resolve(__dirname, '../../docs/design/fixtures/aos-interaction-grammar-v0')
+
+async function readJson(name) {
+  return JSON.parse(await readFile(resolve(fixtureDir, name), 'utf8'))
+}
+
+function walk(value, visit, path = []) {
+  if (!value || typeof value !== 'object') return
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => walk(item, visit, [...path, String(index)]))
+    return
+  }
+  visit(value, path)
+  for (const [key, child] of Object.entries(value)) {
+    walk(child, visit, [...path, key])
+  }
+}
+
+function refPath(value) {
+  return value && typeof value === 'object' && Object.keys(value).length === 1 ? value.$ref : null
+}
+
+function descriptorForRef(fixture, pointer) {
+  if (pointer === '#/see/semantic_targets/0') return fixture.see?.semantic_targets?.[0]
+  if (pointer === '#/previous_target_descriptor') return fixture.previous_target_descriptor
+  throw new Error(`unknown descriptor ref ${pointer}`)
+}
+
+function materializeDescriptor(fixture, descriptorOrRef) {
+  return descriptorForRef(fixture, refPath(descriptorOrRef)) || descriptorOrRef
+}
+
+function namespaceKey(namespace = {}) {
+  return JSON.stringify({
+    app_id: namespace.app_id,
+    canvas_id: namespace.canvas_id,
+    surface_id: namespace.surface_id,
+    component_family: namespace.component_family,
+    structural_owner: namespace.structural_owner,
+  })
+}
+
+function durableIdentityKey(descriptor = {}) {
+  return `${namespaceKey(descriptor.target?.owner_namespace)}\u0000${descriptor.target?.target_id}`
+}
+
+function assertDescriptorShape(descriptor, context = descriptor?.ref || 'descriptor') {
+  assert.ok(descriptor.ref, `${context} requires state-scoped ref`)
+  assert.ok(descriptor.state_id, `${context} requires state_id`)
+  assert.ok(descriptor.target?.target_id, `${context} requires target.target_id`)
+  assert.ok(descriptor.target?.owner_namespace?.app_id, `${context} requires owner namespace app_id`)
+  assert.ok(descriptor.target?.owner_namespace?.canvas_id, `${context} requires owner namespace canvas_id`)
+  assert.ok(Array.isArray(descriptor.actions) && descriptor.actions.length > 0, `${context} requires primitive actions`)
+  assert.ok(descriptor.state && typeof descriptor.state === 'object', `${context} requires current state`)
+  assert.ok(descriptor.provenance?.canvas_id, `${context} requires provenance canvas_id`)
+  assert.ok(descriptor.reacquisition?.machine_fingerprint, `${context} requires machine reacquisition fingerprint`)
+  assert.ok(descriptor.reacquisition?.hint_fingerprint, `${context} requires hint reacquisition fingerprint`)
+}
+
+function assertNoPresentationIdentity(descriptor, context = descriptor?.ref || 'descriptor') {
+  const identityText = JSON.stringify({
+    target_id: descriptor.target?.target_id,
+    owner_namespace: descriptor.target?.owner_namespace,
+  })
+  for (const presentation of [descriptor.name, descriptor.label, descriptor.accessible_name].filter(Boolean)) {
+    assert.notEqual(identityText, presentation, `${context} used presentation text as identity`)
+    assert.equal(identityText.includes(`"${presentation}"`), false, `${context} embedded presentation text in identity`)
+  }
+  walk(descriptor.provenance, (node, path) => {
+    if (path.includes('bounds') || path.includes('center') || path.includes('frame')) {
+      assert.equal(identityText.includes(JSON.stringify(node)), false, `${context} copied coordinates into identity`)
+    }
+  })
+}
+
+function assertTargetRef(fixture, targetRef, context) {
+  assert.ok(targetRef.ref, `${context} requires ref`)
+  assert.ok(targetRef.state_id, `${context} requires state_id`)
+  const descriptor = materializeDescriptor(fixture, targetRef.target_descriptor)
+  assertDescriptorShape(descriptor, context)
+  assert.equal(targetRef.ref, descriptor.ref, `${context} ref must match descriptor`)
+  assert.equal(targetRef.state_id, descriptor.state_id, `${context} state_id must match descriptor`)
+}
+
+function assertReplayPlanIsMachineFirst(plan) {
+  const resolveStep = plan.steps.find((step) => step.kind === 'resolve_descriptor')
+  assert.ok(resolveStep, `${plan.id} requires resolve_descriptor step`)
+  assert.ok(resolveStep.machine_facts_first.includes('target.owner_namespace'))
+  assert.ok(resolveStep.machine_facts_first.includes('target.target_id'))
+  assert.ok(resolveStep.machine_facts_first.some((fact) => fact.includes('capabilities')))
+  assert.ok(resolveStep.hint_facts_only.some((fact) => fact.includes('label_hints') || fact === 'name'))
+  assert.equal(resolveStep.ambiguous_result, 'block')
+}
+
+test('fixture manifest lists the interaction grammar cases', async () => {
+  const manifest = await readJson('manifest.json')
+
+  assert.equal(manifest.schema, 'aos.interaction-grammar.fixture-pack.v0')
+  assert.deepEqual(manifest.fixtures.sort(), [
+    'ambiguous-same-label-reacquisition.json',
+    'stale-ref-replay-plan.json',
+    'toolkit-slider-sequence.json',
+  ])
+})
+
+test('slider sequence links see, intent, execution, gesture, patch, record, and replay through descriptor identity', async () => {
+  const fixture = await readJson('toolkit-slider-sequence.json')
+  const descriptor = fixture.see.semantic_targets[0]
+
+  assertDescriptorShape(descriptor)
+  assertNoPresentationIdentity(descriptor)
+  assert.equal(descriptor.name, 'Brightness')
+  assert.equal(descriptor.actions.includes('set-value'), true)
+
+  assertTargetRef(fixture, fixture.action_intent.target_ref, 'action_intent.target_ref')
+  assert.equal(fixture.action_intent.action_type, 'set-value')
+  assert.equal(fixture.action_intent.source_state_id, descriptor.state_id)
+  assert.equal(fixture.action_intent.input.value, 0.7)
+
+  assert.equal(fixture.execution_result.action_intent_id, fixture.action_intent.id)
+  assert.equal(fixture.execution_result.transaction_id, fixture.action_intent.transaction_id)
+  assert.equal(fixture.execution_result.execution.state_id, descriptor.state_id)
+  assert.equal(durableIdentityKey(materializeDescriptor(fixture, fixture.execution_result.target.target_descriptor)), durableIdentityKey(descriptor))
+  assert.equal(durableIdentityKey(materializeDescriptor(fixture, fixture.execution_result.resolved_target.target_descriptor)), durableIdentityKey(descriptor))
+
+  for (const frame of fixture.gesture_frames) {
+    assert.equal(frame.schema, 'aos.gesture-frame')
+    assert.equal(frame.transaction_id, fixture.action_intent.transaction_id)
+    assert.equal(frame.semantic_action, 'set-value')
+    assert.equal(durableIdentityKey(materializeDescriptor(fixture, frame.semantic_target)), durableIdentityKey(descriptor))
+  }
+
+  assertTargetRef(fixture, fixture.state_patch.target_ref, 'state_patch.target_ref')
+  assert.deepEqual(fixture.state_patch.changes[0].path, ['state', 'value'])
+  assert.equal(fixture.work_record.execution_map.action_intents[0].$ref, '#/action_intent')
+  assert.equal(fixture.work_record.execution_map.execution_results[0].$ref, '#/execution_result')
+  assert.equal(fixture.work_record.execution_map.state_patches[0].$ref, '#/state_patch')
+  assertReplayPlanIsMachineFirst(fixture.recording_replay_plan)
+  assert.equal(fixture.recording_replay_plan.raw_input_policy, 'do_not_blindly_replay_for_aos_owned_slider')
+})
+
+test('execution results preserve current aos do metadata fields when present', async () => {
+  const slider = await readJson('toolkit-slider-sequence.json')
+  const stale = await readJson('stale-ref-replay-plan.json')
+
+  for (const fixture of [slider, stale]) {
+    const result = fixture.execution_result
+    assert.ok(Object.hasOwn(result, 'status'), `${fixture.case} preserves status`)
+    assert.ok(Object.hasOwn(result, 'reason'), `${fixture.case} preserves reason`)
+    assert.ok(Object.hasOwn(result, 'duration_ms'), `${fixture.case} preserves duration_ms`)
+    assert.ok(Object.hasOwn(result.execution, 'backend'), `${fixture.case} preserves backend`)
+    assert.ok(Object.hasOwn(result.execution, 'strategy'), `${fixture.case} preserves strategy`)
+    assert.ok(Object.hasOwn(result.execution, 'fallback_used'), `${fixture.case} preserves fallback_used`)
+    assert.ok(Object.hasOwn(result.execution, 'state_id'), `${fixture.case} preserves state_id`)
+    assert.ok(Object.hasOwn(result, 'target'), `${fixture.case} preserves target details`)
+    assert.ok(Object.hasOwn(result, 'resolved_target'), `${fixture.case} preserves resolved target`)
+    assert.ok(Object.hasOwn(result, 'post_action_state'), `${fixture.case} preserves post-action state`)
+  }
+})
+
+test('stale state scoped refs reject before execution and plan machine-first reacquisition', async () => {
+  const fixture = await readJson('stale-ref-replay-plan.json')
+
+  assertDescriptorShape(fixture.previous_target_descriptor)
+  assertNoPresentationIdentity(fixture.previous_target_descriptor)
+  assertTargetRef(fixture, fixture.action_intent.target_ref, 'stale action_intent.target_ref')
+  assert.equal(fixture.execution_result.status, 'blocked')
+  assert.equal(fixture.execution_result.reason, 'stale_ref')
+  assert.equal(fixture.execution_result.executed, false)
+  assert.equal(fixture.execution_result.resolved_target.status, 'stale_ref')
+  assert.equal(fixture.execution_result.resolved_target.action_blocked, true)
+  assert.notEqual(fixture.execution_result.resolved_target.supplied_state_id, fixture.execution_result.resolved_target.current_state_id)
+  assertReplayPlanIsMachineFirst(fixture.recording_replay_plan)
+})
+
+test('ambiguous same-label reacquisition stays blocked', async () => {
+  const fixture = await readJson('ambiguous-same-label-reacquisition.json')
+
+  assertDescriptorShape(fixture.previous_target_descriptor)
+  fixture.candidates.forEach((candidate) => {
+    assertDescriptorShape(candidate)
+    assertNoPresentationIdentity(candidate)
+  })
+  assert.deepEqual(fixture.candidates.map((candidate) => candidate.name), ['Open', 'Open'])
+  assert.equal(fixture.resolution.status, 'ambiguous')
+  assert.equal(fixture.resolution.action_blocked, true)
+  assert.equal(fixture.resolution.selected_ref, null)
+  assert.deepEqual(fixture.resolution.candidate_refs, fixture.candidates.map((candidate) => candidate.ref))
+  assert.equal(fixture.resolution.labels_used_as_hints_only, true)
+  assertReplayPlanIsMachineFirst(fixture.recording_replay_plan)
+})
+
+test('target-addressed records never use raw coordinates as primary identity', async () => {
+  for (const fixtureName of [
+    'toolkit-slider-sequence.json',
+    'stale-ref-replay-plan.json',
+    'ambiguous-same-label-reacquisition.json',
+  ]) {
+    const fixture = await readJson(fixtureName)
+    walk(fixture, (node, path) => {
+      if (!node.target?.target_id || !node.target?.owner_namespace) return
+      assertNoPresentationIdentity(node, `${fixtureName}:${path.join('.')}`)
+    })
+  }
+})
+


### PR DESCRIPTION
## Summary

- Add the #430 AOS interaction grammar contract note for target descriptors, action intents, execution results, observed input, gesture frames, state patches/evidence, and replay plans.
- Add deterministic fixtures for a toolkit slider sequence, stale state-scoped ref rejection, and ambiguous same-label reacquisition blocking.
- Add a focused Node contract test and narrow doc cross-references from Work Records, shared gesture spine, old see/do research, and the AOS API docs.

## Verification

- `git diff --check`
- `node --test tests/toolkit/aos-target-descriptor-contract.test.mjs`
- `node --test tests/toolkit/runtime-gesture-stream.test.mjs`
- `node --test tests/toolkit/work-record-capture.test.mjs tests/toolkit/work-record-adapter.test.mjs`
- `node --test tests/toolkit/aos-interaction-grammar-contract.test.mjs`

Refs #430

Live AOS was intentionally left paused; this PR uses deterministic docs/fixture/test evidence only.
