### PR TITLE
Clarify listen session source help

### DIFF
--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -5293,7 +5293,7 @@
               ],
               "id" : "channel",
               "kind" : "positional",
-              "required" : true,
+              "required" : false,
               "summary" : "Channel to read from",
               "value_type" : "string"
             },
@@ -5323,6 +5323,21 @@
               "value_type" : "int"
             }
           ],
+          "constraints" : {
+            "required_groups" : [
+              {
+                "one_of" : [
+                  [
+                    "channel"
+                  ],
+                  [
+                    "session-id"
+                  ]
+                ],
+                "summary" : "listen source"
+              }
+            ]
+          },
           "examples" : [
             "aos listen handoff",
             "aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c",
@@ -5351,7 +5366,7 @@
             {
               "id" : "channel",
               "kind" : "positional",
-              "required" : true,
+              "required" : false,
               "summary" : "Channel to follow",
               "value_type" : "string"
             },
@@ -5380,6 +5395,21 @@
               "value_type" : "string"
             }
           ],
+          "constraints" : {
+            "required_groups" : [
+              {
+                "one_of" : [
+                  [
+                    "channel"
+                  ],
+                  [
+                    "session-id"
+                  ]
+                ],
+                "summary" : "listen source"
+              }
+            ]
+          },
           "examples" : [
             "aos listen handoff --follow",
             "aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c --follow"
@@ -5438,7 +5468,7 @@
       "path" : [
         "listen"
       ],
-      "summary" : "Communication — receive from channels"
+      "summary" : "Communication — receive from channels or direct sessions"
     },
     {
       "forms" : [

--- a/tests/external-parser-flags.sh
+++ b/tests/external-parser-flags.sh
@@ -428,6 +428,8 @@ fi
 check_unknown_flag listen-unknown-flag ./aos listen channel --bogus
 check_unknown_arg listen-extra ./aos listen channel unexpected
 check_unknown_arg listen-channels-extra ./aos listen --channels unexpected
+check_code listen-session-id-read-reaches-daemon DAEMON_UNREACHABLE ./aos listen --session-id parser-session --limit 1
+check_code listen-session-id-follow-reaches-daemon DAEMON_UNREACHABLE ./aos listen --session-id parser-session --follow
 err="$STATE_ROOT/tell-register-role-invalid.err"
 if ./aos tell --register --session-id parser-test --role admin 2>"$err"; then
   echo "FAIL: tell register accepted invalid --role value" >&2

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -194,6 +194,33 @@ else
     fail "aos listen with no args did not return MISSING_ARG: $ERR"
 fi
 
+if OUT="$(./aos help listen --json 2>/dev/null)" TEXT="$(./aos help listen 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+assert "channels or direct sessions" in data["summary"], data["summary"]
+for form_id in ["listen-read", "listen-follow"]:
+    form = next(item for item in data["forms"] if item["id"] == form_id)
+    channel = next(arg for arg in form["args"] if arg["id"] == "channel")
+    assert channel["required"] is False, channel
+    groups = form.get("constraints", {}).get("required_groups", [])
+    assert {
+        tuple(item)
+        for group in groups
+        if group.get("summary") == "listen source"
+        for item in group.get("one_of", [])
+    } == {("channel",), ("session-id",)}, groups
+    assert any("--session-id" in item for item in form.get("examples", [])), form
+text = os.environ["TEXT"]
+assert text.count("requires one listen source: <channel> OR --session-id") == 2, text
+PY
+then
+    pass "listen help exposes channel or direct-session source alternatives"
+else
+    fail "listen help source alternatives drifted"
+fi
+
 # --- 8. aos wiki (no subcommand) → MISSING_SUBCOMMAND ---
 if ERR=$(./aos wiki 2>&1 >/dev/null); then
     fail "aos wiki with no args should exit non-zero"


### PR DESCRIPTION
## Summary
- make `aos listen` help advertise channel and `--session-id` as alternative listen sources
- mark the positional channel optional in the read/follow forms and add `listen source` required groups
- update parser/help drift tests so direct-session listen forms keep reaching the daemon boundary instead of failing as missing-channel forms

## Verification
- `bash tests/help-contract.sh`
- `bash tests/external-parser-flags.sh`
- `node --test tests/schemas/aos-external-command-manifest-v0.test.mjs`
- `bash tests/external-command-dispatch.sh`
- `git diff --check`

No Level 4 live UI/native/TCC proof is applicable; this is command manifest/help/parser metadata.