### PR TITLE
Align README command model tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,29 @@
 # agent-os
 
-A macOS automation ecosystem for agents. Perception, action, projection, and voice unified into a single `aos` binary with subcommand groups, plus a typed MCP gateway for external consumers and a Node.js agent host.
+A macOS automation ecosystem for agents. Primitive perception, action,
+projection, and communication verbs are unified into a single `aos` binary, with
+convenience voice output, source-backed recipes, runtime readiness/lifecycle
+commands, a typed MCP gateway for external consumers, and a Node.js agent host.
 
 ## Principle
 
 **Agent tokens are for decisions, not plumbing.** The agent is the brain; the daemon is the nervous system. The daemon handles element resolution, cursor tracking, TTS, visual feedback. The agent decides WHAT and WHY.
 
-## Subcommand groups
+## Public Command Model
 
-| Group | Role | Status |
-|-------|------|--------|
-| `aos see` | Perception — screenshots, AX tree, cursor queries, focus channels, graph navigation | Production |
-| `aos show` | Projection — persistent WKWebView canvases, overlays, HTML→bitmap render | Production |
-| `aos do` | Action — AX semantic actions, CGEvent input, AppleScript verbs, behavioral profiles | Production |
-| `aos say` | Voice — TTS, daemon-driven announcements | Production (TTS); STT planned |
-| `aos serve` | Unified daemon: one socket, one CGEventTap, shared state | Production |
+| Group | Tier | Role |
+|-------|------|------|
+| `aos see` | Primitive | Perception: screenshots, AX tree, cursor queries, focus channels, graph navigation, saved workspace refs |
+| `aos do` | Primitive | Action: saved refs, direct browser/canvas targets, native AX, coordinates, keyboard, AppleScript, behavior profiles |
+| `aos show` | Primitive | Projection: persistent WKWebView canvases, overlays, HTML-to-bitmap render, anchors, shared surfaces |
+| `aos tell` | Primitive | Outbound communication: human, channel, direct session, and future sinks |
+| `aos listen` | Primitive | Inbound communication: channel/direct-session reads and follow today; STT and broader sources planned |
+| `aos say` | Convenience | Direct TTS convenience aligned with `tell human` |
+| `aos recipe` | Higher-order | Source-backed executable procedures built from primitive commands; `aos ops` is the compatibility alias |
+| `aos ready` | Runtime/ops | Front-door readiness gate for agents before runtime work |
+| `aos serve` / `aos service` | Runtime/ops | Unified daemon lifecycle: one socket, one CGEventTap, shared state |
+
+See [docs/api/aos.md](docs/api/aos.md) for the full consumer command table.
 
 ## Track-2 consumers
 

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -104,6 +104,32 @@ else
     fail "public API top-level command table drifted from root consumer help"
 fi
 
+if ROOT_JSON="$(./aos help --json 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+import re
+from pathlib import Path
+
+root = json.loads(os.environ["ROOT_JSON"])
+root_top_level = {command["path"][0] for command in root["commands"]}
+readme = Path("README.md").read_text(encoding="utf-8")
+required = {"see", "do", "show", "tell", "listen", "say", "recipe", "ready", "serve", "service"}
+assert required <= root_top_level, sorted(required - root_top_level)
+for command in required:
+    assert f"`aos {command}`" in readme, command
+for command in ["see", "do", "show", "tell", "listen"]:
+    assert re.search(rf"\| `aos {command}` \| Primitive \|", readme), command
+assert re.search(r"\| `aos say` \| Convenience \|.*tell human", readme), readme
+assert re.search(r"\| `aos recipe` \| Higher-order \|.*`aos ops`", readme), readme
+assert re.search(r"\| `aos ready` \| Runtime/ops \|", readme), readme
+assert re.search(r"\| `aos serve` / `aos service` \| Runtime/ops \|", readme), readme
+PY
+then
+    pass "README public command model covers primitive, convenience, recipe, and runtime tiers"
+else
+    fail "README public command model drifted from canonical tiers"
+fi
+
 # --- 2. aos help show --json → JSON per-command ---
 OUT=$(./aos help show --json 2>/dev/null)
 if echo "$OUT" | grep -q '"path"'; then


### PR DESCRIPTION
## Summary
- update README orientation from the old see/show/do/say/serve list to the current primitive/convenience/recipe/runtime command model
- include `tell`, `listen`, `recipe`, `ready`, and `service` in the top-level product framing
- add a help-contract drift guard so README tier coverage stays aligned with root consumer help

## Verification
- `bash tests/help-contract.sh`
- `git diff --check`

No Level 4 live UI/native/TCC proof is applicable; this is a README/help-contract metadata slice.