### PR TITLE
Align saved capture source help

### DIFF
--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -650,8 +650,32 @@
             {
               "id" : "target",
               "kind" : "positional",
-              "required" : true,
+              "required" : false,
               "summary" : "Capture target to persist into an agent workspace",
+              "value_type" : "string"
+            },
+            {
+              "id" : "region",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Global CG region in points: x,y,w,h",
+              "token" : "--region",
+              "value_type" : "string"
+            },
+            {
+              "id" : "canvas",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Capture a canvas by id",
+              "token" : "--canvas",
+              "value_type" : "string"
+            },
+            {
+              "id" : "channel",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Capture a focus channel by id",
+              "token" : "--channel",
               "value_type" : "string"
             },
             {
@@ -711,8 +735,37 @@
               "value_type" : "string"
             }
           ],
+          "constraints" : {
+            "conflicts" : [
+              [
+                "region",
+                "canvas",
+                "channel"
+              ]
+            ],
+            "required_groups" : [
+              {
+                "one_of" : [
+                  [
+                    "target"
+                  ],
+                  [
+                    "region"
+                  ],
+                  [
+                    "canvas"
+                  ],
+                  [
+                    "channel"
+                  ]
+                ],
+                "summary" : "capture source"
+              }
+            ]
+          },
           "examples" : [
             "aos see capture browser:work --save --mode som --workspace default",
+            "aos see capture --canvas surface-inspector --save --mode som --workspace default",
             "aos see snapshots --workspace default",
             "aos see refs --workspace default --query Save"
           ],
@@ -733,7 +786,7 @@
             "supports_json_flag" : false
           },
           "summary" : "Persist perception into a local agent workspace and return compact saved refs with conformance/proof for canvas, browser, and stable native AX actions with actionable producer verdicts",
-          "usage" : "aos see capture <target> --save [--mode <mode>] [--workspace <id>] [--name <id>] [--query <text>]"
+          "usage" : "aos see capture [<target>|--region <rect>|--canvas <id>|--channel <id>] --save [--mode <mode>] [--workspace <id>] [--name <id>] [--query <text>]"
         },
         {
           "args" : [

--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -425,13 +425,18 @@ assert.ok(captureSaveForm, 'manifest missing see-capture-save form');
 assert.equal(captureForm.execution.mutates_state, false, 'ordinary capture form must not broadly mutate');
 assert.deepEqual(captureForm.execution.mutates_when_flags, ['--save']);
 assert.equal(captureForm.execution.read_only, true, 'ordinary capture form must remain read-style');
-assert.deepEqual(captureForm.output.conditional_modes, [{
-  default_mode: 'json',
-  summary: 'Saved capture returns compact JSON refs after persisting local workspace perception',
-  when_flags: ['--save'],
-}], 'ordinary capture form must expose --save conditional JSON output');
+assert.equal(captureForm.output.default_mode, 'json', 'ordinary capture form must declare JSON output');
+assert.equal(captureForm.output.conditional_modes, undefined, 'ordinary capture form must not describe --save as a different output mode');
 assert.equal(captureSaveForm.execution.mutates_state, true, 'saved capture form must be mutating');
 assert.equal(captureSaveForm.execution.read_only, false, 'saved capture form must not be read-only');
+const captureSourceGroup = (form) => form.constraints?.required_groups?.find((group) => group.summary === 'capture source');
+assert.deepEqual(captureSourceGroup(captureForm)?.one_of, [['target'], ['region'], ['canvas'], ['channel']], 'ordinary capture form must expose all capture source alternatives');
+assert.deepEqual(captureSourceGroup(captureSaveForm)?.one_of, [['target'], ['region'], ['canvas'], ['channel']], 'saved capture form must expose all capture source alternatives');
+assert.equal(captureForm.args.find((arg) => arg.id === 'target')?.required, false, 'ordinary capture target must not be unconditionally required');
+assert.equal(captureSaveForm.args.find((arg) => arg.id === 'target')?.required, false, 'saved capture target must not be unconditionally required');
+assert.ok(captureSaveForm.usage.includes('--region <rect>'), 'saved capture usage must advertise region source');
+assert.ok(captureSaveForm.usage.includes('--canvas <id>'), 'saved capture usage must advertise canvas source');
+assert.ok(captureSaveForm.usage.includes('--channel <id>'), 'saved capture usage must advertise channel source');
 JS
 
 echo "PASS contract drift"

--- a/tests/external-parser-flags.sh
+++ b/tests/external-parser-flags.sh
@@ -277,6 +277,12 @@ assert.deepEqual(parsed.errors, [], 'workspace capture parser must delegate prim
 assert.deepEqual(parsed.passthrough, ['main', '--format', 'jpeg']);
 assert.equal(parsed.target, 'main');
 
+const savedRegion = parseCaptureArgs(['--region', '0,0,10,10', '--save', '--workspace', 'parser-ws', '--name', 'snap-region']);
+assert.deepEqual(savedRegion.errors, [], 'saved capture parser must accept a region source without a positional target');
+assert.equal(savedRegion.target, 'main');
+assert.equal(savedRegion.options.save, true);
+assert.deepEqual(savedRegion.passthrough, ['--region', '0,0,10,10']);
+
 const { readFileSync } = await import('node:fs');
 const help = JSON.parse(readFileSync('./manifests/commands/aos-commands.json', 'utf8'));
 const see = help.commands.find((command) => command.path.join(' ') === 'see');

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -471,35 +471,50 @@ capture_tokens = {arg.get("token") for arg in capture_form["args"]}
 capture_save_tokens = {arg.get("token") for arg in capture_save_form["args"]}
 capture_conflicts = [set(item) for item in capture_form.get("constraints", {}).get("conflicts", [])]
 capture_required_groups = capture_form.get("constraints", {}).get("required_groups", [])
+capture_save_conflicts = [set(item) for item in capture_save_form.get("constraints", {}).get("conflicts", [])]
+capture_save_required_groups = capture_save_form.get("constraints", {}).get("required_groups", [])
 format_arg = next(arg for arg in capture_form["args"] if arg.get("token") == "--format")
 format_values = {item["value"] for item in format_arg["value_type"]["enum"]}
 target_arg = next(arg for arg in capture_form["args"] if arg["id"] == "target")
+capture_save_target_arg = next(arg for arg in capture_save_form["args"] if arg["id"] == "target")
 mode_arg = next(arg for arg in capture_save_form["args"] if arg.get("token") == "--mode")
 mode_values = {item["value"] for item in mode_arg["value_type"]["enum"]}
 save_arg = next(arg for arg in capture_form["args"] if arg.get("token") == "--save")
 capture_save_arg = next(arg for arg in capture_save_form["args"] if arg.get("token") == "--save")
 assert {"--save", "--workspace", "--name", "--mode", "--query"} <= capture_tokens, capture_tokens
-assert {"--save", "--workspace", "--name", "--mode", "--query"} <= capture_save_tokens, capture_save_tokens
+assert {"--region", "--canvas", "--channel", "--save", "--workspace", "--name", "--mode", "--query"} <= capture_save_tokens, capture_save_tokens
 assert {"save", "out"} in capture_conflicts, capture_conflicts
+assert {"region", "canvas", "channel"} in capture_save_conflicts, capture_save_conflicts
 assert target_arg["required"] is False, target_arg
+assert capture_save_target_arg["required"] is False, capture_save_target_arg
 assert {
     tuple(item)
     for group in capture_required_groups
     if group.get("summary") == "capture source"
     for item in group.get("one_of", [])
 } == {("target",), ("region",), ("canvas",), ("channel",)}, capture_required_groups
+assert {
+    tuple(item)
+    for group in capture_save_required_groups
+    if group.get("summary") == "capture source"
+    for item in group.get("one_of", [])
+} == {("target",), ("region",), ("canvas",), ("channel",)}, capture_save_required_groups
 assert format_values == {"png", "jpg", "jpeg", "heic"}, format_values
 assert format_arg["default_value"] == "png", format_arg
 assert mode_values == {"ax", "vision", "som"}, mode_values
 assert "stable native AX press/focus/set-value" in save_arg["summary"], save_arg
 assert "documented saved-ref action matrix" in capture_save_arg["summary"], capture_save_arg
 assert capture_form["examples"][0].startswith("aos see capture") and "--save" in capture_form["examples"][0], capture_form["examples"]
+assert any("--canvas" in item and "--save" in item for item in capture_save_form["examples"]), capture_save_form["examples"]
 assert any("aos see refs" in item for item in capture_save_form["examples"]), capture_save_form["examples"]
 saved_loop_examples = capture_save_form["examples"]
 assert "aos see snapshots --workspace default" in saved_loop_examples, saved_loop_examples
 assert "aos see refs --workspace default --query Save" in saved_loop_examples, saved_loop_examples
 assert "Persist perception" in capture_save_form["summary"], capture_save_form
 assert "stable native AX actions" in capture_save_form["summary"], capture_save_form
+assert "--region <rect>" in capture_save_form["usage"], capture_save_form["usage"]
+assert "--canvas <id>" in capture_save_form["usage"], capture_save_form["usage"]
+assert "--channel <id>" in capture_save_form["usage"], capture_save_form["usage"]
 assert capture_form["execution"]["mutates_state"] is False, capture_form["execution"]
 assert capture_form["execution"]["mutates_when_flags"] == ["--save"], capture_form["execution"]
 assert capture_form["execution"]["read_only"] is True, capture_form["execution"]
@@ -514,6 +529,7 @@ assert "[execution: mutates-state, requires-permissions]" in capture_text, captu
 assert "[output: json; with --save: json]" not in capture_text, capture_text
 assert "[output: json]" in capture_text, capture_text
 assert "requires one capture source: <target> OR --region OR --canvas OR --channel" in capture_text, capture_text
+assert capture_text.count("requires one capture source: <target> OR --region OR --canvas OR --channel") == 2, capture_text
 
 refs = json.loads(os.environ["REFS"])
 refs_form = next(item for item in refs["forms"] if item["id"] == "see-refs")


### PR DESCRIPTION
## Summary
- make `see-capture-save` advertise the same capture source alternatives as ordinary `see capture`
- keep `--save` as the required mutating switch while making `<target>` optional behind the source required group
- update help/parser/workspace drift tests for saved source groups and current JSON output metadata

## Verification
- `bash tests/help-contract.sh`
- `node --test tests/schemas/aos-external-command-manifest-v0.test.mjs`
- `bash tests/external-parser-flags.sh`
- `bash tests/agent-workspace-contract-drift.sh`
- `bash tests/external-command-dispatch.sh`
- `git diff --check`