### PR TITLE
Align direct canvas drag command contract

### DIFF
--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -2785,6 +2785,116 @@
         {
           "args" : [
             {
+              "id" : "target",
+              "kind" : "positional",
+              "required" : true,
+              "summary" : "AOS canvas semantic drag target",
+              "value_type" : "string"
+            },
+            {
+              "id" : "by",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Move the current canvas semantic target by dx,dy",
+              "token" : "--by",
+              "value_type" : "string"
+            },
+            {
+              "id" : "to-value",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Drag a value control to a semantic value",
+              "token" : "--to-value",
+              "value_type" : "string"
+            },
+            {
+              "default_value" : "auto",
+              "id" : "playback",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Canvas drag playback mode; human uses visible pointer playback",
+              "token" : "--playback",
+              "value_type" : {
+                "enum" : [
+                  {
+                    "summary" : "Prefer immediate semantic execution for AOS-owned canvas controls",
+                    "value" : "auto"
+                  },
+                  {
+                    "summary" : "Immediate semantic execution",
+                    "value" : "immediate"
+                  },
+                  {
+                    "summary" : "Visible pointer playback",
+                    "value" : "human"
+                  }
+                ]
+              }
+            },
+            {
+              "id" : "state-id",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Perception state id this action was chosen from",
+              "token" : "--state-id",
+              "value_type" : "string"
+            },
+            {
+              "id" : "dry-run",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Validate and describe the canvas drag without executing it",
+              "token" : "--dry-run",
+              "value_type" : "bool"
+            }
+          ],
+          "constraints" : {
+            "conflicts" : [
+              [
+                "by",
+                "to-value"
+              ]
+            ],
+            "required_groups" : [
+              {
+                "one_of" : [
+                  [
+                    "by"
+                  ],
+                  [
+                    "to-value"
+                  ]
+                ],
+                "summary" : "canvas drag mode"
+              }
+            ]
+          },
+          "examples" : [
+            "aos do drag canvas:surface\/surface:drag-handle --by 80,40 --dry-run",
+            "aos do drag canvas:settings\/brightness-slider --to-value 42 --playback human"
+          ],
+          "summary" : "Direct current canvas semantic drag; separate from saved-ref drag and native coordinate drag",
+          "execution" : {
+            "auto_starts_daemon" : false,
+            "interactive" : false,
+            "mutates_state" : true,
+            "read_only" : false,
+            "requires_permissions" : true,
+            "streaming" : false,
+            "supports_dry_run" : true
+          },
+          "id" : "do-drag-canvas",
+          "output" : {
+            "default_mode" : "json",
+            "error_mode" : "json_stderr",
+            "streaming" : false,
+            "supports_json_flag" : false
+          },
+          "usage" : "aos do drag <canvas:<canvas-id>\/<ref>> (--by <dx,dy>|--to-value <value>) [--playback auto|immediate|human] [--state-id id] [--dry-run]"
+        },
+        {
+          "args" : [
+            {
               "id" : "from",
               "kind" : "positional",
               "required" : true,

--- a/scripts/aos-do-native.mjs
+++ b/scripts/aos-do-native.mjs
@@ -25,13 +25,13 @@ const valueFlags = new Set([
   '--index', '--near', '--match', '--depth', '--timeout',
   '--profile', '--value', '--to', '--dy', '--dx', '--window',
   '--delay', '--variance', '--dwell', '--steps', '--speed',
-  '--state-id',
+  '--state-id', '--by', '--to-value', '--playback',
 ]);
 const booleanFlags = new Set(['--dry-run', '--right', '--double']);
 
 const intFlags = new Set(['--index', '--depth', '--timeout', '--window', '--dwell', '--steps']);
 const numberFlags = new Set(['--dx', '--dy', '--delay', '--variance', '--speed']);
-const coordFlags = new Set(['--near', '--to']);
+const coordFlags = new Set(['--near', '--to', '--by']);
 
 function positionalArgEntries(args) {
   const entries = [];
@@ -158,6 +158,22 @@ function validate(verb, args) {
       break;
     case 'drag':
       if (pos.some((arg) => arg.startsWith('browser:'))) error('native do drag does not accept browser targets', 'INVALID_TARGET');
+      if (pos[0]?.startsWith('canvas:')) {
+        const hasBy = flagPresence(args, '--by');
+        const hasToValue = flagPresence(args, '--to-value');
+        if (pos.length > 1) unknownArg(pos[1]);
+        if (flagPresence(args, '--speed')) unknownArg('--speed');
+        if (hasBy && hasToValue) error('canvas drag accepts exactly one of --by or --to-value', 'INVALID_ARG');
+        if (!hasBy && !hasToValue) error('drag canvas target requires --by dx,dy or --to-value value', 'MISSING_ARG');
+        const playback = flagValue(args, '--playback');
+        if (playback && !['auto', 'immediate', 'human'].includes(playback)) {
+          error(`unsupported playback mode '${playback}'`, 'INVALID_PLAYBACK');
+        }
+        break;
+      }
+      if (flagPresence(args, '--by')) unknownArg('--by');
+      if (flagPresence(args, '--to-value')) unknownArg('--to-value');
+      if (flagPresence(args, '--playback')) unknownArg('--playback');
       if (!(pos.length >= 2 && isCoord(pos[0]) && isCoord(pos[1]))) error('drag requires two coordinate pairs (x1,y1 x2,y2)', 'MISSING_ARG');
       if (pos.length > 2) unknownArg(pos[2]);
       break;

--- a/tests/agent-workspace-canvas-refs.sh
+++ b/tests/agent-workspace-canvas-refs.sh
@@ -223,6 +223,38 @@ jq -e '
   and (.received | index("46") != null)
 ' "$CANVAS_DIRECT_SET_POSITIONAL" >/dev/null || fail "direct canvas positional set-value wrapper normalization drifted: $(cat "$CANVAS_DIRECT_SET_POSITIONAL")"
 
+CANVAS_DIRECT_DRAG_BY="$TMP_DIR/do-canvas-direct-drag-by.json"
+AOS_PATH="$FAKE_CANVAS_AOS" node scripts/aos-do-native.mjs drag canvas:canvas-fixture/canvas-fixture:drag-handle --by 80,40 --dry-run --state-id see_canvas_fixture >"$CANVAS_DIRECT_DRAG_BY"
+jq -e '
+  .status == "dry_run_passthrough"
+  and (.received | index("__do") != null)
+  and (.received | index("drag") != null)
+  and (.received | index("canvas:canvas-fixture/canvas-fixture:drag-handle") != null)
+  and (.received | index("--by") != null)
+  and (.received | index("80,40") != null)
+' "$CANVAS_DIRECT_DRAG_BY" >/dev/null || fail "direct canvas drag --by wrapper validation drifted: $(cat "$CANVAS_DIRECT_DRAG_BY")"
+
+CANVAS_DIRECT_DRAG_TO_VALUE="$TMP_DIR/do-canvas-direct-drag-to-value.json"
+AOS_PATH="$FAKE_CANVAS_AOS" node scripts/aos-do-native.mjs drag canvas:canvas-fixture/brightness-slider --to-value 0.7 --playback human --dry-run >"$CANVAS_DIRECT_DRAG_TO_VALUE"
+jq -e '
+  .status == "dry_run_passthrough"
+  and (.received | index("__do") != null)
+  and (.received | index("drag") != null)
+  and (.received | index("canvas:canvas-fixture/brightness-slider") != null)
+  and (.received | index("--to-value") != null)
+  and (.received | index("0.7") != null)
+  and (.received | index("--playback") != null)
+  and (.received | index("human") != null)
+' "$CANVAS_DIRECT_DRAG_TO_VALUE" >/dev/null || fail "direct canvas drag --to-value wrapper validation drifted: $(cat "$CANVAS_DIRECT_DRAG_TO_VALUE")"
+
+CANVAS_DIRECT_DRAG_BOTH_MODES_ERR="$TMP_DIR/do-canvas-direct-drag-both-modes.err"
+if AOS_PATH="$FAKE_CANVAS_AOS" node scripts/aos-do-native.mjs drag canvas:canvas-fixture/brightness-slider --by 1,1 --to-value 0.7 >"$TMP_DIR/do-canvas-direct-drag-both-modes.out" 2>"$CANVAS_DIRECT_DRAG_BOTH_MODES_ERR"; then
+    fail "direct canvas drag with both drag modes unexpectedly succeeded"
+fi
+expect_error_code "INVALID_ARG" "$CANVAS_DIRECT_DRAG_BOTH_MODES_ERR"
+jq -e '.error | contains("exactly one of --by or --to-value")' "$CANVAS_DIRECT_DRAG_BOTH_MODES_ERR" >/dev/null \
+    || fail "direct canvas drag both-mode error did not explain one-mode rule: $(cat "$CANVAS_DIRECT_DRAG_BOTH_MODES_ERR")"
+
 CANVAS_DIRECT_SET_BOTH_VALUE_SOURCES_ERR="$TMP_DIR/do-canvas-direct-set-value-both-sources.err"
 if AOS_PATH="$FAKE_CANVAS_AOS" node scripts/aos-do-native.mjs set-value canvas:canvas-fixture/brightness-slider 46 --value 47 >"$TMP_DIR/do-canvas-direct-set-value-both-sources.out" 2>"$CANVAS_DIRECT_SET_BOTH_VALUE_SOURCES_ERR"; then
     fail "direct canvas set-value with both value sources unexpectedly succeeded"

--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -397,14 +397,24 @@ assert.ok(!manifest.includes('remains dry-run advisory'), 'manifest save summary
 const doCommand = manifestJSON.commands.find((command) => JSON.stringify(command.path) === JSON.stringify(['do']));
 assert.ok(doCommand, 'manifest missing do command');
 const doDragForm = doCommand.forms.find((form) => form.id === 'do-drag');
+const doCanvasDragForm = doCommand.forms.find((form) => form.id === 'do-drag-canvas');
 const doNativeDragForm = doCommand.forms.find((form) => form.id === 'do-drag-native');
 assert.ok(doDragForm, 'manifest missing saved-ref/browser do-drag form');
+assert.ok(doCanvasDragForm, 'manifest missing direct canvas do-drag form');
 assert.ok(doNativeDragForm, 'manifest missing native coordinate do-drag form');
 assert.ok(!doDragForm.usage.includes('--speed'), 'saved-ref drag usage must not advertise native-only --speed');
 assert.ok(!doDragForm.args.some((arg) => arg.token === '--speed'), 'saved-ref drag args must not advertise native-only --speed');
+assert.ok(!doDragForm.usage.includes('--by'), 'saved-ref drag usage must not advertise direct-canvas --by');
+assert.ok(!doDragForm.usage.includes('--to-value'), 'saved-ref drag usage must not advertise direct-canvas --to-value');
+assert.ok(doCanvasDragForm.usage.includes('canvas:<canvas-id>/<ref>'), 'direct canvas drag usage must advertise canvas target dialect');
+assert.ok(doCanvasDragForm.usage.includes('--by'), 'direct canvas drag usage must advertise --by');
+assert.ok(doCanvasDragForm.usage.includes('--to-value'), 'direct canvas drag usage must advertise --to-value');
+assert.ok(!doCanvasDragForm.usage.includes('ref:<snapshot-id>'), 'direct canvas drag usage must not advertise saved refs');
+assert.ok(!doCanvasDragForm.usage.includes('--speed'), 'direct canvas drag usage must not advertise native-only --speed');
 assert.ok(doNativeDragForm.usage.includes('--speed'), 'native coordinate drag usage must advertise --speed');
 assert.ok(doNativeDragForm.args.some((arg) => arg.token === '--speed'), 'native coordinate drag args must keep --speed');
 assert.ok(!doNativeDragForm.usage.includes('ref:<snapshot-id>'), 'native coordinate drag usage must not advertise saved refs');
+assert.ok(!doNativeDragForm.usage.includes('canvas:<canvas-id>'), 'native coordinate drag usage must not advertise canvas targets');
 
 const seeCommand = manifestJSON.commands.find((command) => JSON.stringify(command.path) === JSON.stringify(['see']));
 assert.ok(seeCommand, 'manifest missing see command');

--- a/tests/external-parser-flags.sh
+++ b/tests/external-parser-flags.sh
@@ -167,6 +167,8 @@ if ! grep -Eq '"code"[[:space:]]*:[[:space:]]*"MISSING_ARG"' "$err"; then
   exit 1
 fi
 check_unknown_arg do-native-drag-extra ./aos do drag 10,10 20,20 unexpected --dry-run
+check_unknown_flag do-native-drag-by-flag ./aos do drag 10,10 20,20 --by 1,1 --dry-run
+check_unknown_flag do-native-drag-to-value-flag ./aos do drag 10,10 20,20 --to-value 0.7 --dry-run
 check_unknown_arg do-native-scroll-extra ./aos do scroll 10,10 unexpected --dx 0 --dy 1 --dry-run
 check_unknown_arg do-native-type-extra ./aos do type hello unexpected --dry-run
 check_unknown_arg do-native-key-extra ./aos do key Enter unexpected --dry-run
@@ -190,6 +192,10 @@ if ! grep -Eq '"code"[[:space:]]*:[[:space:]]*"INVALID_ARG"' "$err"; then
   cat "$err" >&2
   exit 1
 fi
+check_missing_arg do-canvas-drag-mode-missing ./aos do drag canvas:fixture/drag-handle --dry-run
+check_invalid_arg do-canvas-drag-both-modes ./aos do drag canvas:fixture/drag-handle --by 1,1 --to-value 0.7 --dry-run
+check_unknown_flag do-canvas-drag-speed ./aos do drag canvas:fixture/drag-handle --by 1,1 --speed 600 --dry-run
+check_code do-canvas-drag-playback-invalid INVALID_PLAYBACK ./aos do drag canvas:fixture/drag-handle --by 1,1 --playback robot --dry-run
 err="$STATE_ROOT/do-native-scroll-dy-invalid.err"
 if ./aos do scroll 10,10 --dy nope --dry-run 2>"$err"; then
   echo "FAIL: do native scroll accepted invalid --dy value" >&2

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -402,15 +402,25 @@ drag = next(item for item in data["forms"] if item["id"] == "do-drag")
 drag_tokens = {arg.get("token") for arg in drag["args"]}
 assert {"--workspace", "--snapshot", "--dry-run"} <= drag_tokens, drag_tokens
 assert "--speed" not in drag_tokens, drag_tokens
+assert "--by" not in drag_tokens, drag_tokens
+assert "--to-value" not in drag_tokens, drag_tokens
 assert "browser:<session>/<ref>" in drag["usage"], drag["usage"]
 assert "--speed" not in drag["usage"], drag["usage"]
 assert "x1,y1" not in drag["usage"], drag["usage"]
+canvas_drag = next(item for item in data["forms"] if item["id"] == "do-drag-canvas")
+canvas_drag_tokens = {arg.get("token") for arg in canvas_drag["args"]}
+assert {"--by", "--to-value", "--playback", "--state-id", "--dry-run"} <= canvas_drag_tokens, canvas_drag_tokens
+assert "canvas:<canvas-id>/<ref>" in canvas_drag["usage"], canvas_drag["usage"]
+assert "--speed" not in canvas_drag["usage"], canvas_drag["usage"]
+assert "ref:<snapshot-id>" not in canvas_drag["usage"], canvas_drag["usage"]
+assert "x1,y1" not in canvas_drag["usage"], canvas_drag["usage"]
 native_drag = next(item for item in data["forms"] if item["id"] == "do-drag-native")
 native_drag_tokens = {arg.get("token") for arg in native_drag["args"]}
 assert "--speed" in native_drag_tokens, native_drag_tokens
 assert "--speed N" in native_drag["usage"], native_drag["usage"]
 assert "<x1,y1> <x2,y2>" in native_drag["usage"], native_drag["usage"]
 assert "ref:<snapshot-id>" not in native_drag["usage"], native_drag["usage"]
+assert "canvas:<canvas-id>" not in native_drag["usage"], native_drag["usage"]
 PY
 then
     pass "supported saved-ref do actions advertise saved ref targets"

--- a/tests/lib/agent-workspace-fixtures/canvas.sh
+++ b/tests/lib/agent-workspace-fixtures/canvas.sh
@@ -145,6 +145,19 @@ PY
     exit 0
 fi
 
+if [[ "${1:-}" == "__do" && "${2:-}" == "drag" && "${3:-}" == canvas:* ]]; then
+    python3 - "$@" <<'PY'
+import json
+import sys
+
+print(json.dumps({
+    "status": "dry_run_passthrough",
+    "received": sys.argv[1:]
+}))
+PY
+    exit 0
+fi
+
 echo "unexpected fake canvas aos invocation: $*" >&2
 exit 2
 SH


### PR DESCRIPTION
## Summary
- Allow the external `aos do` wrapper to validate and pass direct `canvas:<canvas-id>/<ref>` drag targets through to the existing Swift primitive with `--by` or `--to-value`.
- Add a distinct `do-drag-canvas` help form so direct canvas semantic drag is separate from saved/browser endpoint drag and native coordinate drag.
- Extend parser, help, contract-drift, and fixture-backed canvas tests so `--speed` stays coordinate-only and `--by`/`--to-value` stay direct-canvas-only.

## Verification
- `./aos help do --json | jq '.forms[] | select(.id | startswith("do-drag")) | {id, usage, tokens:[.args[].token?]}'`
- `bash tests/help-contract.sh`
- `bash tests/external-parser-flags.sh`
- `bash tests/agent-workspace-canvas-refs.sh`
- `bash tests/agent-workspace-contract-drift.sh`
- `node --test tests/schemas/aos-external-command-manifest-v0.test.mjs`
- `bash tests/external-command-dispatch.sh`
- `git diff --check`

## DOX / Live Proof
- DOX chain checked for `scripts/`, `manifests/`, and `tests/`; no AGENTS/DOX update needed because this keeps existing command-surface contracts aligned.
- Live UI/native/TCC proof: not run and not required for this slice; existing live canvas smoke remains the Level 4 path for real visible canvas interaction, while this PR proves wrapper/help/parser routing deterministically.