### PR TITLE
Document saved capture source alternatives

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -151,6 +151,11 @@ Typical consumer loop:
 6. Use `recommended_next_command` after a real mutation when a fresh saved
    capture is needed before reusing refs from the surface.
 
+Saved capture uses the same capture-source contract as ordinary capture: supply
+a positional target such as `browser:work` or a source flag such as
+`--region <rect>`, `--canvas <id>`, or `--channel <id>`. `--save` is the
+mutation switch that persists local workspace state.
+
 Saved agent workspaces live under
 `~/.config/aos/{repo|installed}/agent-workspaces/<workspace>/`, or
 `$AOS_STATE_ROOT/{repo|installed}/agent-workspaces/<workspace>/` when the state

--- a/skills/aos-agent-workspace/SKILL.md
+++ b/skills/aos-agent-workspace/SKILL.md
@@ -14,7 +14,8 @@ aos see snapshots --workspace default --json
 aos see refs --workspace default --query Save --json
 aos do click ref:<snapshot-id>:r2 --workspace default --dry-run
 aos do click ref:<snapshot-id>:r2 --workspace default
-aos see capture <capture_target> --save --mode <capture_mode> --workspace default
+aos see capture <capture_source> --save --mode <capture_mode> --workspace default
+aos see capture --canvas surface-inspector --save --mode som --workspace default
 aos do set-value ref:<snapshot-id>:r3 --workspace default --value "42" --dry-run
 aos do fill ref:<snapshot-id>:r4 "updated text" --workspace default --dry-run
 aos do hover ref:<snapshot-id>:r5 --workspace default --dry-run
@@ -28,6 +29,9 @@ aos do focus ref:<snapshot-id>:r7 --workspace default --dry-run
 
 - Use `aos see capture --save` to persist perception into the active runtime
   mode state root: `${AOS_STATE_ROOT:-~/.config/aos}/{repo|installed}/agent-workspaces/`.
+- A saved capture source can be a positional target such as `browser:work` or a
+  source flag such as `--region <rect>`, `--canvas <id>`, or `--channel <id>`.
+  `--save` is the state mutation boundary.
 - Prefer scoped refs: `ref:<snapshot-id>:<ref-id>`.
 - Use bare `ref:<ref-id>` only when one snapshot in the workspace contains that
   ref. If the command returns `REF_AMBIGUOUS`, use its candidate snapshots and
@@ -208,7 +212,7 @@ matrix:
   `ACTION_INCOMPATIBLE`.
 
 After any successful mutation, read `post_action.recommended_next_command`. Run
-the recommended fresh target-aware `aos see capture <capture_target> --save
+the recommended fresh source-aware `aos see capture <capture_source> --save
 --workspace <workspace> --mode <capture_mode>` before using the next ref from
 that surface when the response says fresh capture is recommended. If the saved
 capture stored a query, the recommendation should include `--query <query>`.

--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -376,10 +376,21 @@ assert.ok(
   'API doc must lead with saved capture before base64/pixel fallback examples',
 );
 assert.ok(
+  apiDoc.includes('Saved capture uses the same capture-source contract as ordinary capture')
+  && apiDoc.includes('`--region <rect>`, `--canvas <id>`, or `--channel <id>`')
+  && skill.includes('A saved capture source can be a positional target')
+  && skill.includes('`--region <rect>`, `--canvas <id>`, or `--channel <id>`'),
+  'API doc and workspace skill must describe saved capture source alternatives',
+);
+assert.ok(
   skill.indexOf('aos do click ref:<snapshot-id>:r2 --workspace default --dry-run') >= 0
   && skill.indexOf('aos do click ref:<snapshot-id>:r2 --workspace default\n') > skill.indexOf('aos do click ref:<snapshot-id>:r2 --workspace default --dry-run')
-  && skill.indexOf('aos see capture <capture_target> --save --mode <capture_mode> --workspace default') > skill.indexOf('aos do click ref:<snapshot-id>:r2 --workspace default\n'),
+  && skill.indexOf('aos see capture <capture_source> --save --mode <capture_mode> --workspace default') > skill.indexOf('aos do click ref:<snapshot-id>:r2 --workspace default\n'),
   'AOS workspace skill quick-start must show dry-run, real action, and post-action saved capture refresh',
+);
+assert.ok(
+  skill.indexOf('aos see capture --canvas surface-inspector --save --mode som --workspace default') > skill.indexOf('aos see capture <capture_source> --save --mode <capture_mode> --workspace default'),
+  'AOS workspace skill quick-start must include a saved source-flag capture example',
 );
 
 for (const text of [schemaDoc, apiDoc]) {


### PR DESCRIPTION
## Summary
- describe saved capture sources as positional targets or source flags in the public API doc
- update the AOS agent workspace skill quick-start and post-action recommendation wording from target-aware to source-aware
- add drift assertions so docs and skill text keep the saved capture source alternatives visible

## Verification
- `bash tests/agent-workspace-contract-drift.sh`
- `bash tests/help-contract.sh`
- `git diff --check`