### PR TITLE
Fix Foreman dock config: restore full launch posture

### DIFF
--- a/.docks/foreman/.codex/config.toml
+++ b/.docks/foreman/.codex/config.toml
@@ -1,10 +1,19 @@
 model = "gpt-5.5"
-model_reasoning_effort = "xhigh"
+model_reasoning_effort = "medium"
+personality = "pragmatic"
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+
+[notice]
+hide_full_access_warning = true
 
 [features]
 hooks = true
+goals = true
 multi_agent = true
-goals = false
+js_repl = true
+guardian_approval = true
+prevent_idle_sleep = true
 
 [tui]
 status_line = ["current-dir", "git-branch", "context-remaining", "model-with-reasoning"]


### PR DESCRIPTION
Restores correct Foreman launch posture lost when the subagent guardrails branch was merged.

Changes:
- `model_reasoning_effort`: `xhigh` → `medium` (Foreman delegates; subagents handle the work)
- `goals`: `false` → `true`
- Added: `personality`, `approval_policy`, `sandbox_mode`
- Added: `[notice]` block with `hide_full_access_warning` = true
- Added: `js_repl`, `guardian_approval`, `prevent_idle_sleep` feature flags

Supersedes #445.