### PR TITLE
Align capture jpeg format contract

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -105,6 +105,12 @@ fi
 
 echo "Compiling aos ($BUILD_MODE)..."
 swiftc "${SWIFTC_FLAGS[@]}" "${SOURCES[@]}" "${SHARED_IPC[@]}"
+if command -v codesign >/dev/null 2>&1; then
+    if ! CODESIGN_OUTPUT="$(codesign --force --sign - "$OUTPUT_PATH" 2>&1)"; then
+        printf '%s\n' "$CODESIGN_OUTPUT" >&2
+        exit 1
+    fi
+fi
 printf '%s\n' "$BUILD_MODE" > "$MODE_FILE"
 
 echo "Done: ./aos ($(du -h "$OUTPUT_PATH" | cut -f1 | xargs))"

--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -308,8 +308,12 @@
                     "value" : "png"
                   },
                   {
-                    "summary" : "Lossy JPEG",
+                    "summary" : "Lossy JPEG (.jpg)",
                     "value" : "jpg"
+                  },
+                  {
+                    "summary" : "JPEG alias; output path uses .jpg",
+                    "value" : "jpeg"
                   },
                   {
                     "summary" : "HEIC format",

--- a/src/perceive/capture-pipeline.swift
+++ b/src/perceive/capture-pipeline.swift
@@ -1222,7 +1222,7 @@ func resolveUTType(for format: String) -> UTType {
     case "png":          return .png
     case "jpg", "jpeg":  return .jpeg
     case "heic":         return .heic
-    default: exitError("Unknown format: '\(format)'. Use png, jpg, or heic.", code: "INVALID_FORMAT")
+    default: exitError("Unknown format: '\(format)'. Use png, jpg/jpeg, or heic.", code: "INVALID_FORMAT")
     }
 }
 

--- a/tests/external-parser-flags.sh
+++ b/tests/external-parser-flags.sh
@@ -276,6 +276,17 @@ const parsed = parseCaptureArgs(['main', '--format', 'jpeg']);
 assert.deepEqual(parsed.errors, [], 'workspace capture parser must delegate primitive --format jpeg grammar to Swift');
 assert.deepEqual(parsed.passthrough, ['main', '--format', 'jpeg']);
 assert.equal(parsed.target, 'main');
+
+const { readFileSync } = await import('node:fs');
+const help = JSON.parse(readFileSync('./manifests/commands/aos-commands.json', 'utf8'));
+const see = help.commands.find((command) => command.path.join(' ') === 'see');
+const capture = see.forms.find((form) => form.id === 'see-capture');
+const format = capture.args.find((arg) => arg.token === '--format');
+assert.deepEqual(
+  new Set(format.value_type.enum.map((item) => item.value)),
+  new Set(['png', 'jpg', 'jpeg', 'heic']),
+  'see capture help must document the primitive jpeg format alias'
+);
 JS
 check_code see-capture-unknown-flag UNKNOWN_OPTION ./aos see capture main --bogus
 check_code see-capture-extra UNKNOWN_OPTION ./aos see capture main unexpected
@@ -309,6 +320,19 @@ if ./aos see capture main --format gif 2>"$err"; then
 fi
 if ! grep -Eq '"code"[[:space:]]*:[[:space:]]*"INVALID_FORMAT"' "$err"; then
   echo "FAIL: see capture invalid --format value did not use INVALID_FORMAT" >&2
+  cat "$err" >&2
+  exit 1
+fi
+if ! python3 - "$err" <<'PY'
+import json
+import sys
+
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+if "Use png, jpg/jpeg, or heic." not in data.get("error", ""):
+    raise SystemExit(1)
+PY
+then
+  echo "FAIL: see capture invalid --format value did not document jpeg alias" >&2
   cat "$err" >&2
   exit 1
 fi

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -444,6 +444,8 @@ capture_save_form = next(item for item in capture["forms"] if item["id"] == "see
 capture_tokens = {arg.get("token") for arg in capture_form["args"]}
 capture_save_tokens = {arg.get("token") for arg in capture_save_form["args"]}
 capture_conflicts = [set(item) for item in capture_form.get("constraints", {}).get("conflicts", [])]
+format_arg = next(arg for arg in capture_form["args"] if arg.get("token") == "--format")
+format_values = {item["value"] for item in format_arg["value_type"]["enum"]}
 mode_arg = next(arg for arg in capture_save_form["args"] if arg.get("token") == "--mode")
 mode_values = {item["value"] for item in mode_arg["value_type"]["enum"]}
 save_arg = next(arg for arg in capture_form["args"] if arg.get("token") == "--save")
@@ -451,6 +453,8 @@ capture_save_arg = next(arg for arg in capture_save_form["args"] if arg.get("tok
 assert {"--save", "--workspace", "--name", "--mode", "--query"} <= capture_tokens, capture_tokens
 assert {"--save", "--workspace", "--name", "--mode", "--query"} <= capture_save_tokens, capture_save_tokens
 assert {"save", "out"} in capture_conflicts, capture_conflicts
+assert format_values == {"png", "jpg", "jpeg", "heic"}, format_values
+assert format_arg["default_value"] == "png", format_arg
 assert mode_values == {"ax", "vision", "som"}, mode_values
 assert "stable native AX press/focus/set-value" in save_arg["summary"], save_arg
 assert "documented saved-ref action matrix" in capture_save_arg["summary"], capture_save_arg


### PR DESCRIPTION
## Summary
- document `jpeg` as a first-class `aos see capture --format` alias alongside `jpg`
- update the native invalid-format guidance to advertise `jpg/jpeg`
- explicitly ad-hoc sign repo builds after `swiftc` so rebuilt `./aos` remains runnable for native/error-path verification

## Verification
- `./aos dev build --force --no-restart --json` (pass; pre-existing Swift warnings in canvas-ref targeting and voice APIs)
- `./aos help see --json | jq ...format enum...`
- `AOS_DISABLE_DAEMON_AUTOSTART=1 AOS_BYPASS_PERMISSIONS_SETUP=1 ./aos see capture main --format gif` -> `INVALID_FORMAT`, `Use png, jpg/jpeg, or heic.`
- `bash tests/help-contract.sh`
- `bash tests/external-parser-flags.sh`
- `node --test tests/schemas/aos-external-command-manifest-v0.test.mjs`
- `bash tests/external-command-dispatch.sh`
- `git diff --check`

## DOX
- No AGENTS.md update: the public command contract changed in the owning manifest/tests, and the build entrypoint remains `./aos dev build`; the script now enforces the runnable signing state that the existing workflow already expects.