### PR TITLE
Input event v2 native producer and live-proof readiness

### DIFF
--- a/docs/design/input-event-v2-toolkit-cutover-v0.md
+++ b/docs/design/input-event-v2-toolkit-cutover-v0.md
@@ -99,6 +99,132 @@ work is a native-boundary/live-evidence follow-up, not a deterministic
 JS/toolkit cleanup, once Foreman is ready to route native producer changes and
 TCC-safe live subscriber proof.
 
+## Native/Live Gate Map
+
+### satisfied_by_pr_436_or_437
+
+- `packages/toolkit/runtime/input-events.js` validates canonical raw
+  `input_schema_version: 2` payloads and routed `routed_schema_version: 1`
+  payloads before adding router aliases. Version-claiming payloads with missing
+  required fields now fail deterministically in
+  `tests/toolkit/runtime-input-events.test.mjs`.
+- `packages/toolkit/runtime/gesture-stream.js` consumes
+  `normalizeCanvasInputMessage()` and has canonical routed pointer coverage in
+  `tests/toolkit/runtime-gesture-stream.test.mjs`; no separate gesture-stream
+  compatibility bridge remains.
+- `apps/sigil/renderer/live-modules/input-message.js` delegates
+  `input_event` unwrapping to toolkit normalization. The duplicate app-local
+  unwrap path was removed and guarded by
+  `tests/renderer/input-message.test.mjs`.
+- `tests/daemon-input-surface-ownership.sh` proves the current native builders
+  claim raw v2 or routed v1 only for complete deterministic pointer, scroll,
+  and cancel payloads, and keep helper-only incomplete scroll/cancel payloads
+  unversioned.
+
+### deterministic_js_followup_possible
+
+No remaining owned bridge is safely removable by deterministic JS inspection
+alone. The remaining JS compatibility paths are tied to either native producer
+shape, live active-subscriber proof, child WebView coordinate ownership, or
+external/test producers.
+
+### native_producer_followup_required
+
+- Raw `input_event` fanout: `src/perceive/events.swift`,
+  `src/perceive/daemon.swift`, and `src/daemon/unified.swift`.
+  Missing fact: the daemon still has builder paths that can produce unversioned
+  raw input when scroll/cancel required facts are absent, and canvas fanout in
+  `forwardInputEventToCanvases()` forwards the native payload as-is. Next
+  owner: Foreman routes a native-boundary GDI/Swift slice. Live AOS restart:
+  not required for the deterministic native edit itself, but required later to
+  prove active fanout. Smallest verification: update
+  `tests/daemon-input-surface-ownership.sh` so every daemon-produced raw
+  pointer, scroll, key, cancel, and snapshot payload intended for owned canvas
+  subscribers can claim `input_schema_version: 2`, then run
+  `tests/daemon-input-surface-ownership.sh` and
+  `node --test tests/toolkit/runtime-input-events.test.mjs`.
+- Routed `input_region.event` producer: `src/daemon/input-surface-ownership.swift`
+  and `src/daemon/unified.swift`. Missing fact: the routed bridge still emits
+  top-level compatibility fields beside `routed_input`, and routed helper-only
+  scroll/cancel payloads without `scroll` or `cancel_reason` intentionally do
+  not claim `routed_schema_version: 1`. Next owner: Foreman routes a
+  native-boundary GDI/Swift slice. Live AOS restart: not required for the
+  deterministic native edit itself, but required later to prove live routed
+  delivery. Smallest verification: make routed delivery always include a
+  canonical `routed_input` for owned/captured deliveries, prove it in
+  `tests/daemon-input-surface-ownership.sh`, then rerun
+  `node --test tests/toolkit/runtime-input-events.test.mjs`,
+  `node --test tests/toolkit/stage-affordance.test.mjs`, and
+  `node --test tests/toolkit/panel-chrome.test.mjs`.
+- Local deterministic router bridge:
+  `packages/toolkit/runtime/interaction-region.js`. Missing fact: this helper
+  still routes raw event names such as `left_mouse_down`, `mouse_moved`,
+  `scroll_wheel`, `pointer_cancel`, and `mouse_cancel`. Next owner: GDI only
+  after Foreman accepts a canonical routed-v1 producer/input contract for this
+  helper. Live AOS restart: no. Smallest verification:
+  `node --test tests/toolkit/runtime-interaction-region.test.mjs` with canonical
+  routed-v1 fixtures, after the native routed producer gate is resolved.
+
+### live_aos_evidence_required
+
+- Active `input_event` subscribers:
+  `packages/toolkit/components/surface-inspector/index.js`,
+  `packages/toolkit/components/spatial-telemetry/index.js`,
+  `apps/sigil/renderer/live-modules/main.js`, and
+  `packages/toolkit/panel/chrome.js`. Missing fact: deterministic tests prove
+  these consumers normalize canonical and compatibility shapes, but cannot
+  prove the live daemon only delivers canonical raw v2 payloads to active
+  subscribers. Next owner: Operator after Michael explicitly approves live AOS
+  restart. Live AOS restart: yes. Smallest observation: launch the repo daemon,
+  open each active subscriber surface, trigger pointer, scroll, key, cancel or
+  drag where applicable, and observe through surface debug state or a focused
+  probe that received `input_event` messages carry `input_schema_version: 2`
+  with required fields and no consumer depends on unversioned raw names.
+- Active `input_region.event` consumers:
+  `packages/toolkit/panel/stage-affordance.js`,
+  `packages/toolkit/panel/chrome.js`, and
+  `apps/sigil/renderer/live-modules/main.js`. Missing fact: deterministic tests
+  cover canonical `routed_input` and top-level compatibility, but cannot prove
+  live daemon routed delivery always includes canonical `routed_input` for
+  owned/captured regions. Next owner: Operator after the native producer gate
+  lands and Michael approves live AOS restart. Live AOS restart: yes. Smallest
+  observation: create a stage affordance/minimized chip or Sigil input region,
+  trigger down/drag/up/cancel, and observe `input_region.event.routed_input`
+  with `routed_schema_version: 1`, required region ownership, capture identity
+  for captured deliveries, and DesktopWorld coordinates.
+
+### child_canvas_coordinate_followup_required
+
+- Child WebView `canvas_message` input:
+  `packages/toolkit/runtime/input-events.js`,
+  `apps/sigil/renderer/live-modules/input-message.js`, and
+  `apps/sigil/renderer/live-modules/main.js`. Missing fact: identity-only
+  child messages from Sigil hit/radial surfaces lack parent-resolved
+  DesktopWorld coordinates, so toolkit intentionally leaves them unresolved
+  until the parent supplies `desktop_world`. Next owner: GDI for the
+  parent-coordinate adapter once Foreman routes that slice. Live AOS restart:
+  no for deterministic adapter tests; yes only for final real-input proof.
+  Smallest verification:
+  `node --test tests/renderer/input-message.test.mjs` and
+  `node --test tests/toolkit/runtime-input-events.test.mjs` proving
+  identity-only child messages remain unresolved while parent-resolved child
+  messages normalize to canonical routed v1 with `source_origin: "canvas"`.
+
+### external_or_non_updatable_compatibility
+
+- Unversioned `{type:"input_event", payload}` wrappers in
+  `packages/toolkit/runtime/input-events.js` and focused tests remain bounded
+  compatibility for test fixtures, ad hoc `show post` probes such as
+  `tests/spatial-telemetry-smoke.sh`, and any external canvas producer that
+  cannot be updated in the same repo slice. Missing fact: there is no live
+  inventory proving every non-repo producer has stopped sending unversioned
+  wrapper envelopes. Next owner: Foreman for disposition; Operator only if
+  Foreman asks for a live producer inventory. Live AOS restart: not required
+  unless Foreman requests live inventory. Smallest verification: keep wrapper
+  handling bounded to `input_event` envelopes in
+  `normalizeCanvasInputMessage()` and rerun
+  `node --test tests/toolkit/runtime-input-events.test.mjs`.
+
 ## Migrated Or Guarded In This Slice
 
 - Runtime v2/v1 normalizing now validates version-claiming payloads before

--- a/docs/design/input-event-v2-toolkit-cutover-v0.md
+++ b/docs/design/input-event-v2-toolkit-cutover-v0.md
@@ -48,24 +48,28 @@ the input-region router receives only canonical routed v1 payloads.
 
 Current native raw input is built in `src/perceive/events.swift` and delivered
 from `src/perceive/daemon.swift` into `src/daemon/unified.swift`.
-Deterministic inspection shows complete CGEvent pointer, scroll, key, and
-snapshot move payloads can claim `input_schema_version: 2`, while helper-only
-scroll or cancel payloads without required facts intentionally remain
-unversioned in `tests/daemon-input-surface-ownership.sh`. Removing the raw
-event-name bridge from toolkit is therefore native-boundary work: Foreman must
-route a separate native/live round to prove the daemon no longer emits
-unversioned raw input to active subscribers.
+Deterministic coverage in `tests/daemon-input-surface-ownership.sh` proves
+every current daemon-produced CGEvent pointer name, scroll, key, and
+subscription snapshot move payload can claim `input_schema_version: 2`.
+Incomplete scroll or cancel builder calls without required facts intentionally
+remain unversioned only as helper/non-delivery guards; the current CGEvent
+producer does not emit `pointer_cancel` or `mouse_cancel` into raw
+`input_event`.
 
 Current routed input is built by
 `src/daemon/input-surface-ownership.swift` and delivered by
 `src/daemon/unified.swift` as `input_region.event` with both
-`routed_input` and top-level compatibility fields. Complete routed pointer,
-scroll, and cancel payloads can claim `routed_schema_version: 1`; routed scroll
-or cancel helpers without `scroll` or `cancel_reason` intentionally remain
-unversioned in deterministic Swift coverage. The top-level-only
-`input_region.event` bridge is intentionally retained until a native/live round
-proves every active daemon routed producer includes canonical `routed_input`
-and no live subscriber depends on the top-level fallback.
+`routed_input` and top-level compatibility fields. Deterministic coverage
+proves complete routed pointer and scroll deliveries can claim
+`routed_schema_version: 1` with `source_event` preserving the canonical raw v2
+payload. Complete routed cancel helpers can also claim routed v1 when supplied
+with `cancel_reason`, while helper-only scroll or cancel payloads without
+`scroll` or `cancel_reason` intentionally remain unversioned. Current live
+input-region routing is driven by pointer/scroll CGEvent names; key events do
+not route through `AOSInputRegionRegistry`, and cancel routing remains a
+helper/native-follow-up boundary until a producer supplies an explicit cancel
+reason. The top-level-only `input_region.event` bridge is retained until live
+subscriber proof shows no consumer depends on the top-level fallback fields.
 
 Active owned subscribers currently route through the toolkit normalizer:
 
@@ -118,8 +122,8 @@ TCC-safe live subscriber proof.
   `tests/renderer/input-message.test.mjs`.
 - `tests/daemon-input-surface-ownership.sh` proves the current native builders
   claim raw v2 or routed v1 only for complete deterministic pointer, scroll,
-  and cancel payloads, and keep helper-only incomplete scroll/cancel payloads
-  unversioned.
+  key, snapshot, and cancel payloads, and keep helper-only incomplete
+  scroll/cancel payloads unversioned.
 
 ### deterministic_js_followup_possible
 
@@ -130,32 +134,27 @@ external/test producers.
 
 ### native_producer_followup_required
 
-- Raw `input_event` fanout: `src/perceive/events.swift`,
-  `src/perceive/daemon.swift`, and `src/daemon/unified.swift`.
-  Missing fact: the daemon still has builder paths that can produce unversioned
-  raw input when scroll/cancel required facts are absent, and canvas fanout in
-  `forwardInputEventToCanvases()` forwards the native payload as-is. Next
-  owner: Foreman routes a native-boundary GDI/Swift slice. Live AOS restart:
-  not required for the deterministic native edit itself, but required later to
-  prove active fanout. Smallest verification: update
-  `tests/daemon-input-surface-ownership.sh` so every daemon-produced raw
-  pointer, scroll, key, cancel, and snapshot payload intended for owned canvas
-  subscribers can claim `input_schema_version: 2`, then run
-  `tests/daemon-input-surface-ownership.sh` and
-  `node --test tests/toolkit/runtime-input-events.test.mjs`.
-- Routed `input_region.event` producer: `src/daemon/input-surface-ownership.swift`
-  and `src/daemon/unified.swift`. Missing fact: the routed bridge still emits
-  top-level compatibility fields beside `routed_input`, and routed helper-only
-  scroll/cancel payloads without `scroll` or `cancel_reason` intentionally do
-  not claim `routed_schema_version: 1`. Next owner: Foreman routes a
-  native-boundary GDI/Swift slice. Live AOS restart: not required for the
-  deterministic native edit itself, but required later to prove live routed
-  delivery. Smallest verification: make routed delivery always include a
-  canonical `routed_input` for owned/captured deliveries, prove it in
-  `tests/daemon-input-surface-ownership.sh`, then rerun
-  `node --test tests/toolkit/runtime-input-events.test.mjs`,
-  `node --test tests/toolkit/stage-affordance.test.mjs`, and
-  `node --test tests/toolkit/panel-chrome.test.mjs`.
+- Raw `input_event` fanout: none for current deterministic CGEvent pointer,
+  scroll, key, and snapshot move producers. `src/perceive/daemon.swift`
+  supplies the facts needed by `src/perceive/events.swift`, and
+  `tests/daemon-input-surface-ownership.sh` validates the resulting raw v2
+  payloads against `shared/schemas/input-event-v2.schema.json`. Remaining
+  unversioned scroll/cancel builder calls are helper/non-delivery guards, not
+  current owned-subscriber raw daemon deliveries. Next owner: Foreman only if a
+  future native producer starts emitting cancel. Live AOS restart: no for this
+  deterministic fact; yes only for active-subscriber observation.
+- Routed `input_region.event` producer: no remaining deterministic
+  pointer/scroll routed producer change is required after
+  `src/daemon/input-surface-ownership.swift` preserves canonical raw v2
+  `source_event` objects for complete routed deliveries. Missing fact:
+  top-level compatibility fields beside `routed_input` may still be live
+  subscriber dependencies, and no current deterministic source path proves a
+  live cancel delivery with `cancel_reason`. Next owner: Operator for live
+  subscriber proof after Foreman review; Foreman routes a smaller native slice
+  only if live or future source inspection finds a real cancel producer without
+  `cancel_reason`. Live AOS restart: yes for subscriber proof, no for the
+  deterministic pointer/scroll producer gate now covered by
+  `tests/daemon-input-surface-ownership.sh`.
 - Local deterministic router bridge:
   `packages/toolkit/runtime/interaction-region.js`. Missing fact: this helper
   still routes raw event names such as `left_mouse_down`, `mouse_moved`,

--- a/docs/design/work-cards/gdi-experience-activation-daemon-stability-v0.md
+++ b/docs/design/work-cards/gdi-experience-activation-daemon-stability-v0.md
@@ -1,0 +1,212 @@
+# GDI Experience Activation Daemon Stability V0
+
+## Recipient
+
+GDI deterministic correction round.
+
+## Transfer Kind
+
+Correction round.
+
+## Single Next Goal
+
+Make `aos experience activate sigil` idempotent and daemon-safe so canonical
+Sigil activation does not rewrite live-equivalent content roots, destabilize the
+repo daemon, or leave stale daemon locks.
+
+## Branch / Base
+
+- branch_from: local `main` containing `732fdf3f`
+  (`docs(work-cards): gate input event live proof rerun`).
+- required_start_ref: local `main` containing `732fdf3f` and `5f6445a4`.
+- expected output branch:
+  `gdi/experience-activation-daemon-stability-v0`.
+- tracker issue: #431
+  https://github.com/michaelblum/agent-os/issues/431
+- related published PR: #438
+  https://github.com/michaelblum/agent-os/pull/438
+
+Work in `/Users/Michael/Code/agent-os`, not in `.docks/`. Use the single local
+checkout; do not create linked git worktrees.
+
+## Fresh Context Contract
+
+GDI starts from a fresh context window. Do not assume daemon, branch, issue,
+canvas, config, or artifact state. Read and rediscover before editing.
+
+## Source Artifact
+
+Foreman reviewed the blocked Operator run for
+`docs/design/work-cards/operator-input-event-v2-live-proof-v0.md`.
+
+- first blocked artifact directory:
+  `/tmp/aos-input-event-v2-live-proof-v0/`
+- Foreman blocked-run review comment:
+  https://github.com/michaelblum/agent-os/issues/431#issuecomment-4641262262
+- Foreman bounded recovery attempt after Michael approval:
+  - `./aos clean --json` removed stale lock for dead PID `27724`;
+  - `./aos service start --mode repo --json` succeeded with service PID `54070`,
+    daemon PID `54079`, and active input tap;
+  - `./aos experience activate sigil` printed `Sigil experience active.`;
+  - immediate `./aos service status --mode repo --json` reported
+    `running:false`;
+  - `./aos status --json` reported `diagnosis:"daemon_unmanaged"` with a stale
+    lock for dead PID `54079`;
+  - `launchctl print gui/$(id -u)/com.agent-os.aos.repo` reported last exit code
+    `11`;
+  - `./aos clean --json` removed the new stale lock.
+
+The repo service is currently intentionally left not running. Do not treat this
+card as approval for another live repo service loop.
+
+Current config after the failed recovery is canonical but the service is stopped:
+
+```text
+./aos config get status_item.toggle_url --json
+=> "aos://sigil/renderer/index.html?toolkit-root=toolkit"
+
+./aos config get content.roots.toolkit --json
+=> "/Users/Michael/Code/agent-os/packages/toolkit"
+
+./aos config get content.roots.sigil --json
+=> "/Users/Michael/Code/agent-os/apps/sigil"
+```
+
+The daemon log for the latest failed run shows canonical Sigil setup followed by
+repeated:
+
+```text
+Config: content.roots changed - restart daemon to apply
+```
+
+and then Sigil canvas removal before the launchd service exited with code `11`.
+
+## Read First
+
+- `AGENTS.md`
+- `docs/design/work-cards/operator-input-event-v2-live-proof-v0.md`
+- `docs/design/work-cards/gdi-sigil-status-item-stale-root-recovery-v0.md`
+- `scripts/aos-experience.mjs`
+- `scripts/aos-content-scope.sh`
+- `scripts/aos-config-command.mjs`
+- `scripts/aos-clean.mjs`
+- `scripts/lib/aos-live-operation.mjs`
+- `src/commands/serve.swift`
+- `src/daemon/unified.swift`
+- `src/shared/config.swift`
+- `experiences/sigil/aos-experience.json`
+- `apps/sigil/scripts/launch-common.sh`
+- `tests/guarded-live-operation.sh`
+- `tests/aos-clean-canvas-regression.sh`
+- `tests/content-wait.sh`
+- `tests/sigil-experience-wiki-seed.sh`
+
+## Rediscover State
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline origin/main..main
+./aos service status --mode repo --json
+./aos clean --dry-run --json
+./aos config get status_item.toggle_url --json || true
+./aos config get content.roots.toolkit --json || true
+./aos config get content.roots.sigil --json || true
+```
+
+Do not run `./aos ready`, `./aos status`, service start/restart, `./aos
+experience activate sigil`, repo-mode live smoke, `./aos dev build`, TCC reset,
+or permission repair during rediscovery.
+
+## Problem To Correct
+
+`scripts/aos-experience.mjs` currently resolves Sigil content roots to absolute
+paths, then `ensureContentRoots()` writes those roots through `aos config set`
+on every activation, regardless of whether the configured roots are already
+live-equivalent. In the current repo-mode service, that path is enough to emit
+`Config: content.roots changed - restart daemon to apply` and the launchd daemon
+exits with code `11` during or shortly after canonical Sigil activation.
+
+The correction should make activation idempotent:
+
+- if a configured content root already resolves to the same path as the
+  manifest root, do not rewrite it just because one value is relative and the
+  other is absolute;
+- if branch-scoped stale roots need reconciliation, remove/update only the stale
+  owned keys needed for the active experience;
+- do not require a repo service restart when no effective content-root change is
+  needed;
+- if an effective content-root change really is needed, preserve the existing
+  guarded live-operation contract and require explicit `--allow-start` before
+  restart/start behavior.
+
+## Required Behavior
+
+1. `aos experience activate sigil --dry-run --json` still reports canonical
+   Sigil/toolkit roots and status-item target.
+2. In an isolated state root where `content.roots.toolkit=packages/toolkit` and
+   `content.roots.sigil=apps/sigil`, activation treats those as equivalent to
+   absolute manifest paths and does not perform content-root writes solely to
+   normalize path spelling.
+3. In an isolated state root with stale owned branch-scoped Sigil/toolkit roots,
+   activation still reconciles stale owned keys and sets the canonical current
+   roots/status item.
+4. `aos experience activate sigil --json` without `--allow-start` still fails
+   with `LIVE_START_NOT_ALLOWED` when the operation would need to start or
+   restart a daemon.
+5. `aos clean --dry-run --json` and `aos status --json` continue to diagnose
+   active Sigil status-item drift and stale/broken avatar canvases.
+
+## Hard Boundaries
+
+- Do not run live repo service start/restart or `./aos ready`.
+- Do not run repo-mode `./aos experience activate sigil` against the user's
+  current state.
+- Use isolated daemon/state-root tests for daemon lifecycle reproduction.
+- Do not remove branch-scoped roots as a concept.
+- Do not break status-item stale-root recovery from
+  `gdi-sigil-status-item-stale-root-recovery-v0.md`.
+- Do not broaden into #431 input payload code, TCC, native input tap, radial
+  menu, voice, or general Sigil UI behavior.
+- Do not push, open PRs, mutate #431, or close issues.
+- If Swift/native changes become necessary, stop and report why before running
+  `./aos dev build`.
+
+## Verification
+
+Run focused deterministic checks:
+
+```bash
+git diff --check
+bash tests/guarded-live-operation.sh
+bash tests/aos-clean-canvas-regression.sh
+bash tests/content-wait.sh
+bash tests/sigil-experience-wiki-seed.sh
+```
+
+Add and run a focused regression for idempotent Sigil activation with equivalent
+relative/absolute content roots. Prefer an isolated state root and the existing
+isolated daemon helpers rather than the user's repo service.
+
+If you change command help or guarded-operation semantics, also run:
+
+```bash
+bash tests/help-contract.sh
+bash tests/external-parser-flags.sh
+```
+
+## Completion Report
+
+Report:
+
+- branch and head SHA;
+- files changed;
+- root cause;
+- exact idempotence behavior added;
+- whether stale branch-scoped root recovery still works;
+- exact tests run with pass/fail;
+- confirmation that no repo-mode live start/restart, `./aos ready`, repo-mode
+  `experience activate`, TCC repair, build, push, PR, or issue mutation was run;
+- any remaining runtime blocker before the #431 Operator live proof can be
+  rerun.

--- a/docs/design/work-cards/gdi-input-event-v2-native-boundary-gate-map-v0.md
+++ b/docs/design/work-cards/gdi-input-event-v2-native-boundary-gate-map-v0.md
@@ -1,0 +1,230 @@
+# Input Event V2 Native Boundary Gate Map V0
+
+## Recipient
+
+GDI validation/correction round.
+
+## Transfer Kind
+
+GDI round.
+
+## Branch / Base
+
+- branch_from: local `main` containing this work card.
+- required_start_ref: local `main` containing this work card.
+- published prerequisite base: `origin/main` at or after `7af85dd9`, with PR
+  #437 merged.
+- expected output branch: `gdi/input-event-v2-native-boundary-gate-map-v0`
+
+Work in the single local checkout at `/Users/Michael/Code/agent-os`. Do not
+create linked git worktrees.
+
+## Tracker
+
+- GitHub issue #431:
+  https://github.com/michaelblum/agent-os/issues/431
+- Published prerequisite PR #436:
+  https://github.com/michaelblum/agent-os/pull/436
+- Published prerequisite PR #437:
+  https://github.com/michaelblum/agent-os/pull/437
+- Current audit note:
+  `docs/design/input-event-v2-toolkit-cutover-v0.md`
+- Prior deterministic subscriber-audit card:
+  `docs/design/work-cards/gdi-input-event-v2-native-subscriber-audit-v0.md`
+
+## Fresh Context Contract
+
+GDI starts from a fresh context window. Do not assume branch, checkout, daemon,
+canvas, issue, or prior implementation state. Read and rediscover before
+editing.
+
+## Goal
+
+Turn the remaining #431 native/live hard-cutover gates into an exact
+deterministic gate map: name what is already satisfied by PRs #436/#437, what
+still requires native producer changes, and what still requires a supervised
+live AOS proof after Michael explicitly approves restart.
+
+## Read First
+
+- `AGENTS.md`
+- `src/AGENTS.md`
+- `src/daemon/AGENTS.md`
+- `docs/adr/0015-aos-tcc-capability-broker-boundary.md`
+- `packages/toolkit/AGENTS.md`
+- `packages/toolkit/runtime/AGENTS.md`
+- `packages/toolkit/panel/AGENTS.md`
+- `apps/sigil/AGENTS.md`
+- `docs/design/input-event-v2-toolkit-cutover-v0.md`
+- `docs/design/work-cards/gdi-input-event-v2-native-subscriber-audit-v0.md`
+- `shared/schemas/input-event-v2.schema.json`
+- `shared/schemas/input-event-v2.md`
+- `docs/api/toolkit/runtime.md`
+- GitHub issue #431.
+
+## Rediscover State
+
+Run before editing:
+
+```bash
+git status --short --branch
+git rev-parse HEAD origin/main
+./aos service status --mode repo --json
+./aos dev gh issue view 431 --json
+./aos dev gh pr list --state open --limit 20 --json
+rg -n "input_event|input_region\\.event|routed_input|routed_schema_version|input_schema_version|mouse_moved|left_mouse_down|scroll_wheel|pointer_cancel|mouse_cancel|normalizeCanvasInputMessage|normalizeMessage\\(" src/perceive src/daemon packages/toolkit/runtime packages/toolkit/panel packages/toolkit/components apps/sigil/renderer tests --glob "!**/node_modules/**"
+```
+
+Live AOS is intentionally paused. Do not run `./aos ready`, `./aos status`,
+`./aos clean`, service start/restart, live smoke, raw daemon HTTP calls, `tmux`,
+direct socket control, or lower-level runtime control. Use passive service
+classification only.
+
+## Existing Code To Inspect
+
+- `src/perceive/events.swift` - raw `input_event` payload construction and
+  `input_schema_version: 2` claim gate.
+- `src/perceive/daemon.swift` - CGEvent-to-payload path and missing-fact cases.
+- `src/daemon/unified.swift` - active input-event subscriber accounting,
+  broadcast snapshots, and `input_region.event` routed delivery.
+- `src/daemon/input-surface-ownership.swift` - routed input construction and
+  `routed_schema_version: 1` claim gate.
+- `packages/toolkit/runtime/input-events.js` - canonical normalizer and
+  remaining compatibility categories.
+- `packages/toolkit/runtime/interaction-region.js` - deterministic JS router
+  that still accepts raw event names.
+- `packages/toolkit/panel/chrome.js` - global drag subscriber and routed
+  minimized-chip input consumer.
+- `packages/toolkit/panel/stage-affordance.js` - passive routed input consumer.
+- `packages/toolkit/components/surface-inspector/index.js` - active
+  `input_event` subscriber.
+- `packages/toolkit/components/spatial-telemetry/index.js` - active
+  `input_event` subscriber.
+- `apps/sigil/renderer/live-modules/input-message.js` and
+  `apps/sigil/renderer/live-modules/main.js` - Sigil input normalization and
+  child canvas-origin fallback handling.
+- `tests/daemon-input-surface-ownership.sh` - deterministic Swift harness for
+  native raw/routed claim gates.
+- `tests/renderer/input-message.test.mjs`,
+  `tests/toolkit/runtime-input-events.test.mjs`,
+  `tests/toolkit/runtime-gesture-stream.test.mjs`,
+  `tests/toolkit/stage-affordance.test.mjs`,
+  `tests/toolkit/panel-chrome.test.mjs`,
+  `tests/toolkit/surface-inspector.test.mjs`, and
+  `tests/toolkit/spatial-telemetry-model.test.mjs`.
+
+## Validation Questions
+
+Answer these from deterministic source inspection and tests:
+
+1. Which #431 acceptance bullets are now satisfied by PRs #436/#437?
+2. Which remaining compatibility paths are native producer gates rather than
+   JS/toolkit subscriber gates?
+3. Which remaining compatibility paths are live evidence gates because the
+   daemon must be running to prove active subscriber payload shape?
+4. Which gates are blocked on child WebView/canvas-origin coordinate ownership
+   rather than raw daemon input?
+5. What is the smallest later Operator/live proof needed once Michael approves
+   restarting live AOS?
+
+## Required Behavior
+
+Update `docs/design/input-event-v2-toolkit-cutover-v0.md` with a concise
+Native/Live Gate Map section, or replace stale wording in its existing native
+audit section with equivalent concise content.
+
+The gate map must classify every remaining owned bridge into one of these
+states:
+
+- `satisfied_by_pr_436_or_437`
+- `deterministic_js_followup_possible`
+- `native_producer_followup_required`
+- `live_aos_evidence_required`
+- `child_canvas_coordinate_followup_required`
+- `external_or_non_updatable_compatibility`
+
+For each remaining unsatisfied gate, include:
+
+- exact source paths;
+- what fact is missing;
+- whether the next owner is Foreman, GDI, or Operator;
+- whether live AOS restart is required;
+- the smallest verification command or live observation that would satisfy it.
+
+If source inspection shows a current doc or test assertion is false, correct it
+with the smallest docs/test edit. Do not remove runtime compatibility or change
+product behavior in this round unless the existing code is demonstrably dead and
+the focused tests prove the removal without live evidence.
+
+## Scope
+
+Deterministic validation, gate-map documentation, and focused docs/test
+corrections only. This round may inspect native Swift code and deterministic
+Swift tests, but it must not implement native changes.
+
+## Hard Boundaries / Non-Goals
+
+- Do not restart live AOS or require live canvas/input evidence.
+- Do not run `./aos ready`, `./aos status`, `./aos clean`, service
+  start/restart, live smoke, raw daemon HTTP calls, `tmux`, or direct socket
+  control.
+- Do not edit Swift/native daemon producer files.
+- Do not run `./aos dev build`.
+- Do not push, open a PR, close #431, or mutate GitHub.
+- Do not broaden the toolkit normalizer or add new compatibility aliases.
+- Do not remove compatibility merely because the name looks old; tie removal to
+  a satisfied gate and deterministic evidence.
+- Do not route the next workstream. Recommend the next slice, but Foreman owns
+  acceptance and routing.
+
+## Stop Conditions
+
+Stop and report `blocked_native_boundary` if:
+
+- answering the gate map requires Swift/native producer edits;
+- the missing fact can only come from live AOS payload observation;
+- active subscriber cleanup cannot be proven without live AOS;
+- a compatibility path is tied to an external or non-updatable producer.
+
+If live AOS/TCC evidence becomes the next meaningful step, do not retry or
+repair permissions. Run `.docks/gdi/scripts/human-needed-tcc-reset`, stop with
+`human_needed`, and return the blocker to Foreman.
+
+## Verification
+
+Run the deterministic documentation and focused gate checks:
+
+```bash
+git diff --check
+rg -n "Native/Live Gate Map|native_producer_followup_required|live_aos_evidence_required|child_canvas_coordinate_followup_required" docs/design/input-event-v2-toolkit-cutover-v0.md
+tests/daemon-input-surface-ownership.sh
+node --test tests/renderer/input-message.test.mjs
+node --test tests/schemas/input-event-v2.test.mjs
+node --test tests/toolkit/runtime-input-events.test.mjs
+node --test tests/toolkit/runtime-gesture-stream.test.mjs
+node --test tests/toolkit/stage-affordance.test.mjs
+node --test tests/toolkit/panel-chrome.test.mjs
+node --test tests/toolkit/surface-inspector.test.mjs
+node --test tests/toolkit/spatial-telemetry-model.test.mjs
+```
+
+Also rerun and summarize the focused search:
+
+```bash
+rg -n "input_event|input_region\\.event|routed_input|routed_schema_version|input_schema_version|mouse_moved|left_mouse_down|scroll_wheel|pointer_cancel|mouse_cancel|normalizeCanvasInputMessage|normalizeMessage\\(" src/perceive src/daemon packages/toolkit/runtime packages/toolkit/panel packages/toolkit/components apps/sigil/renderer tests --glob "!**/node_modules/**"
+```
+
+## Completion Report
+
+Report:
+
+- files changed;
+- gate-map classifications and remaining unsatisfied gates;
+- any docs/test corrections made;
+- exact verification commands and pass/fail results;
+- passive AOS service status and confirmation that no live readiness/control
+  commands were run;
+- whether #431 should remain open, and the single smallest next follow-up after
+  Foreman review;
+- local-only state, including dirty files, untracked artifacts, or runtime
+  blockers.

--- a/docs/design/work-cards/gdi-input-event-v2-native-producer-canonical-emission-v0.md
+++ b/docs/design/work-cards/gdi-input-event-v2-native-producer-canonical-emission-v0.md
@@ -1,0 +1,241 @@
+# Input Event V2 Native Producer Canonical Emission V0
+
+## Recipient
+
+GDI implementation/validation round.
+
+## Transfer Kind
+
+GDI round.
+
+## Branch / Base
+
+- branch_from: local `main` containing this work card.
+- required_start_ref: local `main` containing this work card.
+- published prerequisite base: `origin/main` at or after `7af85dd9`, with PR
+  #437 merged.
+- local prerequisite commits:
+  - `db21aa9f` (`docs(work-cards): route input event v2 native gate map`)
+  - `622684e8` (`docs(input): map native live input event gates`)
+- expected output branch:
+  `gdi/input-event-v2-native-producer-canonical-emission-v0`
+
+Work in the single local checkout at `/Users/Michael/Code/agent-os`. Do not
+create linked git worktrees.
+
+## Tracker
+
+- GitHub issue #431:
+  https://github.com/michaelblum/agent-os/issues/431
+- Current gate map:
+  `docs/design/input-event-v2-toolkit-cutover-v0.md`
+- Prior gate-map work card:
+  `docs/design/work-cards/gdi-input-event-v2-native-boundary-gate-map-v0.md`
+- Native boundary ADR:
+  `docs/adr/0015-aos-tcc-capability-broker-boundary.md`
+
+## Native-Boundary Justification
+
+This slice is allowed to touch native Swift because it concerns a privileged
+input fact stream and daemon routed delivery substrate. Keep changes limited to
+input payload construction, routed payload construction, deterministic harness
+coverage, and adjacent docs/tests. Do not move product policy or presentation
+behavior into Swift.
+
+Foreman owns any native rebuild and manual TCC handoff. GDI must not run
+`./aos dev build`.
+
+## Fresh Context Contract
+
+GDI starts from a fresh context window. Do not assume branch, checkout, daemon,
+canvas, issue, or prior implementation state. Read and rediscover before
+editing.
+
+## Goal
+
+Make the deterministic native producer gates from #431 as canonical and
+machine-checkable as possible without live AOS: raw daemon `input_event`
+payloads and routed `input_region.event.routed_input` payloads should claim
+input-event-v2 / routed-v1 whenever the daemon-owned delivery has enough facts,
+and any remaining unversioned producer case must be explicitly classified with
+the smallest live or native follow-up.
+
+## Read First
+
+- `AGENTS.md`
+- `src/AGENTS.md`
+- `src/daemon/AGENTS.md`
+- `docs/adr/0015-aos-tcc-capability-broker-boundary.md`
+- `packages/toolkit/AGENTS.md`
+- `packages/toolkit/runtime/AGENTS.md`
+- `packages/toolkit/panel/AGENTS.md`
+- `apps/sigil/AGENTS.md`
+- `docs/design/input-event-v2-toolkit-cutover-v0.md`
+- `docs/design/work-cards/gdi-input-event-v2-native-boundary-gate-map-v0.md`
+- `shared/schemas/input-event-v2.schema.json`
+- `shared/schemas/input-event-v2.md`
+- `docs/api/toolkit/runtime.md`
+- GitHub issue #431.
+
+## Rediscover State
+
+Run before editing:
+
+```bash
+git status --short --branch
+git rev-parse HEAD origin/main
+./aos service status --mode repo --json
+./aos dev gh issue view 431 --json
+./aos dev gh pr list --state open --limit 20 --json
+rg -n "inputEventData|inputEventPayload|input_schema_version|routed_schema_version|inputRegionRoutedInputPayload|aosInputRegionRoutedInputPayload|routeInputRegionEvent|forwardInputEventToCanvases|input_region\\.event|routed_input" src/perceive src/daemon tests/daemon-input-surface-ownership.sh packages/toolkit/runtime/input-events.js tests/toolkit --glob "!**/node_modules/**"
+```
+
+Live AOS is intentionally paused. Do not run `./aos ready`, `./aos status`,
+`./aos clean`, service start/restart, live smoke, raw daemon HTTP calls, `tmux`,
+direct socket control, or lower-level runtime control. Use passive service
+classification only.
+
+## Existing Code To Inspect
+
+- `src/perceive/events.swift` - raw input payload builder and version claim
+  gate.
+- `src/perceive/daemon.swift` - CGEvent name/payload path for pointer, scroll,
+  and key input.
+- `src/daemon/input-surface-ownership.swift` - routed input payload builder and
+  routed-v1 claim gate.
+- `src/daemon/unified.swift` - input snapshots, input fanout, routed region
+  delivery, and top-level compatibility fields.
+- `tests/daemon-input-surface-ownership.sh` - deterministic Swift harness.
+- `packages/toolkit/runtime/input-events.js` - runtime validation contract for
+  raw v2 and routed v1.
+- `tests/toolkit/runtime-input-events.test.mjs`,
+  `tests/toolkit/stage-affordance.test.mjs`,
+  `tests/toolkit/panel-chrome.test.mjs`, and
+  `tests/renderer/input-message.test.mjs`.
+
+## Required Behavior
+
+### Raw `input_event`
+
+Classify the actual daemon producer path separately from helper-only builder
+calls:
+
+- If `src/perceive/daemon.swift` already provides enough facts for every
+  daemon-produced pointer, scroll, key, and snapshot event to claim
+  `input_schema_version: 2`, add deterministic coverage that proves that fact
+  or document the exact coverage boundary in the gate map.
+- If an actual daemon-produced raw event can still reach owned subscribers
+  without `input_schema_version: 2`, change the native builder/path so it emits
+  a canonical v2 payload, then prove it deterministically.
+- Keep helper-only incomplete scroll/cancel cases unversioned only if they are
+  not daemon-produced deliveries to owned subscribers; label that as a test
+  helper or non-delivery guard, not a standing target.
+
+### Routed `input_region.event`
+
+Make routed delivery canonical where deterministic source state allows:
+
+- `input_region.event` messages should keep `routed_input` as the canonical
+  payload for owned/captured deliveries.
+- If top-level compatibility fields remain on `input_region.event`, the gate
+  map must state that they are retained only until live subscriber proof allows
+  removal.
+- If routed pointer, scroll, key, or cancel deliveries can reach live consumers
+  without `routed_schema_version: 1` because required facts are missing, either
+  fill the missing deterministic facts at the native producer boundary or
+  return a precise native-boundary finding explaining why the fact requires live
+  state that this round cannot prove.
+
+### Docs And Tests
+
+Update `docs/design/input-event-v2-toolkit-cutover-v0.md` so the gate map
+reflects the new deterministic truth after any implementation or classification
+change. Prefer narrowing stale wording over adding a second overlapping gate
+map.
+
+Add or update deterministic tests in `tests/daemon-input-surface-ownership.sh`
+for any native producer change. If you only classify a path as already
+canonical, add the smallest guard that prevents future drift if feasible.
+
+## Scope
+
+Native input payload construction, native routed input payload construction,
+deterministic Swift harness coverage, focused toolkit contract tests, and the
+gate-map doc. JavaScript runtime compatibility removal, live AOS proof, TCC
+work, daemon rebuilds, publication, and issue closure are out of scope.
+
+## Hard Boundaries / Non-Goals
+
+- Do not restart live AOS or require live canvas/input evidence.
+- Do not run `./aos ready`, `./aos status`, `./aos clean`, service
+  start/restart, live smoke, raw daemon HTTP calls, `tmux`, or direct socket
+  control.
+- Do not run `./aos dev build`.
+- Do not edit unrelated Swift/native capability, daemon policy, UI/product
+  behavior, Sigil product behavior, or toolkit presentation code.
+- Do not broaden the toolkit normalizer or add new compatibility aliases.
+- Do not remove runtime compatibility unless deterministic native tests prove
+  the corresponding producer gate is satisfied and all focused JS tests pass.
+- Do not push, open a PR, close #431, or mutate GitHub.
+- Do not route the next workstream. Recommend the next slice, but Foreman owns
+  acceptance and routing.
+
+## Stop Conditions
+
+Stop and report `blocked_native_boundary` if:
+
+- proving canonical emission requires live AOS payload observation;
+- the missing fact is a TCC/input-tap runtime fact rather than source logic;
+- the only honest change requires a daemon rebuild before deterministic tests
+  can be meaningful;
+- the slice would need broader native architecture or product behavior changes.
+
+If live AOS/TCC evidence becomes the next meaningful step, do not retry or
+repair permissions. Run `.docks/gdi/scripts/human-needed-tcc-reset`, stop with
+`human_needed`, and return the blocker to Foreman.
+
+## Verification
+
+Run the deterministic gate:
+
+```bash
+git diff --check
+tests/daemon-input-surface-ownership.sh
+node --test tests/toolkit/runtime-input-events.test.mjs
+node --test tests/toolkit/stage-affordance.test.mjs
+node --test tests/toolkit/panel-chrome.test.mjs
+node --test tests/renderer/input-message.test.mjs
+rg -n "Native/Live Gate Map|native_producer_followup_required|live_aos_evidence_required|child_canvas_coordinate_followup_required" docs/design/input-event-v2-toolkit-cutover-v0.md
+```
+
+If you changed raw schema fixtures or runtime validator assumptions, also run:
+
+```bash
+node --test tests/schemas/input-event-v2.test.mjs
+node --test tests/toolkit/runtime-gesture-stream.test.mjs
+```
+
+Rerun and summarize this focused source search:
+
+```bash
+rg -n "inputEventData|inputEventPayload|input_schema_version|routed_schema_version|inputRegionRoutedInputPayload|aosInputRegionRoutedInputPayload|routeInputRegionEvent|forwardInputEventToCanvases|input_region\\.event|routed_input" src/perceive src/daemon tests/daemon-input-surface-ownership.sh packages/toolkit/runtime/input-events.js tests/toolkit --glob "!**/node_modules/**"
+```
+
+## Completion Report
+
+Report:
+
+- files changed;
+- raw `input_event` producer classification: already canonical, changed, or
+  still blocked, with source paths;
+- routed `input_region.event` producer classification: already canonical,
+  changed, or still blocked, with source paths;
+- any native Swift changes and why they stay inside the TCC/native boundary;
+- any docs/test corrections made;
+- exact verification commands and pass/fail results;
+- passive AOS service status and confirmation that no live readiness/control,
+  rebuild, TCC, push, PR, issue closure, or GitHub mutation was run;
+- whether #431 should remain open and the single smallest next follow-up after
+  Foreman review;
+- local-only state, including dirty files, untracked artifacts, or runtime
+  blockers.

--- a/docs/design/work-cards/operator-input-event-v2-live-proof-v0.md
+++ b/docs/design/work-cards/operator-input-event-v2-live-proof-v0.md
@@ -1,0 +1,275 @@
+# Operator Input Event V2 Live Proof V0
+
+## Recipient
+
+Operator supervised live/HITL verification round.
+
+## Transfer Kind
+
+Operator run.
+
+## Branch / Base
+
+- required_start_ref: local `main` at or after `5f6445a4`
+  (`feat(daemon): canonicalize input region source events`).
+- published review PR: #438
+  https://github.com/michaelblum/agent-os/pull/438
+- tracker issue: #431
+  https://github.com/michaelblum/agent-os/issues/431
+- work in `/Users/Michael/Code/agent-os`, not in `.docks/`.
+- use the single local checkout. Do not create linked git worktrees.
+
+## Fresh Context Contract
+
+Operator starts from a fresh context window. Do not assume daemon, canvas,
+permission, display, branch, issue, or prior verification state. Read and
+rediscover before observing.
+
+This is supervised live evidence collection only. Do not implement fixes,
+create commits, push branches, open/close issues, mutate PRs, or broaden into
+GDI work.
+
+## Goal
+
+Collect bounded live evidence for #431 after the deterministic native-producer
+slice: active `input_event` and `input_region.event` consumers should receive
+and handle canonical daemon payloads, and any remaining dependence on top-level
+`input_region.event` compatibility fields must be reported precisely.
+
+Michael approved this live proof run. Live readiness/control is allowed only for
+this bounded verification. Do not run service start/restart, permission repair,
+or `./aos dev build` unless a later Foreman card explicitly assigns it.
+
+## Read First
+
+- `AGENTS.md`
+- `.docks/operator/AGENTS.md`
+- `apps/sigil/AGENTS.md`
+- `docs/design/input-event-v2-toolkit-cutover-v0.md`
+- `docs/design/work-cards/gdi-input-event-v2-native-producer-canonical-emission-v0.md`
+- `docs/adr/0015-aos-tcc-capability-broker-boundary.md`
+- PR #438 and issue #431.
+
+## Rediscover State
+
+Run and save output under `/tmp/aos-input-event-v2-live-proof-v0/`:
+
+```bash
+mkdir -p /tmp/aos-input-event-v2-live-proof-v0
+git status --short --branch
+git rev-parse HEAD origin/main
+./aos ready --json | tee /tmp/aos-input-event-v2-live-proof-v0/ready.json
+./aos status --json | tee /tmp/aos-input-event-v2-live-proof-v0/status.json
+./aos show list --json | tee /tmp/aos-input-event-v2-live-proof-v0/show-list-before.json
+./aos experience status --json | tee /tmp/aos-input-event-v2-live-proof-v0/experience-status-before.json
+```
+
+If `./aos ready --json` reports `ready:false`,
+`diagnosis=daemon_tcc_grant_stale_or_missing`, `input_tap_not_active`, or a
+permission blocker, stop and report the blocker. Do not improvise a permission
+repair loop.
+
+If `./aos status --json` reports Sigil status-item target drift and you need the
+status-item path for the Sigil proof, run the scoped activation once:
+
+```bash
+./aos experience activate sigil
+./aos experience status --json | tee /tmp/aos-input-event-v2-live-proof-v0/experience-status-after-activate.json
+```
+
+If that command is unavailable or fails, launch Sigil directly with `show
+create` below and report status-item proof as blocked.
+
+## Setup
+
+Use canonical repo content roots:
+
+```bash
+./aos set content.roots.toolkit packages/toolkit
+./aos set content.roots.sigil apps/sigil
+./aos content wait --root toolkit --auto-start --timeout 15s
+./aos content wait --root sigil --auto-start --timeout 15s
+```
+
+Do not run `./aos show remove-all` unless you have confirmed no existing canvas
+is human-owned or needed as evidence. Prefer removing only surfaces created for
+this run during cleanup.
+
+Launch the active consumers:
+
+```bash
+packages/toolkit/components/surface-inspector/launch.sh
+./aos show wait --id surface-inspector --manifest surface-inspector --timeout 10s --json
+
+packages/toolkit/components/spatial-telemetry/launch.sh
+./aos show wait --id spatial-telemetry --manifest spatial-telemetry --timeout 10s --json
+
+apps/sigil/sigilctl-seed.sh --mode repo
+./aos show remove --id avatar-main 2>/dev/null || true
+./aos show create --id avatar-main --url 'aos://sigil/renderer/index.html?aos-surface-transport-probe=1' --track union
+./aos show wait --id avatar-main --timeout 12s --json
+```
+
+Enable and reset the Sigil transport probe before interaction:
+
+```bash
+./aos show eval --id avatar-main --js 'JSON.stringify(window.__sigilDebug?.surfaceTransportProbe?.enable?.() ?? null)' \
+  > /tmp/aos-input-event-v2-live-proof-v0/sigil-probe-enable.json
+./aos show eval --id avatar-main --js 'JSON.stringify(window.__sigilDebug?.surfaceTransportProbe?.reset?.() ?? null)' \
+  > /tmp/aos-input-event-v2-live-proof-v0/sigil-probe-reset.json
+```
+
+## Required Observations
+
+### Raw `input_event` Active Subscribers
+
+Use real pointer/scroll/key input while Surface Inspector, Spatial Telemetry,
+and Sigil are present.
+
+Required evidence:
+
+- Surface Inspector has `inputSubscriptionActive:true`, updated cursor/native
+  cursor state, and no visible error state after real pointer and scroll input.
+- Spatial Telemetry records recent `input_event` entries and updates cursor
+  state after real pointer and scroll input.
+- Sigil's transport probe records input events after real pointer interaction
+  with `avatar-main`.
+
+Capture:
+
+```bash
+./aos show eval --id surface-inspector --js 'JSON.stringify({inputSubscriptionActive: window.__canvasInspectorState?.inputSubscriptionActive ?? null, cursor: window.__canvasInspectorState?.cursor ?? null, nativeCursor: window.__canvasInspectorState?.nativeCursor ?? null, eventCount: window.__canvasInspectorState?.eventCount ?? null})' \
+  > /tmp/aos-input-event-v2-live-proof-v0/surface-inspector-input-state.json
+
+./aos show eval --id spatial-telemetry --js 'JSON.stringify({cursor: window.__spatialTelemetryState?.raw?.cursor ?? null, recentEvents: window.__spatialTelemetryState?.events?.slice(-20) ?? null})' \
+  > /tmp/aos-input-event-v2-live-proof-v0/spatial-telemetry-input-state.json
+
+./aos show eval --id avatar-main --js 'JSON.stringify(window.__sigilDebug?.surfaceTransportProbe?.snapshot?.({windowMs: 10000}) ?? null)' \
+  > /tmp/aos-input-event-v2-live-proof-v0/sigil-input-probe.json
+```
+
+Payload-field proof requirement: if any existing surface or AOS command exposes
+the full received `input_event` payload, capture enough fields to show
+`input_schema_version: 2`, `event_kind`, `sequence`, and kind-specific required
+fields for pointer, scroll, and key. If the current surfaces only expose
+summaries/counters, report that as a remaining observability gap instead of
+claiming payload-field proof.
+
+### Routed `input_region.event` Active Consumers
+
+Use Surface Inspector's panel chrome and Sigil's input regions to prove routed
+delivery is live.
+
+Required evidence:
+
+- Surface Inspector / panel chrome can minimize into a stage-backed chip, then
+  restore or close via real pointer interaction on the chip region.
+- Surface Inspector resource state shows stage layers/input regions/affordances
+  during the minimized state and cleanup after restore/close.
+- Sigil registers input regions and receives routed/input-region activity during
+  real pointer interaction, or reports a precise blocker.
+- No consumer-visible failure indicates dependence on top-level-only
+  `input_region.event` fields instead of canonical `routed_input`.
+
+Suggested capture around minimize/restore:
+
+```bash
+./aos show eval --id surface-inspector --js 'JSON.stringify(window.__canvasInspectorState?.surfaceResources ?? null)' \
+  > /tmp/aos-input-event-v2-live-proof-v0/surface-resources-before-minimize.json
+
+./aos show eval --id surface-inspector --js 'JSON.stringify(window.__aosPanelWindowController?.getState?.() ?? null)' \
+  > /tmp/aos-input-event-v2-live-proof-v0/surface-inspector-panel-before-minimize.json
+```
+
+After real pointer minimize and before restore:
+
+```bash
+./aos show list --json > /tmp/aos-input-event-v2-live-proof-v0/show-list-minimized.json
+./aos show eval --id surface-inspector --js 'JSON.stringify(window.__canvasInspectorState?.surfaceResources ?? null)' \
+  > /tmp/aos-input-event-v2-live-proof-v0/surface-resources-minimized.json
+```
+
+After real pointer restore or close:
+
+```bash
+./aos show list --json > /tmp/aos-input-event-v2-live-proof-v0/show-list-after-restore-or-close.json
+./aos show eval --id avatar-main --js 'JSON.stringify(window.__sigilDebug?.snapshot?.() ?? null)' \
+  > /tmp/aos-input-event-v2-live-proof-v0/sigil-debug-after-input-region.json
+```
+
+Payload-field proof requirement: if a surface exposes the full
+`input_region.event.routed_input`, capture enough fields to show
+`routed_schema_version: 1`, `source_event` as a raw v2 object when available,
+`delivery_role`, `region_id`, `owner_canvas_id`, capture identity for captured
+delivery, and DesktopWorld coordinates. If current surfaces only expose
+resource/counter evidence, report that payload-field visibility remains blocked
+without adding instrumentation.
+
+## Pass / Partial / Fail
+
+Pass:
+
+- repo AOS is ready with active input tap;
+- Surface Inspector, Spatial Telemetry, and Sigil launch;
+- all three active raw `input_event` consumers show live input activity;
+- Surface Inspector/panel chrome and Sigil input-region paths show routed live
+  behavior with no visible compatibility failure;
+- full payload fields are captured, or the report clearly distinguishes the
+  remaining payload-field observability gap.
+
+Partial pass:
+
+- active consumers behave correctly, but full payload fields are not observable
+  through existing surfaces/tools.
+
+Fail:
+
+- readiness blocks;
+- an active consumer fails to launch;
+- real pointer/scroll/key input does not reach an expected consumer;
+- routed input-region interaction fails;
+- a consumer visibly depends on top-level-only `input_region.event` fields.
+
+## Hard Boundaries / Non-Goals
+
+- Do not implement fixes or add temporary instrumentation.
+- Do not run `./aos dev build`.
+- Do not run permission repair, TCC reset, or repeated service restart loops.
+- Do not create commits, branches, PRs, issue comments, or issue closure.
+- Do not use raw daemon HTTP, direct socket control, `tmux`, or launchd state
+  unless an `./aos` command is missing or broken; state the bypass reason if you
+  must use one.
+- Do not broaden into general UI regression coverage.
+
+## Cleanup
+
+Remove only surfaces created for this run unless preserving them is necessary
+evidence:
+
+```bash
+./aos show remove --id spatial-telemetry 2>/dev/null || true
+./aos show remove --id surface-inspector 2>/dev/null || true
+./aos show remove --id avatar-main 2>/dev/null || true
+./aos show list --json | tee /tmp/aos-input-event-v2-live-proof-v0/show-list-final.json
+```
+
+## Completion Report
+
+Report:
+
+- exact `git status --short --branch`;
+- exact `./aos ready --json` verdict summary;
+- whether Sigil status-item drift was present and whether `./aos experience
+  activate sigil` was needed or successful;
+- surfaces launched and commands used;
+- raw `input_event` result for Surface Inspector, Spatial Telemetry, and Sigil;
+- routed `input_region.event` result for panel chrome/stage affordance and Sigil;
+- whether full payload fields were captured, with artifact paths, or the exact
+  observability gap that prevented payload-field proof;
+- pass/partial/fail classification;
+- artifact directory path;
+- cleanup result and any stale canvases, stage layers, input regions, or
+  blockers;
+- next recommended dock: Foreman for acceptance/routing, GDI only if a
+  deterministic fix is now implied, or Operator rerun only if the result was
+  blocked by live environment state.

--- a/docs/design/work-cards/operator-input-event-v2-live-proof-v0.md
+++ b/docs/design/work-cards/operator-input-event-v2-live-proof-v0.md
@@ -102,6 +102,10 @@ status-item path for the Sigil proof, run the scoped activation once:
 ./aos experience status --json | tee /tmp/aos-input-event-v2-live-proof-v0-rerun/experience-status-after-activate.json
 ```
 
+This activation path is permitted only for restart-free `status_item.*` repair.
+It must not rewrite `content.roots.*`, restart the service, or bypass the
+fail-closed live-operation guard.
+
 If that command is unavailable or fails, launch Sigil directly with `show
 create` below and report status-item proof as blocked.
 
@@ -273,8 +277,11 @@ Fail:
 - Do not run `./aos ready`; it auto-starts the daemon by design.
 - Do not run `./aos clean`, permission repair, TCC reset, or service
   start/restart loops.
-- Do not run `./aos set` or `./aos config set`; config changes can require a
-  daemon restart.
+- Do not run `./aos set` or direct `./aos config set` mutations for
+  `content.roots.*` or any restart-triggering config. The only allowed config
+  mutation is the scoped `./aos experience activate sigil` status-item repair
+  above, which must remain restart-free and fail closed without start
+  permission.
 - Do not create commits, branches, PRs, issue comments, or issue closure.
 - Do not use raw daemon HTTP, direct socket control, `tmux`, or launchd state
   unless an `./aos` command is missing or broken; state the bypass reason if you
@@ -301,6 +308,8 @@ Report:
 - exact `./aos service status --mode repo --json` summary;
 - exact `./aos status --json` runtime verdict summary;
 - confirmation that `./aos ready` was not run;
+- confirmation that no `content.roots.*` or other restart-triggering config was
+  mutated;
 - whether Sigil status-item drift was present and whether `./aos experience
   activate sigil` was needed or successful;
 - surfaces launched and commands used;

--- a/docs/design/work-cards/operator-input-event-v2-live-proof-v0.md
+++ b/docs/design/work-cards/operator-input-event-v2-live-proof-v0.md
@@ -10,8 +10,8 @@ Operator run.
 
 ## Branch / Base
 
-- required_start_ref: local `main` at or after `5f6445a4`
-  (`feat(daemon): canonicalize input region source events`).
+- required_start_ref: local `main` containing this corrected work card and
+  `5f6445a4` (`feat(daemon): canonicalize input region source events`).
 - published review PR: #438
   https://github.com/michaelblum/agent-os/pull/438
 - tracker issue: #431
@@ -37,8 +37,28 @@ and handle canonical daemon payloads, and any remaining dependence on top-level
 `input_region.event` compatibility fields must be reported precisely.
 
 Michael approved this live proof run. Live readiness/control is allowed only for
-this bounded verification. Do not run service start/restart, permission repair,
-or `./aos dev build` unless a later Foreman card explicitly assigns it.
+this bounded verification after Foreman/human clears the runtime state. Do not
+run service start/restart, permission repair, `./aos ready`, or `./aos dev
+build` unless a later Foreman card explicitly assigns it.
+
+## Blocked Run Review
+
+The first Operator run under `/tmp/aos-input-event-v2-live-proof-v0/` did not
+reach input observation. Treat it as a blocked live-environment result, not as a
+#431 payload regression.
+
+Observed blocker from that run:
+
+- initial `./aos ready --json` was ready on PID `45958`;
+- Surface Inspector and Spatial Telemetry launched;
+- canonical Sigil launch blocked before observation;
+- a follow-up `./aos ready --json` auto-started a new daemon on PID `27724`;
+- `./aos status --json` then still reported stale/unmanaged PID `45958`;
+- current Foreman passive review found repo service loaded but not running,
+  launchd last exit code `11`, and a stale lock for dead PID `27724`.
+
+For the rerun, leave `/tmp/aos-input-event-v2-live-proof-v0/` intact and save
+new evidence under `/tmp/aos-input-event-v2-live-proof-v0-rerun/`.
 
 ## Read First
 
@@ -52,29 +72,34 @@ or `./aos dev build` unless a later Foreman card explicitly assigns it.
 
 ## Rediscover State
 
-Run and save output under `/tmp/aos-input-event-v2-live-proof-v0/`:
+Run and save output under `/tmp/aos-input-event-v2-live-proof-v0-rerun/`:
 
 ```bash
-mkdir -p /tmp/aos-input-event-v2-live-proof-v0
+mkdir -p /tmp/aos-input-event-v2-live-proof-v0-rerun
 git status --short --branch
 git rev-parse HEAD origin/main
-./aos ready --json | tee /tmp/aos-input-event-v2-live-proof-v0/ready.json
-./aos status --json | tee /tmp/aos-input-event-v2-live-proof-v0/status.json
-./aos show list --json | tee /tmp/aos-input-event-v2-live-proof-v0/show-list-before.json
-./aos experience status --json | tee /tmp/aos-input-event-v2-live-proof-v0/experience-status-before.json
+./aos service status --mode repo --json | tee /tmp/aos-input-event-v2-live-proof-v0-rerun/service-status-before.json
+./aos status --json | tee /tmp/aos-input-event-v2-live-proof-v0-rerun/status.json
+./aos show list --json | tee /tmp/aos-input-event-v2-live-proof-v0-rerun/show-list-before.json
+./aos experience status --json | tee /tmp/aos-input-event-v2-live-proof-v0-rerun/experience-status-before.json
 ```
 
-If `./aos ready --json` reports `ready:false`,
-`diagnosis=daemon_tcc_grant_stale_or_missing`, `input_tap_not_active`, or a
-permission blocker, stop and report the blocker. Do not improvise a permission
-repair loop.
+If `service-status-before.json` is not `status:"ok"`, `running:true`, and
+`target_matches_expected:true`, stop and report `blocked_runtime_not_ready`.
+Do not start the service from this card.
+
+If `status.json` reports `runtime_verdict.ready:false`,
+`diagnosis=daemon_tcc_grant_stale_or_missing`, `input_tap_not_active`,
+`daemon_unmanaged`, `daemon_unreachable`, or a permission blocker, stop and
+report the blocker. Do not run `./aos ready`, `./aos clean`, service
+start/restart, or a permission repair loop.
 
 If `./aos status --json` reports Sigil status-item target drift and you need the
 status-item path for the Sigil proof, run the scoped activation once:
 
 ```bash
 ./aos experience activate sigil
-./aos experience status --json | tee /tmp/aos-input-event-v2-live-proof-v0/experience-status-after-activate.json
+./aos experience status --json | tee /tmp/aos-input-event-v2-live-proof-v0-rerun/experience-status-after-activate.json
 ```
 
 If that command is unavailable or fails, launch Sigil directly with `show
@@ -82,14 +107,23 @@ create` below and report status-item proof as blocked.
 
 ## Setup
 
-Use canonical repo content roots:
+Verify canonical repo content roots without mutating config:
 
 ```bash
-./aos set content.roots.toolkit packages/toolkit
-./aos set content.roots.sigil apps/sigil
-./aos content wait --root toolkit --auto-start --timeout 15s
-./aos content wait --root sigil --auto-start --timeout 15s
+./aos config get content.roots.toolkit --json | tee /tmp/aos-input-event-v2-live-proof-v0-rerun/content-root-toolkit.json
+./aos config get content.roots.sigil --json | tee /tmp/aos-input-event-v2-live-proof-v0-rerun/content-root-sigil.json
+./aos content wait --root toolkit --timeout 15s
+./aos content wait --root sigil --timeout 15s
 ```
+
+If either content root is not the canonical repo path (`packages/toolkit` and
+`apps/sigil`), stop and report `blocked_content_root_drift`. Do not run `./aos
+set`; setting content roots can require a daemon restart, and this rerun is not
+allowed to start or restart the daemon.
+
+Do not pass `--auto-start` to `content wait`; the current command policy rejects
+auto-start without an explicit start allowance, and this rerun is not allowed to
+start the daemon.
 
 Do not run `./aos show remove-all` unless you have confirmed no existing canvas
 is human-owned or needed as evidence. Prefer removing only surfaces created for
@@ -114,9 +148,9 @@ Enable and reset the Sigil transport probe before interaction:
 
 ```bash
 ./aos show eval --id avatar-main --js 'JSON.stringify(window.__sigilDebug?.surfaceTransportProbe?.enable?.() ?? null)' \
-  > /tmp/aos-input-event-v2-live-proof-v0/sigil-probe-enable.json
+  > /tmp/aos-input-event-v2-live-proof-v0-rerun/sigil-probe-enable.json
 ./aos show eval --id avatar-main --js 'JSON.stringify(window.__sigilDebug?.surfaceTransportProbe?.reset?.() ?? null)' \
-  > /tmp/aos-input-event-v2-live-proof-v0/sigil-probe-reset.json
+  > /tmp/aos-input-event-v2-live-proof-v0-rerun/sigil-probe-reset.json
 ```
 
 ## Required Observations
@@ -139,13 +173,13 @@ Capture:
 
 ```bash
 ./aos show eval --id surface-inspector --js 'JSON.stringify({inputSubscriptionActive: window.__canvasInspectorState?.inputSubscriptionActive ?? null, cursor: window.__canvasInspectorState?.cursor ?? null, nativeCursor: window.__canvasInspectorState?.nativeCursor ?? null, eventCount: window.__canvasInspectorState?.eventCount ?? null})' \
-  > /tmp/aos-input-event-v2-live-proof-v0/surface-inspector-input-state.json
+  > /tmp/aos-input-event-v2-live-proof-v0-rerun/surface-inspector-input-state.json
 
 ./aos show eval --id spatial-telemetry --js 'JSON.stringify({cursor: window.__spatialTelemetryState?.raw?.cursor ?? null, recentEvents: window.__spatialTelemetryState?.events?.slice(-20) ?? null})' \
-  > /tmp/aos-input-event-v2-live-proof-v0/spatial-telemetry-input-state.json
+  > /tmp/aos-input-event-v2-live-proof-v0-rerun/spatial-telemetry-input-state.json
 
 ./aos show eval --id avatar-main --js 'JSON.stringify(window.__sigilDebug?.surfaceTransportProbe?.snapshot?.({windowMs: 10000}) ?? null)' \
-  > /tmp/aos-input-event-v2-live-proof-v0/sigil-input-probe.json
+  > /tmp/aos-input-event-v2-live-proof-v0-rerun/sigil-input-probe.json
 ```
 
 Payload-field proof requirement: if any existing surface or AOS command exposes
@@ -175,26 +209,26 @@ Suggested capture around minimize/restore:
 
 ```bash
 ./aos show eval --id surface-inspector --js 'JSON.stringify(window.__canvasInspectorState?.surfaceResources ?? null)' \
-  > /tmp/aos-input-event-v2-live-proof-v0/surface-resources-before-minimize.json
+  > /tmp/aos-input-event-v2-live-proof-v0-rerun/surface-resources-before-minimize.json
 
 ./aos show eval --id surface-inspector --js 'JSON.stringify(window.__aosPanelWindowController?.getState?.() ?? null)' \
-  > /tmp/aos-input-event-v2-live-proof-v0/surface-inspector-panel-before-minimize.json
+  > /tmp/aos-input-event-v2-live-proof-v0-rerun/surface-inspector-panel-before-minimize.json
 ```
 
 After real pointer minimize and before restore:
 
 ```bash
-./aos show list --json > /tmp/aos-input-event-v2-live-proof-v0/show-list-minimized.json
+./aos show list --json > /tmp/aos-input-event-v2-live-proof-v0-rerun/show-list-minimized.json
 ./aos show eval --id surface-inspector --js 'JSON.stringify(window.__canvasInspectorState?.surfaceResources ?? null)' \
-  > /tmp/aos-input-event-v2-live-proof-v0/surface-resources-minimized.json
+  > /tmp/aos-input-event-v2-live-proof-v0-rerun/surface-resources-minimized.json
 ```
 
 After real pointer restore or close:
 
 ```bash
-./aos show list --json > /tmp/aos-input-event-v2-live-proof-v0/show-list-after-restore-or-close.json
+./aos show list --json > /tmp/aos-input-event-v2-live-proof-v0-rerun/show-list-after-restore-or-close.json
 ./aos show eval --id avatar-main --js 'JSON.stringify(window.__sigilDebug?.snapshot?.() ?? null)' \
-  > /tmp/aos-input-event-v2-live-proof-v0/sigil-debug-after-input-region.json
+  > /tmp/aos-input-event-v2-live-proof-v0-rerun/sigil-debug-after-input-region.json
 ```
 
 Payload-field proof requirement: if a surface exposes the full
@@ -209,7 +243,8 @@ without adding instrumentation.
 
 Pass:
 
-- repo AOS is ready with active input tap;
+- repo AOS is already running and `./aos status --json` reports ready with
+  active input tap;
 - Surface Inspector, Spatial Telemetry, and Sigil launch;
 - all three active raw `input_event` consumers show live input activity;
 - Surface Inspector/panel chrome and Sigil input-region paths show routed live
@@ -224,7 +259,8 @@ Partial pass:
 
 Fail:
 
-- readiness blocks;
+- passive service/status readiness blocks;
+- the daemon stops, becomes unreachable, or is reclassified unmanaged mid-run;
 - an active consumer fails to launch;
 - real pointer/scroll/key input does not reach an expected consumer;
 - routed input-region interaction fails;
@@ -234,7 +270,11 @@ Fail:
 
 - Do not implement fixes or add temporary instrumentation.
 - Do not run `./aos dev build`.
-- Do not run permission repair, TCC reset, or repeated service restart loops.
+- Do not run `./aos ready`; it auto-starts the daemon by design.
+- Do not run `./aos clean`, permission repair, TCC reset, or service
+  start/restart loops.
+- Do not run `./aos set` or `./aos config set`; config changes can require a
+  daemon restart.
 - Do not create commits, branches, PRs, issue comments, or issue closure.
 - Do not use raw daemon HTTP, direct socket control, `tmux`, or launchd state
   unless an `./aos` command is missing or broken; state the bypass reason if you
@@ -250,7 +290,7 @@ evidence:
 ./aos show remove --id spatial-telemetry 2>/dev/null || true
 ./aos show remove --id surface-inspector 2>/dev/null || true
 ./aos show remove --id avatar-main 2>/dev/null || true
-./aos show list --json | tee /tmp/aos-input-event-v2-live-proof-v0/show-list-final.json
+./aos show list --json | tee /tmp/aos-input-event-v2-live-proof-v0-rerun/show-list-final.json
 ```
 
 ## Completion Report
@@ -258,7 +298,9 @@ evidence:
 Report:
 
 - exact `git status --short --branch`;
-- exact `./aos ready --json` verdict summary;
+- exact `./aos service status --mode repo --json` summary;
+- exact `./aos status --json` runtime verdict summary;
+- confirmation that `./aos ready` was not run;
 - whether Sigil status-item drift was present and whether `./aos experience
   activate sigil` was needed or successful;
 - surfaces launched and commands used;

--- a/scripts/aos-experience.mjs
+++ b/scripts/aos-experience.mjs
@@ -142,7 +142,7 @@ function runContentStatus() {
 }
 
 function norm(value) {
-  return path.resolve(value);
+  return path.resolve(repoRoot, value);
 }
 
 function rootsLive(roots) {
@@ -312,7 +312,14 @@ function ensureContentRoots(roots, steps, allowStart) {
   if (removedRoots.length > 0) {
     steps.push({ id: 'content-root:reconcile', status: 'success', removed: removedRoots });
   }
+  const config = readRuntimeConfig();
+  const configuredRoots = config.content?.roots || {};
   for (const root of roots) {
+    const configuredPath = configuredRoots[root.key];
+    if (typeof configuredPath === 'string' && norm(configuredPath) === norm(root.path)) {
+      steps.push({ id: `content-root:${root.key}`, status: 'unchanged', path: configuredPath, canonical_path: root.path });
+      continue;
+    }
     requireSuccess(runAos(['config', 'set', `content.roots.${root.key}`, root.path]), `set content root ${root.key}`);
     steps.push({ id: `content-root:${root.key}`, status: 'success', path: root.path });
   }

--- a/src/daemon/input-surface-ownership.swift
+++ b/src/daemon/input-surface-ownership.swift
@@ -141,6 +141,9 @@ func aosInputRegionRoutedInputPayload(
     gestureID: String?
 ) -> [String: Any] {
     let eventKind = (data["event_kind"] as? String) ?? aosInputRegionEventKind(event)
+    let sourceEvent: Any = (data["input_schema_version"] as? Int) == 2
+        ? data
+        : (sourceSequence ?? event)
     var routed: [String: Any] = [
         "event_kind": eventKind,
         "type": event,
@@ -150,7 +153,7 @@ func aosInputRegionRoutedInputPayload(
         "gesture_id": gestureID ?? sourceSequence ?? "\(event):\(route.region.id)",
         "coordinate_authority": "daemon",
         "source_origin": "daemon",
-        "source_event": sourceSequence ?? event,
+        "source_event": sourceEvent,
         "region_id": route.region.id,
         "owner_canvas_id": route.region.ownerCanvasID,
     ]

--- a/tests/aos-clean-canvas-regression.sh
+++ b/tests/aos-clean-canvas-regression.sh
@@ -82,6 +82,34 @@ assert any("removed stale daemon lock mode=installed pid=999999" in action for a
 PY
 test ! -e "$STATE_ROOT/installed/daemon.lock"
 
+write_status_item_config() {
+  local enabled="$1"
+  local toggle_url="$2"
+  python3 - "$STATE_ROOT" "$enabled" "$toggle_url" <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+enabled = sys.argv[2] == "true"
+toggle_url = sys.argv[3]
+config_path = root / "repo" / "config.json"
+try:
+    config = json.loads(config_path.read_text())
+except Exception:
+    config = {}
+config["status_item"] = {
+    "enabled": enabled,
+    "toggle_id": "avatar-main",
+    "toggle_url": toggle_url,
+    "toggle_at": [200, 200, 300, 300],
+    "toggle_track": "union",
+    "icon": "sigil",
+}
+config_path.write_text(json.dumps(config, indent=2) + "\n")
+PY
+}
+
 mkdir -p "$STATE_ROOT/repo"
 cat >"$STATE_ROOT/repo/experience-state.json" <<'JSON'
 {
@@ -90,10 +118,8 @@ cat >"$STATE_ROOT/repo/experience-state.json" <<'JSON'
 }
 JSON
 
-./aos config set status_item.enabled true >/dev/null
-./aos config set status_item.toggle_id avatar-main >/dev/null
-./aos config set status_item.toggle_url 'aos://sigil_old_branch/renderer/index.html?toolkit-root=toolkit_old_branch' >/dev/null
-./aos config set status_item.toggle_track union >/dev/null
+aos_test_kill_root "$STATE_ROOT"
+write_status_item_config true 'aos://sigil_old_branch/renderer/index.html?toolkit-root=toolkit_old_branch'
 
 DRIFT_DRY_RUN="$(./aos clean --dry-run --json)"
 DRIFT_DRY_RUN="$DRIFT_DRY_RUN" python3 - <<'PY'
@@ -110,7 +136,10 @@ PY
 BRANCH_SUFFIX="$(git branch --show-current | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/_/g; s/^_+//; s/_+$//')"
 SIGIL_ROOT="sigil_${BRANCH_SUFFIX:-worktree}"
 TOOLKIT_ROOT="toolkit_${BRANCH_SUFFIX:-worktree}"
-./aos config set status_item.toggle_url "aos://$SIGIL_ROOT/renderer/index.html?toolkit-root=$TOOLKIT_ROOT" >/dev/null
+write_status_item_config false "aos://$SIGIL_ROOT/renderer/index.html?toolkit-root=$TOOLKIT_ROOT"
+./aos clean --json >/dev/null
+aos_test_start_daemon "$STATE_ROOT" repo "$ROOT_DIR" toolkit "$ROOT_DIR/packages/toolkit" sigil "$ROOT_DIR/apps/sigil" \
+  || { echo "FAIL: isolated daemon did not become ready after status drift check"; exit 1; }
 
 create_canvas() {
   local id="$1"
@@ -191,44 +220,6 @@ for canvas_id in os.environ["DIAGNOSTIC_IDS"].split():
 for canvas_id in os.environ["UNOWNED_IDS"].split():
     assert canvas_id in stale_ids, (canvas_id, payload)
 PY
-
-./aos config set status_item.toggle_url 'aos://sigil_old_branch/renderer/index.html?toolkit-root=toolkit_old_branch' >/dev/null
-./aos show remove --id avatar-main >/dev/null
-./aos show create \
-  --id avatar-main \
-  --at 80,80,240,120 \
-  --url 'http://127.0.0.1:49152/sigil_old_branch/renderer/index.html?toolkit-root=toolkit_old_branch' \
-  >/dev/null
-STALE_AVATAR_DRY_RUN="$(./aos clean --dry-run --json)"
-STALE_AVATAR_DRY_RUN="$STALE_AVATAR_DRY_RUN" python3 - <<'PY'
-import json, os
-
-payload = json.loads(os.environ["STALE_AVATAR_DRY_RUN"])
-assert payload["status"] == "dirty", payload
-notes = "\n".join(payload.get("notes", []))
-assert "Active experience sigil status item target drift" in notes, payload
-assert "missing content root" in notes, payload
-assert "Active experience sigil canvas avatar-main is loaded at" not in notes, payload
-PY
-./aos config set status_item.toggle_url "aos://$SIGIL_ROOT/renderer/index.html?toolkit-root=$TOOLKIT_ROOT" >/dev/null
-STALE_AVATAR_DRY_RUN="$(./aos clean --dry-run --json)"
-STALE_AVATAR_DRY_RUN="$STALE_AVATAR_DRY_RUN" python3 - <<'PY'
-import json, os
-
-payload = json.loads(os.environ["STALE_AVATAR_DRY_RUN"])
-assert payload["status"] == "dirty", payload
-notes = "\n".join(payload.get("notes", []))
-assert "Active experience sigil status item target drift" not in notes, payload
-assert "missing content root" not in notes, payload
-assert "Active experience sigil canvas avatar-main is loaded at" in notes, payload
-assert any(canvas.get("id") == "avatar-main" for canvas in payload.get("canvases", [])), payload
-PY
-./aos show remove --id avatar-main >/dev/null
-./aos show create \
-  --id avatar-main \
-  --at 80,80,240,120 \
-  --url "http://127.0.0.1:49152/$SIGIL_ROOT/renderer/index.html?toolkit-root=$TOOLKIT_ROOT" \
-  >/dev/null
 
 OWNED_STATUS="$(./aos status --json)"
 OWNED_STATUS="$OWNED_STATUS" OWNED_IDS="$OWNED_IDS" DIAGNOSTIC_IDS="$DIAGNOSTIC_IDS" UNOWNED_IDS="$UNOWNED_IDS" python3 - <<'PY'

--- a/tests/aos-clean-canvas-regression.sh
+++ b/tests/aos-clean-canvas-regression.sh
@@ -202,6 +202,7 @@ OWNED_IDS="avatar-main sigil-hit-avatar-main sigil-radial-menu-avatar-main sigil
 DIAGNOSTIC_IDS="sigil-render-performance sigil-interaction-trace aos-desktop-world-stage"
 UNOWNED_IDS="surface-inspector __log__ clean-unowned-canvas"
 
+write_status_item_config true "aos://$SIGIL_ROOT/renderer/index.html?toolkit-root=$TOOLKIT_ROOT"
 OWNED_DRY_RUN="$(./aos clean --dry-run --json)"
 OWNED_DRY_RUN="$OWNED_DRY_RUN" OWNED_IDS="$OWNED_IDS" DIAGNOSTIC_IDS="$DIAGNOSTIC_IDS" UNOWNED_IDS="$UNOWNED_IDS" python3 - <<'PY'
 import json, os
@@ -220,6 +221,40 @@ for canvas_id in os.environ["DIAGNOSTIC_IDS"].split():
 for canvas_id in os.environ["UNOWNED_IDS"].split():
     assert canvas_id in stale_ids, (canvas_id, payload)
 PY
+
+write_status_item_config true 'aos://sigil_old_branch/renderer/index.html?toolkit-root=toolkit_old_branch'
+./aos show update \
+  --id avatar-main \
+  --url 'http://127.0.0.1:49152/sigil_old_branch/renderer/index.html?toolkit-root=toolkit_old_branch' \
+  >/dev/null
+STALE_AVATAR_DRY_RUN="$(./aos clean --dry-run --json)"
+STALE_AVATAR_DRY_RUN="$STALE_AVATAR_DRY_RUN" python3 - <<'PY'
+import json, os
+
+payload = json.loads(os.environ["STALE_AVATAR_DRY_RUN"])
+assert payload["status"] == "dirty", payload
+notes = "\n".join(payload.get("notes", []))
+assert "Active experience sigil status item target drift" in notes, payload
+assert "missing content root" in notes, payload
+assert "Active experience sigil canvas avatar-main is loaded at" not in notes, payload
+PY
+write_status_item_config true "aos://$SIGIL_ROOT/renderer/index.html?toolkit-root=$TOOLKIT_ROOT"
+STALE_AVATAR_DRY_RUN="$(./aos clean --dry-run --json)"
+STALE_AVATAR_DRY_RUN="$STALE_AVATAR_DRY_RUN" python3 - <<'PY'
+import json, os
+
+payload = json.loads(os.environ["STALE_AVATAR_DRY_RUN"])
+assert payload["status"] == "dirty", payload
+notes = "\n".join(payload.get("notes", []))
+assert "Active experience sigil status item target drift" not in notes, payload
+assert "missing content root" not in notes, payload
+assert "Active experience sigil canvas avatar-main is loaded at" in notes, payload
+assert any(canvas.get("id") == "avatar-main" for canvas in payload.get("canvases", [])), payload
+PY
+./aos show update \
+  --id avatar-main \
+  --url "http://127.0.0.1:49152/$SIGIL_ROOT/renderer/index.html?toolkit-root=$TOOLKIT_ROOT" \
+  >/dev/null
 
 OWNED_STATUS="$(./aos status --json)"
 OWNED_STATUS="$OWNED_STATUS" OWNED_IDS="$OWNED_IDS" DIAGNOSTIC_IDS="$DIAGNOSTIC_IDS" UNOWNED_IDS="$UNOWNED_IDS" python3 - <<'PY'

--- a/tests/daemon-input-surface-ownership.sh
+++ b/tests/daemon-input-surface-ownership.sh
@@ -192,15 +192,44 @@ let rawPointer = inputEventData(type: "left_mouse_down", x: 25, y: 25, flags: fl
 assert(rawPointer["input_schema_version"] as? Int == 2, "complete pointer events may claim input v2")
 writeJSON("raw-pointer", rawPointer)
 
+for pointerType in [
+    "left_mouse_down",
+    "left_mouse_up",
+    "left_mouse_dragged",
+    "right_mouse_down",
+    "right_mouse_up",
+    "right_mouse_dragged",
+    "middle_mouse_down",
+    "middle_mouse_up",
+    "middle_mouse_dragged",
+    "other_mouse_down",
+    "other_mouse_up",
+    "other_mouse_dragged",
+    "mouse_moved",
+] {
+    let payload = inputEventData(type: pointerType, x: 25, y: 25, flags: flags)
+    assert(payload["input_schema_version"] as? Int == 2, "\(pointerType) daemon payload may claim input v2")
+    assert(payload["event_kind"] as? String == "pointer", "\(pointerType) daemon payload is pointer kind")
+}
+
+let rawSnapshot = inputEventData(type: "mouse_moved", x: 25, y: 25, flags: flags)
+assert(rawSnapshot["input_schema_version"] as? Int == 2, "input_event snapshot mouse move may claim input v2")
+writeJSON("raw-snapshot", rawSnapshot)
+
 let unsupportedScroll = inputEventData(type: "scroll_wheel", x: 25, y: 25, flags: flags)
-assert(unsupportedScroll["input_schema_version"] == nil, "scroll without dx/dy must remain legacy-shaped")
+assert(unsupportedScroll["input_schema_version"] == nil, "helper-only scroll without dx/dy must remain legacy-shaped")
 
 let rawScroll = inputEventData(type: "scroll_wheel", x: 25, y: 25, flags: flags, scrollDX: 2, scrollDY: -8)
 assert(rawScroll["input_schema_version"] as? Int == 2, "complete scroll events may claim input v2")
 writeJSON("raw-scroll", rawScroll)
 
+let rawKey = inputEventData(type: "key_down", keyCode: 36, flags: flags)
+assert(rawKey["input_schema_version"] as? Int == 2, "daemon key payload may claim input v2")
+assert(rawKey["event_kind"] as? String == "key", "daemon key payload is key kind")
+writeJSON("raw-key", rawKey)
+
 let unsupportedCancel = inputEventData(type: "pointer_cancel", flags: flags)
-assert(unsupportedCancel["input_schema_version"] == nil, "cancel without cancel_reason must remain legacy-shaped")
+assert(unsupportedCancel["input_schema_version"] == nil, "helper-only cancel without cancel_reason must remain legacy-shaped")
 
 let rawCancel = inputEventData(type: "pointer_cancel", flags: flags, cancelReason: "surface_removed")
 assert(rawCancel["input_schema_version"] as? Int == 2, "complete cancel events may claim input v2")
@@ -231,6 +260,7 @@ let routedPointer = aosInputRegionRoutedInputPayload(
     gestureID: rawPointer["gesture_id"] as? String
 )
 assert(routedPointer["routed_schema_version"] as? Int == 1, "complete routed pointer may claim routed v1")
+assert((routedPointer["source_event"] as? [String: Any])?["input_schema_version"] as? Int == 2, "routed pointer should preserve canonical raw v2 source_event")
 writeJSON("routed-pointer", routedPointer)
 
 let scrollRoute = AOSInputRegionRoute(
@@ -250,6 +280,7 @@ let routedScrollLegacy = aosInputRegionRoutedInputPayload(
     gestureID: "g-2"
 )
 assert(routedScrollLegacy["routed_schema_version"] == nil, "routed scroll without scroll data must not claim v1")
+assert(routedScrollLegacy["source_event"] as? String == "daemon:2", "helper-only unversioned routed scroll should keep string source_event")
 
 let routedScroll = aosInputRegionRoutedInputPayload(
     event: "scroll_wheel",
@@ -261,6 +292,7 @@ let routedScroll = aosInputRegionRoutedInputPayload(
     gestureID: rawScroll["gesture_id"] as? String
 )
 assert(routedScroll["routed_schema_version"] as? Int == 1, "complete routed scroll may claim routed v1")
+assert((routedScroll["source_event"] as? [String: Any])?["input_schema_version"] as? Int == 2, "routed scroll should preserve canonical raw v2 source_event")
 writeJSON("routed-scroll", routedScroll)
 
 let cancelRoute = AOSInputRegionRoute(
@@ -280,6 +312,7 @@ let routedCancelLegacy = aosInputRegionRoutedInputPayload(
     gestureID: "g-4"
 )
 assert(routedCancelLegacy["routed_schema_version"] == nil, "routed cancel without cancel_reason must not claim v1")
+assert(routedCancelLegacy["source_event"] as? String == "daemon:4", "helper-only unversioned routed cancel should keep string source_event")
 
 let routedCancel = aosInputRegionRoutedInputPayload(
     event: "pointer_cancel",
@@ -291,6 +324,7 @@ let routedCancel = aosInputRegionRoutedInputPayload(
     gestureID: rawCancel["gesture_id"] as? String
 )
 assert(routedCancel["routed_schema_version"] as? Int == 1, "complete routed cancel may claim routed v1")
+assert((routedCancel["source_event"] as? [String: Any])?["input_schema_version"] as? Int == 2, "routed cancel should preserve canonical raw v2 source_event")
 writeJSON("routed-cancel", routedCancel)
 
 print("PASS input event v2 builder and routed payload contract")

--- a/tests/schemas/aos-experience-v0.test.mjs
+++ b/tests/schemas/aos-experience-v0.test.mjs
@@ -170,3 +170,82 @@ process.exit(0);
   assert(calls.some((args) => args.join('\0') === ['config', 'set', 'status_item.toggle_track', 'none'].join('\0')), calls);
   assert(calls.some((args) => args.join('\0') === ['show', 'remove', '--id', 'avatar-main'].join('\0')), calls);
 });
+
+test('Sigil activation does not rewrite equivalent relative canonical content roots', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'aos-experience-roots-idempotent-'));
+  const binDir = path.join(tmp, 'bin');
+  const fakeAos = path.join(tmp, 'fake-aos.mjs');
+  const fakeGit = path.join(binDir, 'git');
+  const logPath = path.join(tmp, 'aos-calls.jsonl');
+  await fs.mkdir(path.join(tmp, 'repo'), { recursive: true });
+  await fs.mkdir(binDir, { recursive: true });
+  await fs.writeFile(fakeGit, `#!/usr/bin/env bash
+if [[ "$*" == "-C ${repoRoot} branch --show-current" ]]; then
+  echo main
+  exit 0
+fi
+exec /usr/bin/git "$@"
+`, { mode: 0o755 });
+  await fs.writeFile(fakeAos, `#!/usr/bin/env node
+import fs from 'node:fs';
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.FAKE_AOS_LOG, JSON.stringify(args) + '\\n');
+if (args.join('\\0') === ['content', 'status', '--json'].join('\\0')) {
+  console.log(JSON.stringify({
+    roots: {
+      toolkit: '${path.join(repoRoot, 'packages/toolkit')}',
+      sigil: '${path.join(repoRoot, 'apps/sigil')}'
+    }
+  }));
+}
+process.exit(0);
+`, { mode: 0o755 });
+  await fs.writeFile(path.join(tmp, 'repo', 'config.json'), JSON.stringify({
+    content: {
+      roots: {
+        toolkit: 'packages/toolkit',
+        sigil: 'apps/sigil',
+      },
+    },
+    status_item: {
+      enabled: true,
+      toggle_id: 'avatar-main',
+      toggle_url: 'aos://sigil/renderer/index.html?toolkit-root=toolkit',
+      toggle_at: [200, 200, 300, 300],
+      toggle_track: 'union',
+      icon: 'sigil',
+    },
+  }));
+
+  const activate = spawnSync('node', ['scripts/aos-experience.mjs', 'activate', 'sigil', '--json'], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      AOS_PATH: fakeAos,
+      AOS_STATE_ROOT: tmp,
+      AOS_RUNTIME_MODE: 'repo',
+      AOS_BYPASS_PREFLIGHT: '1',
+      FAKE_AOS_LOG: logPath,
+      PATH: `${binDir}:${process.env.PATH}`,
+    },
+    encoding: 'utf8',
+  });
+  assert.equal(activate.status, 0, `${activate.stdout}${activate.stderr}`);
+  const payload = JSON.parse(activate.stdout);
+  assert.equal(payload.status, 'success');
+  assert.equal(payload.content_roots.find((root) => root.id === 'toolkit')?.key, 'toolkit');
+  assert.equal(payload.content_roots.find((root) => root.id === 'sigil')?.key, 'sigil');
+  assert.equal(payload.steps.find((step) => step.id === 'content-root:toolkit')?.status, 'unchanged');
+  assert.equal(payload.steps.find((step) => step.id === 'content-root:sigil')?.status, 'unchanged');
+
+  const config = JSON.parse(await fs.readFile(path.join(tmp, 'repo', 'config.json'), 'utf8'));
+  assert.equal(config.content.roots.toolkit, 'packages/toolkit');
+  assert.equal(config.content.roots.sigil, 'apps/sigil');
+  const calls = (await fs.readFile(logPath, 'utf8'))
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line));
+  assert(!calls.some((args) => args.join('\0') === ['config', 'set', 'content.roots.toolkit', path.join(repoRoot, 'packages/toolkit')].join('\0')), calls);
+  assert(!calls.some((args) => args.join('\0') === ['config', 'set', 'content.roots.sigil', path.join(repoRoot, 'apps/sigil')].join('\0')), calls);
+  assert(!calls.some((args) => args.join('\0') === ['service', 'restart', '--mode', 'repo'].join('\0')), calls);
+});

--- a/tests/sigil-experience-wiki-seed.sh
+++ b/tests/sigil-experience-wiki-seed.sh
@@ -15,7 +15,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-./aos experience activate sigil --json >"$ROOT/activate.json"
+./aos experience activate sigil --json --allow-start >"$ROOT/activate.json"
 
 test -f "$ROOT/repo/wiki/sigil/agents/default.md" || {
   echo "FAIL: Sigil namespace seed missing after experience activation"


### PR DESCRIPTION
## Summary

- Adds the deterministic #431 native/live gate map and native producer routing work cards.
- Canonicalizes routed `input_region.event.routed_input.source_event` so complete routed deliveries preserve raw input-event-v2 source payloads when available.
- Extends the Swift harness to prove current daemon-produced raw pointer variants, scroll, key, and subscription snapshot move payloads claim `input_schema_version: 2`, while incomplete helper-only scroll/cancel builders remain unversioned guards.
- Routes the supervised live proof, records the blocked run classification, and gates any rerun behind a passive already-running repo service plus explicit Michael approval.
- Fixes `aos experience activate sigil` so live-equivalent Sigil/toolkit content roots are not rewritten, preserving daemon stability before the corrected live proof can be retried.
- Restores stale Sigil status-item drift coverage in the clean-canvas regression test.
- Clarifies the Operator rerun config boundary: no `content.roots.*` or restart-triggering config mutation, while scoped restart-free `status_item.*` repair through `./aos experience activate sigil` remains allowed.

## Reviewer Focus

- Check the Swift native-boundary change stays limited to daemon routed input payload construction for the privileged input fact stream.
- Check the deterministic harness coverage proves raw v2 source preservation for current complete native deliveries without blessing helper-only incomplete events.
- Check the Operator live-proof card gates are strict enough: no `./aos ready`, `./aos clean`, service start/restart, TCC repair, direct `content.roots.*` mutation, or restart-triggering config mutation inside the rerun; the only permitted mutation is scoped restart-free Sigil `status_item.*` repair through `./aos experience activate sigil`.
- Check the Sigil experience activation fix treats relative and absolute live-equivalent roots as unchanged without removing stale owned-root reconciliation.
- Check the restored clean-canvas regression still covers stale Sigil status-item drift.

## Published Head

- Branch: `gdi/input-event-v2-native-producer-canonical-emission-v0`
- Head: `a6bb152b` (`docs(work-cards): clarify live proof config boundary`)
- Base: `main`
- Issue: #431

## Verification

Foreman reran the accepted checks before publication:

- `git diff --check`
- `git diff --check b2651e99..HEAD`
- `git diff --check 1d724f33326fa1f6f4dc35453c7430d0729b6abd..HEAD`
- `git diff --check -- docs/design/work-cards/operator-input-event-v2-live-proof-v0.md`
- `tests/daemon-input-surface-ownership.sh`
- `bash tests/guarded-live-operation.sh`
- `bash tests/aos-clean-canvas-regression.sh`
- `bash tests/content-wait.sh`
- `bash tests/sigil-experience-wiki-seed.sh`
- `node --test tests/toolkit/runtime-input-events.test.mjs`
- `node --test tests/toolkit/stage-affordance.test.mjs`
- `node --test tests/toolkit/panel-chrome.test.mjs`
- `node --test tests/renderer/input-message.test.mjs`
- `node --test tests/schemas/input-event-v2.test.mjs`
- `node --test tests/toolkit/runtime-gesture-stream.test.mjs`
- `node --test tests/schemas/aos-experience-v0.test.mjs`
- `./aos experience activate sigil --dry-run --json`

`./aos dev gh pr checks 438 --json` currently reports no checks for the branch.

## Runtime Boundary

No corrected Operator live proof was rerun for this update. The accepted blocked Operator run did not reach raw `input_event` or routed `input_region.event` observation and is classified as AOS lifecycle/status-item readiness fallout, not payload regression evidence.

Current final passive state before publication: repo service installed but unloaded/not running, target path matches expected, and `./aos clean --dry-run --json` reports clean. Live AOS remains paused; #431 stays open until PR disposition and an explicitly approved corrected Operator live proof, or a new blocker classification.
