### PR TITLE
Align API top-level command table

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -94,6 +94,7 @@ The current top-level commands are:
 
 | Command | Role |
 | --- | --- |
+| `aos launch` | manifest-backed source-owned app launcher |
 | `aos ready` | front-door readiness gate; starts/checks AOS and reports blockers |
 | `aos status` | read-only runtime/session status snapshot |
 | `aos recipe` | source-backed executable recipes: list, explain, dry-run, run |
@@ -107,6 +108,7 @@ The current top-level commands are:
 | `aos introspect` | Session self-review over recent `./aos` usage |
 | `aos help` | Registry and command-specific help |
 | `aos say` | Voice output |
+| `aos voice` | registry-backed voice catalog, assignments, providers, and session bindings |
 | `aos tell` | Communication output: human, channel, or direct session routing |
 | `aos listen` | Communication input: channel or direct session reads/follow |
 | `aos wiki` | local knowledge-base workflows |
@@ -117,7 +119,6 @@ The current top-level commands are:
 | `aos service` | launchd lifecycle for the daemon |
 | `aos experience` | active AOS experience-layer status, activation, and deactivation |
 | `aos runtime` | packaged runtime utilities |
-| `aos dev` | repo development workflow classification, recommendations, and build wrapper |
 | `aos permissions` | preflight and onboarding |
 | `aos doctor` | detailed runtime and permission diagnostics |
 | `aos clean` | explicit stale daemon / canvas cleanup |

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -78,6 +78,32 @@ else
     fail "internal command demotion from root consumer help drifted"
 fi
 
+if ROOT_JSON="$(./aos help --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+import re
+from pathlib import Path
+
+root = json.loads(os.environ["ROOT_JSON"])
+root_top_level = {command["path"][0] for command in root["commands"]}
+docs = Path("docs/api/aos.md").read_text(encoding="utf-8")
+section = docs.split("The current top-level commands are:", 1)[1].split("## Core Usage Patterns", 1)[0]
+docs_top_level = set()
+for line in section.splitlines():
+    match = re.match(r"\| `aos ([^` ]+)` \|", line)
+    if match:
+        docs_top_level.add(match.group(1))
+assert docs_top_level == root_top_level, {
+    "missing_from_docs": sorted(root_top_level - docs_top_level),
+    "stale_in_docs": sorted(docs_top_level - root_top_level),
+}
+PY
+then
+    pass "public API top-level command table matches root consumer help"
+else
+    fail "public API top-level command table drifted from root consumer help"
+fi
+
 # --- 2. aos help show --json → JSON per-command ---
 OUT=$(./aos help show --json 2>/dev/null)
 if echo "$OUT" | grep -q '"path"'; then


### PR DESCRIPTION
## Summary
- align `docs/api/aos.md` top-level command table with consumer root help
- add missing `aos launch` and `aos voice` entries
- remove hidden maintainer-only `aos dev` from the consumer top-level table while keeping the dedicated dev section later in the doc
- add a help-contract guard comparing that table to `./aos help --json`

## Verification
- `bash tests/help-contract.sh`
- `bash tests/dev-workflow-router.sh`
- `git diff --check`

## DOX
- No AGENTS.md update: this updates the owning public API doc and adds a drift guard; ownership/workflow rules are unchanged.