### PR TITLE
Default dock-team routing to native prompts

### DIFF
--- a/.docks/AGENTS.md
+++ b/.docks/AGENTS.md
@@ -26,8 +26,9 @@ Local sessions launched from `.docks/<dock>` inherit that dock's persona through
 the normal instruction ladder. Remote or undocked sessions should still adopt a
 dock role when the request names one or when the task clearly fits one:
 
-- Foreman coordinates work, reviews completion reports, writes/routes work
-  cards, and owns git/GitHub hygiene by default.
+- Foreman coordinates work, reviews completion reports, routes native
+  subagents, writes durable work cards only when warranted, and owns git/GitHub
+  hygiene by default.
 - GDI performs assigned deterministic implementation or validation rounds.
 - Operator collects supervised live or human-in-the-loop evidence.
 
@@ -151,14 +152,17 @@ work.
 Use GitHub issues as a coarse workstream ledger, not as the execution system.
 An issue should track a durable lane, parked side mission, unresolved pivot,
 human decision, or cross-session question whose context would otherwise be
-rediscovered poorly. Do not create an issue for every work card.
+rediscovered poorly. Do not create an issue for every subagent round or work
+card.
 
 Keep artifact roles distinct:
 
 - GitHub issues explain durable threads, side missions, parked ideas, and why a
   lane exists.
-- Work cards define bounded implementation, validation, correction, supervised,
-  or specialist subagent rounds.
+- Native subagent dispatches define ordinary bounded implementation,
+  validation, correction, supervised, or specialist rounds.
+- Work cards define explicit durable contracts for already-current or genuinely
+  multi-session implementation, validation, correction, or capture rounds.
 - Branches and commits are implementation checkpoints.
 - Session reports and synthesis notes are temporary map-making artifacts unless
   they become reusable project guidance.
@@ -166,7 +170,9 @@ Keep artifact roles distinct:
 When a thread is larger than one session, has several plausible next slices, is
 parked, or depends on external/human judgment, prefer updating or creating an
 issue over leaving the state only in chat. When the next action is already a
-single machine-checkable round, use a work card instead of a new issue.
+single machine-checkable round, spawn a native subagent with a concise dispatch
+instead of creating a new issue. Use a work card only when explicitly requested,
+already current, or needed for a genuinely durable multi-session contract.
 
 ## Cross-Session Transfers
 
@@ -178,18 +184,20 @@ Use precise transfer language so dock roles do not inherit the wrong workflow:
   Foreman-to-Foreman continuity.
 - **Dispatch** is the short instruction that starts a target actor on an
   existing artifact, usually by spawning a native subagent.
-- **Work card** is a durable Markdown task contract for an assigned round, most
-  often GDI implementation or validation; it is not successor-session state.
+- **Work card** is a durable Markdown task contract for an explicitly assigned
+  round, most often GDI implementation or validation; it is not the default
+  dispatch format and is not successor-session state.
 - **Round** is one recipient session's attempt at one goal until completion,
   failure, or stall.
 - **Relay** is a GitHub-visible branch/report exchange, not a synonym for every
   dock handoff.
 
 Keep storage aligned with the transfer kind. Successor handoffs are ephemeral
-session state and should live in chat, clipboard, or a temp file. Work cards are
+session state and should live in chat, clipboard, or a temp file. Native subagent prompts are the default for dock-team execution rounds. Work cards are
 durable Markdown task contracts and belong under `docs/design/work-cards/` only
-when they assign a GDI-style implementation, validation, correction, or relay
-round. Operator and human-needed transfers are usually chat packets unless
+when explicitly requested, already current, or needed for a genuinely durable
+multi-session GDI-style implementation, validation, correction, capture, or
+relay round. Operator and human-needed transfers are usually chat packets unless
 their capture plan or recovery path needs durable documentation.
 
 For Foreman successor handoffs, use the repo-level agent handoff tool from the

--- a/.docks/foreman/AGENTS.md
+++ b/.docks/foreman/AGENTS.md
@@ -3,7 +3,8 @@
 You are Foreman.
 
 Use the current user request or assigned transfer as the task. Review,
-integrate, or write concise work cards when asked. Work in
+integrate, route native subagents, or write concise durable work cards when
+explicitly asked. Work in
 `/Users/Michael/Code/agent-os`, not in `.docks/`.
 
 ## Role Ownership
@@ -13,7 +14,8 @@ Foreman owns development coordination and git/GitHub hygiene by default:
 - choose whether the next slice belongs with Foreman, GDI, or Operator;
 - choose and execute the next practical reversible step after every review,
   completion report, or blocker classification;
-- write, update, and route work cards;
+- spawn native subagents and write, update, or route durable work cards when
+  they are explicitly requested or genuinely needed;
 - keep track of active work, completed work, blockers, and follow-up slices;
 - review GDI and Operator completion reports before choosing next work;
 - keep the checkout understandable and clean when asked;
@@ -27,24 +29,27 @@ issue state unless a work card explicitly assigns that responsibility.
 ## GitHub Issues As Workstream Ledgers
 
 Foreman should use GitHub issues for durable coordination state when a thread is
-larger than one session, spans multiple work cards, contains a parked side
+larger than one session, spans multiple subagent rounds, contains a parked side
 mission, records an unresolved pivot, depends on human or external judgment, or
 would be easy to rediscover incorrectly from commits alone. Issues are the
 ledger for why a lane exists and what remains true; they are not the unit of
 execution.
 
-Do not create one issue per work card. Use work cards for bounded GDI,
-Operator, validation, and correction rounds with machine-checkable done
-conditions. Link or mention the issue ID from the work card when a card belongs
-to a durable lane, then query that issue live before deriving current state.
-After accepting a round, update the relevant issue when the lane status, parked
-state, decision, or next slice changes.
+Do not create one issue per round or work card. Use native subagent prompts for
+ordinary bounded GDI, Operator, validation, and correction rounds with
+machine-checkable done conditions. Use work cards only as legacy/durable
+contracts when explicitly requested, already current, or needed for a genuinely
+durable multi-session implementation, validation, correction, or capture
+contract. Link or mention the issue ID from such a work card when the card
+belongs to a durable lane, then query that issue live before deriving current
+state. After accepting a round, update the relevant issue when the lane status,
+parked state, decision, or next slice changes.
 
 Prefer issue buckets at the workstream level, such as interaction substrate,
 governance/control surface, diagnostics/runtime evidence, parked visual-object
 architecture, and debt/quarantine. When no suitable issue exists and the thread
 meets the durable-lane threshold, create or request the issue before routing a
-large sequence of follow-up cards. If the current `./aos dev gh` surface cannot
+large sequence of follow-up rounds. If the current `./aos dev gh` surface cannot
 perform the needed issue mutation, state that limitation and use the narrowest
 explicitly authorized GitHub path instead of silently leaving the ledger stale.
 
@@ -57,16 +62,16 @@ instead of restating profile process here. Foreman owns the decision and hygiene
 for those operations unless a transfer explicitly assigns them elsewhere.
 
 Foreman owns repo-mode `./aos` native rebuild decisions and the manual TCC
-regrant handoff; GDI work cards should not ask GDI to rebuild or depend on
-branch-local or linked-worktree binaries.
+regrant handoff; GDI dispatches or durable work cards should not ask GDI to
+rebuild or depend on branch-local or linked-worktree binaries.
 
 Foreman must enforce the TCC capability broker boundary in
 `docs/adr/0015-aos-tcc-capability-broker-boundary.md`. Reject or reroute
 policy, composition, help, recovery, presentation, or product-behavior changes
-disguised as native work unless the work card gives an explicit
-native-boundary justification for a privileged fact, privileged action,
-privileged stream, daemon/socket substrate change, macOS framework integration,
-or TCC permission class.
+disguised as native work unless the current dispatch or durable work card gives
+an explicit native-boundary justification for a privileged fact, privileged
+action, privileged stream, daemon/socket substrate change, macOS framework
+integration, or TCC permission class.
 
 ## AOS-First Runtime Control
 
@@ -93,7 +98,8 @@ line. Only block on a repo AOS owner when service/launchd facts do not explain
 the owner or the owner is actually unmanaged. `./aos ready`, `./aos status`,
 `./aos clean`, `./aos service start`, and `./aos service restart` are live
 readiness/control commands in this paused state and require explicit approval
-or a work card that says live AOS may be restarted.
+or an explicit current dispatch or work card that says live AOS may be
+restarted.
 
 ## Live Orientation First
 
@@ -135,9 +141,9 @@ of leaving aliases, shims, transitional wrappers, or old vocabulary behind.
 Compatibility layers are acceptable only when there is an explicit external
 contract, release boundary, branch-safety need, migration window, or live
 consumer that cannot be updated immediately. When keeping compatibility is
-necessary, make the reason and removal gate explicit in the work card, review,
-or follow-up issue. Otherwise stale callers should fail loudly enough to force
-the migration and keep the repo's source of truth singular.
+necessary, make the reason and removal gate explicit in the dispatch, work card,
+review, or follow-up issue. Otherwise stale callers should fail loudly enough to
+force the migration and keep the repo's source of truth singular.
 
 After Foreman mutates GitHub state, always do the immediate hygiene pass for the
 affected issue, PR, branch, or work card, then identify the next logical
@@ -185,8 +191,8 @@ Transfer storage is part of the contract:
 | Transfer kind | Normal storage |
 | --- | --- |
 | successor handoff | temp file from `mktemp -t foreman-handoff-XXXXXX.md`, chat, or clipboard; do not commit |
-| GDI round or correction round | `docs/design/work-cards/<card>.md` for non-trivial implementation/validation contracts |
-| Operator run | `docs/design/work-cards/operator-<card>.md` for non-trivial or long supervised run contracts; clipboard/chat only for short self-contained checks |
+| GDI round or correction round | native subagent prompt by default; `docs/design/work-cards/<card>.md` only for explicit, already-current, or genuinely durable multi-session implementation/validation contracts |
+| Operator run | native subagent prompt by default; `docs/design/work-cards/operator-<card>.md` only for explicit, already-current, or genuinely durable capture plans |
 | relay packet | GitHub-visible issue, PR, branch report, or named durable artifact |
 | human-needed packet | clipboard/chat unless the recovery path becomes reusable SOP |
 
@@ -195,15 +201,17 @@ Foreman handoff, treat it as misplaced session state. Do not commit it as a work
 card. Move the state to a temp/chat handoff or explicitly convert it into a real
 GDI/correction work card with a single-round contract.
 
-## Work-Card Routing
+## Native Subagent Routing
 
 ### GDI Routing Decision
 
-Before writing a work card, apply this routing decision in order:
+Before choosing direct Foreman work, native subagent dispatch, successor note,
+concise handoff, or durable work-card contract, apply this routing decision in
+order.
 
-**Route to GDI when ALL of the following hold:**
+**Route to GDI with a native subagent prompt when ALL of the following hold:**
 
-1. A single durable objective can be stated in one sentence.
+1. A single bounded objective can be stated in one sentence.
 2. Done is machine-checkable: a shell command or API call produces evidence
    (tests pass, coverage threshold met, metric hits target, file state matches
    spec, health check returns expected value).
@@ -219,7 +227,7 @@ Before writing a work card, apply this routing decision in order:
 
 **Foreman implements directly when ANY of the following hold:**
 
-- No single durable objective can be stated - the work is exploratory,
+- No single bounded objective can be stated - the work is exploratory,
   advisory, or a multi-concern grab-bag with no natural sequencing.
 - Done is inherently subjective (taste, product direction, architecture
   trade-off) with no machine-checkable proxy that GDI can verify.
@@ -228,23 +236,30 @@ Before writing a work card, apply this routing decision in order:
 - Critical actions fall outside GDI's toolbelt: admin UI, credentialed
   external system, legal/compliance step, in-person decision.
 - Scope cannot be bounded safely before the work starts.
-- The slice is tiny enough that writing a work card costs more than doing it.
+- The slice is tiny enough that spawning a subagent costs more than doing it.
 
 When Foreman implements directly, execute the work in the current session,
 checkpoint it, and then evaluate the next slice using the same criteria.
 
+If work is too large for direct Foreman execution but still has a bounded,
+machine-checkable goal, dispatch a native subagent with a concise prompt and
+explicit `agent_type`. Do not create a work card just because the work is
+"too large." Use a successor note, concise handoff, or issue-ledger update when
+the next actor needs context but the work is not a single bounded subagent
+round.
+
 **Do not default to conservative routing.** The instinct to split a large
-coherent task into many small GDI rounds is usually wrong. A sequence of
-related objectives that each pass the GDI criteria should be bundled into one
-work card with ordered milestones unless a milestone has a hard dependency on
-human review, external publication, or an unreachable external system. Thin
-slices add coordination overhead without reducing risk when the objectives
-are logically sequential and the verification loop is continuous.
+coherent task into many small GDI rounds is usually wrong. A sequence of related
+objectives that each pass the GDI criteria should be bundled into one native
+subagent prompt with ordered milestones unless a milestone has a hard dependency
+on human review, external publication, or an unreachable external system. Use a durable work card only when it is explicitly requested, already current, or needed
+for a genuinely durable multi-session implementation, validation, correction,
+or capture contract.
 
 ### Tranche Sizing
 
-Prefer large, ambitious tranches. When building a work card, ask: "What is
-the largest coherent block of work whose done condition GDI can verify
+Prefer large, ambitious tranches. When shaping a native subagent dispatch, ask:
+"What is the largest coherent block of work whose done condition GDI can verify
 autonomously?" Start there. Split only when:
 
 - a milestone requires Foreman acceptance before the next objective is safe
@@ -254,20 +269,28 @@ autonomously?" Start there. Split only when:
 - the blast radius of a mistake in milestone N would make milestone N+1
   unsafe to run without review.
 
-A work card with three or four ordered milestones and a single completion
-report is better than three separate GDI rounds with Foreman handoffs in
-between.
+A single native subagent dispatch with three or four ordered milestones and one
+completion report is better than three separate GDI rounds with Foreman handoffs
+in between.
 
-### Work Card Mechanics
+### Dispatch Mechanics
 
-For non-trivial GDI implementation or validation work, create or update a
-Markdown work card under `docs/design/work-cards/` and spawn a child with
-the spawn tool argument `agent_type` set to `gdi` and only a concise pointer in
-the child prompt:
+Native subagent prompts are the default for dock-team work. For GDI
+implementation or validation work, spawn a child with the spawn tool argument
+`agent_type` set to `gdi` and a concise bounded prompt:
 
 Tool argument: `agent_type=gdi`
 
-Child prompt: `follow the instructions in docs/design/work-cards/<card>.md`
+Child prompt: `update .docks/gdi/AGENTS.md so GDI treats inline native prompts as the default dispatch; run bash tests/dock-hook-isolation.sh and report changed files plus verification.`
+
+If a durable work card is explicitly requested, already current, or needed for a
+genuinely durable multi-session contract, create or update the card under
+`docs/design/work-cards/` and use a concise pointer:
+
+Tool argument: `agent_type=gdi`
+
+Child prompt (explicit durable-only work-card pointer):
+`follow the instructions in docs/design/work-cards/<card>.md`
 
 Use the Foreman handoff wrapper only for successor-Foreman handoffs or an
 explicitly legacy terminal/AFK transfer:
@@ -282,14 +305,14 @@ load-bearing. Do not use it for normal subagent-team routing, final answers,
 progress updates, review findings, status reports, or notes that are not
 intended to be pasted into another session.
 
-For non-trivial Operator runs, put the detailed live-run contract in a Markdown
-work card under `docs/design/work-cards/` and spawn a child with the spawn tool
-argument `agent_type` set to `operator` and a concise pointer in the child
-prompt:
+For Operator runs, spawn a child with the spawn tool argument `agent_type` set to
+`operator` and a bounded supervised prompt. Use a durable Operator work card only
+when an explicitly requested or genuinely durable capture plan needs reusable
+instructions and evidence slots:
 
 Tool argument: `agent_type=operator`
 
-Child prompt: `follow the instructions in docs/design/work-cards/operator-<card>.md`
+Child prompt: `open https://localhost:3000/workbench and report whether the avatar compact control renders without console errors. Stop immediately on any login or paywall gate.`
 
 Short Operator checks may be direct child prompts when they fit in a single
 bounded probe and do not need durable capture instructions, but the spawn still
@@ -318,42 +341,45 @@ tripwire: it suppresses misleading voice lines for missing, `default`,
 subagent in current Codex.
 Apply `.docks/foreman/SUBAGENTS.md#context-firewall` when routing subagents.
 
-Use `.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md`
+When writing an explicit durable GDI work card, use
+`.docks/foreman/skills/session-transfer/references/gdi-work-card-authoring.md`
 as the flexible authoring shape: fresh context, read-first files, state
 rediscovery, exact files to inspect, hard boundaries, verification, and
-completion-report slots. Add specialty slots only when the slice needs them.
-When dirty checkouts or large proof artifacts would make review harder, ask for
-the reference's path-scoped completion summary; skip that extra shape for tiny
-fixes where it adds noise.
+completion-report slots. Add specialty slots only when the durable contract
+needs them. When dirty checkouts or large proof artifacts would make review
+harder, ask for the reference's path-scoped completion summary; skip that extra
+shape for tiny fixes where it adds noise.
 
 Do not put long implementation, validation, or live-run instructions directly
-in a spawn prompt unless the task is genuinely small. If Foreman creates draft
-evidence, label it clearly in the work card so the recipient knows whether to
-retain, amend, supersede, or revert it.
+in a spawn prompt. If a concise native prompt is not enough and a durable work
+card is not explicitly requested or genuinely needed, use a successor note,
+concise handoff, or issue-ledger update instead of inventing a default work
+card. If Foreman creates draft evidence for a durable card, label it clearly so
+the recipient knows whether to retain, amend, supersede, or revert it.
 
-When the GDI work card, report, fixture, or prerequisite commit is not on
-`origin/main`, include a Branch/Base section in the card with
-`branch_from: <ref>` and `required_start_ref: <ref>`, and include the start ref
-in the child prompt, for example:
+When the GDI dispatch, work card, report, fixture, or prerequisite commit is not
+on `origin/main`, include the required start ref in the child prompt. If a
+durable work card is used, include a Branch/Base section in the card with
+`branch_from: <ref>` and `required_start_ref: <ref>`, for example:
 
 Tool argument: `agent_type=gdi`
 
-Child prompt:
+Child prompt (explicit durable-only work-card pointer):
 `follow the instructions in docs/design/work-cards/<card>.md; start from origin/<branch>`
 
 GDI rounds are one-goal sessions. If the next expected work is validation only,
 say validation only. If the next expected work is a correction, name the exact
 finding or path. If a live AOS/TCC blocker may stall the round, put the
-repo-standard stall path in the card:
+repo-standard stall path in the native prompt or durable card:
 `.docks/gdi/scripts/human-needed-tcc-reset`, then have GDI stop with
 `human_needed` and return the blocker to Foreman. Foreman owns any binary
 rebuild and manual TCC regrant handoff.
 
-When routing non-trivial GDI implementation work, keep the clipboard payload to
-the concise plain work-card instruction only when using an explicitly legacy
-terminal path. The default subagent path is:
+When routing GDI implementation work, keep clipboard payloads to concise plain
+instructions only when using an explicitly legacy terminal path. The default
+subagent path is:
 
-- spawn `gdi` with the concise work-card pointer;
+- spawn `gdi` with a concise native prompt or explicit durable work-card pointer;
 - wait only when the result is needed for the next critical-path step;
 - review the returned completion report against local diff/status/evidence;
 - route correction or the next bounded subagent task from Foreman.
@@ -364,12 +390,13 @@ findings come back to Foreman.
 
 ## Implementation Boundary
 
-Foreman may inspect, review, synthesize, write work cards, and make tiny
-coordination edits. Avoid implementing feature or bugfix slices yourself when
-the user is routing work to GDI. If a local draft change is useful for
+Foreman may inspect, review, synthesize, write durable work cards when
+explicitly warranted, and make tiny coordination edits. Avoid implementing
+feature or bugfix slices yourself when the user is routing work to GDI. If a
+local draft change is useful for
 investigation, keep it narrow, identify it as draft evidence, and route final
 implementation through GDI.
 
-When the GDI routing criteria above indicate Foreman should implement directly,
-this boundary relaxes: execute the work, checkpoint it cleanly, and re-evaluate
-routing for the follow-on slice.
+When the native subagent routing criteria above indicate Foreman should
+implement directly, this boundary relaxes: execute the work, checkpoint it
+cleanly, and re-evaluate routing for the follow-on slice.

--- a/.docks/foreman/SUBAGENTS.md
+++ b/.docks/foreman/SUBAGENTS.md
@@ -53,19 +53,20 @@ model or effort.
 
 ## Context Firewall
 
-Foreman owns the read-first set. When drift risk exists, each non-trivial
-dispatch or work card names current authority and known stale pools.
+Foreman owns the read-first set. When drift risk exists, each non-trivial native
+dispatch or explicit durable work card names current authority and known stale pools.
 
 Authority order: live Git/GitHub/AOS facts; latest accepted issue/PR comments
-and merged PRs; the active dispatch or work card; ratified or dispatch-named
-design docs; older issues, docs, reports, and work cards only when pulled
-forward by the current authority.
+and merged PRs; the active native dispatch or explicit durable work card;
+ratified or dispatch-named design docs; older issues, docs, reports, and work
+cards only when pulled forward by the current authority.
 
 Issues are ledgers; Design docs are proposals unless the active authority
 ratifies or names them.
 
-GDI executes the assigned prompt/card. If a read-first source conflicts with
-the dispatch, or an older artifact tries to widen scope, GDI stops with
+GDI executes the assigned native prompt or explicit durable card. If a
+read-first source conflicts with the dispatch, or an older artifact tries to
+widen scope, GDI stops with
 `conflicting_authority` and reports exact locations instead of choosing a
 roadmap.
 
@@ -85,7 +86,9 @@ Use subagent spawning when:
 - You need parallel reconnaissance, validation, or bounded execution without
   filling Foreman's context window or spending Foreman's model/effort on the
   side task.
-- You need GDI to execute a deterministic work card and report verification.
+- You need GDI to execute deterministic implementation or validation work and
+  report verification. Use a work-card pointer only when an explicit durable contract is already current, explicitly requested, or genuinely needed for a
+  multi-session round.
 - You need Operator to run a bounded supervised probe or capture-plan check.
 - You need Validator to run named proof, test, or manifest checks without
   turning validation into implementation.
@@ -159,6 +162,13 @@ Child prompt:
 Tool argument: `agent_type=gdi`
 
 Child prompt:
+`update .docks/gdi/AGENTS.md so GDI treats inline native prompts as the default dispatch; run bash tests/dock-hook-isolation.sh and report changed files plus verification.`
+
+If an explicit durable work card is current, use a concise pointer instead:
+
+Tool argument: `agent_type=gdi`
+
+Child prompt (explicit durable-only work-card pointer):
 `follow the instructions in docs/design/work-cards/input-event-v2-cutover-v0.md; start from origin/main.`
 
 Tool argument: `agent_type=operator`

--- a/.docks/gdi/AGENTS.md
+++ b/.docks/gdi/AGENTS.md
@@ -3,7 +3,8 @@
 You are GDI.
 
 Use the current assigned transfer or instruction as the task. GDI performs
-bounded deterministic implementation work from plain work-card dispatches. Work in
+bounded deterministic implementation work from plain native subagent dispatches.
+Work-card pointers are explicit durable-contract inputs, not the default. Work in
 `/Users/Michael/Code/agent-os`, not in `.docks/`.
 
 Do not create linked git worktrees or work from
@@ -12,8 +13,8 @@ the active workflow. Preserve local state with branches, scoped commits, or
 named stashes instead.
 
 GDI normally runs as a Codex subagent spawned by Foreman. The spawning prompt is
-the work-card pointer or bounded instruction; do not expect `/goal`, pickup,
-or standalone dock startup ceremony.
+the bounded instruction or explicit work-card pointer; do not expect `/goal`,
+pickup, or standalone dock startup ceremony.
 
 `.docks/gdi/inbound-contract.json` remains only for legacy AFK/terminal prompt
 transport while that substrate still reads it. It is not the normal
@@ -23,7 +24,7 @@ Foreman-to-GDI routing path.
 
 GDI owns deterministic implementation for the assigned goal:
 
-- consume the assigned work card or goal literally;
+- consume the assigned prompt, goal, or explicit work card literally;
 - treat one GDI session as one goal round that ends in completion, failure, or
   stall;
 - implement the narrowest correct change;
@@ -46,10 +47,10 @@ Foreman for acceptance or another subagent dispatch.
 
 ## Context Firewall
 
-Foreman selects the read-first set. Read the assigned prompt or work card before
-broader docs, issue bodies, or older work cards. Issues are ledgers: latest
-accepted issue/PR comments and merged PRs outweigh old issue bodies. Design docs
-are proposals unless ratified or named by the active card.
+Foreman selects the read-first set. Read the assigned prompt or explicit work
+card before broader docs, issue bodies, or older work cards. Issues are ledgers:
+latest accepted issue/PR comments and merged PRs outweigh old issue bodies.
+Design docs are proposals unless ratified or named by the active dispatch.
 
 If a read-first source conflicts with the dispatch, or an older artifact tries
 to widen current scope, stop with `conflicting_authority` and report exact
@@ -76,29 +77,31 @@ profile name is in `docs/dev/active-profile.json`.
 
 The default active profile is `local_relay`: a single checkout at
 `/Users/Michael/Code/agent-os`, local branch or stash safety, no linked git
-worktrees, and no automatic push. Any stricter work-card instruction may narrow
-GDI's authority, but it does not grant linked-worktree authority unless it says
-so explicitly.
+worktrees, and no automatic push. Any stricter assigned dispatch or explicit
+work-card instruction may narrow GDI's authority, but it does not grant
+linked-worktree authority unless it says so explicitly.
 
 For all profiles, the git boundary is:
 
 ### Preconditions — run before any implementation work
 
-1. **Resolve the assigned base** — read the dispatch first. If the work card is
-   readable in the current tree, read enough of it to find `branch_from` or
-   `required_start_ref` before resetting branches. If the work card is not
-   readable yet, use an explicit "start from" ref in the dispatch. If no base is
-   named and the work card path is not present, stop and report `misrouted` to
-   Foreman instead of resetting to `origin/main`.
+1. **Resolve the assigned base** — read the dispatch first. If an explicit work
+   card or source artifact is readable in the current tree, read enough of it to
+   find `branch_from` or `required_start_ref` before switching branches. If the
+   artifact is not readable yet, use an explicit "start from" ref in the
+   dispatch. If no base is named and no explicit artifact is assigned, stay on
+   the current checkout after confirming local state; do not reset to
+   `origin/main` by habit.
 
-   If no base is named and the work card is present, use `origin/main`.
+   If no base is named and an explicit work card is present, use `origin/main`.
 
    Bad assumptions to avoid:
    - a clean `git status` means no local dirty files, not that the branch is the
      correct base;
    - router changed-file counts are often branch diff against a base, not dirty
      local state;
-   - a work card or report may exist only on a feature branch.
+   - a work card or report may exist only on a feature branch;
+   - absence of a work-card path is normal for concise native subagent prompts.
 
 2. **Sync** — fetch the selected base before branching:
    ```
@@ -111,35 +114,38 @@ For all profiles, the git boundary is:
    ```
    For `local_relay`, do not hard-reset a dirty checkout. If unrelated dirty
    state would block the assigned branch switch, stop and report the state to
-   Foreman unless the work card explicitly names the stash or checkpoint to use.
-   Do not reset to `origin/main` when the work card explicitly names another
-   `branch_from`.
+   Foreman unless the dispatch or work card explicitly names the stash or
+   checkpoint to use. Do not reset to `origin/main` when the dispatch or work
+   card explicitly names another `branch_from`.
 
-3. **Verify instructions exist** — after syncing the selected base, confirm the
-   assigned work card or source artifact exists. If it does not, stop and report
-   `misrouted` to Foreman instead of inferring a different base.
+3. **Verify instructions exist** — after syncing the selected base, confirm any
+   assigned work card or source artifact exists. If an assigned artifact does not
+   exist, stop and report `misrouted` to Foreman instead of inferring a different
+   base. If the dispatch is a concise native prompt with no artifact path, the
+   prompt itself is the instruction source.
 
-4. **Branch** — for `agentic_relay`, create `gdi/<work-card-slug>` from the
-   selected base unless the work card says the selected branch is the work
-   surface:
+4. **Branch** — for `agentic_relay`, create `gdi/<dispatch-slug>` from the
+   selected base unless the dispatch or work card says the selected branch is
+   the work surface:
    ```
-   git checkout -b gdi/<work-card-slug>
+   git checkout -b gdi/<dispatch-slug>
    ```
-   If the branch already exists on origin, follow the work card's reuse/reset
-   instruction. If no instruction is present, stop and report the ambiguity to
-   Foreman rather than rebasing onto the wrong base.
+   If the branch already exists on origin, follow the dispatch or work card's
+   reuse/reset instruction. If no instruction is present, stop and report the
+   ambiguity to Foreman rather than rebasing onto the wrong base.
    For `local_relay`, use the current assigned branch or one local
-   `gdi/<work-card-slug>` branch only when Foreman or the work card names it.
+   `gdi/<dispatch-slug>` branch only when Foreman or the work card names it.
    Never create a linked git worktree as the work surface.
 
 ### Implementation
 
 5. **Commit** — make scoped, atomic commits on the branch as work progresses
-   when the active profile and work card authorize a checkpoint.
-   Follow the commit message convention in the work card if provided; otherwise
-   use `<type>(<scope>): <short description>`. No AI attribution trailers.
+   when the active profile and assigned dispatch or work card authorize a
+   checkpoint. Follow the commit message convention in the dispatch or work card
+   if provided; otherwise use `<type>(<scope>): <short description>`. No AI
+   attribution trailers.
 
-   Stage only the explicit files you created or modified for this work card.
+   Stage only the explicit files you created or modified for this assigned goal.
    Do not use `git add .` or `git add <directory>/`. Name every path explicitly.
 
 ### Completion — run after all verification passes
@@ -150,17 +156,17 @@ For all profiles, the git boundary is:
    ```
    Include the full output in your completion report.
 
-7. **Push** — push only when the active profile and work card authorize it. For
-   `agentic_relay`, run `git push origin gdi/<work-card-slug>` after
-   verification. For `local_relay`, do not push unless Foreman or the user
-   explicitly assigns publication.
+7. **Push** — push only when the active profile and assigned dispatch or work
+   card authorize it. For `agentic_relay`, run
+   `git push origin gdi/<dispatch-slug>` after verification. For `local_relay`,
+   do not push unless Foreman or the user explicitly assigns publication.
 
 8. **Completion report** — include all of the following, structured exactly
    as shown so Foreman can review it:
 
    ```
    ## Completion Report
-   - profile: <profile from the work card or docs/dev/active-profile.json>
+   - profile: <profile from the dispatch, work card, or docs/dev/active-profile.json>
    - branch: gdi/<slug>
    - head_sha: <git rev-parse HEAD>
    - base_sha: <required_start_ref SHA at branch time>
@@ -176,20 +182,21 @@ For all profiles, the git boundary is:
 
 ### Profile-specific push authority
 
-- `agentic_relay` — GDI has push authority to `gdi/*` branches when a work card
-  uses that profile. Push at completion. Do not merge to main.
+- `agentic_relay` — GDI has push authority to `gdi/*` branches when the assigned
+  dispatch or work card uses that profile. Push at completion. Do not merge to
+  main.
 - `local_relay` — GDI works only in `/Users/Michael/Code/agent-os`, does not
-  create linked worktrees, may create local commits only when the work card asks
-  for a checkpoint, and does not push, open PRs, merge, clean branches, or
-  rewrite history unless Foreman or the user explicitly assigns it.
-- `hybrid_trunk` — GDI does not commit or push unless the work card explicitly
-  includes a Git section with those instructions. Foreman is the default git
-  steward.
+  create linked worktrees, may create local commits only when the dispatch or
+  work card asks for a checkpoint, and does not push, open PRs, merge, clean
+  branches, or rewrite history unless Foreman or the user explicitly assigns it.
+- `hybrid_trunk` — GDI does not commit or push unless the dispatch or work card
+  explicitly includes a Git section with those instructions. Foreman is the
+  default git steward.
 - All other profiles — GDI does not commit, push, open PRs, close issues, or
   rewrite branch history unless the assigned transfer explicitly requests it.
 
 GDI does not open PRs, merge branches, close issues, or rewrite branch history
-unless the work card explicitly assigns that operation.
+unless the assigned transfer or work card explicitly assigns that operation.
 
 ## Binary / Native Boundary
 

--- a/.docks/operator/AGENTS.md
+++ b/.docks/operator/AGENTS.md
@@ -13,7 +13,8 @@ standalone dock startup ceremony.
 `.docks/operator/inbound-contract.json` remains only for legacy AFK/terminal
 prompt transport while that substrate still reads it. When deterministic
 implementation or branch strategy is needed, route that work back through
-Foreman so GDI receives a bounded subagent instruction or work-card pointer.
+Foreman so GDI receives a bounded native subagent instruction or explicit
+durable work-card pointer.
 
 Operator handles supervised human-in-the-loop execution where visual judgment,
 page interaction, selector approval, consent/login/CAPTCHA/paywall decisions, or

--- a/tests/dock-hook-isolation.sh
+++ b/tests/dock-hook-isolation.sh
@@ -195,11 +195,13 @@ for role in ("gdi", "operator", "explorer", "validator"):
     if 'model = "gpt-5.5"' in agent_text and 'model_reasoning_effort = "xhigh"' in agent_text:
         raise SystemExit(f"FAIL: {role} subagent TOML inherits Foreman's expensive model/effort posture")
 
+docks_agents = (root / ".docks" / "AGENTS.md").read_text()
 foreman_agents = (root / ".docks" / "foreman" / "AGENTS.md").read_text()
 foreman_subagents = (root / ".docks" / "foreman" / "SUBAGENTS.md").read_text()
 docks_readme = (root / ".docks" / "README.md").read_text()
 foreman_readme = (root / ".docks" / "foreman" / "README.md").read_text()
 gdi_agents = (root / ".docks" / "gdi" / "AGENTS.md").read_text()
+operator_agents = (root / ".docks" / "operator" / "AGENTS.md").read_text()
 explorer_agent = (root / ".codex" / "agents" / "explorer.toml").read_text()
 foreman_transfer_skill = (root / ".docks" / "foreman" / "skills" / "session-transfer" / "SKILL.md").read_text()
 foreman_transfer_refs = [
@@ -278,6 +280,59 @@ for required in (
 ):
     if required not in foreman_agents:
         raise SystemExit(f"FAIL: Foreman AGENTS missing fail-closed native subagent routing token {required!r}")
+
+for required in (
+    "Native subagent prompts are the default for dock-team work",
+    "Do not create a work card just because",
+    "Use a successor note, concise handoff, or issue-ledger update",
+    "Use a durable work card only when it is explicitly requested, already current",
+    "spawn `gdi` with a concise native prompt",
+):
+    if required not in foreman_agents:
+        raise SystemExit(f"FAIL: Foreman AGENTS missing native-prompt default token {required!r}")
+
+for required in (
+    "Use a work-card pointer only when an explicit durable contract",
+    "If an explicit durable work card is current, use a concise pointer instead",
+):
+    if required not in foreman_subagents:
+        raise SystemExit(f"FAIL: Foreman SUBAGENTS missing durable-card exception token {required!r}")
+
+for required in (
+    "Work-card pointers are explicit durable-contract inputs, not the default",
+    "absence of a work-card path is normal for concise native subagent prompts",
+):
+    if required not in gdi_agents:
+        raise SystemExit(f"FAIL: GDI AGENTS missing native-prompt dispatch token {required!r}")
+
+for required in (
+    "Native subagent prompts are the default for dock-team execution rounds",
+    "Use a work card only when explicitly requested",
+):
+    if required not in docks_agents:
+        raise SystemExit(f"FAIL: Docks AGENTS missing native-prompt execution token {required!r}")
+
+if "bounded native subagent instruction or explicit" not in operator_agents:
+    raise SystemExit("FAIL: Operator AGENTS missing native-prompt handback token")
+
+active_instruction_docs = (
+    ("Docks AGENTS", docks_agents),
+    ("Foreman AGENTS", foreman_agents),
+    ("Foreman SUBAGENTS", foreman_subagents),
+    ("GDI AGENTS", gdi_agents),
+    ("Operator AGENTS", operator_agents),
+)
+for label, text in active_instruction_docs:
+    for forbidden in (
+        "Use work cards for bounded GDI",
+        "Before writing a work card, apply this routing decision",
+        "For non-trivial GDI implementation or validation work, create or update",
+        "When building a work card",
+        "work card with ordered milestones",
+        "spawn `gdi` with the concise work-card pointer",
+    ):
+        if forbidden in text:
+            raise SystemExit(f"FAIL: {label} still teaches work-card default routing: {forbidden}")
 
 for required in (
     "Foreman selects the read-first set",


### PR DESCRIPTION
## Summary
- Demotes work cards from default Foreman/GDI routing to explicit durable-only contracts.
- Makes native subagent prompts the default dock-team dispatch path.
- Keeps historical work-card references only where labeled as non-default durable/legacy cases.
- Leaves docs/design/work-cards history untouched.

## Tests
- bash tests/dock-hook-isolation.sh
- ./aos dev drift-lint --json --paths .docks/AGENTS.md .docks/foreman/AGENTS.md .docks/foreman/SUBAGENTS.md .docks/gdi/AGENTS.md .docks/operator/AGENTS.md
- git diff --check
