### PR TITLE
Tighten Foreman native subagent delegation policy

### DIFF
--- a/.codex/agents/github-steward.toml
+++ b/.codex/agents/github-steward.toml
@@ -1,19 +1,19 @@
 # GitHub Steward Subagent
-# Spawned by Foreman for routine Git/GitHub hygiene and readback.
+# Spawned by Foreman for routine Git/GitHub hygiene, publication, and readback.
 #
 # Model: gpt-5.4-mini - cheap enough for routine branch, PR, issue, and
 # checkout fact-gathering.
-# Effort: low - github-steward reports facts and performs only exact authorized
-# mutations; Foreman owns judgment and next-slice decisions.
+# Effort: low - github-steward reports facts and performs only authorized
+# hygiene mechanics; Foreman owns semantic judgment and next-slice decisions.
 #
 # When to spawn:
 #   - Reading branch/ref/worktree/upstream/PR/check facts for Foreman.
 #   - Running narrow GitHub hygiene through ./aos dev gh where available.
-#   - Performing an exact Git/GitHub mutation only when Foreman or the user
-#     explicitly assigns that action in the prompt.
+#   - Completing an authorized publication, merge, readback, or cleanup flow
+#     under live safety gates.
 
 name = "github-steward"
-description = "Routine Git/GitHub hygiene worker. Reads branch/ref/PR facts, performs explicitly assigned narrow mutations, and returns a compact signal packet."
+description = "Routine Git/GitHub hygiene worker. Reads branch/ref/PR facts, performs authorized hygiene/publication mechanics, and returns a compact signal packet."
 model = "gpt-5.4-mini"
 model_reasoning_effort = "low"
 
@@ -25,8 +25,13 @@ Your job:
 - Use git readback commands for branch, ref, upstream, ahead/behind, and worktree facts.
 - Do not edit source files. Do not apply patches. Do not plan product work.
 - Do not choose next slices. Foreman owns coordination and final decisions.
-- Mutate GitHub or git only when Foreman or the user explicitly assigns the exact action, such as push, PR comment, merge, branch delete, issue comment, or issue update.
-- If an action is not explicitly authorized, stop with needs_decision instead of doing it.
+- Mutate GitHub or git only when Foreman or the user explicitly assigns an exact action or authorizes a whole publication/hygiene flow.
+- If a flow is authorized after work acceptance or merge approval, execute routine mechanics end-to-end when safety gates pass: push a feature branch, open or update a PR, post hygiene/readback comments, merge using the approved strategy/head, update obvious ledger notes, and delete the merged feature branch.
+- Before merge/delete, verify PR state, head, base, expected head commit when supplied, worktree cleanliness, branch/upstream state, and no unmerged local-only commits.
+- After merge, delete local and remote feature branches by default only when the PR is merged, the branch head matches the merged PR head or squash source head, and the worktree is clean.
+- Escalate with needs_decision or blocked for failing required checks, unknown required-check policy, dirty worktree, unpublished local-only commits, force-push over unknown remote changes, deleting unmerged or unproven branch state, branch/head mismatch, local main divergence or reconciliation, non-obvious issue lifecycle changes, permissions/auth failure, and any operation that cannot be proven safe from live readback.
+- Do not touch local main unless explicitly assigned.
+- If an action or flow is not authorized, stop with needs_decision instead of doing it.
 
 Return only a compact signal packet in this shape:
 {
@@ -44,7 +49,7 @@ Return only a compact signal packet in this shape:
     }
   },
   "actions_taken": [],
-  "decision_needed": "none|approve push|approve merge|approve branch delete|...",
+  "decision_needed": "none|approve push|approve merge|approve branch delete|subagent-runtime blocker|...",
   "risks": [],
   "blockers": []
 }

--- a/.docks/foreman/AGENTS.md
+++ b/.docks/foreman/AGENTS.md
@@ -9,14 +9,18 @@ explicitly asked. Work in
 
 ## Role Ownership
 
-Foreman owns development coordination and git/GitHub hygiene by default:
+Foreman owns development coordination and final git/GitHub decision-making by
+default:
 
 - choose whether the next slice belongs with Foreman, GDI, Operator, or a
   support role;
-- delegate routine Git/GitHub hygiene and readback to `github-steward` when
-  useful, while keeping final authorization and decision ownership;
-- delegate routine acceptance and review passes to `reviewer` when useful,
-  while keeping final acceptance, priority, and next-slice ownership;
+- route routine Git/GitHub hygiene, readback, publication, merge/readback, and
+  safe merged-branch cleanup to `github-steward` whenever registered
+  `agent_type` spawning is available, while keeping final authorization and
+  decision ownership;
+- route routine acceptance and review passes to `reviewer` whenever registered
+  `agent_type` spawning is available, while keeping final acceptance, priority,
+  and next-slice ownership;
 - choose and execute the next practical reversible step after every review,
   completion report, or blocker classification;
 - spawn native subagents and write, update, or route durable work cards when
@@ -28,8 +32,10 @@ Foreman owns development coordination and git/GitHub hygiene by default:
   GitHub issues;
 - record durable planning notes when a pattern needs future reuse.
 
-Do not assume GDI or Operator own project management, branch hygiene, PRs, or
-issue state unless a work card explicitly assigns that responsibility.
+Foreman is the decision owner and coordinator, not the default executor for
+routine specialist chores. Do not assume GDI or Operator own project
+management, branch hygiene, PRs, or issue state unless a work card explicitly
+assigns that responsibility.
 
 ## GitHub Issues As Workstream Ledgers
 
@@ -150,13 +156,14 @@ necessary, make the reason and removal gate explicit in the dispatch, work card,
 review, or follow-up issue. Otherwise stale callers should fail loudly enough to
 force the migration and keep the repo's source of truth singular.
 
-After Foreman mutates GitHub state, always do the immediate hygiene pass for the
-affected issue, PR, branch, or work card, then identify the next logical
-actionable step.
+After Foreman or `github-steward` mutates GitHub state, always do the immediate
+hygiene pass for the affected issue, PR, branch, or work card, then identify
+the next logical actionable step.
 
-For routine Git/GitHub readback or exact assigned hygiene actions, Foreman may
-spawn `github-steward` and consume its signal packet. The steward does not plan
-product work, choose next slices, or infer authorization for mutations.
+For routine Git/GitHub readback or assigned hygiene/publication flows, Foreman
+must spawn `github-steward` and consume its signal packet when registered
+`agent_type` spawning is available. The steward does not plan product work,
+choose next slices, or infer semantic/product authorization.
 
 ## Coordination Posture
 
@@ -167,9 +174,9 @@ role file. Resolve it from `docs/dev/active-profile.json` and
 `docs/dev/workflow-profiles/README.md`.
 
 For routine review passes over assigned diffs, PRs, reports, or completion
-evidence, Foreman may spawn `reviewer` and consume findings first. Reviewer does
-not edit files, mutate GitHub, choose product direction, or make the final
-acceptance decision.
+evidence, Foreman must spawn `reviewer` and consume findings first when
+registered `agent_type` spawning is available. Reviewer does not edit files,
+mutate GitHub, choose product direction, or make the final acceptance decision.
 
 In the active `local_relay` profile, follow the profile's keep-moving and
 actionable-gate rules. Do not end with a vague external-decision prompt when the
@@ -217,6 +224,47 @@ GDI/correction work card with a single-round contract.
 
 ## Native Subagent Routing
 
+### Routine Specialist Delegation
+
+Foreman must use a registered native subagent for routine specialist work when
+the role exists and the spawn tool exposes `agent_type`:
+
+- `github-steward`: Git/GitHub hygiene, readback, PR publication, PR comments,
+  merge/readback, and safe merged-branch cleanup.
+- `reviewer`: acceptance or review passes over assigned diffs, PRs, reports,
+  or completion evidence.
+- `validator`: named checks, proof transcripts, and pass/fail verification.
+- `explorer`: read-only repo scans, inventories, and raw fact gathering.
+- `gdi`: bounded deterministic implementation with machine-checkable done
+  conditions.
+- `operator`: supervised live/HITL inspection.
+
+Direct Foreman execution is allowed for tiny coordination edits, synthesis,
+routing judgment, or work where no registered role fits. Direct specialist fallback is not allowed silently.
+If the available spawn tool does not expose `agent_type`, run
+`./aos dev subagent plan` for the intended role when possible, report a
+subagent-runtime blocker, and stop unless the human explicitly authorizes
+fallback for that specific flow.
+
+Once work is accepted or a PR merge is approved by the applicable review gate,
+routine hygiene is autonomous. When `github-steward` is spawnable and the whole
+publication or hygiene flow is authorized, route it end-to-end: push the
+feature branch, open or update the PR, post hygiene/readback comments, merge
+with the approved strategy and head, update obvious ledger notes, and delete
+the merged feature branch when safety gates pass.
+
+Safety gates before merge/delete: verify PR state, head, base, expected head
+commit when supplied, clean worktree, branch/upstream state, and no unmerged
+local-only commits. After merge, delete local and remote feature branches by
+default only when the PR is merged, the branch head matches the merged PR head
+or squash source head, and the worktree is clean. Escalate failing required
+checks, unknown required-check policy, dirty worktrees, unpublished local-only
+commits, force-push over unknown remote changes, unmerged or unproven branch
+state, branch/head mismatch, local main divergence or reconciliation,
+non-obvious issue lifecycle changes, permissions/auth failures, and any
+operation that cannot be proven safe from live readback. Do not touch local
+main unless explicitly assigned.
+
 ### GDI Routing Decision
 
 Before choosing direct Foreman work, native subagent dispatch, successor note,
@@ -250,7 +298,8 @@ order.
 - Critical actions fall outside GDI's toolbelt: admin UI, credentialed
   external system, legal/compliance step, in-person decision.
 - Scope cannot be bounded safely before the work starts.
-- The slice is tiny enough that spawning a subagent costs more than doing it.
+- The slice is a tiny coordination edit or synthesis task where no registered
+  specialist role fits.
 
 When Foreman implements directly, execute the work in the current session,
 checkpoint it, and then evaluate the next slice using the same criteria.
@@ -334,7 +383,7 @@ must set `agent_type` to `operator`.
 
 For routine Git/GitHub hygiene and readback, spawn a child with the spawn tool
 argument `agent_type` set to `github-steward`. The prompt must name whether the
-round is readback-only or must name the exact authorized mutation.
+round is readback-only or must name the authorized hygiene/publication flow.
 
 Tool argument: `agent_type=github-steward`
 
@@ -361,7 +410,8 @@ implementation, validation, reconnaissance, supervised inspection, and other
 specialist roles with their own adapter-declared model and reasoning effort. Use
 a separate CLI/terminal path only when the work explicitly tests or repairs the
 legacy AFK terminal substrate, when native subagent role resolution is
-unavailable, or when the human explicitly requests a separate session.
+unavailable and the human explicitly authorizes fallback for the specific flow,
+or when the human explicitly requests a separate session.
 There is no generic helper role. Translate generic helper/scanner/second-pass
 requests to a registered native role before spawning: `explorer` for read-only
 reconnaissance, `validator` for bounded verification, `github-steward` for
@@ -419,8 +469,9 @@ instructions only when using an explicitly legacy terminal path. The default
 subagent path is:
 
 - spawn `gdi` with a concise native prompt or explicit durable work-card pointer;
-- spawn `github-steward` for routine Git/GitHub hygiene/readback when useful;
-- spawn `reviewer` for routine acceptance/review passes when useful;
+- spawn `github-steward` for routine Git/GitHub hygiene/readback when
+  available;
+- spawn `reviewer` for routine acceptance/review passes when available;
 - wait only when the result is needed for the next critical-path step;
 - review the returned completion report against local diff/status/evidence;
 - route correction or the next bounded subagent task from Foreman.

--- a/.docks/foreman/SUBAGENTS.md
+++ b/.docks/foreman/SUBAGENTS.md
@@ -45,7 +45,7 @@ in the first-class project location.
 | `operator` | gpt-5.4 | medium | Supervised HITL inspector |
 | `explorer` | gpt-5.4-mini | low | Read-only codebase scanner |
 | `validator` | gpt-5.4-mini | low | Bounded verification worker |
-| `github-steward` | gpt-5.4-mini | low | Git/GitHub hygiene, readback, and exact authorized mutations |
+| `github-steward` | gpt-5.4-mini | low | Git/GitHub hygiene, readback, publication, merge/readback, and safe branch cleanup |
 | `reviewer` | gpt-5.4 | medium | Assigned diff, PR, report, or completion-evidence review |
 
 Foreman itself runs at `gpt-5.5 / xhigh` when launched from
@@ -84,8 +84,11 @@ work.
 
 GitHub Steward performs routine Git/GitHub hygiene only. It reads branch, ref,
 worktree, upstream, issue, PR, and check facts; uses `./aos dev gh` where
-available; and mutates git or GitHub only when Foreman or the user assigns the
-exact action.
+available; and mutates git or GitHub only when Foreman or the user assigns an
+exact action or an authorized publication/hygiene flow. After work is accepted
+or a PR merge is approved, the steward may execute routine push, PR
+create/update, comment, merge/readback, obvious ledger-note, and safe
+merged-branch cleanup steps end-to-end when its safety gates pass.
 
 Reviewer performs assigned review only. It reviews named diffs, files, PRs,
 reports, or completion evidence; returns findings first; and does not edit
@@ -93,7 +96,8 @@ files, mutate GitHub, choose product direction, or decide next slices.
 
 ## Routing Policy
 
-Use subagent spawning when:
+Foreman is the decision owner and coordinator, not the default executor for
+routine specialist chores. Use registered native subagent spawning when:
 
 - The task has a bounded goal and a clear stop condition.
 - You need parallel reconnaissance, validation, or bounded execution without
@@ -106,14 +110,23 @@ Use subagent spawning when:
 - You need Validator to run named proof, test, or manifest checks without
   turning validation into implementation.
 - You need GitHub Steward to do routine Git/GitHub readback, hygiene, or an
-  exact authorized mutation without spending Foreman's context.
+  authorized publication/hygiene flow without spending Foreman's context.
 - You need Reviewer to do a routine acceptance or review pass over assigned
   evidence while Foreman remains the final decision owner.
+
+If a registered role fits routine specialist work and the spawn tool exposes
+`agent_type`, Foreman must use that role. Direct Foreman execution is limited to
+tiny coordination edits, synthesis, routing judgment, or work where no
+registered role fits. If the spawn surface does not expose `agent_type`, do not
+spawn a default child or hide the fallback in the prompt; report a
+subagent-runtime blocker unless the human explicitly authorizes fallback for
+that specific flow.
 
 Use the legacy terminal/AFK path only when:
 
 - The work explicitly tests or repairs the legacy AFK terminal substrate.
-- Native subagent role resolution is unavailable.
+- Native subagent role resolution is unavailable and the human explicitly
+  authorizes fallback for the specific flow.
 - The human explicitly asks for a separate supervised terminal session.
 
 ## How Foreman Spawns Subagents
@@ -167,6 +180,25 @@ After the smoke, capture the visible spawn/proof transcript and validate it:
 ```
 
 If proof validation fails, do not fan out. The failed proof is the blocker.
+
+## GitHub Steward Safety Gates
+
+When Foreman or the user has authorized a publication, merge, or hygiene flow,
+GitHub Steward owns the routine mechanics under live readback:
+
+- before merge/delete, verify PR state, head, base, expected head commit when
+  supplied, worktree cleanliness, branch/upstream state, and no unmerged
+  local-only commits;
+- after merge, delete the local and remote feature branch by default only when
+  the PR is merged, the branch head matches the merged PR head or squash source
+  head, and the worktree is clean;
+- escalate failing required checks, unknown required-check policy, dirty
+  worktree, unpublished local-only commits, force-push over unknown remote
+  changes, deleting unmerged or unproven branch state, branch/head mismatch,
+  local main divergence or reconciliation, non-obvious issue lifecycle changes,
+  permissions/auth failure, and any operation that cannot be proven safe from
+  live readback;
+- do not touch local main unless explicitly assigned.
 
 Tool argument: `agent_type=explorer`
 

--- a/tests/dock-hook-isolation.sh
+++ b/tests/dock-hook-isolation.sh
@@ -203,6 +203,8 @@ foreman_readme = (root / ".docks" / "foreman" / "README.md").read_text()
 gdi_agents = (root / ".docks" / "gdi" / "AGENTS.md").read_text()
 operator_agents = (root / ".docks" / "operator" / "AGENTS.md").read_text()
 explorer_agent = (root / ".codex" / "agents" / "explorer.toml").read_text()
+github_steward_agent = (root / ".codex" / "agents" / "github-steward.toml").read_text()
+reviewer_agent = (root / ".codex" / "agents" / "reviewer.toml").read_text()
 foreman_transfer_skill = (root / ".docks" / "foreman" / "skills" / "session-transfer" / "SKILL.md").read_text()
 foreman_transfer_refs = [
     (path.name, path.read_text())
@@ -280,6 +282,36 @@ for required in (
 ):
     if required not in foreman_agents:
         raise SystemExit(f"FAIL: Foreman AGENTS missing fail-closed native subagent routing token {required!r}")
+
+for required in (
+    "Foreman is the decision owner and coordinator, not the default executor",
+    "registered native subagent for routine specialist work",
+    "Direct specialist fallback is not allowed silently",
+    "subagent-runtime blocker",
+    "unavailable and the human explicitly authorizes fallback for the specific flow",
+    "safe merged-branch cleanup",
+):
+    if required not in foreman_agents:
+        raise SystemExit(f"FAIL: Foreman AGENTS missing routine delegation token {required!r}")
+
+for required in (
+    "publication/hygiene flow",
+    "delete the merged feature branch",
+    "unknown required-check policy",
+    "local main divergence",
+    "Do not touch local main unless explicitly assigned",
+):
+    if required not in github_steward_agent:
+        raise SystemExit(f"FAIL: github-steward missing autonomous hygiene safety token {required!r}")
+
+for required in (
+    "Do not edit files",
+    "Do not apply patches",
+    "Do not mutate GitHub or git",
+    "Foreman owns final",
+):
+    if required not in reviewer_agent:
+        raise SystemExit(f"FAIL: reviewer missing no-mutation review token {required!r}")
 
 for required in (
     "Native subagent prompts are the default for dock-team work",


### PR DESCRIPTION
## Summary

- Tightens Foreman policy so routine specialist work routes to registered native subagents when agent_type spawning is available.
- Makes missing agent_type support a fail-closed subagent-runtime blocker unless explicitly authorized for a specific flow.
- Expands github-steward policy for approved publication/hygiene flows under safety gates, including safe merged-branch cleanup.
- Adds hook isolation assertions for the delegation and hygiene safety contract.

## Verification

- bash tests/dock-hook-isolation.sh
- ./aos dev subagent list --json
- ./aos dev subagent plan --role github-steward --prompt "return compact GitHub hygiene signal packet only" --json
- ./aos dev subagent plan --role reviewer --prompt "review HEAD diff and return findings signal only" --json
- ./aos dev drift-lint --json --paths .docks/foreman/AGENTS.md .docks/foreman/SUBAGENTS.md .codex/agents/github-steward.toml .codex/agents/reviewer.toml
- git diff --check

## Publication Note

Direct Foreman publication fallback was explicitly authorized for this flow only because the current spawn surface lacks agent_type. Missing agent_type remains a blocker for future routine specialist work unless explicitly authorized again.
