### PR TITLE
docs(input): audit native subscriber cutover gates

### DIFF
--- a/apps/sigil/renderer/live-modules/input-message.js
+++ b/apps/sigil/renderer/live-modules/input-message.js
@@ -17,15 +17,6 @@ export function normalizeMessage(msg = {}) {
     }
 
     const payload = (msg?.payload && typeof msg.payload === 'object' && msg.payload !== null) ? msg.payload : null;
-    if (msg?.type === 'input_event' && payload) {
-        return {
-            ...msg,
-            ...payload,
-            envelope_type: msg.type,
-            type: payload.type ?? msg.type,
-        };
-    }
-
     const merged = payload ? { ...payload, ...msg } : { ...msg };
     merged.type = msg?.type ?? payload?.type ?? merged.type;
     return merged;

--- a/docs/design/input-event-v2-toolkit-cutover-v0.md
+++ b/docs/design/input-event-v2-toolkit-cutover-v0.md
@@ -44,6 +44,61 @@ fixtures. It does not need a separate legacy alias path.
 for local deterministic routing helpers. That is a native producer bridge until
 the input-region router receives only canonical routed v1 payloads.
 
+## Native Producer And Active Subscriber Audit
+
+Current native raw input is built in `src/perceive/events.swift` and delivered
+from `src/perceive/daemon.swift` into `src/daemon/unified.swift`.
+Deterministic inspection shows complete CGEvent pointer, scroll, key, and
+snapshot move payloads can claim `input_schema_version: 2`, while helper-only
+scroll or cancel payloads without required facts intentionally remain
+unversioned in `tests/daemon-input-surface-ownership.sh`. Removing the raw
+event-name bridge from toolkit is therefore native-boundary work: Foreman must
+route a separate native/live round to prove the daemon no longer emits
+unversioned raw input to active subscribers.
+
+Current routed input is built by
+`src/daemon/input-surface-ownership.swift` and delivered by
+`src/daemon/unified.swift` as `input_region.event` with both
+`routed_input` and top-level compatibility fields. Complete routed pointer,
+scroll, and cancel payloads can claim `routed_schema_version: 1`; routed scroll
+or cancel helpers without `scroll` or `cancel_reason` intentionally remain
+unversioned in deterministic Swift coverage. The top-level-only
+`input_region.event` bridge is intentionally retained until a native/live round
+proves every active daemon routed producer includes canonical `routed_input`
+and no live subscriber depends on the top-level fallback.
+
+Active owned subscribers currently route through the toolkit normalizer:
+
+- `packages/toolkit/components/surface-inspector/index.js` subscribes to
+  `input_event` for cursor tracking, mouse effects, and annotation hover.
+  Retain compatibility until live subscriber evidence proves only canonical raw
+  v2 reaches it.
+- `packages/toolkit/components/spatial-telemetry/index.js` subscribes to
+  `input_event` and summarizes cursor telemetry through
+  `normalizeCanvasInputMessage()`. Retain compatibility until native fanout is
+  live-proven canonical.
+- `apps/sigil/renderer/live-modules/main.js` subscribes to `input_event` and
+  delegates input normalization through
+  `apps/sigil/renderer/live-modules/input-message.js`. Sigil's duplicate
+  app-local `input_event` unwrap was removed; unresolved child
+  `canvas_message` input remains intentionally retained until parent
+  DesktopWorld coordinates are supplied and toolkit can emit canonical
+  canvas-origin routed v1.
+- `packages/toolkit/panel/chrome.js` temporarily subscribes to global
+  `input_event` during panel drags and handles minimized-chip
+  `input_region.event` messages. Retain raw and top-level routed
+  compatibility until daemon routed delivery and live panel drag subscribers
+  are proven canonical.
+- `packages/toolkit/panel/stage-affordance.js` filters
+  `input_region.event` by region id for passive DesktopWorld hit regions. It is
+  intentionally retained as routed producer compatibility until canonical
+  `routed_input` delivery is native/live-proven.
+
+No Swift/native files were changed in this audit. The remaining hard-cutover
+work is a native-boundary/live-evidence follow-up, not a deterministic
+JS/toolkit cleanup, once Foreman is ready to route native producer changes and
+TCC-safe live subscriber proof.
+
 ## Migrated Or Guarded In This Slice
 
 - Runtime v2/v1 normalizing now validates version-claiming payloads before
@@ -55,6 +110,10 @@ the input-region router receives only canonical routed v1 payloads.
 - Schema fixtures now include a valid routed captured cancel example alongside
   existing raw pointer, raw scroll, raw key, raw cancel, routed owned pointer,
   routed captured drag, routed scroll, and invalid version-claiming examples.
+- Sigil input normalization no longer keeps a duplicate app-local
+  `input_event` unwrap after toolkit normalization; that owned compatibility is
+  removable in this deterministic JS round and now covered by
+  `tests/renderer/input-message.test.mjs`.
 
 ## Replay Boundary
 

--- a/docs/design/work-cards/gdi-input-event-v2-native-subscriber-audit-v0.md
+++ b/docs/design/work-cards/gdi-input-event-v2-native-subscriber-audit-v0.md
@@ -1,0 +1,207 @@
+# Input Event V2 Native Subscriber Audit V0
+
+## Recipient
+
+GDI validation/correction round.
+
+## Transfer Kind
+
+GDI round.
+
+## Branch / Base
+
+- branch_from: local `main` containing this work card.
+- required_start_ref: local `main` containing this work card.
+- published prerequisite base: `origin/main` at or after `4168fa60`, with PR
+  #436 merged.
+- expected output branch: `gdi/input-event-v2-native-subscriber-audit-v0`
+
+Work in the single local checkout at `/Users/Michael/Code/agent-os`. Do not
+create linked git worktrees.
+
+## Tracker
+
+- GitHub issue #431:
+  https://github.com/michaelblum/agent-os/issues/431
+- Published prerequisite PR #436:
+  https://github.com/michaelblum/agent-os/pull/436
+- Current audit note:
+  `docs/design/input-event-v2-toolkit-cutover-v0.md`
+
+## Fresh Context Contract
+
+GDI starts from a fresh context window. Do not assume branch, checkout, daemon,
+canvas, issue, or prior implementation state. Read and rediscover before
+editing.
+
+## Goal
+
+Decide and tighten the remaining deterministic #431 native-producer and active
+subscriber compatibility surface after PR #436, while returning a
+native-boundary finding instead of editing Swift or requiring live AOS.
+
+## Read First
+
+- `AGENTS.md`
+- `src/AGENTS.md`
+- `src/daemon/AGENTS.md`
+- `packages/toolkit/AGENTS.md`
+- `packages/toolkit/runtime/AGENTS.md`
+- `packages/toolkit/panel/AGENTS.md`
+- `apps/sigil/AGENTS.md`
+- `docs/design/input-event-v2-toolkit-cutover-v0.md`
+- `docs/design/work-cards/gdi-input-event-v2-toolkit-cutover-v0.md`
+- `shared/schemas/input-event-v2.schema.json`
+- `shared/schemas/input-event-v2.md`
+- `docs/api/toolkit/runtime.md`
+- GitHub issue #431.
+
+## Rediscover State
+
+Run before editing:
+
+```bash
+git status --short --branch
+git rev-parse HEAD origin/main
+./aos service status --mode repo --json
+./aos dev gh issue view 431 --json
+./aos dev gh pr list --state open --limit 20 --json
+rg -n "input_event|input_region\\.event|routed_input|routed_schema_version|input_schema_version|mouse_moved|left_mouse_down|scroll_wheel|pointer_cancel|mouse_cancel|normalizeCanvasInputMessage|normalizeMessage\\(" src apps packages tests --glob "!**/node_modules/**"
+```
+
+Live AOS is intentionally paused. Do not run `./aos ready`, `./aos status`,
+`./aos clean`, service start/restart, live smoke, or lower-level socket/PTY
+control. Use passive classification only.
+
+## Existing Code To Inspect
+
+- `src/perceive/events.swift` - native input-event payload builder and v2 claim
+  gate.
+- `src/perceive/daemon.swift` - CGEvent to `inputEventData()` path.
+- `src/daemon/unified.swift` - `input_event` subscription snapshots, broadcast,
+  and `input_region.event` routing.
+- `src/daemon/input-surface-ownership.swift` - routed input payload helper and
+  routed-v1 claim gate.
+- `packages/toolkit/runtime/input-events.js` - canonical toolkit normalizer and
+  remaining unversioned bridges.
+- `packages/toolkit/runtime/interaction-region.js` - JS local deterministic
+  routing helper that still accepts raw event names.
+- `packages/toolkit/panel/stage-affordance.js` and
+  `packages/toolkit/panel/chrome.js` - routed/global input consumers.
+- `packages/toolkit/components/surface-inspector/index.js` - active
+  `input_event` subscriber using toolkit normalization.
+- `packages/toolkit/components/spatial-telemetry/index.js` - active
+  `input_event` subscriber using toolkit normalization.
+- `apps/sigil/renderer/live-modules/input-message.js` and
+  `apps/sigil/renderer/live-modules/main.js` - active Sigil normalization and
+  fallback handling around daemon input envelopes.
+- `tests/daemon-input-surface-ownership.sh` - deterministic Swift coverage for
+  producer and routed payload claim gates.
+- `tests/toolkit/runtime-input-events.test.mjs`,
+  `tests/toolkit/runtime-gesture-stream.test.mjs`,
+  `tests/toolkit/stage-affordance.test.mjs`,
+  `tests/toolkit/panel-chrome.test.mjs`,
+  `tests/toolkit/surface-inspector.test.mjs`, and
+  `tests/toolkit/spatial-telemetry-model.test.mjs`.
+
+## Required Behavior
+
+### Audit Result
+
+Update `docs/design/input-event-v2-toolkit-cutover-v0.md` or add a concise
+adjacent note only if the current note is missing current facts. The result must
+name the remaining owned active producer/subscriber bridges, not just generic
+compatibility categories.
+
+Classify each bridge as one of:
+
+- removable in this deterministic JS/toolkit round;
+- intentionally retained with a concrete external/native/live removal gate;
+- native-boundary work that Foreman must route separately.
+
+### JS/Toolkit Correction
+
+If inspection shows an owned JS fallback is redundant after the #436 toolkit
+normalizer, remove or narrow it with focused tests. Likely candidates include
+duplicate fallback unwrapping in `apps/sigil/renderer/live-modules/input-message.js`
+or tests that still teach owned components to rely on broad unversioned wrapper
+payloads when a canonical fixture is available.
+
+Do not remove compatibility that still has a named active producer or live
+consumer. If the only honest cleanup requires Swift/native producer changes or
+live runtime proof, stop with a native-boundary finding instead of editing
+native files.
+
+### Native Boundary
+
+Inspect Swift producer code and deterministic Swift tests, but do not edit Swift
+or run `./aos dev build` in this round. Foreman owns native rebuild and any TCC
+handoff. A finding is sufficient when the remaining work is "native producer
+must always emit canonical v2/routed-v1" or "needs live subscriber evidence."
+
+## Scope
+
+Deterministic audit, JS/toolkit/Sigil subscriber cleanup where safe, docs note
+updates, and tests. Native Swift implementation, daemon rebuilds, TCC work,
+live smoke, issue closure, PR publication, and GitHub mutation are out of scope.
+
+## Hard Boundaries / Non-Goals
+
+- Do not restart live AOS or require live canvas/input evidence.
+- Do not run `./aos ready`, `./aos status`, `./aos clean`, service
+  start/restart, live smoke, raw daemon HTTP calls, `tmux`, or direct socket
+  control.
+- Do not edit Swift/native daemon producer files.
+- Do not run `./aos dev build`.
+- Do not close #431.
+- Do not broaden the toolkit normalizer or add new compatibility aliases.
+- Do not start Sigil remodel or migrate unrelated product interaction state.
+
+## Stop Conditions
+
+Stop and report `blocked_native_boundary` if:
+
+- the remaining #431 work requires Swift/native producer edits;
+- deterministic tests prove a live payload shape is still unknown;
+- active consumer cleanup cannot be proven without live AOS;
+- narrowing a fallback would break a named external or non-updatable producer.
+
+If live AOS/TCC evidence becomes the next meaningful step, do not retry or
+repair permissions. Run `.docks/gdi/scripts/human-needed-tcc-reset`, stop with
+`human_needed`, and return the blocker to Foreman.
+
+## Verification
+
+Run the focused deterministic gate for any changes:
+
+```bash
+git diff --check
+node --test tests/schemas/input-event-v2.test.mjs
+node --test tests/toolkit/runtime-input-events.test.mjs
+node --test tests/toolkit/runtime-gesture-stream.test.mjs
+node --test tests/toolkit/stage-affordance.test.mjs
+node --test tests/toolkit/panel-chrome.test.mjs
+node --test tests/toolkit/surface-inspector.test.mjs
+node --test tests/toolkit/spatial-telemetry-model.test.mjs
+tests/daemon-input-surface-ownership.sh
+```
+
+Also rerun a focused search and classify remaining hits:
+
+```bash
+rg -n "input_event|input_region\\.event|routed_input|routed_schema_version|input_schema_version|mouse_moved|left_mouse_down|scroll_wheel|pointer_cancel|mouse_cancel|normalizeCanvasInputMessage|normalizeMessage\\(" src apps packages tests --glob "!**/node_modules/**"
+```
+
+## Completion Report
+
+Report:
+
+- files changed;
+- active producer/subscriber bridges classified;
+- any JS/toolkit compatibility removed or narrowed;
+- any native-boundary finding, with exact paths and line-level evidence;
+- exact verification commands and pass/fail results;
+- live AOS status classification and confirmation that no live readiness/control
+  commands were run;
+- whether #431 should remain open, close, or split into a smaller native
+  follow-up after Foreman review.

--- a/tests/daemon-input-surface-ownership.sh
+++ b/tests/daemon-input-surface-ownership.sh
@@ -296,8 +296,22 @@ writeJSON("routed-cancel", routedCancel)
 print("PASS input event v2 builder and routed payload contract")
 SWIFT
 
+cat >"$TMP/json-value.swift" <<'SWIFT'
+import Foundation
+
+enum JSONValue: Codable, Equatable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case object([String: JSONValue])
+    case array([JSONValue])
+    case null
+}
+SWIFT
+
 swiftc \
   "$ROOT/src/shared/types.swift" \
+  "$TMP/json-value.swift" \
   "$ROOT/src/perceive/models.swift" \
   "$ROOT/src/perceive/events.swift" \
   "$ROOT/src/daemon/input-surface-ownership.swift" \

--- a/tests/renderer/input-message.test.mjs
+++ b/tests/renderer/input-message.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import { normalizeMessage } from '../../apps/sigil/renderer/live-modules/input-message.js'
 
-test('normalizeMessage unwraps legacy input_event payload type and coordinates', () => {
+test('normalizeMessage delegates input_event payload unwrapping to toolkit normalization', () => {
   const msg = normalizeMessage({
     type: 'input_event',
     payload: {
@@ -17,6 +17,13 @@ test('normalizeMessage unwraps legacy input_event payload type and coordinates',
   assert.equal(msg.envelope_type, 'input_event')
   assert.equal(msg.x, 120)
   assert.equal(msg.y, 240)
+})
+
+test('Sigil input normalizer does not keep a duplicate input_event unwrap branch', async () => {
+  const source = await readFile(new URL('../../apps/sigil/renderer/live-modules/input-message.js', import.meta.url), 'utf8')
+
+  assert.doesNotMatch(source, /msg\?\.type === 'input_event' && payload/)
+  assert.match(source, /normalizeCanvasInputMessage\(msg\)/)
 })
 
 test('normalizeMessage preserves non-input envelope type precedence', () => {


### PR DESCRIPTION
Refs #431.

## Summary
- Removes the Sigil renderer duplicate `input_event` unwrap after toolkit normalization.
- Adds renderer guard coverage for delegation and no duplicate unwrap behavior.
- Documents the active producer/subscriber audit plus native/live removal gates.
- Fixes the deterministic daemon input surface ownership harness compile path with a local `JSONValue` stub and executable bit.

## Verification
- `git diff --check`
- `node --test tests/renderer/input-message.test.mjs`
- `tests/daemon-input-surface-ownership.sh`
- `node --test tests/schemas/input-event-v2.test.mjs`
- `node --test tests/toolkit/runtime-input-events.test.mjs`
- `node --test tests/toolkit/runtime-gesture-stream.test.mjs`
- `node --test tests/toolkit/stage-affordance.test.mjs`
- `node --test tests/toolkit/panel-chrome.test.mjs`
- `node --test tests/toolkit/surface-inspector.test.mjs`
- `node --test tests/toolkit/spatial-telemetry-model.test.mjs`

## Runtime / Boundary Notes
- Live AOS stayed paused; passive repo service status remained degraded/not running.
- No `./aos ready`, `./aos status`, service start/restart, live smoke, `./aos dev build`, Swift/native edits, or TCC work was run.
- #431 should remain open after this PR unless a later review confirms the broader native/live hard-cutover lane is fully satisfied.