### PR TITLE
Correct see capture output metadata

### DIFF
--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -638,16 +638,7 @@
           },
           "id" : "see-capture",
           "output" : {
-            "conditional_modes" : [
-              {
-                "default_mode" : "json",
-                "summary" : "Saved capture returns compact JSON refs after persisting local workspace perception",
-                "when_flags" : [
-                  "--save"
-                ]
-              }
-            ],
-            "default_mode" : "none",
+            "default_mode" : "json",
             "error_mode" : "json_stderr",
             "streaming" : false,
             "supports_json_flag" : false

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -503,18 +503,15 @@ assert "stable native AX actions" in capture_save_form["summary"], capture_save_
 assert capture_form["execution"]["mutates_state"] is False, capture_form["execution"]
 assert capture_form["execution"]["mutates_when_flags"] == ["--save"], capture_form["execution"]
 assert capture_form["execution"]["read_only"] is True, capture_form["execution"]
-assert capture_form["output"]["conditional_modes"] == [{
-    "default_mode": "json",
-    "summary": "Saved capture returns compact JSON refs after persisting local workspace perception",
-    "when_flags": ["--save"],
-}], capture_form["output"]
+assert "conditional_modes" not in capture_form["output"], capture_form["output"]
+assert capture_form["output"]["default_mode"] == "json", capture_form["output"]
 assert capture_save_form["execution"]["mutates_state"] is True, capture_save_form["execution"]
 assert capture_save_form["execution"]["read_only"] is False, capture_save_form["execution"]
 assert "--save" in capture["summary"], capture["summary"]
 capture_text = os.environ["CAPTURE_TEXT"]
 assert "[execution: read-only, mutates-with --save, requires-permissions]" in capture_text, capture_text
 assert "[execution: mutates-state, requires-permissions]" in capture_text, capture_text
-assert "[output: none; with --save: json]" in capture_text, capture_text
+assert "[output: json; with --save: json]" not in capture_text, capture_text
 assert "[output: json]" in capture_text, capture_text
 assert "requires one capture source: <target> OR --region OR --canvas OR --channel" in capture_text, capture_text
 


### PR DESCRIPTION
## Summary
- set ordinary `aos see capture` output metadata to JSON, matching the Swift `SuccessResponse` envelope and architecture docs
- remove the `--save` conditional output mode because save changes JSON shape, not output mode
- update help-contract assertions for rendered output metadata

## Verification
- `bash tests/help-contract.sh`
- `node --test tests/schemas/aos-external-command-manifest-v0.test.mjs`
- `bash tests/external-command-dispatch.sh`
- `./aos help see capture | rg '\\[output:|requires one capture source'`\n- `git diff --check`\n\n## DOX\n- No AGENTS.md update: this narrows manifest metadata to match existing implementation/docs; ownership and workflow rules are unchanged.