### PR TITLE
Hide internal browser helpers from consumer help

### DIFF
--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -9510,6 +9510,7 @@
       "summary" : "Knowledge base — browse, search, invoke workflow plugins"
     },
     {
+      "consumer_discovery" : false,
       "forms" : [
         {
           "args" : [

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -43,7 +43,7 @@ else
 fi
 rm -f /tmp/aos-root-help.out /tmp/aos-root-help.err /tmp/aos-root-help-flag.out /tmp/aos-root-help-flag.err /tmp/aos-do-help-flag.json /tmp/aos-do-help-flag.err
 
-if ROOT_JSON="$(./aos help --json 2>/dev/null)" ROOT_TEXT="$(./aos 2>/dev/null)" DIRECT_DEV="$(./aos help dev --json 2>/dev/null)" python3 - <<'PY'
+if ROOT_JSON="$(./aos help --json 2>/dev/null)" ROOT_TEXT="$(./aos 2>/dev/null)" DIRECT_DEV="$(./aos help dev --json 2>/dev/null)" DIRECT_BROWSER="$(./aos help browser --json 2>/dev/null)" python3 - <<'PY'
 import json
 import os
 from pathlib import Path
@@ -51,18 +51,31 @@ from pathlib import Path
 root = json.loads(os.environ["ROOT_JSON"])
 manifest = json.loads(Path("manifests/commands/aos-commands.json").read_text(encoding="utf-8"))
 assert all(command["path"] != ["dev"] for command in root["commands"]), root
+assert all(command["path"] != ["browser"] for command in root["commands"]), root
+for command in root["commands"]:
+    summary = command.get("summary", "")
+    assert "not user-facing" not in summary.lower(), command
+    assert "internal" not in summary.lower(), command
+    assert "debug helper" not in summary.lower(), command
 assert "\n  dev" not in os.environ["ROOT_TEXT"], os.environ["ROOT_TEXT"]
+assert "\n  browser" not in os.environ["ROOT_TEXT"], os.environ["ROOT_TEXT"]
 direct = json.loads(os.environ["DIRECT_DEV"])
 assert direct["path"] == ["dev"], direct
 assert direct["consumer_discovery"] is False, direct
 assert any(form["id"] == "dev-classify" for form in direct["forms"]), direct
+direct_browser = json.loads(os.environ["DIRECT_BROWSER"])
+assert direct_browser["path"] == ["browser"], direct_browser
+assert direct_browser["consumer_discovery"] is False, direct_browser
+assert any(form["id"] == "browser-parse-target" for form in direct_browser["forms"]), direct_browser
 manifest_dev = next(command for command in manifest["commands"] if command["path"] == ["dev"])
 assert manifest_dev["consumer_discovery"] is False, manifest_dev
+manifest_browser = next(command for command in manifest["commands"] if command["path"] == ["browser"])
+assert manifest_browser["consumer_discovery"] is False, manifest_browser
 PY
 then
-    pass "root consumer help excludes dev while direct dev help resolves"
+    pass "root consumer help excludes internal command groups while direct help resolves"
 else
-    fail "dev demotion from root consumer help drifted"
+    fail "internal command demotion from root consumer help drifted"
 fi
 
 # --- 2. aos help show --json → JSON per-command ---


### PR DESCRIPTION
## Summary
- Mark the internal `aos browser _...` helper group as `consumer_discovery: false` so root consumer help does not advertise it.
- Extend the help contract test to verify hidden internal command groups remain directly addressable through `aos help <command> --json` while staying out of root help.
- Add a generic root-help guard against summaries that label commands internal, debug-only, or not user-facing.

## Verification
- `./aos help --json | jq -e 'all(.commands[]; .path != ["browser"] and .path != ["dev"])'`
- `./aos help browser --json | jq -e '.path == ["browser"] and .consumer_discovery == false and any(.forms[]; .id == "browser-parse-target")'`
- `bash tests/help-contract.sh`
- `bash tests/external-command-dispatch.sh`
- `node --test tests/schemas/aos-external-command-manifest-v0.test.mjs`
- `git diff --check`

## DOX / Live Proof
- DOX chain checked for `manifests/commands/aos-commands.json` and `tests/help-contract.sh`; no AGENTS/DOX update needed because existing command-surface docs already define `consumer_discovery: false` behavior.
- Live UI/native/TCC proof: not applicable; this is a static help/manifest contract change.