### PR TITLE
feat(toolkit): tighten input event v2 normalization

### DIFF
--- a/docs/api/toolkit/runtime.md
+++ b/docs/api/toolkit/runtime.md
@@ -87,19 +87,25 @@ Input regions are daemon-owned hit areas that toolkit surfaces can register when
 - `removeInputRegion(id)` emits `input_region.remove`.
 - `inputRegionContainsRect(rect)` is a deterministic local predicate for rectangle hit checks in tests and routing helpers.
 
-Daemon input region events arrive as `input_region.event` bridge messages. V0
-deliveries keep current top-level fields for existing owned consumers and
-include a canonical `routed_input` payload matching
-`shared/schemas/input-event-v2`:
+Daemon input region events arrive as `input_region.event` bridge messages; that
+name is the bridge channel, not a payload schema version. Current daemon
+deliveries keep top-level fields for existing owned consumers and include a
+canonical `routed_input` payload matching `shared/schemas/input-event-v2`:
 `routed_schema_version`, `delivery_role`, `region_id`, `owner_canvas_id`,
 stable `capture_id` for captured drags, `source_origin`,
 `source_event`/`source_sequence`, `desktop_world`, and
-`coordinate_authority`. Consumers should call `normalizeCanvasInputMessage(msg)`
-from `packages/toolkit/runtime/input-events.js` instead of parsing
-`input_region.event` directly; it normalizes current daemon events, v2 raw
-events, `input_event` envelopes, routed envelopes, and input-region delivery
-wrappers into one object with camelCase fields such as `gestureId`,
-`captureId`, `deliveryRole`, `regionId`, `ownerCanvasId`,
+`coordinate_authority`. A `routed_schema_version: 1` claim must include the
+required routed fields for its `event_kind` and `delivery_role`; incomplete
+claims are errors.
+
+Consumers should call `normalizeCanvasInputMessage(msg)` from
+`packages/toolkit/runtime/input-events.js` instead of parsing
+`input_region.event` directly. Its preferred path is canonical raw
+input-event-v2 payloads and routed-v1 envelopes. It also accepts explicitly
+bounded bridges for native raw event-name fanout, unversioned `input_event`
+wrappers, top-level-only `input_region.event` compatibility, and canvas-origin
+synthetic messages. Normalized output adds camelCase fields such as
+`gestureId`, `captureId`, `deliveryRole`, `regionId`, `ownerCanvasId`,
 `sourceCanvasId`, `sourceOrigin`, `sourceSequence`, and `sourceEvent`.
 
 Child hit WebViews that forward DOM input through `canvas_message` should use
@@ -110,9 +116,10 @@ payload supplies `source_origin: "canvas"`, `source_canvas_id`,
 `owner_canvas_id`, `source_event`, child-local offsets, pointer id, and optional
 scroll deltas. The parent supplies authoritative DesktopWorld coordinates in
 `facts.desktopWorld` after resolving the current child frame and display
-geometry. The normalized result carries `coordinate_authority: "toolkit"`, a
-toolkit `source_sequence`, stable `gesture_id` / `capture_id` for a pointer
-sequence, `desktop_world` plus `x`/`y`, and camelCase aliases for router code.
+geometry. `createCanvasOriginInputEvent()` emits canonical routed-v1 fields for
+pointer, scroll, and cancel events. `normalizeCanvasOriginInputMessage()` then
+adds router aliases such as `x`/`y`, camelCase identity fields, and child-local
+offsets for existing toolkit code.
 
 Use the [surface interaction decision tree](../../recipes/aos-surface-interaction-decision-tree.md)
 (`docs/guides/aos-surface-interaction-decision-tree.md`) before adding a

--- a/docs/design/input-event-v2-toolkit-cutover-v0.md
+++ b/docs/design/input-event-v2-toolkit-cutover-v0.md
@@ -1,0 +1,63 @@
+# Input Event v2 Toolkit Cutover V0
+
+## Contract Split
+
+`input_event` is the daemon event-stream channel name. `input-event-v2` is the
+payload schema for raw observed input on that channel. A payload may claim
+`input_schema_version: 2` only when it includes the required fields for its
+`event_kind`.
+
+`aos_routed_input` is the toolkit routed delivery payload. Daemon
+`input_region.event` bridge messages carry it under `routed_input` with
+`routed_schema_version: 1`. Routed delivery has its own required fields by
+`event_kind` and `delivery_role`; owned and captured deliveries require
+`region_id` and `owner_canvas_id`, and captured deliveries require
+`capture_id`.
+
+## Toolkit Consumers
+
+`packages/toolkit/runtime/input-events.js` remains the owned normalization
+boundary. Its canonical path is raw v2 payloads and routed v1 envelopes. It now
+throws when a payload claims `input_schema_version: 2` or
+`routed_schema_version: 1` without the required fields that the runtime depends
+on.
+
+The remaining unversioned compatibility paths are:
+
+- raw event-name fanout such as `mouse_moved`, `left_mouse_down`,
+  `scroll_wheel`, `pointer_cancel`, and `mouse_cancel`; removal gate: the native
+  canvas fanout publishes only canonical raw v2 payloads to toolkit-owned
+  consumers;
+- unversioned `{type:"input_event", payload}` wrappers; removal gate: external
+  and test producers stop using wrapper envelopes without schema claims;
+- top-level-only `input_region.event` messages; removal gate: the daemon routed
+  producer always includes canonical `routed_input`;
+- `canvas_message` child WebView input forwarded through
+  `createCanvasOriginInputEvent()`; removal gate: child hit WebViews can emit
+  canonical routed v1 directly with parent-supplied DesktopWorld coordinates.
+
+`packages/toolkit/runtime/gesture-stream.js` consumes
+`normalizeCanvasInputMessage()` and is covered with canonical routed pointer
+fixtures. It does not need a separate legacy alias path.
+
+`packages/toolkit/runtime/interaction-region.js` still accepts raw event names
+for local deterministic routing helpers. That is a native producer bridge until
+the input-region router receives only canonical routed v1 payloads.
+
+## Migrated Or Guarded In This Slice
+
+- Runtime v2/v1 normalizing now validates version-claiming payloads before
+  adding camelCase router aliases.
+- Canvas-origin synthetic messages emit canonical routed v1 payloads for
+  pointer, scroll, and cancel cases.
+- Top-level-only `input_region.event` compatibility no longer fabricates a
+  `routed_schema_version: 1` payload.
+- Schema fixtures now include a valid routed captured cancel example alongside
+  existing raw pointer, raw scroll, raw key, raw cancel, routed owned pointer,
+  routed captured drag, routed scroll, and invalid version-claiming examples.
+
+## Replay Boundary
+
+Raw input remains evidence for interaction grammar and Work Recording frame
+contracts. AOS-owned replay should use the interaction and recording languages,
+not unversioned input aliases or mixed raw/routed payload shapes.

--- a/docs/design/work-cards/gdi-input-event-v2-toolkit-cutover-v0.md
+++ b/docs/design/work-cards/gdi-input-event-v2-toolkit-cutover-v0.md
@@ -1,0 +1,243 @@
+# Input Event V2 Toolkit Cutover V0
+
+## Recipient
+
+GDI contract, fixture, toolkit-runtime, and docs round.
+
+## Transfer Kind
+
+GDI round.
+
+## Branch / Base
+
+- branch_from: local `main` containing this work card.
+- required_start_ref: local `main` containing this work card.
+- published prerequisite base: `origin/main` at `b72a7b27` or later, with PR
+  #435 merged.
+- expected output branch: `gdi/input-event-v2-toolkit-cutover-v0`
+
+Do not reset to an older `origin/main`. The #429 target descriptor contract,
+#430 interaction grammar contract, and #428 Work Recording frame contract are
+published prerequisites.
+
+## Source Artifact
+
+- GitHub issue #431:
+  https://github.com/michaelblum/agent-os/issues/431
+- Published prerequisite PR #435:
+  https://github.com/michaelblum/agent-os/pull/435
+- Current published contracts:
+  - `shared/schemas/input-event-v2.schema.json`
+  - `shared/schemas/input-event-v2.md`
+  - `docs/design/aos-interaction-grammar-v0.md`
+  - `docs/design/aos-work-recording-frame-contract-v0.md`
+- Related lanes:
+  - #427 gesture stream is published and currently consumes normalized input.
+  - #430 and #428 consume observed input as evidence, not canonical replay.
+  - #431 owns the input-event-v2 hard cutover.
+
+## Fresh Context Contract
+
+GDI starts from a fresh context window. Do not assume branch, checkout, daemon,
+canvas, issue, or prior implementation state. Read and rediscover before
+editing.
+
+## Goal
+
+Cut toolkit-owned input consumers and docs toward canonical input-event-v2 /
+routed-v1 payloads, while leaving any remaining compatibility behind explicit
+external or native-producer gates instead of broad permanent aliases.
+
+## Read First
+
+- `AGENTS.md`
+- `packages/toolkit/AGENTS.md`
+- `packages/toolkit/runtime/AGENTS.md`
+- `shared/schemas/input-event-v2.schema.json`
+- `shared/schemas/input-event-v2.md`
+- `shared/schemas/daemon-event.md`
+- `docs/api/toolkit/runtime.md`
+- `packages/toolkit/runtime/input-events.js`
+- `packages/toolkit/runtime/gesture-stream.js`
+- `packages/toolkit/runtime/interaction-region.js`
+- `tests/schemas/input-event-v2.test.mjs`
+- `tests/toolkit/runtime-input-events.test.mjs`
+- `tests/toolkit/runtime-gesture-stream.test.mjs`
+- `docs/design/work-cards/input-event-v2-version-truth-correction-v0.md`
+
+## Rediscover State
+
+Run before editing:
+
+```bash
+git status --short --branch
+git rev-parse HEAD origin/main
+./aos service status --mode repo --json
+./aos dev gh issue view 431 --json
+rg -n "input_schema_version|routed_schema_version|input_region\\.event|aos_routed_input|input_event|legacy|compat|mouse_moved|left_mouse_down|scroll_wheel|pointer_cancel|mouse_cancel|normalizeCanvasInputMessage|createCanvasOriginInputEvent" shared/schemas docs/api docs/design packages/toolkit tests --glob "*.md" --glob "*.json" --glob "*.js" --glob "*.mjs"
+```
+
+Live AOS is intentionally paused for this workstream. Do not run `./aos ready`,
+`./aos status`, `./aos clean`, service start/restart, or live smoke unless
+Michael explicitly approves it in a new instruction. This slice is
+deterministic-only.
+
+## Existing Code And Docs To Inspect
+
+- `shared/schemas/input-event-v2.schema.json` and
+  `shared/schemas/input-event-v2.md` - canonical raw daemon payload and routed
+  toolkit envelope contracts.
+- `packages/toolkit/runtime/input-events.js` - current compatibility normalizer
+  for raw event names, `input_event` envelopes, routed input, and
+  canvas-origin synthetic messages.
+- `packages/toolkit/runtime/gesture-stream.js` - #427 gesture stream consumer
+  that should consume canonical normalized routed/raw input first.
+- `packages/toolkit/runtime/interaction-region.js` - routed region events and
+  capture delivery surface.
+- `docs/api/toolkit/runtime.md` and `shared/schemas/daemon-event.md` - docs
+  that must distinguish daemon stream channel names from versioned payload
+  schemas.
+- `shared/schemas/fixtures/input-event-v2/` - existing valid, invalid, and
+  sequence fixtures.
+- `tests/schemas/input-event-v2.test.mjs`,
+  `tests/toolkit/runtime-input-events.test.mjs`, and
+  `tests/toolkit/runtime-gesture-stream.test.mjs` - deterministic guardrails.
+
+## Required Behavior
+
+### Audit And Plan
+
+Add or update a concise current note, likely
+`docs/design/input-event-v2-toolkit-cutover-v0.md`, that records:
+
+- `input_event` is the daemon/event-stream channel name; `input-event-v2` is
+  the payload schema.
+- `aos_routed_input` / `input_region.event` is a routed delivery envelope with
+  its own `routed_schema_version: 1`.
+- every toolkit-owned consumer that still accepts raw legacy event names,
+  wrapper envelopes, or canvas-origin compatibility messages;
+- which compatibility remains because of a native producer or external
+  non-updatable source, with a removal gate;
+- which owned consumers are migrated or guarded in this slice.
+
+The note should not describe mixed legacy/current shapes as the desired steady
+state.
+
+### Fixtures And Tests
+
+Ensure canonical v2/routed fixture coverage includes at least:
+
+- raw pointer;
+- raw scroll;
+- raw key;
+- raw cancel;
+- routed owned pointer;
+- routed captured drag;
+- routed scroll;
+- routed cancel.
+
+Add invalid fixtures or test cases where useful so future changes fail if an
+owned payload claims `input_schema_version: 2` or `routed_schema_version: 1`
+without required fields.
+
+### Toolkit Runtime Cutover
+
+Tighten `packages/toolkit/runtime/input-events.js` and adjacent tests so:
+
+- canonical raw v2 payloads and routed v1 envelopes are the preferred internal
+  path;
+- invalid version-claiming payloads fail loudly enough for tests to catch them
+  instead of being silently normalized as if valid;
+- broad compatibility paths are narrowed to named sources, such as
+  canvas-origin synthetic messages or explicit external/native-producer gates;
+- `createCanvasOriginInputEvent()` emits canonical routed v1 fields for
+  supported pointer, scroll, and cancel cases when it claims
+  `routed_schema_version: 1`;
+- any remaining unversioned raw event-name support is clearly documented as a
+  compatibility bridge, not a target state.
+
+Update `gesture-stream.js` only if inspection shows it depends on broad legacy
+aliases rather than the canonical normalized fields. Keep any change narrow and
+covered by `runtime-gesture-stream` tests.
+
+### Docs
+
+Update `shared/schemas/input-event-v2.md`, `docs/api/toolkit/runtime.md`,
+`shared/schemas/daemon-event.md`, and adjacent design notes only as needed to
+make the standing contract clear:
+
+- channel names are not schema versions;
+- versioned payloads must validate against their schema for the declared event
+  kind;
+- routed delivery has separate required fields by delivery role;
+- raw input remains evidence for #430/#428, not the primary replay language for
+  AOS-owned Work Recordings.
+
+## Scope
+
+Toolkit runtime input normalization, schema fixtures/tests, and current docs.
+
+Native Swift producer changes, daemon rebuilds, TCC permission work, live smoke,
+and broad app migrations are out of scope for this GDI round.
+
+## Hard Boundaries / Non-Goals
+
+- Do not restart live AOS or require live canvas/input evidence.
+- Do not run `./aos ready`, `./aos status`, `./aos clean`, service
+  start/restart, or live smoke.
+- Do not edit Swift/native daemon producer code in this round. If the cutover
+  requires a native producer change, stop with a clear native-boundary finding
+  and return it to Foreman.
+- Do not run `./aos dev build`; Foreman owns native rebuilds and TCC regrant
+  handoff.
+- Do not start Work Recording runtime recorder/replayer work.
+- Do not change #429/#430/#428 descriptor, interaction, or recording contracts
+  except for narrow cross-references needed by this cutover.
+- Do not push, open PRs, or mutate GitHub issues.
+
+## Stop Conditions
+
+Stop with a clear report instead of continuing if:
+
+- the only honest cutover path requires Swift/native daemon producer changes;
+- owned toolkit consumers cannot be migrated without live AOS evidence;
+- existing schemas conflict with required canonical routed payloads in a way
+  that needs Foreman architecture judgment;
+- compatibility cannot be narrowed without breaking an identified external
+  consumer.
+
+## Verification
+
+Run deterministic checks:
+
+```bash
+git diff --check
+node --test tests/schemas/input-event-v2.test.mjs
+node --test tests/toolkit/runtime-input-events.test.mjs
+node --test tests/toolkit/runtime-gesture-stream.test.mjs
+node --test tests/toolkit/aos-interaction-grammar-contract.test.mjs tests/toolkit/aos-work-recording-frame-contract.test.mjs
+rg -n "legacy|compat|current shape|mixed shape|input_schema_version: 2|routed_schema_version: 1|mouse_moved|left_mouse_down|scroll_wheel|pointer_cancel|mouse_cancel" shared/schemas docs/api docs/design packages/toolkit tests --glob "*.md" --glob "*.json" --glob "*.js" --glob "*.mjs"
+```
+
+For remaining `rg` hits, classify them in the completion report as current
+canonical guidance, fixture/test coverage, explicitly gated compatibility,
+historical/work-card text, native-boundary debt, or unrelated local examples.
+
+## Completion Report
+
+Return a path-scoped report with:
+
+- branch and head SHA;
+- base SHA;
+- files changed;
+- audit/design note path and migration/removal-gate summary;
+- fixture/test changes and what event kinds they cover;
+- toolkit runtime changes and which compatibility paths remain;
+- whether `gesture-stream.js` changed and why;
+- docs updated;
+- exact verification commands and pass/fail results;
+- remaining drift-scan hits and classification;
+- confirmation that live AOS was not restarted and native build was not run;
+- any native-boundary finding that Foreman must route separately;
+- local-only state, including dirty/untracked files and ignored artifacts;
+- recommended next slice only if the round reveals one concrete follow-up.

--- a/packages/toolkit/runtime/input-events.js
+++ b/packages/toolkit/runtime/input-events.js
@@ -1,9 +1,8 @@
 // input-events.js — normalize canvas input stream envelopes.
 //
-// The daemon-side canvas fanout currently delivers raw input event names like
-// `mouse_moved` and `left_mouse_down` directly to canvases, while some
-// synthetic/tests paths still post `{ type: 'input_event', payload: {...} }`.
-// Consumers should accept either form until the daemon contract is unified.
+// Canonical callers should provide raw input-event-v2 payloads or routed-v1
+// envelopes. Unversioned event names and wrappers remain only as explicit
+// bridges for native producer fanout and canvas-origin synthetic messages.
 
 const RAW_INPUT_EVENT_TYPES = new Set([
   'left_mouse_down',
@@ -45,6 +44,100 @@ const POINTER_PHASE_BY_TYPE = {
   mouse_cancel: 'cancel',
 }
 
+const RAW_REQUIRED_BY_KIND = {
+  pointer: ['phase', 'device', 'timestamp_monotonic_ms', 'sequence', 'native', 'display_id', 'topology_version', 'button', 'buttons', 'modifiers'],
+  scroll: ['phase', 'device', 'timestamp_monotonic_ms', 'sequence', 'native', 'display_id', 'topology_version', 'scroll', 'modifiers'],
+  key: ['timestamp_monotonic_ms', 'sequence', 'key', 'modifiers'],
+  cancel: ['phase', 'timestamp_monotonic_ms', 'sequence', 'cancel_reason'],
+}
+
+const ROUTED_REQUIRED_BY_KIND = {
+  pointer: ['phase', 'button', 'buttons'],
+  scroll: ['phase', 'scroll'],
+  key: ['key'],
+  cancel: ['phase', 'cancel_reason'],
+}
+
+const POINTER_ROUTED_PHASES = new Set(['down', 'move', 'drag', 'up', 'enter', 'hover', 'leave', 'hover_cancel'])
+const CANONICAL_CANCEL_REASONS = new Set([
+  'os_cancelled',
+  'surface_removed',
+  'surface_suspended',
+  'surface_disabled',
+  'owner_disconnected',
+  'topology_stale',
+  'capture_timeout',
+  'emergency_command',
+])
+
+const RAW_ALLOWED_COMMON_FIELDS = [
+  'input_schema_version',
+  'event_kind',
+  'type',
+  'timestamp_monotonic_ms',
+  'sequence',
+  'source_origin',
+  'source_canvas_id',
+  'gesture_id',
+  'x',
+  'y',
+  'native',
+  'display_id',
+  'topology_version',
+  'desktop_world',
+  'coordinate_authority',
+  'modifiers',
+  'flags',
+]
+
+const RAW_ALLOWED_FIELDS_BY_KIND = {
+  pointer: new Set([...RAW_ALLOWED_COMMON_FIELDS, 'phase', 'device', 'button', 'buttons', 'click_count']),
+  scroll: new Set([...RAW_ALLOWED_COMMON_FIELDS, 'phase', 'device', 'scroll']),
+  key: new Set([
+    'input_schema_version',
+    'event_kind',
+    'type',
+    'timestamp_monotonic_ms',
+    'sequence',
+    'source_origin',
+    'source_canvas_id',
+    'key',
+    'key_code',
+    'modifiers',
+    'flags',
+    'native',
+    'display_id',
+    'topology_version',
+    'desktop_world',
+    'coordinate_authority',
+  ]),
+  cancel: new Set([...RAW_ALLOWED_COMMON_FIELDS, 'phase', 'caused_by_sequence', 'cancel_reason', 'button', 'buttons']),
+}
+
+const ROUTED_ALLOWED_FIELDS = new Set([
+  'routed_schema_version',
+  'event_kind',
+  'type',
+  'delivery_role',
+  'sequence',
+  'gesture_id',
+  'desktop_world',
+  'coordinate_authority',
+  'source_origin',
+  'source_canvas_id',
+  'owner_canvas_id',
+  'source_sequence',
+  'source_event',
+  'phase',
+  'region_id',
+  'capture_id',
+  'cancel_reason',
+  'button',
+  'buttons',
+  'scroll',
+  'key',
+])
+
 export function isCanvasInputEventType(type) {
   return typeof type === 'string' && RAW_INPUT_EVENT_TYPES.has(type)
 }
@@ -66,6 +159,128 @@ function pickString(...values) {
     if (typeof value === 'string' && value.length > 0) return value
   }
   return null
+}
+
+function assertRequiredFields(event, fields, context) {
+  const missing = fields.filter((field) => event[field] === undefined || event[field] === null)
+  if (missing.length) {
+    throw new Error(`${context} missing required field(s): ${missing.join(', ')}`)
+  }
+}
+
+function assertAllowedFields(event, allowed, context) {
+  const unknown = Object.keys(event).filter((field) => !allowed.has(field))
+  if (unknown.length) {
+    throw new Error(`${context} has unsupported field(s): ${unknown.join(', ')}`)
+  }
+}
+
+function assertPoint(value, field, context) {
+  if (!value || typeof value !== 'object' || finiteNumber(value.x) === null || finiteNumber(value.y) === null) {
+    throw new Error(`${context} requires ${field}.x and ${field}.y`)
+  }
+}
+
+function assertSequence(value, field, context) {
+  if (!value || typeof value !== 'object' || value.source === undefined || value.value === undefined) {
+    throw new Error(`${context} requires ${field}.source and ${field}.value`)
+  }
+}
+
+function assertScroll(value, field, context) {
+  if (!value || typeof value !== 'object' || finiteNumber(value.dx) === null || finiteNumber(value.dy) === null || value.unit !== 'point') {
+    throw new Error(`${context} requires ${field}.dx, ${field}.dy, and ${field}.unit "point"`)
+  }
+}
+
+function assertButtons(value, field, context) {
+  if (!value || typeof value !== 'object' || typeof value.left !== 'boolean' || typeof value.right !== 'boolean' || typeof value.middle !== 'boolean' || !Array.isArray(value.other_pressed)) {
+    throw new Error(`${context} requires ${field} button-state booleans`)
+  }
+}
+
+function validateRawV2InputEvent(event) {
+  const context = 'input-event-v2 payload'
+  assertRequiredFields(event, ['input_schema_version', 'event_kind', 'type', 'timestamp_monotonic_ms', 'sequence'], context)
+  const required = RAW_REQUIRED_BY_KIND[event.event_kind]
+  if (!required) throw new Error(`${context} has unsupported event_kind: ${event.event_kind}`)
+  assertAllowedFields(event, RAW_ALLOWED_FIELDS_BY_KIND[event.event_kind], context)
+  assertRequiredFields(event, required, context)
+  assertSequence(event.sequence, 'sequence', context)
+  if (event.native) assertPoint(event.native, 'native', context)
+  if (event.desktop_world || event.coordinate_authority) {
+    assertPoint(event.desktop_world, 'desktop_world', context)
+    assertRequiredFields(event, ['coordinate_authority'], context)
+  }
+  if (event.event_kind === 'pointer' && !['down', 'move', 'drag', 'up'].includes(event.phase)) {
+    throw new Error(`${context} pointer phase is invalid: ${event.phase}`)
+  }
+  if (event.event_kind === 'scroll') {
+    if (event.phase !== 'scroll') throw new Error(`${context} scroll phase must be "scroll"`)
+    assertScroll(event.scroll, 'scroll', context)
+  }
+  if (event.event_kind === 'key' && event.phase !== undefined) {
+    throw new Error(`${context} key events must not include phase`)
+  }
+  if (event.event_kind === 'cancel') {
+    if (event.phase !== 'cancel') throw new Error(`${context} cancel phase must be "cancel"`)
+    if (!CANONICAL_CANCEL_REASONS.has(event.cancel_reason)) throw new Error(`${context} cancel_reason is invalid: ${event.cancel_reason}`)
+  }
+  if (event.buttons) assertButtons(event.buttons, 'buttons', context)
+}
+
+function validateRoutedV1InputEvent(event) {
+  const context = 'routed-v1 input payload'
+  assertRequiredFields(event, [
+    'routed_schema_version',
+    'event_kind',
+    'type',
+    'delivery_role',
+    'sequence',
+    'gesture_id',
+    'desktop_world',
+    'coordinate_authority',
+    'source_origin',
+    'source_event',
+  ], context)
+  const required = ROUTED_REQUIRED_BY_KIND[event.event_kind]
+  if (!required) throw new Error(`${context} has unsupported event_kind: ${event.event_kind}`)
+  assertAllowedFields(event, ROUTED_ALLOWED_FIELDS, context)
+  assertRequiredFields(event, required, context)
+  assertSequence(event.sequence, 'sequence', context)
+  assertPoint(event.desktop_world, 'desktop_world', context)
+  if (event.source_sequence) assertSequence(event.source_sequence, 'source_sequence', context)
+  if (event.delivery_role === 'owned' || event.delivery_role === 'captured') {
+    assertRequiredFields(event, ['region_id', 'owner_canvas_id'], context)
+  }
+  if (event.delivery_role === 'captured') {
+    assertRequiredFields(event, ['capture_id'], context)
+  }
+  if (!['observed', 'owned', 'captured'].includes(event.delivery_role)) {
+    throw new Error(`${context} delivery_role is invalid: ${event.delivery_role}`)
+  }
+  if (event.event_kind === 'pointer') {
+    if (!POINTER_ROUTED_PHASES.has(event.phase)) throw new Error(`${context} pointer phase is invalid: ${event.phase}`)
+    assertButtons(event.buttons, 'buttons', context)
+  }
+  if (event.event_kind === 'scroll') {
+    if (event.phase !== 'scroll') throw new Error(`${context} scroll phase must be "scroll"`)
+    assertScroll(event.scroll, 'scroll', context)
+  }
+  if (event.event_kind === 'cancel' && event.phase !== 'cancel') {
+    throw new Error(`${context} cancel phase must be "cancel"`)
+  }
+  if (event.source_event && typeof event.source_event === 'object') {
+    if (event.source_event.input_schema_version !== 2) {
+      throw new Error(`${context} source_event object must be a raw input-event-v2 payload`)
+    }
+    validateRawV2InputEvent(event.source_event)
+  }
+}
+
+function validateVersionedInputEvent(event) {
+  if (event.input_schema_version === 2) validateRawV2InputEvent(event)
+  if (event.routed_schema_version === 1) validateRoutedV1InputEvent(event)
 }
 
 function childLocalPoint(payload = {}, facts = {}) {
@@ -126,6 +341,13 @@ function inferButtons(button, phase) {
   }
 }
 
+function eventKindForType(type) {
+  if (type === 'scroll_wheel') return 'scroll'
+  if (type === 'pointer_cancel' || type === 'mouse_cancel') return 'cancel'
+  if (type === 'key_down' || type === 'key_up') return 'key'
+  return 'pointer'
+}
+
 export function createCanvasOriginInputEvent(message = {}, facts = {}) {
   const payload = (message?.payload && typeof message.payload === 'object') ? message.payload : message
   if (!payload || typeof payload !== 'object') return null
@@ -159,11 +381,17 @@ export function createCanvasOriginInputEvent(message = {}, facts = {}) {
     payload.parentCanvasId,
     payload.parent,
   )
+  const regionId = pickString(
+    facts.regionId,
+    facts.region_id,
+    payload.region_id,
+    payload.regionId,
+    sourceCanvasId,
+  )
   const pointerId = facts.pointerId ?? facts.pointer_id ?? payload.pointer_id ?? payload.pointerId ?? null
   const phase = facts.phase || payload.phase || POINTER_PHASE_BY_TYPE[type] || null
   const button = inferButton(type, payload)
   const desktopWorld = desktopWorldPoint(payload, facts)
-  const native = nativePoint(payload, facts)
   const childLocal = childLocalPoint(payload, facts)
   const sourceSequence = pickObject(facts.sourceSequence, facts.source_sequence, payload.source_sequence, payload.sourceSequence) || {
     source: 'toolkit',
@@ -188,10 +416,18 @@ export function createCanvasOriginInputEvent(message = {}, facts = {}) {
         unit: payload.scroll_unit || payload.scrollUnit || 'point',
       }
     : undefined
+  const eventKind = eventKindForType(type)
+  const cancelReason = pickString(
+    facts.cancelReason,
+    facts.cancel_reason,
+    payload.cancel_reason,
+    payload.cancelReason,
+    'surface_removed',
+  )
 
-  return {
+  const event = {
     routed_schema_version: 1,
-    event_kind: type === 'scroll_wheel' ? 'scroll' : 'pointer',
+    event_kind: eventKind,
     type,
     phase,
     delivery_role: payload.delivery_role || facts.deliveryRole || facts.delivery_role || 'owned',
@@ -199,31 +435,39 @@ export function createCanvasOriginInputEvent(message = {}, facts = {}) {
     gesture_id: gestureId,
     ...(captureId ? { capture_id: captureId } : {}),
     desktop_world: desktopWorld,
-    native,
     coordinate_authority: 'toolkit',
     source_origin: 'canvas',
     source_canvas_id: sourceCanvasId,
     owner_canvas_id: ownerCanvasId,
+    region_id: regionId,
     source_event: sourceEvent,
     source_sequence: sourceSequence,
-    button,
-    buttons: payload.buttons || inferButtons(button, phase),
-    ...(scroll ? { scroll, dx: scroll.dx, dy: scroll.dy } : {}),
+    ...(eventKind === 'pointer' ? {
+      button,
+      buttons: payload.buttons || inferButtons(button, phase),
+    } : {}),
+    ...(eventKind === 'scroll' ? { scroll } : {}),
+    ...(eventKind === 'cancel' ? { cancel_reason: cancelReason } : {}),
+  }
+  validateRoutedV1InputEvent(event)
+  return event
+}
+
+export function normalizeCanvasOriginInputMessage(message = {}, facts = {}) {
+  const event = createCanvasOriginInputEvent(message, facts)
+  if (!event) return null
+  const normalized = normalizeCanvasInputMessage(event)
+  const payload = (message?.payload && typeof message.payload === 'object') ? message.payload : message
+  const childLocal = childLocalPoint(payload, facts)
+  return {
+    ...normalized,
     ...(childLocal ? {
       child_local: childLocal,
       childLocal,
       offsetX: childLocal.x,
       offsetY: childLocal.y,
     } : {}),
-    ...(payload.screenX !== undefined ? { screenX: payload.screenX } : {}),
-    ...(payload.screenY !== undefined ? { screenY: payload.screenY } : {}),
-    source_payload: payload,
   }
-}
-
-export function normalizeCanvasOriginInputMessage(message = {}, facts = {}) {
-  const event = createCanvasOriginInputEvent(message, facts)
-  return event ? normalizeCanvasInputMessage(event) : null
 }
 
 function pointFromV2Event(event) {
@@ -236,6 +480,7 @@ function pointFromV2Event(event) {
 }
 
 function normalizeV2InputEvent(event, envelopeType = null) {
+  validateVersionedInputEvent(event)
   const point = pointFromV2Event(event)
   return {
     ...event,
@@ -276,8 +521,7 @@ function normalizeInputRegionEnvelope(msg) {
   const type = typeof sourceEvent === 'string' && isCanvasInputEventType(sourceEvent)
     ? sourceEvent
     : (payload.input_type || payload.event_type || payload.type || msg.type)
-  const synthesized = {
-    routed_schema_version: 1,
+  const compat = {
     event_kind: type === 'scroll_wheel' ? 'scroll' : 'pointer',
     type,
     phase: payload.phase ?? null,
@@ -295,13 +539,22 @@ function normalizeInputRegionEnvelope(msg) {
     button: payload.button || 'none',
     buttons: payload.buttons || { left: false, right: false, middle: false, other_pressed: [] },
   }
-  const normalized = normalizeV2InputEvent(synthesized, 'input_region.event')
   return {
     ...msg,
-    ...normalized,
+    ...compat,
+    ...pointFromV2Event(compat),
+    envelopeType: 'input_region.event',
+    eventKind: compat.event_kind,
+    gestureId: compat.gesture_id ?? null,
+    captureId: compat.capture_id ?? null,
+    deliveryRole: compat.delivery_role ?? null,
+    regionId: compat.region_id ?? null,
+    ownerCanvasId: compat.owner_canvas_id ?? null,
+    sourceOrigin: compat.source_origin ?? null,
+    sourceSequence: compat.source_sequence ?? compat.sequence ?? null,
+    sourceEvent: compat.source_event ?? null,
     native,
     inputRegionEventType: msg.type,
-    routedInput: synthesized,
   }
 }
 

--- a/shared/schemas/daemon-event.md
+++ b/shared/schemas/daemon-event.md
@@ -103,6 +103,9 @@ fields are the V0 compatibility surface; `routed_input` is the canonical
 `delivery_role`, stable `capture_id` for captured drags, `region_id`,
 `owner_canvas_id`, `source_event`/`source_sequence`, `source_origin`,
 `desktop_world`, and `coordinate_authority`.
+`input_region.event` is the bridge message type. `routed_schema_version: 1` is
+the routed payload version and must validate for the declared routed event kind
+and delivery role.
 Canvases can subscribe to `input_region` with `snapshot:true` to receive
 `input_region.snapshot` plus live register/update/remove notifications.
 

--- a/shared/schemas/fixtures/input-event-v2/valid/routed-captured-cancel.json
+++ b/shared/schemas/fixtures/input-event-v2/valid/routed-captured-cancel.json
@@ -1,0 +1,28 @@
+{
+  "routed_schema_version": 1,
+  "event_kind": "cancel",
+  "type": "pointer_cancel",
+  "phase": "cancel",
+  "delivery_role": "captured",
+  "sequence": {
+    "source": "toolkit",
+    "value": "cancel-47",
+    "synthetic": true
+  },
+  "gesture_id": "g-47",
+  "desktop_world": {
+    "x": 714,
+    "y": 373
+  },
+  "coordinate_authority": "toolkit",
+  "region_id": "sigil-avatar",
+  "capture_id": "daemon:47:sigil-avatar",
+  "cancel_reason": "surface_removed",
+  "source_event": "daemon:47",
+  "source_origin": "toolkit",
+  "owner_canvas_id": "avatar-main",
+  "source_sequence": {
+    "source": "daemon",
+    "value": 47
+  }
+}

--- a/shared/schemas/input-event-v2.md
+++ b/shared/schemas/input-event-v2.md
@@ -87,6 +87,11 @@ Fixtures live under `shared/schemas/fixtures/input-event-v2/`:
 - `sequences/` contains mixed-source ordering fixtures for daemon events and
   toolkit synthetic events.
 
+The valid set covers raw pointer, scroll, key, and cancel payloads plus routed
+owned pointer, captured drag, scroll, and captured cancel deliveries. The
+invalid set includes version-claiming raw and routed payloads that omit required
+fields such as `scroll`, `cancel_reason`, `region_id`, or `capture_id`.
+
 Run:
 
 ```sh

--- a/tests/toolkit/runtime-gesture-stream.test.mjs
+++ b/tests/toolkit/runtime-gesture-stream.test.mjs
@@ -8,6 +8,36 @@ import {
 } from '../../packages/toolkit/runtime/gesture-stream.js'
 import { createDocument, patchSpreadSupport } from './zag-adapter-test-utils.mjs'
 
+function routedPointer(overrides = {}) {
+  const type = overrides.type || 'left_mouse_down'
+  const { sequenceValue = 'gesture-test', ...eventOverrides } = overrides
+  const phaseByType = {
+    left_mouse_down: 'down',
+    left_mouse_dragged: 'drag',
+    left_mouse_up: 'up',
+    pointer_cancel: 'hover_cancel',
+  }
+  return {
+    routed_schema_version: 1,
+    event_kind: 'pointer',
+    type,
+    phase: phaseByType[type] || 'down',
+    delivery_role: 'captured',
+    sequence: { source: 'daemon', value: sequenceValue },
+    gesture_id: 'g1',
+    desktop_world: { x: 10, y: 20 },
+    coordinate_authority: 'toolkit',
+    source_origin: 'daemon',
+    source_event: type,
+    region_id: 'avatar-hit',
+    owner_canvas_id: 'avatar-main',
+    capture_id: 'c1',
+    button: 'left',
+    buttons: { left: true, right: false, middle: false, other_pressed: [] },
+    ...eventOverrides,
+  }
+}
+
 test('createPointerGestureStream normalizes canvas input into drag gesture frames', () => {
   const stream = createPointerGestureStream({
     kind: 'drag',
@@ -18,27 +48,24 @@ test('createPointerGestureStream normalizes canvas input into drag gesture frame
   const frames = []
   stream.subscribe((frame) => frames.push(frame))
 
-  stream.handleCanvasInput({
-    routed_schema_version: 1,
+  stream.handleCanvasInput(routedPointer({
     type: 'left_mouse_down',
-    gesture_id: 'g1',
-    capture_id: 'c1',
     desktop_world: { x: 10, y: 20 },
-  }, { now: 1000 })
-  stream.handleCanvasInput({
-    routed_schema_version: 1,
+    sequenceValue: 1,
+  }), { now: 1000 })
+  stream.handleCanvasInput(routedPointer({
     type: 'left_mouse_dragged',
-    gesture_id: 'g1',
-    capture_id: 'c1',
+    phase: 'drag',
     desktop_world: { x: 30, y: 25 },
-  }, { now: 1016 })
-  stream.handleCanvasInput({
-    routed_schema_version: 1,
+    sequenceValue: 2,
+  }), { now: 1016 })
+  stream.handleCanvasInput(routedPointer({
     type: 'left_mouse_up',
-    gesture_id: 'g1',
-    capture_id: 'c1',
+    phase: 'up',
     desktop_world: { x: 50, y: 20 },
-  }, { now: 1032 })
+    buttons: { left: false, right: false, middle: false, other_pressed: [] },
+    sequenceValue: 3,
+  }), { now: 1032 })
 
   assert.deepEqual(frames.map((frame) => frame.type), [
     'gesture.drag.start',
@@ -65,16 +92,16 @@ test('createPointerGestureStream ignores orphan canvas move before a start', () 
   const frames = []
   stream.subscribe((frame) => frames.push(frame))
 
-  const orphan = stream.handleCanvasInput({
-    routed_schema_version: 1,
+  const orphan = stream.handleCanvasInput(routedPointer({
     type: 'left_mouse_dragged',
+    phase: 'drag',
     desktop_world: { x: 10, y: 20 },
-  }, { now: 1000 })
-  const start = stream.handleCanvasInput({
-    routed_schema_version: 1,
+  }), { now: 1000 })
+  const start = stream.handleCanvasInput(routedPointer({
     type: 'left_mouse_down',
+    phase: 'down',
     desktop_world: { x: 15, y: 25 },
-  }, { now: 1016 })
+  }), { now: 1016 })
 
   assert.equal(orphan, null)
   assert.equal(start?.type, 'gesture.drag.start')
@@ -88,16 +115,18 @@ test('createPointerGestureStream ignores orphan canvas terminal frames', () => {
   const frames = []
   stream.subscribe((frame) => frames.push(frame))
 
-  const end = stream.handleCanvasInput({
-    routed_schema_version: 1,
+  const end = stream.handleCanvasInput(routedPointer({
     type: 'left_mouse_up',
+    phase: 'up',
     desktop_world: { x: 10, y: 20 },
-  }, { now: 1000 })
-  const cancel = stream.handleCanvasInput({
-    routed_schema_version: 1,
+    buttons: { left: false, right: false, middle: false, other_pressed: [] },
+  }), { now: 1000 })
+  const cancel = stream.handleCanvasInput(routedPointer({
     type: 'pointer_cancel',
+    phase: 'hover_cancel',
     desktop_world: { x: 10, y: 20 },
-  }, { now: 1016 })
+    buttons: { left: false, right: false, middle: false, other_pressed: [] },
+  }), { now: 1016 })
 
   assert.equal(end, null)
   assert.equal(cancel, null)
@@ -110,11 +139,11 @@ test('createPointerGestureStream publishes cancel before destroying an active st
   const frames = []
   stream.subscribe((frame) => frames.push(frame))
 
-  stream.handleCanvasInput({
-    routed_schema_version: 1,
+  stream.handleCanvasInput(routedPointer({
     type: 'left_mouse_down',
+    phase: 'down',
     desktop_world: { x: 1, y: 2 },
-  }, { now: 1000 })
+  }), { now: 1000 })
   stream.destroy()
 
   assert.deepEqual(frames.map((frame) => frame.type), [

--- a/tests/toolkit/runtime-input-events.test.mjs
+++ b/tests/toolkit/runtime-input-events.test.mjs
@@ -49,26 +49,36 @@ test('normalizeCanvasInputMessage adapts raw v2 pointer coordinates for current 
       type: 'right_mouse_down',
       event_kind: 'pointer',
       phase: 'down',
+      device: 'mouse',
+      timestamp_monotonic_ms: 1000,
       sequence: { source: 'daemon', value: 12 },
       gesture_id: 'g-12',
       native: { x: 10, y: 20 },
       desktop_world: { x: 110, y: 220 },
       coordinate_authority: 'daemon',
+      display_id: 1,
+      topology_version: 4,
       button: 'right',
       buttons: { left: false, right: true, middle: false, other_pressed: [] },
+      modifiers: { shift: false, ctrl: false, cmd: false, opt: false, fn: false, caps_lock: false },
     }),
     {
       input_schema_version: 2,
       type: 'right_mouse_down',
       event_kind: 'pointer',
       phase: 'down',
+      device: 'mouse',
+      timestamp_monotonic_ms: 1000,
       sequence: { source: 'daemon', value: 12 },
       gesture_id: 'g-12',
       native: { x: 10, y: 20 },
       desktop_world: { x: 110, y: 220 },
       coordinate_authority: 'daemon',
+      display_id: 1,
+      topology_version: 4,
       button: 'right',
       buttons: { left: false, right: true, middle: false, other_pressed: [] },
+      modifiers: { shift: false, ctrl: false, cmd: false, opt: false, fn: false, caps_lock: false },
       x: 110,
       y: 220,
       envelopeType: null,
@@ -95,8 +105,14 @@ test('normalizeCanvasInputMessage unwraps v2 input_event envelopes', () => {
       type: 'scroll_wheel',
       event_kind: 'scroll',
       phase: 'scroll',
+      device: 'mouse',
+      timestamp_monotonic_ms: 1000,
+      sequence: { source: 'daemon', value: 13 },
       native: { x: 20, y: 40 },
+      display_id: 1,
+      topology_version: 4,
       scroll: { dx: 0, dy: -4, unit: 'point' },
+      modifiers: { shift: false, ctrl: false, cmd: false, opt: false, fn: false, caps_lock: false },
     },
   })
 
@@ -112,6 +128,7 @@ test('normalizeCanvasInputMessage preserves routed delivery metadata', () => {
     routed_schema_version: 1,
     type: 'left_mouse_dragged',
     event_kind: 'pointer',
+    phase: 'drag',
     delivery_role: 'captured',
     sequence: { source: 'daemon', value: 18 },
     gesture_id: 'g-18',
@@ -123,6 +140,8 @@ test('normalizeCanvasInputMessage preserves routed delivery metadata', () => {
     capture_id: 'cap-18',
     source_event: 'daemon:18',
     source_sequence: { source: 'daemon', value: 18 },
+    button: 'left',
+    buttons: { left: true, right: false, middle: false, other_pressed: [] },
   })
 
   assert.equal(normalized.type, 'left_mouse_dragged')
@@ -199,6 +218,7 @@ test('createCanvasOriginInputEvent builds stable child canvas source identity', 
   assert.equal(event.source_origin, 'canvas')
   assert.equal(event.source_canvas_id, 'sigil-hit-avatar-main')
   assert.equal(event.owner_canvas_id, 'avatar-main')
+  assert.equal(event.region_id, 'sigil-hit-avatar-main')
   assert.equal(event.source_event, 'left_mouse_dragged')
   assert.deepEqual(event.source_sequence, {
     source: 'toolkit',
@@ -207,8 +227,86 @@ test('createCanvasOriginInputEvent builds stable child canvas source identity', 
   assert.equal(event.gesture_id, 'canvas:sigil-hit-avatar-main:avatar-main:9:left')
   assert.equal(event.capture_id, 'canvas:sigil-hit-avatar-main:avatar-main:9:left:capture')
   assert.deepEqual(event.desktop_world, { x: 300, y: 410 })
-  assert.deepEqual(event.child_local, { x: 12, y: 18 })
+  assert.equal(Object.hasOwn(event, 'child_local'), false)
   assert.equal(event.coordinate_authority, 'toolkit')
+})
+
+test('createCanvasOriginInputEvent builds canonical routed cancel events', () => {
+  const event = createCanvasOriginInputEvent({
+    type: 'canvas_message',
+    id: 'hit-child',
+    payload: {
+      source_origin: 'canvas',
+      source_canvas_id: 'hit-child',
+      owner_canvas_id: 'owner-canvas',
+      kind: 'pointer_cancel',
+      cancel_reason: 'surface_removed',
+    },
+  }, {
+    desktopWorld: { x: 3, y: 5 },
+  })
+
+  assert.equal(event.routed_schema_version, 1)
+  assert.equal(event.event_kind, 'cancel')
+  assert.equal(event.phase, 'cancel')
+  assert.equal(event.cancel_reason, 'surface_removed')
+  assert.equal(event.region_id, 'hit-child')
+  assert.equal(event.owner_canvas_id, 'owner-canvas')
+  assert.equal(Object.hasOwn(event, 'button'), false)
+  assert.equal(Object.hasOwn(event, 'buttons'), false)
+})
+
+test('normalizeCanvasInputMessage rejects incomplete version-claiming payloads', () => {
+  assert.throws(
+    () => normalizeCanvasInputMessage({
+      input_schema_version: 2,
+      event_kind: 'scroll',
+      type: 'scroll_wheel',
+      phase: 'scroll',
+      sequence: { source: 'daemon', value: 1 },
+    }),
+    /input-event-v2 payload missing required field/,
+  )
+
+  assert.throws(
+    () => normalizeCanvasInputMessage({
+      routed_schema_version: 1,
+      event_kind: 'pointer',
+      type: 'left_mouse_down',
+      delivery_role: 'owned',
+      sequence: { source: 'toolkit', value: 'owned-1' },
+      gesture_id: 'g-owned-1',
+      desktop_world: { x: 1, y: 2 },
+      coordinate_authority: 'toolkit',
+      source_origin: 'canvas',
+      source_event: 'left_mouse_down',
+      phase: 'down',
+      button: 'left',
+      buttons: { left: true, right: false, middle: false, other_pressed: [] },
+    }),
+    /routed-v1 input payload missing required field/,
+  )
+
+  assert.throws(
+    () => normalizeCanvasInputMessage({
+      routed_schema_version: 1,
+      event_kind: 'pointer',
+      type: 'left_mouse_down',
+      delivery_role: 'owned',
+      sequence: { source: 'toolkit', value: 'owned-2' },
+      gesture_id: 'g-owned-2',
+      desktop_world: { x: 1, y: 2 },
+      coordinate_authority: 'toolkit',
+      source_origin: 'canvas',
+      source_event: { type: 'left_mouse_down' },
+      region_id: 'region',
+      owner_canvas_id: 'owner',
+      phase: 'down',
+      button: 'left',
+      buttons: { left: true, right: false, middle: false, other_pressed: [] },
+    }),
+    /source_event object must be a raw input-event-v2 payload/,
+  )
 })
 
 test('normalizeCanvasInputMessage leaves identity-only child canvas envelopes unresolved', () => {


### PR DESCRIPTION
Refs #431.

## Summary
- Tighten toolkit normalization so version-claiming raw v2 and routed v1 payloads are validated before router aliases are added.
- Require routed v1 source_event objects to be valid raw input-event-v2 payloads, matching the JSON Schema contract.
- Move runtime/gesture tests and docs toward canonical routed payloads, with an audit note for the remaining compatibility bridges and removal gates.

## Verification
- git diff --check
- node --test tests/schemas/input-event-v2.test.mjs
- node --test tests/toolkit/runtime-input-events.test.mjs
- node --test tests/toolkit/runtime-gesture-stream.test.mjs
- node --test tests/toolkit/aos-interaction-grammar-contract.test.mjs tests/toolkit/aos-work-recording-frame-contract.test.mjs
- node --test tests/toolkit/stage-affordance.test.mjs
- Additional Foreman probe: every valid fixture under shared/schemas/fixtures/input-event-v2/valid/*.json normalized successfully through normalizeCanvasInputMessage().

## Runtime Boundary
- Live AOS remained intentionally paused; no ./aos ready, ./aos status, service start/restart, or live smoke was run.
- No native Swift files were edited and ./aos dev build was not run.
