### PR TITLE
Add dev gh PR create surface

### DIFF
--- a/.docks/foreman/dock.json
+++ b/.docks/foreman/dock.json
@@ -35,6 +35,7 @@
     "dev.github.pr_list",
     "dev.github.pr_view",
     "dev.github.pr_checks",
+    "dev.github.pr_create",
     "dev.github.pr_comment",
     "dev.github.pr_merge",
     "dev.github.ci_inspect",

--- a/docs/dev/agent-capabilities.json
+++ b/docs/dev/agent-capabilities.json
@@ -601,6 +601,84 @@
       }
     },
     {
+      "id": "dev.github.pr_create",
+      "label": "GitHub PR Create",
+      "summary": "Create a GitHub pull request through explicit base/head branches, title, and body file using ./aos dev gh.",
+      "status": "active",
+      "roles": ["foreman"],
+      "entry_paths": ["aos_developer"],
+      "adapter": {
+        "kind": "aos_cli",
+        "command": ["./aos", "dev", "gh", "pr", "create"]
+      },
+      "mutability": {
+        "class": "external_write",
+        "side_effects": ["github_pr_create"],
+        "requires_explicit_assignment": true,
+        "requires_human_approval": false,
+        "requires_body_file": true
+      },
+      "execution": {
+        "cwd_policy": "repo_root",
+        "timeout_seconds": 30,
+        "network": "required",
+        "raw_process": false,
+        "audit": "required"
+      },
+      "inputs": [
+        {
+          "name": "base",
+          "summary": "Base branch for the pull request.",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        {
+          "name": "head",
+          "summary": "Head branch for the pull request.",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        {
+          "name": "title",
+          "summary": "GitHub pull request title.",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        {
+          "name": "body_file",
+          "summary": "Markdown file containing the pull request body.",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      ],
+      "outputs": [
+        {
+          "name": "pull_request_json",
+          "summary": "Created pull request number, URL, state, head branch, and base branch.",
+          "required": true,
+          "schema": {
+            "type": "object"
+          }
+        }
+      ],
+      "failure_policy": {
+        "bubble_up": true,
+        "retry": "none"
+      }
+    },
+    {
       "id": "dev.github.pr_comment",
       "label": "GitHub PR Comment",
       "summary": "Write a GitHub pull request comment through a body file using ./aos dev gh.",

--- a/scripts/aos-dev-gh-spec.mjs
+++ b/scripts/aos-dev-gh-spec.mjs
@@ -10,6 +10,7 @@ export const DEV_GH_COMMAND_PATHS = [
   ['pr', 'list'],
   ['pr', 'view'],
   ['pr', 'checks'],
+  ['pr', 'create'],
   ['pr', 'comment'],
   ['pr', 'merge'],
   ['ci', 'inspect'],

--- a/scripts/aos-dev-gh.mjs
+++ b/scripts/aos-dev-gh.mjs
@@ -19,6 +19,15 @@ function die(message, code = 'ERROR', exitCode = 1) {
   process.exit(exitCode);
 }
 
+function printJSONTo(stream, value) {
+  stream.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function dieStructured(message, code = 'ERROR', exitCode = 1) {
+  printJSONTo(process.stderr, { status: 'error', code, error: message });
+  process.exit(exitCode);
+}
+
 function invocationDisplayName() {
   return process.env.AOS_INVOCATION_DISPLAY_NAME || './aos';
 }
@@ -69,12 +78,12 @@ const FLAG_SPECS = {
     },
   },
   '--title': {
-    summary: 'an issue title',
+    summary: (command) => command === 'pr:create' ? 'a PR title' : 'an issue title',
     assign: (options, value, command, flag) => {
       options.title = value;
       if (command === 'issue:edit') appendOperation(options, value, command, flag);
     },
-    invalid: '--title is only valid for issue create and edit subcommands',
+    invalid: '--title is only valid for issue create/edit and PR create subcommands',
   },
   '--pr': {
     summary: 'a PR number',
@@ -211,6 +220,7 @@ const COMMAND_FLAGS = new Map([
   ])],
   ['label:list', new Set([...COMMON_FLAGS, '--limit', '--search', '--sort', '--order'])],
   ['pr:list', new Set([...COMMON_FLAGS, ...LIST_FLAGS, ...PR_LIST_FLAGS])],
+  ['pr:create', new Set([...COMMON_FLAGS, '--title', '--base', '--head'])],
   ['pr:merge', new Set([...COMMON_FLAGS, ...PR_MERGE_STRATEGY_FLAGS, '--match-head-commit'])],
 ]);
 
@@ -228,7 +238,7 @@ function flagErrorMessage(flag, command, allowedFlags) {
   return null;
 }
 
-function parseOptions(args, command = 'common') {
+function parseOptions(args, command = 'common', config = {}) {
   const options = {
     json: false,
     repo: null,
@@ -255,10 +265,11 @@ function parseOptions(args, command = 'common') {
     issueEditOperations: [],
     positionals: [],
   };
+  const fail = config.structuredErrors ? dieStructured : die;
   const allowedFlags = COMMAND_FLAGS.get(command) ?? COMMAND_FLAGS.get('common');
   const requireValueAt = (index, flag, summary) => {
     if (index < 0 || index + 1 >= args.length || args[index + 1].startsWith('--')) {
-      die(`${flag} requires ${summary}`, 'MISSING_ARG');
+      fail(`${flag} requires ${summary}`, 'MISSING_ARG');
     }
     return args[index + 1];
   };
@@ -267,8 +278,8 @@ function parseOptions(args, command = 'common') {
     const spec = FLAG_SPECS[arg];
     if (spec) {
       const error = flagErrorMessage(arg, command, allowedFlags);
-      if (error) die(error, 'UNKNOWN_FLAG');
-      if (!allowedFlags.has(arg)) die(`Unknown dev gh flag: ${arg}`, 'UNKNOWN_FLAG');
+      if (error) fail(error, 'UNKNOWN_FLAG');
+      if (!allowedFlags.has(arg)) fail(`Unknown dev gh flag: ${arg}`, 'UNKNOWN_FLAG');
       if (spec.summary) {
         const summary = typeof spec.summary === 'function' ? spec.summary(command) : spec.summary;
         const value = requireValueAt(i, arg, summary);
@@ -279,7 +290,7 @@ function parseOptions(args, command = 'common') {
         i += 1;
       }
     } else if (arg.startsWith('--')) {
-      die(`Unknown dev gh flag: ${arg}`, 'UNKNOWN_FLAG');
+      fail(`Unknown dev gh flag: ${arg}`, 'UNKNOWN_FLAG');
     } else {
       options.positionals.push(arg);
       i += 1;
@@ -330,6 +341,7 @@ function runGhAndExit(args, cwd) {
 }
 
 function emitCompositeErrorAndExit(command, result, json) {
+  cleanupTempBodyFiles();
   if (json) {
     printJSON({
       status: 'error',
@@ -343,6 +355,28 @@ function emitCompositeErrorAndExit(command, result, json) {
     writeProcessOutput(result);
   }
   process.exit(result.status);
+}
+
+function normalizePullRequestPayload(payload) {
+  if (!payload || typeof payload !== 'object') return null;
+  if (
+    payload.number == null ||
+    payload.url == null ||
+    payload.state == null ||
+    payload.headRefName == null ||
+    payload.baseRefName == null
+  ) {
+    return null;
+  }
+  return {
+    status: 'success',
+    authority: 'gh_cli',
+    number: payload.number ?? null,
+    url: payload.url ?? null,
+    state: payload.state ?? null,
+    head: payload.headRefName ?? null,
+    base: payload.baseRefName ?? null,
+  };
 }
 
 function parseJSON(text) {
@@ -749,6 +783,37 @@ function prCommand(args) {
     appendRepo(ghArgs, repoFullName);
     if (options.json) ghArgs.push('--json', 'name,state,bucket,link,startedAt,completedAt,workflow');
     runGhAndExit(ghArgs, repoRoot);
+  } else if (action === 'create') {
+    const options = parseOptions(args.slice(1), 'pr:create', { structuredErrors: true });
+    if (options.positionals.length > 0) dieStructured(`Unknown dev gh pr argument: ${options.positionals[0]}`, 'UNKNOWN_ARG');
+    if (!options.title) dieStructured('dev gh pr create requires --title <title>', 'MISSING_ARG');
+    if (!options.base) dieStructured('dev gh pr create requires --base <branch>', 'MISSING_ARG');
+    if (!options.head) dieStructured('dev gh pr create requires --head <branch>', 'MISSING_ARG');
+    if (!options.bodyFile) dieStructured('dev gh pr create requires --body-file <path|->', 'MISSING_ARG');
+    const repoRoot = repoRootFrom(options);
+    const repoFullName = repositoryFullName(options, repoRoot);
+    const bodyFile = materializeBodyFile(options.bodyFile, 'PR');
+    const ghArgs = ['pr', 'create'];
+    appendRepo(ghArgs, repoFullName);
+    ghArgs.push('--base', options.base, '--head', options.head, '--title', options.title, '--body-file', bodyFile);
+    const createResult = runGh(ghArgs, repoRoot);
+    if (createResult.status !== 0) emitCompositeErrorAndExit(ghArgs, createResult, options.json);
+    if (!options.json) {
+      cleanupTempBodyFiles();
+      writeProcessOutput(createResult);
+      process.exit(createResult.status);
+    }
+    const createdPR = firstLine(createResult.stdout) ?? firstLine(createResult.stderr);
+    if (!createdPR) dieStructured('Could not identify created PR from gh pr create output', 'MISSING_PR');
+    const viewArgs = ['pr', 'view', createdPR];
+    appendRepo(viewArgs, repoFullName);
+    viewArgs.push('--json', 'number,url,state,headRefName,baseRefName');
+    const viewResult = runGh(viewArgs, repoRoot);
+    if (viewResult.status !== 0) emitCompositeErrorAndExit(viewArgs, viewResult, options.json);
+    const payload = normalizePullRequestPayload(parseJSON(viewResult.stdout));
+    if (!payload) dieStructured('Could not parse created PR JSON from gh pr view', 'INVALID_JSON');
+    cleanupTempBodyFiles();
+    printJSON(payload);
   } else if (action === 'comment') {
     const options = parseOptions(args.slice(1));
     if (options.positionals.length === 0) die('dev gh pr comment requires exactly one PR number', 'MISSING_ARG');

--- a/tests/aos-dev-gh-help-parity.test.mjs
+++ b/tests/aos-dev-gh-help-parity.test.mjs
@@ -69,7 +69,7 @@ function assertDeltaDoc(result, output, label = 'dev gh help') {
   assert.doesNotMatch(output, /UNKNOWN_COMMAND/, label);
   assert.match(output, /^\.\/aos dev gh — sanctioned GitHub workflow subset/m, label);
   assert.match(output, /Non-interactive only: commands fail instead of prompting\./, label);
-  assert.match(output, /Body-writing commands use --body-file; issue create\/comment and pr comment require it\./, label);
+  assert.match(output, /Body-writing commands use --body-file <path\|->; stdin is accepted via - or \/dev\/stdin\./, label);
   assert.match(output, /pr merge requires exactly one explicit strategy: --squash, --merge, or --rebase\./, label);
   assert.match(output, /List commands take bounded --limit values for inventory scans\./, label);
   assert.match(output, /context\s+Reports local gh auth, repository, branch, current PR, and dirty checkout state\./, label);

--- a/tests/dev-workflow-router.sh
+++ b/tests/dev-workflow-router.sh
@@ -601,6 +601,7 @@ assert "dev.github.issue_close" in ids, ids
 assert "dev.github.issue_edit" in ids, ids
 assert "dev.github.label_list" in ids, ids
 assert "dev.github.pr_comment" in ids, ids
+assert "dev.github.pr_create" in ids, ids
 assert "dev.github.pr_merge" in ids, ids
 assert "dev.github.pr_checks" in ids, ids
 assert "dev.subagent.dispatch_contract" in ids, ids
@@ -656,6 +657,24 @@ then
     pass "dev capabilities explain returns PR comment metadata"
 else
     fail "dev capabilities explain did not return expected PR comment metadata"
+fi
+
+if OUT="$(./aos dev capabilities explain dev.github.pr_create --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+capability = data["capability"]
+assert capability["id"] == "dev.github.pr_create", data
+assert capability["adapter"]["kind"] == "aos_cli", data
+assert capability["mutability"]["class"] == "external_write", data
+assert capability["mutability"]["requires_body_file"] is True, data
+assert capability["execution"]["raw_process"] is False, data
+PY
+then
+    pass "dev capabilities explain returns PR create metadata"
+else
+    fail "dev capabilities explain did not return expected PR create metadata"
 fi
 
 if OUT="$(./aos dev capabilities explain dev.github.issue_create --json 2>/dev/null)" python3 - <<'PY'
@@ -820,6 +839,7 @@ assert "dev.github.issue_close" in ids, ids
 assert "dev.github.issue_edit" in ids, ids
 assert "dev.github.label_list" in ids, ids
 assert "dev.github.pr_comment" in ids, ids
+assert "dev.github.pr_create" in ids, ids
 assert "dev.github.pr_merge" in ids, ids
 assert "dev.github.pr_checks" in ids, ids
 assert "dev.subagent.dispatch_contract" in ids, ids
@@ -864,6 +884,7 @@ assert "dev.github.issue_create" not in ids, ids
 assert "dev.github.issue_close" not in ids, ids
 assert "dev.github.issue_edit" not in ids, ids
 assert "dev.github.pr_comment" not in ids, ids
+assert "dev.github.pr_create" not in ids, ids
 assert "dev.github.pr_merge" not in ids, ids
 assert "dev.subagent.dispatch_contract" not in ids, ids
 assert "dev.build.aos" in ids, ids
@@ -907,6 +928,7 @@ assert "dev.github.issue_create" not in ids, ids
 assert "dev.github.issue_close" not in ids, ids
 assert "dev.github.issue_edit" not in ids, ids
 assert "dev.github.pr_comment" not in ids, ids
+assert "dev.github.pr_create" not in ids, ids
 assert "dev.github.pr_merge" not in ids, ids
 assert "dev.subagent.dispatch_contract" not in ids, ids
 assert all(item["mutability_class"] == "read_only" for item in data["capabilities"]), data
@@ -1001,6 +1023,17 @@ if [[ "$cmd" == "pr list --repo michaelblum/agent-os --state all --limit 30 --au
 fi
 if [[ "$cmd" == "pr checks 298 --repo michaelblum/agent-os --json name,state,bucket,link,startedAt,completedAt,workflow" ]]; then
     echo '[{"name":"unit","state":"failure","bucket":"fail","link":"https://github.com/michaelblum/agent-os/actions/runs/987","workflow":"CI"}]'
+    exit 0
+fi
+if [[ "$cmd" == pr\ create\ --repo\ michaelblum/agent-os\ --base\ main\ --head\ foreman/dev-gh-pr-create-v0\ --title\ Add\ PR\ create\ --body-file\ * ]]; then
+    body_file="${cmd##* --body-file }"
+    cat "$body_file" >> "$GH_BODY_LOG"
+    printf '\n---\n' >> "$GH_BODY_LOG"
+    echo "https://github.com/michaelblum/agent-os/pull/433"
+    exit 0
+fi
+if [[ "$cmd" == "pr view https://github.com/michaelblum/agent-os/pull/433 --repo michaelblum/agent-os --json number,url,state,headRefName,baseRefName" ]]; then
+    echo '{"number":433,"url":"https://github.com/michaelblum/agent-os/pull/433","state":"OPEN","headRefName":"foreman/dev-gh-pr-create-v0","baseRefName":"main"}'
     exit 0
 fi
 if [[ "$cmd" == pr\ merge\ 410\ --repo\ michaelblum/agent-os\ --merge\ --match-head-commit\ abc123\ --body-file\ * ]]; then
@@ -1329,6 +1362,111 @@ then
     pass "dev gh pr view includes reviewDecision in JSON output"
 else
     fail "dev gh pr view did not request reviewDecision JSON"
+fi
+
+: > "$GH_ARGS_LOG"
+: > "$GH_BODY_LOG"
+if OUT="$(./aos dev gh pr create --base main --head foreman/dev-gh-pr-create-v0 --title "Add PR create" --body-file "$BODY" --json 2>/dev/null)" &&
+   OUT="$OUT" python3 - <<'PY' &&
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert data["status"] == "success", data
+assert data["authority"] == "gh_cli", data
+assert data["number"] == 433, data
+assert data["url"] == "https://github.com/michaelblum/agent-os/pull/433", data
+assert data["state"] == "OPEN", data
+assert data["head"] == "foreman/dev-gh-pr-create-v0", data
+assert data["base"] == "main", data
+PY
+   grep -q "pr create --repo michaelblum/agent-os --base main --head foreman/dev-gh-pr-create-v0 --title Add PR create --body-file $BODY" "$GH_ARGS_LOG" &&
+   grep -q "pr view https://github.com/michaelblum/agent-os/pull/433 --repo michaelblum/agent-os --json number,url,state,headRefName,baseRefName" "$GH_ARGS_LOG" &&
+   grep -q "accepted state" "$GH_BODY_LOG" &&
+   ! grep -q "accepted state" "$GH_ARGS_LOG"; then
+    pass "dev gh pr create shells out with body-file and returns JSON readback"
+else
+    fail "dev gh pr create did not dispatch through expected body-file flow"
+fi
+
+if ERR="$(./aos dev gh pr create --base main --head foreman/dev-gh-pr-create-v0 --body-file "$BODY" --json 2>&1 >/dev/null)"; then
+    fail "dev gh pr create should require --title"
+elif ERR="$ERR" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["ERR"])
+assert data["code"] == "MISSING_ARG", data
+assert data["error"] == "dev gh pr create requires --title <title>", data
+PY
+then
+    pass "dev gh pr create requires structured --title"
+else
+    fail "dev gh pr create missing title error mismatch: $ERR"
+fi
+
+if ERR="$(./aos dev gh pr create --head foreman/dev-gh-pr-create-v0 --title "Add PR create" --body-file "$BODY" --json 2>&1 >/dev/null)"; then
+    fail "dev gh pr create should require --base"
+elif ERR="$ERR" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["ERR"])
+assert data["code"] == "MISSING_ARG", data
+assert data["error"] == "dev gh pr create requires --base <branch>", data
+PY
+then
+    pass "dev gh pr create requires structured --base"
+else
+    fail "dev gh pr create missing base error mismatch: $ERR"
+fi
+
+if ERR="$(./aos dev gh pr create --base main --title "Add PR create" --body-file "$BODY" --json 2>&1 >/dev/null)"; then
+    fail "dev gh pr create should require --head"
+elif ERR="$ERR" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["ERR"])
+assert data["code"] == "MISSING_ARG", data
+assert data["error"] == "dev gh pr create requires --head <branch>", data
+PY
+then
+    pass "dev gh pr create requires structured --head"
+else
+    fail "dev gh pr create missing head error mismatch: $ERR"
+fi
+
+if ERR="$(./aos dev gh pr create --base main --head foreman/dev-gh-pr-create-v0 --title "Add PR create" --json 2>&1 >/dev/null)"; then
+    fail "dev gh pr create should require --body-file"
+elif ERR="$ERR" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["ERR"])
+assert data["code"] == "MISSING_ARG", data
+assert data["error"] == "dev gh pr create requires --body-file <path|->", data
+PY
+then
+    pass "dev gh pr create requires structured --body-file"
+else
+    fail "dev gh pr create missing body-file error mismatch: $ERR"
+fi
+
+if ERR="$(./aos dev gh pr create --base main --head foreman/dev-gh-pr-create-v0 --title "Add PR create" --body-file --json 2>&1 >/dev/null)"; then
+    fail "dev gh pr create should reject missing --body-file values before a flag"
+elif ERR="$ERR" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["ERR"])
+assert data["code"] == "MISSING_ARG", data
+assert data["error"] == "--body-file requires a path or -", data
+PY
+then
+    pass "dev gh pr create treats flag-after---body-file as structured missing value"
+else
+    fail "dev gh pr create missing body-file value error mismatch: $ERR"
 fi
 
 : > "$GH_ARGS_LOG"

--- a/tests/schemas/aos-agent-capability-manifest-v0.test.mjs
+++ b/tests/schemas/aos-agent-capability-manifest-v0.test.mjs
@@ -153,6 +153,7 @@ test('typed AOS GitHub capabilities stay non-raw and explicit for writes', async
     'dev.github.issue_create',
     'dev.github.issue_close',
     'dev.github.issue_edit',
+    'dev.github.pr_create',
     'dev.github.pr_comment',
     'dev.github.pr_merge',
   ]) {
@@ -168,6 +169,7 @@ test('typed AOS GitHub capabilities stay non-raw and explicit for writes', async
   assert.equal(capabilities.get('dev.github.issue_create').mutability.requires_body_file, true);
   assert.equal(capabilities.get('dev.github.issue_close').mutability.requires_body_file, false);
   assert.equal(capabilities.get('dev.github.issue_edit').mutability.requires_body_file, false);
+  assert.equal(capabilities.get('dev.github.pr_create').mutability.requires_body_file, true);
   assert.equal(capabilities.get('dev.github.pr_comment').mutability.requires_body_file, true);
   assert.equal(capabilities.get('dev.github.pr_merge').mutability.requires_body_file, false);
 });
@@ -188,6 +190,7 @@ test('canonical manifest includes the initial developer capability set', async (
     'dev.github.pr_list',
     'dev.github.pr_view',
     'dev.github.pr_checks',
+    'dev.github.pr_create',
     'dev.github.pr_comment',
     'dev.github.pr_merge',
     'dev.github.ci_inspect',

--- a/tests/schemas/aos-dock-profile-v0.test.mjs
+++ b/tests/schemas/aos-dock-profile-v0.test.mjs
@@ -149,6 +149,9 @@ test('role envelopes preserve the intended coordination boundaries', async () =>
   assert.ok(profiles.get('foreman').allowed_capabilities.includes('dev.github.pr_comment'));
   assert.ok(!profiles.get('gdi').allowed_capabilities.includes('dev.github.pr_comment'));
   assert.ok(!profiles.get('operator').allowed_capabilities.includes('dev.github.pr_comment'));
+  assert.ok(profiles.get('foreman').allowed_capabilities.includes('dev.github.pr_create'));
+  assert.ok(!profiles.get('gdi').allowed_capabilities.includes('dev.github.pr_create'));
+  assert.ok(!profiles.get('operator').allowed_capabilities.includes('dev.github.pr_create'));
   assert.ok(profiles.get('foreman').allowed_capabilities.includes('dev.github.pr_merge'));
   assert.ok(!profiles.get('gdi').allowed_capabilities.includes('dev.github.pr_merge'));
   assert.ok(!profiles.get('operator').allowed_capabilities.includes('dev.github.pr_merge'));


### PR DESCRIPTION
## Summary

- add `./aos dev gh pr create --base <branch> --head <branch> --title <title> --body-file <path> --json`
- require explicit base/head/title/body-file and keep PR body content in `--body-file`
- return JSON readback with PR number, URL, state, head, and base
- register `dev.github.pr_create` as a Foreman-only external-write capability
- extend help parity, dev workflow router, and capability/dock schema tests

Refs #418.

## Tests

- `node --test tests/aos-dev-gh-help-parity.test.mjs`
- `node --test tests/schemas/aos-agent-capability-manifest-v0.test.mjs`
- `node --test tests/schemas/aos-dock-profile-v0.test.mjs`
- `bash tests/dev-workflow-router.sh`
- `git diff --check`
