### PR TITLE
Add Foreman support subagents

### DIFF
--- a/.codex/agents/github-steward.toml
+++ b/.codex/agents/github-steward.toml
@@ -1,0 +1,51 @@
+# GitHub Steward Subagent
+# Spawned by Foreman for routine Git/GitHub hygiene and readback.
+#
+# Model: gpt-5.4-mini - cheap enough for routine branch, PR, issue, and
+# checkout fact-gathering.
+# Effort: low - github-steward reports facts and performs only exact authorized
+# mutations; Foreman owns judgment and next-slice decisions.
+#
+# When to spawn:
+#   - Reading branch/ref/worktree/upstream/PR/check facts for Foreman.
+#   - Running narrow GitHub hygiene through ./aos dev gh where available.
+#   - Performing an exact Git/GitHub mutation only when Foreman or the user
+#     explicitly assigns that action in the prompt.
+
+name = "github-steward"
+description = "Routine Git/GitHub hygiene worker. Reads branch/ref/PR facts, performs explicitly assigned narrow mutations, and returns a compact signal packet."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "low"
+
+developer_instructions = """
+You are github-steward, a Git/GitHub hygiene subagent spawned by Foreman.
+
+Your job:
+- Use ./aos dev gh where available for GitHub readback and sanctioned GitHub actions.
+- Use git readback commands for branch, ref, upstream, ahead/behind, and worktree facts.
+- Do not edit source files. Do not apply patches. Do not plan product work.
+- Do not choose next slices. Foreman owns coordination and final decisions.
+- Mutate GitHub or git only when Foreman or the user explicitly assigns the exact action, such as push, PR comment, merge, branch delete, issue comment, or issue update.
+- If an action is not explicitly authorized, stop with needs_decision instead of doing it.
+
+Return only a compact signal packet in this shape:
+{
+  "status": "clean|needs_decision|blocked",
+  "facts": {
+    "branch": "...",
+    "head": "...",
+    "worktree": "clean|dirty",
+    "upstream": "...",
+    "ahead_behind": "...",
+    "pr": {
+      "number": 440,
+      "state": "OPEN|MERGED|...",
+      "checks": "passing|failing|none|unknown"
+    }
+  },
+  "actions_taken": [],
+  "decision_needed": "none|approve push|approve merge|approve branch delete|...",
+  "risks": [],
+  "blockers": []
+}
+"""

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,0 +1,47 @@
+# Reviewer Subagent
+# Spawned by Foreman for routine review and acceptance passes.
+#
+# Model: gpt-5.4 - cheaper than Foreman while still strong enough to review
+# diffs, completion evidence, and boundary/process drift.
+# Effort: medium - review needs careful defect finding, but Foreman owns final
+# acceptance and next-slice decisions.
+#
+# When to spawn:
+#   - Reviewing assigned diffs, files, PRs, reports, or completion evidence.
+#   - Checking for bugs, regressions, missing tests, bad boundaries,
+#     instruction drift, authority conflicts, or unsafe process changes.
+
+name = "reviewer"
+description = "Routine review worker. Reviews assigned diffs/files/PR evidence, returns findings first, and never edits files or mutates GitHub."
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+
+developer_instructions = """
+You are reviewer, a review-only subagent spawned by Foreman.
+
+Your job:
+- Review only the assigned diffs, files, PRs, reports, or completion evidence.
+- Do not edit files. Do not apply patches. Do not mutate GitHub or git.
+- Do not choose product direction, next slices, merge strategy, or publication actions.
+- Prioritize bugs, regressions, missing tests, bad boundaries, instruction drift, authority conflicts, and unsafe process changes.
+- Put findings first. Use file and line references when possible.
+- If there are no findings, say clean and name residual risk.
+
+Return only a compact signal packet in this shape:
+{
+  "status": "clean|findings|blocked",
+  "findings": [
+    {
+      "severity": "blocker|major|minor",
+      "path": "...",
+      "line": 123,
+      "issue": "...",
+      "recommendation": "..."
+    }
+  ],
+  "tests_reviewed": [],
+  "residual_risk": [],
+  "decision_signal": "accept|request_changes|needs_human"
+}
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -32,5 +32,13 @@ description = "Read-only codebase scanner. Maps surfaces, locates patterns, and 
 config_file = "agents/validator.toml"
 description = "Bounded verification worker. Runs named checks, inspects evidence, and reports pass/fail facts without editing files."
 
+[agents.github-steward]
+config_file = "agents/github-steward.toml"
+description = "Routine Git/GitHub hygiene worker. Reads branch/ref/PR facts, performs explicitly assigned narrow mutations, and returns a compact signal packet."
+
+[agents.reviewer]
+config_file = "agents/reviewer.toml"
+description = "Routine review worker. Reviews assigned diffs/files/PR evidence, returns findings first, and never edits files or mutates GitHub."
+
 [notice]
 hide_full_access_warning = true

--- a/.docks/foreman/.codex/config.toml
+++ b/.docks/foreman/.codex/config.toml
@@ -29,3 +29,11 @@ description = "Read-only codebase scanner. Maps surfaces, locates patterns, and 
 [agents.validator]
 config_file = "../../../.codex/agents/validator.toml"
 description = "Bounded verification worker. Runs named checks, inspects evidence, and reports pass/fail facts without editing files."
+
+[agents.github-steward]
+config_file = "../../../.codex/agents/github-steward.toml"
+description = "Routine Git/GitHub hygiene worker. Reads branch/ref/PR facts, performs explicitly assigned narrow mutations, and returns a compact signal packet."
+
+[agents.reviewer]
+config_file = "../../../.codex/agents/reviewer.toml"
+description = "Routine review worker. Reviews assigned diffs/files/PR evidence, returns findings first, and never edits files or mutates GitHub."

--- a/.docks/foreman/AGENTS.md
+++ b/.docks/foreman/AGENTS.md
@@ -11,7 +11,12 @@ explicitly asked. Work in
 
 Foreman owns development coordination and git/GitHub hygiene by default:
 
-- choose whether the next slice belongs with Foreman, GDI, or Operator;
+- choose whether the next slice belongs with Foreman, GDI, Operator, or a
+  support role;
+- delegate routine Git/GitHub hygiene and readback to `github-steward` when
+  useful, while keeping final authorization and decision ownership;
+- delegate routine acceptance and review passes to `reviewer` when useful,
+  while keeping final acceptance, priority, and next-slice ownership;
 - choose and execute the next practical reversible step after every review,
   completion report, or blocker classification;
 - spawn native subagents and write, update, or route durable work cards when
@@ -149,6 +154,10 @@ After Foreman mutates GitHub state, always do the immediate hygiene pass for the
 affected issue, PR, branch, or work card, then identify the next logical
 actionable step.
 
+For routine Git/GitHub readback or exact assigned hygiene actions, Foreman may
+spawn `github-steward` and consume its signal packet. The steward does not plan
+product work, choose next slices, or infer authorization for mutations.
+
 ## Coordination Posture
 
 Foreman keeps the workstream moving, but the detailed branch, publication,
@@ -156,6 +165,11 @@ review, and cleanup process belongs to the active workflow profile, not this
 role file. Resolve it from `docs/dev/active-profile.json` and
 `docs/dev/workflow-profiles.json`, then apply the profile-specific guidance in
 `docs/dev/workflow-profiles/README.md`.
+
+For routine review passes over assigned diffs, PRs, reports, or completion
+evidence, Foreman may spawn `reviewer` and consume findings first. Reviewer does
+not edit files, mutate GitHub, choose product direction, or make the final
+acceptance decision.
 
 In the active `local_relay` profile, follow the profile's keep-moving and
 actionable-gate rules. Do not end with a vague external-decision prompt when the
@@ -318,6 +332,30 @@ Short Operator checks may be direct child prompts when they fit in a single
 bounded probe and do not need durable capture instructions, but the spawn still
 must set `agent_type` to `operator`.
 
+For routine Git/GitHub hygiene and readback, spawn a child with the spawn tool
+argument `agent_type` set to `github-steward`. The prompt must name whether the
+round is readback-only or must name the exact authorized mutation.
+
+Tool argument: `agent_type=github-steward`
+
+Child prompt:
+`return a compact GitHub hygiene signal packet for the current branch. Do not mutate git or GitHub.`
+
+Tool argument: `agent_type=github-steward`
+
+Child prompt:
+`comment on PR 440 with the approved release note in /tmp/pr-440-note.md, then return a compact GitHub hygiene signal packet.`
+
+For routine acceptance or review passes, spawn a child with the spawn tool
+argument `agent_type` set to `reviewer`. The prompt must name the assigned diff,
+file, PR, report, or completion evidence and must not ask Reviewer to edit,
+mutate GitHub, or choose next work.
+
+Tool argument: `agent_type=reviewer`
+
+Child prompt:
+`review HEAD diff and return findings signal only. Do not edit files or mutate GitHub.`
+
 Foreman owns routing judgment. Prefer subagent dispatch for bounded team tasks:
 implementation, validation, reconnaissance, supervised inspection, and other
 specialist roles with their own adapter-declared model and reasoning effort. Use
@@ -326,10 +364,11 @@ legacy AFK terminal substrate, when native subagent role resolution is
 unavailable, or when the human explicitly requests a separate session.
 There is no generic helper role. Translate generic helper/scanner/second-pass
 requests to a registered native role before spawning: `explorer` for read-only
-reconnaissance, `validator` for bounded verification, `gdi` for deterministic
-implementation, and `operator` for supervised live/HITL inspection. The first
-spawn attempt must use that registered role; do not probe with a generic helper
-spawn and rely on the hook to correct it.
+reconnaissance, `validator` for bounded verification, `github-steward` for
+routine Git/GitHub hygiene and readback, `reviewer` for assigned review passes,
+`gdi` for deterministic implementation, and `operator` for supervised live/HITL
+inspection. The first spawn attempt must use that registered role; do not probe
+with a generic helper spawn and rely on the hook to correct it.
 Never emulate role selection by writing `agent_type: <role>` inside the child
 prompt. If the available spawn tool does not expose an `agent_type` argument,
 do not spawn a default child; stop with a role-resolution blocker after running
@@ -380,6 +419,8 @@ instructions only when using an explicitly legacy terminal path. The default
 subagent path is:
 
 - spawn `gdi` with a concise native prompt or explicit durable work-card pointer;
+- spawn `github-steward` for routine Git/GitHub hygiene/readback when useful;
+- spawn `reviewer` for routine acceptance/review passes when useful;
 - wait only when the result is needed for the next critical-path step;
 - review the returned completion report against local diff/status/evidence;
 - route correction or the next bounded subagent task from Foreman.

--- a/.docks/foreman/SUBAGENTS.md
+++ b/.docks/foreman/SUBAGENTS.md
@@ -17,6 +17,8 @@ broad fan-out.
   operator.toml                  <- spawnable Operator subagent config
   explorer.toml                  <- spawnable Explorer utility config
   validator.toml                 <- spawnable Validator utility config
+  github-steward.toml            <- spawnable Git/GitHub hygiene utility config
+  reviewer.toml                  <- spawnable review utility config
 ```
 
 The `.docks/` tree is the AOS team layer. It owns role definitions, scripts,
@@ -43,6 +45,8 @@ in the first-class project location.
 | `operator` | gpt-5.4 | medium | Supervised HITL inspector |
 | `explorer` | gpt-5.4-mini | low | Read-only codebase scanner |
 | `validator` | gpt-5.4-mini | low | Bounded verification worker |
+| `github-steward` | gpt-5.4-mini | low | Git/GitHub hygiene, readback, and exact authorized mutations |
+| `reviewer` | gpt-5.4 | medium | Assigned diff, PR, report, or completion-evidence review |
 
 Foreman itself runs at `gpt-5.5 / xhigh` when launched from
 `.docks/foreman` (see `.docks/foreman/.codex/config.toml`). That expensive
@@ -78,6 +82,15 @@ Validator performs bounded verification only. It runs named checks or inspects
 named evidence, reports pass/fail facts, and does not edit files or decide next
 work.
 
+GitHub Steward performs routine Git/GitHub hygiene only. It reads branch, ref,
+worktree, upstream, issue, PR, and check facts; uses `./aos dev gh` where
+available; and mutates git or GitHub only when Foreman or the user assigns the
+exact action.
+
+Reviewer performs assigned review only. It reviews named diffs, files, PRs,
+reports, or completion evidence; returns findings first; and does not edit
+files, mutate GitHub, choose product direction, or decide next slices.
+
 ## Routing Policy
 
 Use subagent spawning when:
@@ -92,6 +105,10 @@ Use subagent spawning when:
 - You need Operator to run a bounded supervised probe or capture-plan check.
 - You need Validator to run named proof, test, or manifest checks without
   turning validation into implementation.
+- You need GitHub Steward to do routine Git/GitHub readback, hygiene, or an
+  exact authorized mutation without spending Foreman's context.
+- You need Reviewer to do a routine acceptance or review pass over assigned
+  evidence while Foreman remains the final decision owner.
 
 Use the legacy terminal/AFK path only when:
 
@@ -114,17 +131,19 @@ inherit Foreman's model/effort.
 There is no generic helper role. If a user asks for a helper, scanner, second
 set of eyes, or lightweight pass, Foreman must translate that request to a
 registered role before spawning: `explorer` for read-only reconnaissance,
-`validator` for bounded verification, `gdi` for deterministic implementation,
-and `operator` for supervised live/HITL inspection. The first spawn attempt
-must use the registered role; a blocked generic/default spawn is a routing
-mistake, even if Foreman recovers by retrying correctly.
+`validator` for bounded verification, `github-steward` for routine Git/GitHub
+hygiene and readback, `reviewer` for assigned review passes, `gdi` for
+deterministic implementation, and `operator` for supervised live/HITL
+inspection. The first spawn attempt must use the registered role; a blocked
+generic/default spawn is a routing mistake, even if Foreman recovers by retrying
+correctly.
 
 Before broad fan-out, smoke one child. The visible spawn/status line and
 SubagentStart/SubagentStop voice labels must identify the intended role
-(`explorer`, `validator`, `gdi`, or `operator`), not `default`, and the visible
-model/effort must match the native agent config. If it says `default`, `Gibbs`,
-or inherits Foreman's `gpt-5.5 / xhigh`, stop and fix role loading before
-continuing.
+(`explorer`, `validator`, `github-steward`, `reviewer`, `gdi`, or `operator`),
+not `default`, and the visible model/effort must match the native agent config.
+If it says `default`, `Gibbs`, or inherits Foreman's `gpt-5.5 / xhigh`, stop
+and fix role loading before continuing.
 
 Foreman's `PreToolUse` hook blocks recognized spawn-tool calls that omit
 `agent_type`, use `default`, or name an unregistered role. `SubagentStart`
@@ -158,6 +177,16 @@ Tool argument: `agent_type=validator`
 
 Child prompt:
 `run bash tests/dock-hook-isolation.sh and report the pass/fail result and any exact failure line. Do not edit files.`
+
+Tool argument: `agent_type=github-steward`
+
+Child prompt:
+`return a compact GitHub hygiene signal packet for the current branch. Do not mutate git or GitHub.`
+
+Tool argument: `agent_type=reviewer`
+
+Child prompt:
+`review HEAD diff and return findings signal only. Do not edit files or mutate GitHub.`
 
 Tool argument: `agent_type=gdi`
 

--- a/tests/dev-workflow-router.sh
+++ b/tests/dev-workflow-router.sh
@@ -325,10 +325,16 @@ data = json.loads(os.environ["OUT"])
 roles = {item["role"]: item for item in data["roles"]}
 assert data["status"] == "success", data
 assert data["agents_root"] == ".codex/agents", data
-assert {"explorer", "gdi", "operator", "validator"} <= set(roles), roles
+assert {"explorer", "gdi", "github-steward", "operator", "reviewer", "validator"} <= set(roles), roles
 assert roles["explorer"]["model"] == "gpt-5.4-mini", roles["explorer"]
 assert roles["explorer"]["model_reasoning_effort"] == "low", roles["explorer"]
 assert roles["explorer"]["agent_config_path"] == ".codex/agents/explorer.toml", roles["explorer"]
+assert roles["github-steward"]["model"] == "gpt-5.4-mini", roles["github-steward"]
+assert roles["github-steward"]["model_reasoning_effort"] == "low", roles["github-steward"]
+assert roles["github-steward"]["agent_config_path"] == ".codex/agents/github-steward.toml", roles["github-steward"]
+assert roles["reviewer"]["model"] == "gpt-5.4", roles["reviewer"]
+assert roles["reviewer"]["model_reasoning_effort"] == "medium", roles["reviewer"]
+assert roles["reviewer"]["agent_config_path"] == ".codex/agents/reviewer.toml", roles["reviewer"]
 assert roles["validator"]["model"] == "gpt-5.4-mini", roles["validator"]
 assert roles["validator"]["model_reasoning_effort"] == "low", roles["validator"]
 PY

--- a/tests/dock-hook-isolation.sh
+++ b/tests/dock-hook-isolation.sh
@@ -167,7 +167,7 @@ dock_local_agents_dir = root / ".docks" / "foreman" / ".codex" / "agents"
 if dock_local_agents_dir.exists():
     raise SystemExit(f"FAIL: Foreman dock must not own native agent configs: {dock_local_agents_dir}")
 
-for role in ("gdi", "operator", "explorer", "validator"):
+for role in ("gdi", "operator", "explorer", "validator", "github-steward", "reviewer"):
     role_header = f"[agents.{role}]"
     repo_config_line = f'config_file = "agents/{role}.toml"'
     foreman_config_line = f'config_file = "../../../.codex/agents/{role}.toml"'
@@ -266,7 +266,7 @@ for label, text in (
 ):
     if "Spawn gdi:" in text or "Spawn operator:" in text or "Spawn explorer:" in text:
         raise SystemExit(f"FAIL: {label} still teaches prompt-text role selection")
-    for forbidden in ("agent_type: gdi", "agent_type: operator", "agent_type: explorer", "agent_type: validator"):
+    for forbidden in ("agent_type: gdi", "agent_type: operator", "agent_type: explorer", "agent_type: validator", "agent_type: github-steward", "agent_type: reviewer"):
         if forbidden in text:
             raise SystemExit(f"FAIL: {label} still formats agent_type as prompt text: {forbidden}")
 
@@ -428,6 +428,13 @@ explorer_spawn_payload='{"tool_name":"spawn_agent","tool_input":{"agent_type":"e
 out="$(printf '%s' "$explorer_spawn_payload" | PATH="$fake_bin:$PATH" AOS_DOCK_AOS_BIN="$fake_aos" AOS_FAKE_LOG="$log_file" bash ".docks/foreman/hooks/pre-tool-use.sh")"
 if [[ -n "$out" ]]; then
   echo "FAIL: expected explicit explorer spawn PreToolUse payload to emit no JSON, got $out" >&2
+  exit 1
+fi
+
+reviewer_spawn_payload='{"tool_name":"spawn_agent","tool_input":{"agent_type":"reviewer","prompt":"Review assigned diff only."}}'
+out="$(printf '%s' "$reviewer_spawn_payload" | PATH="$fake_bin:$PATH" AOS_DOCK_AOS_BIN="$fake_aos" AOS_FAKE_LOG="$log_file" bash ".docks/foreman/hooks/pre-tool-use.sh")"
+if [[ -n "$out" ]]; then
+  echo "FAIL: expected explicit reviewer spawn PreToolUse payload to emit no JSON, got $out" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- add native github-steward and reviewer support roles
- register both roles in root and Foreman Codex configs
- update Foreman routing/catalog guidance and role inventory tests

## Verification
- bash tests/dock-hook-isolation.sh
- bash tests/dev-workflow-router.sh
- ./aos dev subagent list --json
- ./aos dev subagent plan --role github-steward --prompt "return compact GitHub hygiene signal packet only" --json
- ./aos dev subagent plan --role reviewer --prompt "review HEAD diff and return findings signal only" --json
- git diff --check