### PR TITLE
Enable multi_agent_v2 and normalize steward key to github-steward

### DIFF
--- a/.docks/foreman/.codex/config.toml
+++ b/.docks/foreman/.codex/config.toml
@@ -11,6 +11,7 @@ hide_full_access_warning = true
 hooks = true
 goals = true
 multi_agent = true
+multi_agent_v2 = true
 js_repl = true
 guardian_approval = true
 prevent_idle_sleep = true
@@ -30,8 +31,8 @@ description = "Read-only codebase scanner. Maps surfaces, locates patterns, and 
 config_file = "../../../.codex/agents/validator.toml"
 description = "Bounded verification worker. Runs named checks, inspects evidence, and reports pass/fail facts without editing files."
 
-[agents.steward]
-config_file = "../../../.codex/agents/steward.toml"
+[agents.github-steward]
+config_file = "../../../.codex/agents/github-steward.toml"
 description = "Routine Git/GitHub hygiene worker. Reads branch/ref/PR facts, performs explicitly assigned narrow mutations, and returns a compact signal packet."
 
 [agents.reviewer]


### PR DESCRIPTION
## What

Two changes to `.docks/foreman/.codex/config.toml`:

1. **`multi_agent_v2 = true`** added to `[features]` — this is the flag that exposes the `agent_type` field in the spawn tool surface. Without it, Foreman only sees `multi_agent_v1.spawn_agent` which has no `agent_type` channel, so custom agent TOML bindings are silently ignored and subagents inherit Foreman's `gpt-5.5 / medium` posture.

2. **`[agents.steward]` → `[agents.github-steward]`** with `config_file` updated to `../../../.codex/agents/github-steward.toml` — normalizes the table key to match the TOML `name = "github-steward"` field, which is how Codex resolves the config from the `agent_type` value at spawn time.

## Why

The `foreman/enable-agent-type-spawn-v0` branch (merged as PR #444) correctly wired the guardrails and fail-closed logic but left `multi_agent_v2` unenabled. Live testing confirmed the spawner was still running at `multi_agent_v1`, meaning `agent_type=github-steward` had no channel to travel through and subagents always launched at Foreman's model/effort.

See [openai/codex#15250](https://github.com/openai/codex/issues/15250) for the upstream confirmation that `multi_agent_v2` is required for structured `agent_type` resolution.

## Test

After merge, relaunch from `.docks/foreman` and delegate a bounded task. The spawned child should show `gpt-5.4-mini / low` (github-steward's config) instead of `gpt-5.5 / medium`.