### PR TITLE
Clarify see capture source requirements

### DIFF
--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -273,7 +273,7 @@
               ],
               "id" : "target",
               "kind" : "positional",
-              "required" : true,
+              "required" : false,
               "summary" : "Capture target",
               "value_type" : "string"
             },
@@ -591,7 +591,26 @@
               "label" : [
                 "xray"
               ]
-            }
+            },
+            "required_groups" : [
+              {
+                "one_of" : [
+                  [
+                    "target"
+                  ],
+                  [
+                    "region"
+                  ],
+                  [
+                    "canvas"
+                  ],
+                  [
+                    "channel"
+                  ]
+                ],
+                "summary" : "capture source"
+              }
+            ]
           },
           "examples" : [
             "aos see capture browser:work --save --mode som --workspace default",

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -470,8 +470,10 @@ capture_save_form = next(item for item in capture["forms"] if item["id"] == "see
 capture_tokens = {arg.get("token") for arg in capture_form["args"]}
 capture_save_tokens = {arg.get("token") for arg in capture_save_form["args"]}
 capture_conflicts = [set(item) for item in capture_form.get("constraints", {}).get("conflicts", [])]
+capture_required_groups = capture_form.get("constraints", {}).get("required_groups", [])
 format_arg = next(arg for arg in capture_form["args"] if arg.get("token") == "--format")
 format_values = {item["value"] for item in format_arg["value_type"]["enum"]}
+target_arg = next(arg for arg in capture_form["args"] if arg["id"] == "target")
 mode_arg = next(arg for arg in capture_save_form["args"] if arg.get("token") == "--mode")
 mode_values = {item["value"] for item in mode_arg["value_type"]["enum"]}
 save_arg = next(arg for arg in capture_form["args"] if arg.get("token") == "--save")
@@ -479,6 +481,13 @@ capture_save_arg = next(arg for arg in capture_save_form["args"] if arg.get("tok
 assert {"--save", "--workspace", "--name", "--mode", "--query"} <= capture_tokens, capture_tokens
 assert {"--save", "--workspace", "--name", "--mode", "--query"} <= capture_save_tokens, capture_save_tokens
 assert {"save", "out"} in capture_conflicts, capture_conflicts
+assert target_arg["required"] is False, target_arg
+assert {
+    tuple(item)
+    for group in capture_required_groups
+    if group.get("summary") == "capture source"
+    for item in group.get("one_of", [])
+} == {("target",), ("region",), ("canvas",), ("channel",)}, capture_required_groups
 assert format_values == {"png", "jpg", "jpeg", "heic"}, format_values
 assert format_arg["default_value"] == "png", format_arg
 assert mode_values == {"ax", "vision", "som"}, mode_values
@@ -507,6 +516,7 @@ assert "[execution: read-only, mutates-with --save, requires-permissions]" in ca
 assert "[execution: mutates-state, requires-permissions]" in capture_text, capture_text
 assert "[output: none; with --save: json]" in capture_text, capture_text
 assert "[output: json]" in capture_text, capture_text
+assert "requires one capture source: <target> OR --region OR --canvas OR --channel" in capture_text, capture_text
 
 refs = json.loads(os.environ["REFS"])
 refs_form = next(item for item in refs["forms"] if item["id"] == "see-refs")


### PR DESCRIPTION
## Summary
- make `see capture` target optional at the arg level because explicit `--region`, `--canvas`, and `--channel` forms are valid
- add a `capture source` required group so help explains the valid alternatives
- guard the JSON and rendered help contract in `tests/help-contract.sh`

## Verification
- `bash tests/help-contract.sh`
- `node --test tests/schemas/aos-external-command-manifest-v0.test.mjs`
- `./aos help see capture` shows `requires one capture source: <target> OR --region OR --canvas OR --channel`
- `./aos help see capture --json | jq ...required_groups...`
- `git diff --check`

## DOX
- No AGENTS.md update: this narrows command metadata to match existing examples/parser behavior; ownership and workflow rules are unchanged.