### PR TITLE
docs(aos): define work recording frame contract

### DIFF
--- a/docs/design/aos-interaction-grammar-v0.md
+++ b/docs/design/aos-interaction-grammar-v0.md
@@ -146,6 +146,10 @@ until the input-event-v2 cutover is designed.
 - Work Recording owns durable intent storage, execution-map storage, evidence,
   replay plans, health, and repair patches. It records and verifies work; it
   does not make raw input replay canonical.
+- The Work Recording frame contract defines the baseline, delta, keyframe,
+  evidence-ref, replay-policy, and frame-health storage layer over this
+  interaction family:
+  [`aos-work-recording-frame-contract-v0.md`](aos-work-recording-frame-contract-v0.md).
 - Raw `input_event` / input-event-v2 is source evidence and compatibility debt.
   It is not the canonical recording grammar for AOS-owned controls.
 
@@ -161,4 +165,3 @@ proves:
 - stale `state_id`/`ref` rejection before execution, followed by a
   machine-first reacquisition replay plan;
 - ambiguous same-label reacquisition that remains blocked.
-

--- a/docs/design/aos-work-recording-frame-contract-v0.md
+++ b/docs/design/aos-work-recording-frame-contract-v0.md
@@ -1,0 +1,135 @@
+# AOS Work Recording Frame Contract V0
+
+**Status:** contract note for #428 deterministic fixtures
+**Depends on:** #429 target descriptors, #430 interaction grammar, and #427
+gesture frames
+
+## Purpose
+
+A Work Recording is an ordered frame pack over the interaction record family in
+[`aos-interaction-grammar-v0.md`](aos-interaction-grammar-v0.md). It stores the
+baseline context for a run, compact semantic deltas after the baseline,
+periodic recovery snapshots, immutable evidence references, replay policy, and
+frame health. It does not make raw pointer streams, labels, accessible names,
+or coordinates the durable language of AOS-owned recordings.
+
+For target-addressed AOS interactions, durable identity remains
+`target.target_id` scoped by `target.owner_namespace`. State-scoped `ref` and
+`state_id` identify the immediate action attempt. Labels, accessible names,
+source names, and coordinates can support human review, accessibility, visible
+playback, or reacquisition hints, but they are not recording identity.
+
+## Frame Family
+
+### `recording_baseline`
+
+`recording_baseline` is the first snapshot for a recording segment. It captures
+the relevant surfaces, state ids, target descriptors, environment metadata, and
+Work Record context needed to interpret later deltas.
+
+Required target-addressed content:
+
+- `state_id` for the captured perception state.
+- relevant `target_descriptors[]` with `target.target_id`,
+  `target.owner_namespace`, `actions`, `state`, `provenance`, and
+  `reacquisition`.
+- `work_record_ref` or Work Record context that names the durable run.
+- `replay_policy_ref` or inline policy context that keeps replay and repair
+  under Work Record gates.
+
+The baseline is a snapshot for interpretation and recovery. It is not a command
+to replay the screen exactly.
+
+### `recording_delta_frame`
+
+`recording_delta_frame` is the compact frame after a baseline. It can contain
+references to or embedded copies of the #430 interaction records produced by a
+transaction:
+
+- `action_intents[]`
+- `execution_results[]`
+- optional `gesture_frames[]`
+- optional `observed_input[]`
+- `state_patches[]`
+- annotation or Surface Inspector observations
+- `evidence_refs[]`
+- artifact refs
+
+These pieces stay typed. A delta frame must not collapse an intent, execution
+result, gesture frame, observed input, and state patch into one untyped event
+payload.
+
+### `recording_keyframe`
+
+`recording_keyframe` is a periodic full or partial snapshot for recovery. It can
+refresh surface state, relevant descriptors, state patch anchors, and artifact
+routes. It does not replace semantic delta frames: the recording still stores
+what action was requested, how it executed, what optional gesture evidence was
+observed, and what state changed.
+
+### `recording_evidence_ref`
+
+`recording_evidence_ref` is an immutable receipt that links a frame to existing
+Work Record `evidence[]` entries and artifact routes. It can point at before
+and after perception, `aos do` results, gesture-frame traces, Surface Inspector
+annotation snapshots, screenshots, verifier output, or exported artifacts.
+
+Evidence references are append-only. Replay or repair must not rewrite
+historical frames or evidence to make a later run look successful.
+
+### `recording_replay_policy`
+
+`recording_replay_policy` is semantic replay policy for AOS-owned surfaces:
+
+1. re-perceive the relevant surface;
+2. resolve target descriptors by `owner_namespace`, `target_id`, role,
+   capabilities, structural path, range shape, and other machine facts;
+3. use labels, accessible names, source names, and coordinates only as hints;
+4. block on stale, missing, or ambiguous target resolution;
+5. reissue #430 `action_intent` records when a unique target is resolved;
+6. verify expected `state_patch` records or Work Record postconditions;
+7. keep replay and repair behind existing Work Record gates.
+
+Raw `input_event` / input-event-v2 payloads are observed input evidence and
+#431 compatibility/cutover debt. Blind raw input replay is not the default for
+AOS-owned surfaces.
+
+## Ownership Boundaries
+
+- Work Recording owns baseline, delta, and keyframe storage; replay policy;
+  evidence refs; frame health; and repair patch records.
+- The #430 interaction grammar owns target descriptors, action intents,
+  execution results, observed input, gesture frames, state patches, and replay
+  plans.
+- The toolkit gesture stream owns `aos.gesture-frame` production and passive
+  observation. Gesture frames are optional recording evidence or human-visible
+  playback frames, not the whole recording model.
+- `aos do` owns execution result metadata, target resolution, stale or
+  ambiguous rejection, backend, strategy, fallback, state id, status, reason,
+  and duration.
+- Raw `input_event` / input-event-v2 payloads remain evidence and #431 debt, not
+  the primary Work Recording language.
+
+## Repair And Health
+
+Replay failure records frame health instead of editing history. If target
+resolution is stale or ambiguous, the recording appends a `repairable` health
+record that references the original frame, evidence, and policy gate. A future
+repair patch may update the repairable execution map or descriptor resolution
+knowledge under an explicit Work Record gate, but it must preserve the original
+baseline, delta, keyframe, and evidence refs.
+
+## Fixture Cases
+
+The deterministic fixture pack in
+[`docs/design/fixtures/aos-work-recording-frame-v0/`](fixtures/aos-work-recording-frame-v0/)
+proves:
+
+- a single-thumb toolkit slider recording:
+  `recording_baseline -> action_intent -> execution_result -> gesture.drag.* ->
+  state_patch -> Surface Inspector observation -> recording_delta_frame ->
+  recording_replay_policy`;
+- a compact keyframe that is a periodic recovery checkpoint while the semantic
+  action and state delta remain in the delta frame;
+- a blocked replay where stale or ambiguous target resolution preserves
+  historical frames/evidence and appends repair-needed health.

--- a/docs/design/aos-work-records-and-self-healing-recipes.md
+++ b/docs/design/aos-work-records-and-self-healing-recipes.md
@@ -117,6 +117,13 @@ plans is defined in
 store that family in their intent, execution-map, evidence, health, and replay
 policy layers; they do not collapse it into raw input replay.
 
+Work Recording frame packs over that family are defined in
+[`aos-work-recording-frame-contract-v0.md`](aos-work-recording-frame-contract-v0.md).
+The recording layer owns baseline snapshots, compact delta frames, periodic
+keyframes, evidence refs, replay policy, and frame health. The interaction
+grammar still owns target descriptors, action intents, execution results,
+optional gesture frames, observed input evidence, and state patches.
+
 Coordinates can be recorded, but they are fallback material. When semantic
 targets exist, prefer the AOS target descriptor vocabulary: state-scoped `ref`
 and `state_id` for the immediate action, durable `target.target_id` scoped by

--- a/docs/design/fixtures/aos-work-recording-frame-v0/blocked-replay-repair-needed.json
+++ b/docs/design/fixtures/aos-work-recording-frame-v0/blocked-replay-repair-needed.json
@@ -1,0 +1,156 @@
+{
+  "schema": "aos.work-recording-frame.fixture.v0",
+  "case": "blocked_replay_records_repairable_without_rewriting_history",
+  "recording_id": "recording:display-brightness-070",
+  "original_frame_refs": [
+    "frame:baseline:display-brightness:001",
+    "frame:delta:display-brightness:002"
+  ],
+  "original_evidence_refs": [
+    "evidence:before-see",
+    "evidence:do-set-value",
+    "evidence:after-see"
+  ],
+  "history_mutation_policy": "append_only",
+  "previous_target_descriptor": {
+    "ref": "display-brightness-slider",
+    "state_id": "see_recording_slider001",
+    "role": "slider",
+    "name": "Brightness",
+    "target": {
+      "target_id": "control:display-brightness",
+      "owner_namespace": {
+        "app_id": "aos-toolkit-demo",
+        "canvas_id": "display-settings-panel",
+        "surface_id": "display-settings-panel",
+        "component_family": "toolkit.zag.slider",
+        "structural_owner": [
+          "settings-workbench",
+          "display-section"
+        ]
+      }
+    },
+    "state": {
+      "value": 0.4,
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "orientation": "horizontal",
+      "thumb_count": 1
+    },
+    "actions": [
+      "drag",
+      "set-value",
+      "focus"
+    ],
+    "provenance": {
+      "canvas_id": "display-settings-panel",
+      "do_target": "canvas:display-settings-panel/display-brightness-slider"
+    },
+    "reacquisition": {
+      "strategy": "owner-structural-fingerprint",
+      "machine_fingerprint": {
+        "role": "slider",
+        "structural_path": [
+          "settings-workbench",
+          "display-section",
+          "field:brightness"
+        ],
+        "capabilities": [
+          "drag",
+          "set-value",
+          "focus"
+        ],
+        "range_shape": {
+          "min": 0,
+          "max": 1,
+          "step": 0.05,
+          "orientation": "horizontal",
+          "thumb_count": 1
+        }
+      },
+      "hint_fingerprint": {
+        "label_hints": [
+          "Brightness"
+        ]
+      }
+    }
+  },
+  "replay_attempt": {
+    "id": "replay-attempt:display-brightness-070:stale",
+    "policy_ref": "replay-policy:display-brightness-070",
+    "requested_action_intent_ref": "intent:set-brightness-070",
+    "resolution": {
+      "status": "ambiguous",
+      "action_blocked": true,
+      "selected_ref": null,
+      "machine_facts_first": [
+        "target.owner_namespace",
+        "target.target_id",
+        "role",
+        "reacquisition.machine_fingerprint.structural_path",
+        "reacquisition.machine_fingerprint.capabilities"
+      ],
+      "hint_facts_only": [
+        "name",
+        "reacquisition.hint_fingerprint.label_hints"
+      ],
+      "candidate_refs": [
+        "display-brightness-slider",
+        "display-brightness-slider-secondary"
+      ],
+      "labels_used_as_hints_only": true
+    },
+    "execution_result": {
+      "id": "result:replay-blocked-brightness-070",
+      "transaction_id": "txn:replay-brightness-070",
+      "action_intent_id": "intent:set-brightness-070",
+      "status": "blocked",
+      "reason": "ambiguous_target_resolution",
+      "executed": false,
+      "execution": {
+        "backend": null,
+        "strategy": "semantic_reacquire_then_do",
+        "fallback_used": false,
+        "state_id": "see_recording_slider001"
+      },
+      "target": {
+        "target_dialect": "canvas",
+        "canvas_id": "display-settings-panel",
+        "ref": "display-brightness-slider",
+        "target_descriptor": {
+          "$ref": "#/previous_target_descriptor"
+        }
+      },
+      "resolved_target": {
+        "status": "ambiguous",
+        "action_blocked": true
+      },
+      "post_action_state": null
+    }
+  },
+  "appended_health_record": {
+    "id": "frame-health:display-brightness-070:repair-needed",
+    "kind": "recording_frame_health",
+    "verdict": "repairable",
+    "reason": "Replay blocked because target resolution was ambiguous.",
+    "affected_frame_refs": [
+      "frame:baseline:display-brightness:001",
+      "frame:delta:display-brightness:002"
+    ],
+    "evidence_refs": [
+      "evidence:before-see",
+      "evidence:do-set-value",
+      "evidence:after-see"
+    ],
+    "repair_policy": {
+      "mode": "append_repair_patch",
+      "repair_requires_workflow_gate": true,
+      "gate_refs": [
+        "workflow-gate:recording-repair-review"
+      ],
+      "must_preserve_historical_frames": true,
+      "must_preserve_historical_evidence": true
+    }
+  }
+}

--- a/docs/design/fixtures/aos-work-recording-frame-v0/manifest.json
+++ b/docs/design/fixtures/aos-work-recording-frame-v0/manifest.json
@@ -1,0 +1,15 @@
+{
+  "schema": "aos.work-recording-frame.fixture-pack.v0",
+  "contract": "../../aos-work-recording-frame-contract-v0.md",
+  "depends_on": [
+    "../../aos-interaction-grammar-v0.md",
+    "../../aos-shared-gesture-spine-v0.md",
+    "../../../../shared/schemas/aos-semantic-targets.md",
+    "../../../../shared/schemas/aos-work-record-v0.md"
+  ],
+  "fixtures": [
+    "toolkit-slider-recording.json",
+    "periodic-keyframe-checkpoint.json",
+    "blocked-replay-repair-needed.json"
+  ]
+}

--- a/docs/design/fixtures/aos-work-recording-frame-v0/periodic-keyframe-checkpoint.json
+++ b/docs/design/fixtures/aos-work-recording-frame-v0/periodic-keyframe-checkpoint.json
@@ -1,0 +1,115 @@
+{
+  "schema": "aos.work-recording-frame.fixture.v0",
+  "case": "periodic_keyframe_is_recovery_checkpoint",
+  "recording_id": "recording:display-brightness-070",
+  "target_descriptor": {
+    "ref": "display-brightness-slider",
+    "state_id": "see_recording_slider010",
+    "role": "slider",
+    "name": "Brightness",
+    "target": {
+      "target_id": "control:display-brightness",
+      "owner_namespace": {
+        "app_id": "aos-toolkit-demo",
+        "canvas_id": "display-settings-panel",
+        "surface_id": "display-settings-panel",
+        "component_family": "toolkit.zag.slider",
+        "structural_owner": [
+          "settings-workbench",
+          "display-section"
+        ]
+      }
+    },
+    "state": {
+      "value": 0.7,
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "orientation": "horizontal",
+      "thumb_count": 1
+    },
+    "actions": [
+      "drag",
+      "set-value",
+      "focus"
+    ],
+    "provenance": {
+      "canvas_id": "display-settings-panel",
+      "do_target": "canvas:display-settings-panel/display-brightness-slider"
+    },
+    "reacquisition": {
+      "strategy": "owner-structural-fingerprint",
+      "machine_fingerprint": {
+        "role": "slider",
+        "structural_path": [
+          "settings-workbench",
+          "display-section",
+          "field:brightness"
+        ],
+        "capabilities": [
+          "drag",
+          "set-value",
+          "focus"
+        ],
+        "range_shape": {
+          "min": 0,
+          "max": 1,
+          "step": 0.05,
+          "orientation": "horizontal",
+          "thumb_count": 1
+        }
+      },
+      "hint_fingerprint": {
+        "label_hints": [
+          "Brightness"
+        ]
+      }
+    }
+  },
+  "previous_delta_frame_ref": "frame:delta:display-brightness:002",
+  "semantic_delta_refs": {
+    "action_intent_refs": [
+      "intent:set-brightness-070"
+    ],
+    "execution_result_refs": [
+      "result:set-brightness-070"
+    ],
+    "state_patch_refs": [
+      "patch:set-brightness-070"
+    ]
+  },
+  "frame": {
+    "schema": "aos.work-recording-frame",
+    "schema_version": 0,
+    "frame_type": "recording_keyframe",
+    "id": "frame:keyframe:display-brightness:010",
+    "recording_id": "recording:display-brightness-070",
+    "work_record_ref": "work-record:display-brightness-slider-070",
+    "sequence": 10,
+    "after_frame_id": "frame:delta:display-brightness:002",
+    "keyframe_reason": "periodic_recovery_checkpoint",
+    "snapshot_scope": "partial_surface",
+    "state_id": "see_recording_slider010",
+    "target_descriptors": [
+      {
+        "$ref": "#/target_descriptor"
+      }
+    ],
+    "state_summary": {
+      "display-brightness-slider": {
+        "value": 0.7
+      }
+    },
+    "does_not_replace_semantic_deltas": true,
+    "recovery_from_frame_ref": "frame:keyframe:display-brightness:010",
+    "evidence_refs": [
+      {
+        "type": "recording_evidence_ref",
+        "evidence_id": "evidence:keyframe-010-see",
+        "artifact_ref": "artifact:recordings/display-brightness/keyframe-010-see.json",
+        "immutable": true
+      }
+    ]
+  }
+}
+

--- a/docs/design/fixtures/aos-work-recording-frame-v0/toolkit-slider-recording.json
+++ b/docs/design/fixtures/aos-work-recording-frame-v0/toolkit-slider-recording.json
@@ -1,0 +1,415 @@
+{
+  "schema": "aos.work-recording-frame.fixture.v0",
+  "case": "toolkit_single_thumb_slider_recording",
+  "work_record": {
+    "id": "work-record:display-brightness-slider-070",
+    "schema_version": "2026-05-work-record-v0",
+    "execution_map": {
+      "replay_policy": {
+        "mode": "report_only",
+        "replay_requires_workflow_gate": true,
+        "repair_requires_workflow_gate": true,
+        "gate_refs": [
+          "workflow-gate:recording-replay-review"
+        ]
+      }
+    },
+    "evidence": [
+      {
+        "id": "evidence:before-see",
+        "kind": "aos_see_capture",
+        "immutable": true,
+        "artifact_ref": "artifact:recordings/display-brightness/before-see.json"
+      },
+      {
+        "id": "evidence:do-set-value",
+        "kind": "aos_do_result",
+        "immutable": true,
+        "artifact_ref": "artifact:recordings/display-brightness/do-set-value.json"
+      },
+      {
+        "id": "evidence:gesture-trace",
+        "kind": "aos_gesture_frame_trace",
+        "immutable": true,
+        "artifact_ref": "artifact:recordings/display-brightness/gesture-trace.json"
+      },
+      {
+        "id": "evidence:surface-inspector-observation",
+        "kind": "surface_inspector_annotation_snapshot",
+        "immutable": true,
+        "artifact_ref": "artifact:recordings/display-brightness/inspector-observation.json"
+      },
+      {
+        "id": "evidence:after-see",
+        "kind": "aos_see_capture",
+        "immutable": true,
+        "artifact_ref": "artifact:recordings/display-brightness/after-see.json"
+      }
+    ]
+  },
+  "target_descriptor": {
+    "ref": "display-brightness-slider",
+    "state_id": "see_recording_slider001",
+    "surface": "display-settings-panel",
+    "role": "slider",
+    "name": "Brightness",
+    "kind": "semantic_target",
+    "enabled": true,
+    "target": {
+      "target_id": "control:display-brightness",
+      "owner_namespace": {
+        "app_id": "aos-toolkit-demo",
+        "canvas_id": "display-settings-panel",
+        "surface_id": "display-settings-panel",
+        "component_family": "toolkit.zag.slider",
+        "structural_owner": [
+          "settings-workbench",
+          "display-section"
+        ]
+      }
+    },
+    "state": {
+      "value": 0.4,
+      "min": 0,
+      "max": 1,
+      "step": 0.05,
+      "orientation": "horizontal",
+      "thumb_count": 1
+    },
+    "actions": [
+      "drag",
+      "set-value",
+      "focus"
+    ],
+    "provenance": {
+      "canvas_id": "display-settings-panel",
+      "do_target": "canvas:display-settings-panel/display-brightness-slider",
+      "bounds": {
+        "x": 24,
+        "y": 72,
+        "width": 240,
+        "height": 32
+      }
+    },
+    "reacquisition": {
+      "strategy": "owner-structural-fingerprint",
+      "machine_fingerprint": {
+        "role": "slider",
+        "structural_path": [
+          "settings-workbench",
+          "display-section",
+          "field:brightness"
+        ],
+        "capabilities": [
+          "drag",
+          "set-value",
+          "focus"
+        ],
+        "range_shape": {
+          "min": 0,
+          "max": 1,
+          "step": 0.05,
+          "orientation": "horizontal",
+          "thumb_count": 1
+        }
+      },
+      "hint_fingerprint": {
+        "label_hints": [
+          "Brightness"
+        ],
+        "source_hints": {
+          "dom_id": "brightness"
+        }
+      }
+    }
+  },
+  "frames": [
+    {
+      "schema": "aos.work-recording-frame",
+      "schema_version": 0,
+      "frame_type": "recording_baseline",
+      "id": "frame:baseline:display-brightness:001",
+      "recording_id": "recording:display-brightness-070",
+      "work_record_ref": "work-record:display-brightness-slider-070",
+      "sequence": 0,
+      "captured_at": "2026-06-06T23:40:00Z",
+      "state_id": "see_recording_slider001",
+      "surfaces": [
+        {
+          "canvas_id": "display-settings-panel",
+          "surface_id": "display-settings-panel",
+          "state_id": "see_recording_slider001"
+        }
+      ],
+      "target_descriptors": [
+        {
+          "$ref": "#/target_descriptor"
+        }
+      ],
+      "environment": {
+        "runtime_mode": "repo",
+        "capture_source": "deterministic_fixture"
+      },
+      "replay_policy_ref": "#/recording_replay_policy",
+      "evidence_refs": [
+        {
+          "type": "recording_evidence_ref",
+          "evidence_id": "evidence:before-see",
+          "artifact_ref": "artifact:recordings/display-brightness/before-see.json",
+          "immutable": true
+        }
+      ]
+    },
+    {
+      "schema": "aos.work-recording-frame",
+      "schema_version": 0,
+      "frame_type": "recording_delta_frame",
+      "id": "frame:delta:display-brightness:002",
+      "recording_id": "recording:display-brightness-070",
+      "work_record_ref": "work-record:display-brightness-slider-070",
+      "sequence": 1,
+      "after_frame_id": "frame:baseline:display-brightness:001",
+      "transaction_id": "txn:set-brightness-070",
+      "action_intents": [
+        {
+          "id": "intent:set-brightness-070",
+          "transaction_id": "txn:set-brightness-070",
+          "action_type": "set-value",
+          "source_state_id": "see_recording_slider001",
+          "target_ref": {
+            "ref": "display-brightness-slider",
+            "state_id": "see_recording_slider001",
+            "target_descriptor": {
+              "$ref": "#/target_descriptor"
+            }
+          },
+          "input": {
+            "kind": "scalar",
+            "value": 0.7
+          },
+          "constraints": {
+            "expected_role": "slider",
+            "allowed_actions": [
+              "set-value"
+            ],
+            "playback": "semantic"
+          },
+          "caller": {
+            "kind": "recording_capture",
+            "id": "work-record:display-brightness-slider-070"
+          }
+        }
+      ],
+      "execution_results": [
+        {
+          "id": "result:set-brightness-070",
+          "transaction_id": "txn:set-brightness-070",
+          "action_intent_id": "intent:set-brightness-070",
+          "action_type": "set-value",
+          "status": "success",
+          "reason": null,
+          "duration_ms": 42,
+          "executed": true,
+          "execution": {
+            "backend": "canvas",
+            "strategy": "canvas_semantic_set_value",
+            "fallback_used": false,
+            "state_id": "see_recording_slider001"
+          },
+          "target": {
+            "target_dialect": "canvas",
+            "canvas_id": "display-settings-panel",
+            "ref": "display-brightness-slider",
+            "target_descriptor": {
+              "$ref": "#/target_descriptor"
+            }
+          },
+          "resolved_target": {
+            "status": "resolved",
+            "ref": "display-brightness-slider",
+            "state_id": "see_recording_slider001",
+            "target_descriptor": {
+              "$ref": "#/target_descriptor"
+            }
+          },
+          "post_action_state": {
+            "state_id": "see_recording_slider002",
+            "state": {
+              "value": 0.7
+            }
+          }
+        }
+      ],
+      "gesture_frames": [
+        {
+          "schema": "aos.gesture-frame",
+          "schema_version": 0,
+          "type": "gesture.drag.start",
+          "phase": "start",
+          "gesture_id": "gesture:brightness-human-playback",
+          "transaction_id": "txn:set-brightness-070",
+          "semantic_target": {
+            "$ref": "#/target_descriptor"
+          },
+          "semantic_action": "set-value"
+        },
+        {
+          "schema": "aos.gesture-frame",
+          "schema_version": 0,
+          "type": "gesture.drag.move",
+          "phase": "move",
+          "gesture_id": "gesture:brightness-human-playback",
+          "transaction_id": "txn:set-brightness-070",
+          "semantic_target": {
+            "$ref": "#/target_descriptor"
+          },
+          "semantic_action": "set-value"
+        },
+        {
+          "schema": "aos.gesture-frame",
+          "schema_version": 0,
+          "type": "gesture.drag.end",
+          "phase": "end",
+          "gesture_id": "gesture:brightness-human-playback",
+          "transaction_id": "txn:set-brightness-070",
+          "semantic_target": {
+            "$ref": "#/target_descriptor"
+          },
+          "semantic_action": "set-value"
+        }
+      ],
+      "state_patches": [
+        {
+          "id": "patch:set-brightness-070",
+          "transaction_id": "txn:set-brightness-070",
+          "target_ref": {
+            "ref": "display-brightness-slider",
+            "state_id": "see_recording_slider001",
+            "target_descriptor": {
+              "$ref": "#/target_descriptor"
+            }
+          },
+          "before_state": {
+            "state_id": "see_recording_slider001",
+            "value": 0.4
+          },
+          "after_state": {
+            "state_id": "see_recording_slider002",
+            "value": 0.7
+          },
+          "changes": [
+            {
+              "op": "replace",
+              "path": [
+                "state",
+                "value"
+              ],
+              "from": 0.4,
+              "value": 0.7
+            }
+          ],
+          "verified_by": [
+            "evidence:after-see"
+          ],
+          "evidence_refs": [
+            "evidence:do-set-value",
+            "evidence:after-see"
+          ]
+        }
+      ],
+      "observations": [
+        {
+          "kind": "surface_inspector_annotation",
+          "observer": "surface-inspector:minimap",
+          "transaction_id": "txn:set-brightness-070",
+          "observed_frame_refs": [
+            "gesture:brightness-human-playback"
+          ],
+          "artifact_ref": "artifact:recordings/display-brightness/inspector-observation.json",
+          "evidence_ref": "evidence:surface-inspector-observation"
+        }
+      ],
+      "evidence_refs": [
+        {
+          "type": "recording_evidence_ref",
+          "evidence_id": "evidence:do-set-value",
+          "artifact_ref": "artifact:recordings/display-brightness/do-set-value.json",
+          "immutable": true
+        },
+        {
+          "type": "recording_evidence_ref",
+          "evidence_id": "evidence:gesture-trace",
+          "artifact_ref": "artifact:recordings/display-brightness/gesture-trace.json",
+          "immutable": true
+        },
+        {
+          "type": "recording_evidence_ref",
+          "evidence_id": "evidence:surface-inspector-observation",
+          "artifact_ref": "artifact:recordings/display-brightness/inspector-observation.json",
+          "immutable": true
+        },
+        {
+          "type": "recording_evidence_ref",
+          "evidence_id": "evidence:after-see",
+          "artifact_ref": "artifact:recordings/display-brightness/after-see.json",
+          "immutable": true
+        }
+      ],
+      "frame_health": {
+        "verdict": "valid",
+        "reason": "Semantic intent, execution result, optional gesture frames, inspector observation, and state patch are linked by transaction id."
+      }
+    }
+  ],
+  "recording_replay_policy": {
+    "schema": "aos.work-recording-replay-policy",
+    "schema_version": 0,
+    "id": "replay-policy:display-brightness-070",
+    "mode": "semantic_reacquire_then_do",
+    "raw_input_policy": "do_not_blindly_replay_for_aos_owned_surface",
+    "work_record_gates": {
+      "replay_requires_workflow_gate": true,
+      "repair_requires_workflow_gate": true,
+      "gate_refs": [
+        "workflow-gate:recording-replay-review"
+      ]
+    },
+    "steps": [
+      {
+        "kind": "re_perceive",
+        "surface": "display-settings-panel"
+      },
+      {
+        "kind": "resolve_descriptor",
+        "machine_facts_first": [
+          "target.owner_namespace",
+          "target.target_id",
+          "role",
+          "reacquisition.machine_fingerprint.structural_path",
+          "reacquisition.machine_fingerprint.capabilities",
+          "reacquisition.machine_fingerprint.range_shape"
+        ],
+        "hint_facts_only": [
+          "name",
+          "reacquisition.hint_fingerprint.label_hints",
+          "provenance.bounds"
+        ],
+        "ambiguous_result": "block",
+        "missing_result": "block"
+      },
+      {
+        "kind": "issue_action_intent",
+        "action_type": "set-value",
+        "input": {
+          "kind": "scalar",
+          "value": 0.7
+        }
+      },
+      {
+        "kind": "verify_state_patch",
+        "state_patch_ref": "patch:set-brightness-070"
+      }
+    ]
+  }
+}
+

--- a/docs/design/work-cards/gdi-aos-work-recording-frame-contract-v0.md
+++ b/docs/design/work-cards/gdi-aos-work-recording-frame-contract-v0.md
@@ -1,0 +1,271 @@
+# AOS Work Recording Frame Contract V0
+
+## Recipient
+
+GDI contract, fixture, and test round.
+
+## Transfer Kind
+
+GDI round.
+
+## Branch / Base
+
+- branch_from: local `main` containing this work card.
+- required_start_ref: local `main` containing this work card.
+- published prerequisite base: `origin/main` at `f65a4c63` or later, with PR
+  #434 merged.
+- expected output branch: `gdi/aos-work-recording-frame-contract-v0`
+
+Do not reset to an older `origin/main`. The #429 target descriptor contract,
+#427 gesture frame proof, and #430 interaction grammar contract are published
+prerequisites.
+
+## Source Artifact
+
+- GitHub issue #428:
+  https://github.com/michaelblum/agent-os/issues/428
+- Published prerequisite PR #434:
+  https://github.com/michaelblum/agent-os/pull/434
+- Prerequisite lanes:
+  - #427 gesture-frame proof is published.
+  - #429 target descriptor contract is published.
+  - #430 interaction grammar contract is published and #430 is closed.
+  - #431 input-event-v2 hard cutover remains separate debt.
+  - #428 owns this Work Recording schema/design lane.
+
+## Fresh Context Contract
+
+GDI starts from a fresh context window. Do not assume branch, checkout, daemon,
+canvas, issue, or prior implementation state. Read and rediscover before
+editing.
+
+## Goal
+
+Define and prove the first Work Recording frame contract that stores #430
+interaction records as baseline snapshots, delta frames, evidence, and replay
+policy without making raw input replay, labels, or coordinates the durable
+recording language.
+
+## Read First
+
+- `AGENTS.md`
+- `docs/design/aos-work-records-and-self-healing-recipes.md`
+- `docs/design/aos-interaction-grammar-v0.md`
+- `docs/design/aos-shared-gesture-spine-v0.md`
+- `shared/schemas/aos-semantic-targets.md`
+- `shared/schemas/aos-work-record-v0.md`
+- `shared/schemas/aos-work-record-v0.schema.json`
+- `docs/design/fixtures/aos-interaction-grammar-v0/manifest.json`
+- `docs/design/fixtures/aos-interaction-grammar-v0/toolkit-slider-sequence.json`
+- `tests/toolkit/aos-interaction-grammar-contract.test.mjs`
+- `tests/toolkit/work-record-capture.test.mjs`
+- `tests/toolkit/work-record-adapter.test.mjs`
+- `tests/toolkit/work-record-verifier.test.mjs`
+
+## Rediscover State
+
+Run before editing:
+
+```bash
+git status --short --branch
+git rev-parse HEAD origin/main
+./aos service status --mode repo --json
+./aos dev gh issue view 428 --json
+./aos dev gh issue view 430 --json
+rg -n "baseline snapshot|delta frame|keyframe|state_patch|recording_replay_plan|aos\\.gesture-frame|execution_map|replay_policy|target\\.target_id|owner_namespace|raw input replay|avatar\\.controls\\.scale" docs/design shared/schemas tests/toolkit packages/toolkit --glob "*.md" --glob "*.json" --glob "*.js" --glob "*.mjs"
+```
+
+Live AOS is intentionally paused for this workstream. Do not run `./aos ready`,
+`./aos status`, `./aos clean`, service start/restart, or live smoke unless
+Michael explicitly approves it in a new instruction. This slice is
+deterministic-only.
+
+## Existing Code And Docs To Inspect
+
+- `docs/design/aos-work-records-and-self-healing-recipes.md` - current Work
+  Record design seed and the lane that needs the baseline/delta-frame contract.
+- `shared/schemas/aos-work-record-v0.md` and
+  `shared/schemas/aos-work-record-v0.schema.json` - current schema-backed Work
+  Record v0 sketch, capture-builder notes, report-only verifier boundary, and
+  replay/repair gates.
+- `docs/design/aos-interaction-grammar-v0.md` and
+  `docs/design/fixtures/aos-interaction-grammar-v0/toolkit-slider-sequence.json`
+  - the published interaction record family and slider fixture that the Work
+  Recording frame contract should consume.
+- `docs/design/aos-shared-gesture-spine-v0.md` - gesture frame lifecycle and
+  passive Surface Inspector observation boundary.
+- `shared/schemas/fixtures/aos-work-record-v0/valid/*.json` - existing
+  schema-backed Work Record fixtures and style.
+- `packages/toolkit/workbench/work-record-capture.js`,
+  `packages/toolkit/workbench/work-record-verifier.js`, and
+  `packages/toolkit/workbench/work-record-evidence-adapters.js` - current
+  producer/verifier boundaries. Runtime changes are not required unless a tiny
+  helper is needed for deterministic fixture validation.
+
+## Required Behavior
+
+### Contract Note
+
+Add a current design note, likely
+`docs/design/aos-work-recording-frame-contract-v0.md`, that defines the Work
+Recording frame family over the #430 interaction grammar:
+
+- `recording_baseline`: first snapshot of relevant surfaces, state ids, target
+  descriptors, environment metadata, and Work Record/replay policy context.
+- `recording_delta_frame`: compact frame after the baseline that can contain
+  action intents, execution results, optional gesture frames, observed input
+  evidence, state patches, annotation/inspector observations, and artifact
+  refs.
+- `recording_keyframe`: periodic full or partial snapshot for recovery, not a
+  replacement for semantic deltas.
+- `recording_evidence_ref`: immutable receipts linking frames to existing Work
+  Record `evidence[]` entries and artifact routes.
+- `recording_replay_policy`: semantic replay policy that re-perceives, resolves
+  descriptors, reissues action intents, and verifies state patches under Work
+  Record gates.
+
+The note must state ownership boundaries:
+
+- Work Recording owns baseline/delta/keyframe storage, replay policy, evidence
+  refs, frame health, and repair patch records.
+- #430 interaction grammar owns the shape of target descriptors, action
+  intents, execution results, observed input, gesture frames, state patches,
+  and replay plans.
+- Toolkit gesture stream owns `aos.gesture-frame` production and passive
+  observation, not the whole recording model.
+- `aos do` owns execution result metadata and target resolution.
+- Raw `input_event` / input-event-v2 payloads remain observed input evidence
+  and #431 compatibility/cutover debt, not the primary Work Recording language.
+
+### Fixture Pack
+
+Add deterministic fixtures, likely under
+`docs/design/fixtures/aos-work-recording-frame-v0/`, with at least:
+
+- `manifest.json`;
+- a toolkit single-thumb slider recording showing:
+  `recording_baseline -> action_intent -> execution_result -> optional
+  gesture.drag.* frames -> state_patch -> Surface Inspector/annotation
+  observation -> recording_delta_frame -> replay_policy`;
+- a compact keyframe example that proves recovery snapshots are periodic
+  checkpoints and do not replace semantic action/state deltas;
+- a blocked replay example for stale or ambiguous target resolution that
+  preserves the original frame/evidence and records a repair-needed health
+  state without rewriting historical frames.
+
+The fixtures may reference or reuse the #430 slider fixture, but the Work
+Recording frame fixture must show what belongs in the recording layer rather
+than simply duplicating the interaction grammar fixture.
+
+### Tests
+
+Add a focused Node test, likely
+`tests/toolkit/aos-work-recording-frame-contract.test.mjs`, that validates the
+fixture pack and fails if:
+
+- baseline/delta/keyframe records omit the target descriptor identity required
+  by #429/#430 for target-addressed interactions;
+- labels/accessibility names or coordinates become durable recording identity;
+- delta frames collapse action intents, execution results, gesture frames, and
+  state patches into one undifferentiated event payload;
+- gesture frames are treated as the entire Work Recording model rather than
+  optional evidence/playback frames linked by transaction id;
+- raw input replay becomes the default replay policy for AOS-owned surfaces;
+- replay/repair policy drops the existing Work Record gates or mutates
+  historical evidence/frames instead of recording a repair-needed state.
+
+Prefer fixture validation and small helpers in the test file over broad runtime
+changes. If you update the JSON Schema, keep it additive and prove all existing
+Work Record v0 fixtures still validate.
+
+### Existing Docs And Schemas
+
+Update adjacent current docs only as needed:
+
+- `docs/design/aos-work-records-and-self-healing-recipes.md` should point to
+  the new Work Recording frame contract and replace provisional examples such
+  as `avatar.controls.scale` with descriptor-aware language or clearly mark
+  them as historical shorthand.
+- `shared/schemas/aos-work-record-v0.md` may get a narrow section describing
+  how baseline/delta/keyframe frame packs relate to the existing
+  `intent + execution_map + evidence + health` model.
+- `shared/schemas/aos-work-record-v0.schema.json` should change only if the
+  fixture contract needs an additive schema slot. Do not break existing valid
+  fixtures unless the card identifies and updates every owned caller/test in
+  the same slice.
+- `docs/design/aos-interaction-grammar-v0.md` may get a narrow cross-reference
+  back to the Work Recording frame contract if useful.
+
+## Scope
+
+Schema/design docs, deterministic fixtures, focused Node tests, and narrow
+current-doc/schema cross-references.
+
+Runtime recorder, replayer, repair automation, daemon/native producers, live
+capture, and broad Work Record UI changes are out of scope.
+
+## Hard Boundaries / Non-Goals
+
+- Do not restart live AOS or require live canvas/input evidence.
+- Do not run `./aos ready`, `./aos status`, `./aos clean`, service
+  start/restart, or live smoke.
+- Do not implement a recorder, replayer, autonomous repair loop, or `aos do`
+  runtime changes.
+- Do not start #431 input-event-v2 hard cutover or normalize legacy input
+  payloads in this slice.
+- Do not change native/Swift or TCC broker code.
+- Do not introduce Pi `@e` / `@w` syntax as canonical AOS syntax.
+- Do not make raw coordinates or human-readable labels primary identity for
+  AOS-owned targets or Work Recording frames.
+- Do not close #428; Foreman will decide after review.
+- Do not push, open PRs, or mutate GitHub issues.
+
+## Stop Conditions
+
+Stop with a clear report instead of continuing if:
+
+- the existing Work Record v0 schema blocks a useful additive frame contract in
+  a way that requires broad migration judgment;
+- a useful fixture requires live AOS evidence, native producer changes, or a
+  real recorder implementation;
+- the design requires unresolved #431 input-event-v2 decisions;
+- the round discovers existing Work Record producers would need breaking
+  changes to remain coherent.
+
+## Verification
+
+Run deterministic checks:
+
+```bash
+git diff --check
+node --test tests/toolkit/aos-target-descriptor-contract.test.mjs
+node --test tests/toolkit/aos-interaction-grammar-contract.test.mjs
+node --test tests/toolkit/work-record-capture.test.mjs tests/toolkit/work-record-adapter.test.mjs tests/toolkit/work-record-verifier.test.mjs
+node --test tests/toolkit/aos-work-recording-frame-contract.test.mjs
+rg -n "avatar\\.controls\\.scale|settings\\.opacity|accessible names over coordinates|human-readable.*identity|label.*identity|name.*identity|semantic_target\\.id|target\\.id|raw input replay|blind raw" docs/design shared/schemas docs/api packages/toolkit tests/toolkit --glob "*.md" --glob "*.json" --glob "*.js" --glob "*.mjs"
+```
+
+For remaining `rg` hits, classify them in the completion report as current
+canonical guidance, historical/research and visibly marked, fixture-negative,
+unrelated local object identity, or deferred #431 work.
+
+## Completion Report
+
+Return a path-scoped report with:
+
+- branch and head SHA;
+- base SHA;
+- files changed;
+- contract note path and summary of the recording frame family;
+- fixture paths and what each proves;
+- test path and exact assertions added;
+- docs/schema cross-references updated;
+- whether `shared/schemas/aos-work-record-v0.schema.json` changed and why;
+- how baseline/delta/keyframe records preserve #430 interaction record
+  boundaries;
+- how replay/repair gates and immutable evidence/history are preserved;
+- exact verification commands and pass/fail results;
+- remaining drift-scan hits and classification;
+- confirmation that live AOS was not restarted;
+- local-only state, including dirty/untracked files and ignored artifacts;
+- recommended next slice only if the round reveals one concrete follow-up.

--- a/shared/schemas/aos-work-record-v0.md
+++ b/shared/schemas/aos-work-record-v0.md
@@ -248,6 +248,31 @@ The schema requires both `replay_requires_workflow_gate` and
 evidence-backed replay or repair loops need an explicit Workflow gate even when
 the record has an executable or compatibility origin.
 
+## Work Recording Frame Packs
+
+Work Recording frame packs are an additive recording layer over this Work
+Record shape. The frame contract is defined in
+[`docs/design/aos-work-recording-frame-contract-v0.md`](../../docs/design/aos-work-recording-frame-contract-v0.md).
+
+Baseline, delta, and keyframe records relate to the existing model as follows:
+
+- `recording_baseline` captures the initial surface state, state ids, target
+  descriptors, environment metadata, and Work Record/replay policy context.
+- `recording_delta_frame` stores typed #430 interaction records: action
+  intents, execution results, optional gesture frames, observed input evidence,
+  state patches, observations, and artifact refs.
+- `recording_keyframe` is a periodic recovery snapshot. It does not replace the
+  semantic action/state delta records.
+- `recording_evidence_ref` points to existing immutable `evidence[]` entries
+  and artifact routes.
+- `recording_replay_policy` re-perceives, resolves target descriptors, reissues
+  semantic action intents, and verifies state patches under the same replay and
+  repair gates required by `execution_map.replay_policy`.
+
+The v0 JSON Schema does not add a top-level frame-pack slot yet. Fixtures keep
+the recording contract beside Work Records until a runtime producer needs an
+additive persisted field.
+
 ## Capture Builder And Report-Only Profile
 
 The first runtime producer is intentionally narrow:

--- a/tests/toolkit/aos-work-recording-frame-contract.test.mjs
+++ b/tests/toolkit/aos-work-recording-frame-contract.test.mjs
@@ -1,0 +1,226 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const fixtureDir = resolve(__dirname, '../../docs/design/fixtures/aos-work-recording-frame-v0')
+
+async function readJson(name) {
+  return JSON.parse(await readFile(resolve(fixtureDir, name), 'utf8'))
+}
+
+function walk(value, visit, path = []) {
+  if (!value || typeof value !== 'object') return
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => walk(item, visit, [...path, String(index)]))
+    return
+  }
+  visit(value, path)
+  for (const [key, child] of Object.entries(value)) {
+    walk(child, visit, [...path, key])
+  }
+}
+
+function refPath(value) {
+  return value && typeof value === 'object' && Object.keys(value).length === 1 ? value.$ref : null
+}
+
+function descriptorForRef(fixture, pointer) {
+  if (pointer === '#/target_descriptor') return fixture.target_descriptor
+  if (pointer === '#/previous_target_descriptor') return fixture.previous_target_descriptor
+  throw new Error(`unknown descriptor ref ${pointer}`)
+}
+
+function materializeDescriptor(fixture, descriptorOrRef) {
+  return descriptorForRef(fixture, refPath(descriptorOrRef)) || descriptorOrRef
+}
+
+function namespaceKey(namespace = {}) {
+  return JSON.stringify({
+    app_id: namespace.app_id,
+    canvas_id: namespace.canvas_id,
+    surface_id: namespace.surface_id,
+    component_family: namespace.component_family,
+    structural_owner: namespace.structural_owner,
+  })
+}
+
+function durableIdentityKey(descriptor = {}) {
+  return `${namespaceKey(descriptor.target?.owner_namespace)}\u0000${descriptor.target?.target_id}`
+}
+
+function assertDescriptorShape(descriptor, context = descriptor?.ref || 'descriptor') {
+  assert.ok(descriptor.ref, `${context} requires state-scoped ref`)
+  assert.ok(descriptor.state_id, `${context} requires state_id`)
+  assert.ok(descriptor.target?.target_id, `${context} requires target.target_id`)
+  assert.ok(descriptor.target?.owner_namespace?.app_id, `${context} requires owner namespace app_id`)
+  assert.ok(descriptor.target?.owner_namespace?.canvas_id, `${context} requires owner namespace canvas_id`)
+  assert.ok(Array.isArray(descriptor.actions) && descriptor.actions.length > 0, `${context} requires primitive actions`)
+  assert.ok(descriptor.state && typeof descriptor.state === 'object', `${context} requires current state`)
+  assert.ok(descriptor.provenance?.canvas_id, `${context} requires provenance canvas_id`)
+  assert.ok(descriptor.reacquisition?.machine_fingerprint, `${context} requires machine reacquisition fingerprint`)
+  assert.ok(descriptor.reacquisition?.hint_fingerprint, `${context} requires hint reacquisition fingerprint`)
+}
+
+function assertNoPresentationIdentity(descriptor, context = descriptor?.ref || 'descriptor') {
+  const identityText = JSON.stringify({
+    target_id: descriptor.target?.target_id,
+    owner_namespace: descriptor.target?.owner_namespace,
+  })
+  for (const presentation of [descriptor.name, descriptor.label, descriptor.accessible_name].filter(Boolean)) {
+    assert.notEqual(identityText, presentation, `${context} used presentation text as identity`)
+    assert.equal(identityText.includes(`"${presentation}"`), false, `${context} embedded presentation text in identity`)
+  }
+  walk(descriptor.provenance, (node, path) => {
+    if (path.includes('bounds') || path.includes('center') || path.includes('frame')) {
+      assert.equal(identityText.includes(JSON.stringify(node)), false, `${context} copied coordinates into identity`)
+    }
+  })
+}
+
+function assertTargetRef(fixture, targetRef, context) {
+  assert.ok(targetRef.ref, `${context} requires ref`)
+  assert.ok(targetRef.state_id, `${context} requires state_id`)
+  const descriptor = materializeDescriptor(fixture, targetRef.target_descriptor)
+  assertDescriptorShape(descriptor, context)
+  assert.equal(targetRef.ref, descriptor.ref, `${context} ref must match descriptor`)
+  assert.equal(targetRef.state_id, descriptor.state_id, `${context} state_id must match descriptor`)
+}
+
+function assertReplayPolicyIsSemanticAndGated(policy) {
+  assert.equal(policy.mode, 'semantic_reacquire_then_do')
+  assert.equal(policy.raw_input_policy, 'do_not_blindly_replay_for_aos_owned_surface')
+  assert.equal(policy.work_record_gates.replay_requires_workflow_gate, true)
+  assert.equal(policy.work_record_gates.repair_requires_workflow_gate, true)
+
+  const resolveStep = policy.steps.find((step) => step.kind === 'resolve_descriptor')
+  assert.ok(resolveStep, `${policy.id} requires resolve_descriptor step`)
+  assert.ok(resolveStep.machine_facts_first.includes('target.owner_namespace'))
+  assert.ok(resolveStep.machine_facts_first.includes('target.target_id'))
+  assert.ok(resolveStep.machine_facts_first.some((fact) => fact.includes('capabilities')))
+  assert.ok(resolveStep.hint_facts_only.some((fact) => fact.includes('label_hints') || fact === 'name'))
+  assert.equal(resolveStep.ambiguous_result, 'block')
+  assert.equal(resolveStep.missing_result, 'block')
+}
+
+test('fixture manifest lists the recording frame cases', async () => {
+  const manifest = await readJson('manifest.json')
+
+  assert.equal(manifest.schema, 'aos.work-recording-frame.fixture-pack.v0')
+  assert.deepEqual(manifest.fixtures.sort(), [
+    'blocked-replay-repair-needed.json',
+    'periodic-keyframe-checkpoint.json',
+    'toolkit-slider-recording.json',
+  ])
+})
+
+test('baseline and delta frames preserve descriptor identity without label or coordinate identity', async () => {
+  const fixture = await readJson('toolkit-slider-recording.json')
+  const descriptor = fixture.target_descriptor
+  const baseline = fixture.frames.find((frame) => frame.frame_type === 'recording_baseline')
+  const delta = fixture.frames.find((frame) => frame.frame_type === 'recording_delta_frame')
+
+  assertDescriptorShape(descriptor)
+  assertNoPresentationIdentity(descriptor)
+  assert.equal(descriptor.name, 'Brightness')
+  assert.equal(baseline.state_id, descriptor.state_id)
+  assert.equal(durableIdentityKey(materializeDescriptor(fixture, baseline.target_descriptors[0])), durableIdentityKey(descriptor))
+
+  assertTargetRef(fixture, delta.action_intents[0].target_ref, 'delta.action_intents[0].target_ref')
+  assertTargetRef(fixture, delta.state_patches[0].target_ref, 'delta.state_patches[0].target_ref')
+  assert.equal(durableIdentityKey(materializeDescriptor(fixture, delta.execution_results[0].target.target_descriptor)), durableIdentityKey(descriptor))
+})
+
+test('delta frames keep interaction records typed instead of collapsing them into an event blob', async () => {
+  const fixture = await readJson('toolkit-slider-recording.json')
+  const delta = fixture.frames.find((frame) => frame.frame_type === 'recording_delta_frame')
+
+  assert.ok(Array.isArray(delta.action_intents) && delta.action_intents.length === 1)
+  assert.ok(Array.isArray(delta.execution_results) && delta.execution_results.length === 1)
+  assert.ok(Array.isArray(delta.gesture_frames) && delta.gesture_frames.length === 3)
+  assert.ok(Array.isArray(delta.state_patches) && delta.state_patches.length === 1)
+  assert.ok(Array.isArray(delta.observations) && delta.observations.length === 1)
+  assert.equal(Object.hasOwn(delta, 'events'), false)
+  assert.equal(delta.action_intents[0].transaction_id, delta.transaction_id)
+  assert.equal(delta.execution_results[0].transaction_id, delta.transaction_id)
+  assert.equal(delta.state_patches[0].transaction_id, delta.transaction_id)
+})
+
+test('gesture frames are optional linked evidence/playback frames, not the recording model', async () => {
+  const fixture = await readJson('toolkit-slider-recording.json')
+  const delta = fixture.frames.find((frame) => frame.frame_type === 'recording_delta_frame')
+  const descriptorKey = durableIdentityKey(fixture.target_descriptor)
+
+  assert.equal(delta.frame_type, 'recording_delta_frame')
+  for (const frame of delta.gesture_frames) {
+    assert.equal(frame.schema, 'aos.gesture-frame')
+    assert.equal(frame.transaction_id, delta.transaction_id)
+    assert.equal(frame.semantic_action, 'set-value')
+    assert.equal(durableIdentityKey(materializeDescriptor(fixture, frame.semantic_target)), descriptorKey)
+  }
+  assert.ok(delta.evidence_refs.some((ref) => ref.evidence_id === 'evidence:gesture-trace'))
+  assert.ok(delta.observations.some((item) => item.kind === 'surface_inspector_annotation'))
+})
+
+test('replay policy is semantic, machine-first, and preserves Work Record gates', async () => {
+  const fixture = await readJson('toolkit-slider-recording.json')
+
+  assertReplayPolicyIsSemanticAndGated(fixture.recording_replay_policy)
+  assert.equal(fixture.work_record.execution_map.replay_policy.replay_requires_workflow_gate, true)
+  assert.equal(fixture.work_record.execution_map.replay_policy.repair_requires_workflow_gate, true)
+})
+
+test('keyframes are recovery checkpoints and do not replace semantic deltas', async () => {
+  const fixture = await readJson('periodic-keyframe-checkpoint.json')
+  const keyframe = fixture.frame
+
+  assertDescriptorShape(fixture.target_descriptor)
+  assertNoPresentationIdentity(fixture.target_descriptor)
+  assert.equal(keyframe.frame_type, 'recording_keyframe')
+  assert.equal(keyframe.keyframe_reason, 'periodic_recovery_checkpoint')
+  assert.equal(keyframe.does_not_replace_semantic_deltas, true)
+  assert.deepEqual(fixture.semantic_delta_refs.action_intent_refs, ['intent:set-brightness-070'])
+  assert.deepEqual(fixture.semantic_delta_refs.execution_result_refs, ['result:set-brightness-070'])
+  assert.deepEqual(fixture.semantic_delta_refs.state_patch_refs, ['patch:set-brightness-070'])
+})
+
+test('blocked replay appends repair-needed health without mutating historical frames or evidence', async () => {
+  const fixture = await readJson('blocked-replay-repair-needed.json')
+  const health = fixture.appended_health_record
+
+  assertDescriptorShape(fixture.previous_target_descriptor)
+  assertNoPresentationIdentity(fixture.previous_target_descriptor)
+  assert.equal(fixture.history_mutation_policy, 'append_only')
+  assert.equal(fixture.replay_attempt.resolution.status, 'ambiguous')
+  assert.equal(fixture.replay_attempt.resolution.action_blocked, true)
+  assert.equal(fixture.replay_attempt.resolution.selected_ref, null)
+  assert.equal(fixture.replay_attempt.resolution.labels_used_as_hints_only, true)
+  assert.equal(fixture.replay_attempt.execution_result.executed, false)
+  assert.equal(health.verdict, 'repairable')
+  assert.equal(health.repair_policy.repair_requires_workflow_gate, true)
+  assert.equal(health.repair_policy.must_preserve_historical_frames, true)
+  assert.equal(health.repair_policy.must_preserve_historical_evidence, true)
+  assert.deepEqual(health.affected_frame_refs, fixture.original_frame_refs)
+  assert.deepEqual(health.evidence_refs, fixture.original_evidence_refs)
+})
+
+test('recording fixtures never make raw input replay, labels, or coordinates durable identity', async () => {
+  for (const fixtureName of [
+    'toolkit-slider-recording.json',
+    'periodic-keyframe-checkpoint.json',
+    'blocked-replay-repair-needed.json',
+  ]) {
+    const fixture = await readJson(fixtureName)
+    walk(fixture, (node, path) => {
+      if (node.target?.target_id && node.target?.owner_namespace) {
+        assertNoPresentationIdentity(node, `${fixtureName}:${path.join('.')}`)
+      }
+      if (node.raw_input_policy) {
+        assert.notEqual(node.raw_input_policy, 'blind_raw_replay')
+        assert.notEqual(node.raw_input_policy, 'default_raw_input_replay')
+      }
+    })
+  }
+})


### PR DESCRIPTION
## Summary

- Add the #428 Work Recording frame contract over the published #430 interaction grammar.
- Add deterministic fixtures for a toolkit slider recording, periodic keyframe checkpoint, and blocked replay repair handling.
- Add a focused Node contract test and narrow cross-references from the interaction grammar, Work Records design, and Work Record v0 schema sketch.

## Foreman Review Note

Foreman made one small review correction before checkpointing: the blocked replay frame-health verdict uses the existing Work Record health vocabulary `repairable` instead of introducing a new `repair_needed` verdict.

## Verification

- `git diff --check`
- `node --test tests/toolkit/aos-target-descriptor-contract.test.mjs`
- `node --test tests/toolkit/aos-interaction-grammar-contract.test.mjs`
- `node --test tests/toolkit/work-record-capture.test.mjs tests/toolkit/work-record-adapter.test.mjs tests/toolkit/work-record-verifier.test.mjs`
- `node --test tests/toolkit/aos-work-recording-frame-contract.test.mjs`

Refs #428

Live AOS was intentionally left paused; this PR uses deterministic docs/fixture/test evidence only.
