### PR TITLE
Clarify tell session target help

### DIFF
--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -5023,7 +5023,7 @@
               ],
               "id" : "audience",
               "kind" : "positional",
-              "required" : true,
+              "required" : false,
               "summary" : "Target: human, channel name, or canonical session id",
               "value_type" : "string"
             },
@@ -5077,6 +5077,19 @@
             }
           ],
           "constraints" : {
+            "required_groups" : [
+              {
+                "one_of" : [
+                  [
+                    "audience"
+                  ],
+                  [
+                    "session-id"
+                  ]
+                ],
+                "summary" : "tell target"
+              }
+            ],
             "one_of" : [
               [
                 "text",

--- a/tests/external-parser-flags.sh
+++ b/tests/external-parser-flags.sh
@@ -405,6 +405,7 @@ check_unknown_arg ops-list-extra ./aos ops list unexpected
 check_unknown_arg ops-explain-extra ./aos ops explain runtime/status-snapshot unexpected
 check_unknown_flag tell-unknown-flag ./aos tell channel --bogus hello
 check_unknown_arg tell-who-extra ./aos tell --who unexpected
+check_code tell-session-id-message-reaches-daemon DAEMON_UNREACHABLE ./aos tell --session-id parser-session "status update"
 err="$STATE_ROOT/tell-json-missing.err"
 if ./aos tell channel --json --from tester 2>"$err"; then
   echo "FAIL: tell accepted missing --json value" >&2

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -185,6 +185,31 @@ else
     fail "aos tell with no args did not return MISSING_ARG: $ERR"
 fi
 
+if OUT="$(./aos help tell --json 2>/dev/null)" TEXT="$(./aos help tell 2>/dev/null)" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["OUT"])
+form = next(item for item in data["forms"] if item["id"] == "tell-message")
+audience = next(arg for arg in form["args"] if arg["id"] == "audience")
+assert audience["required"] is False, audience
+groups = form.get("constraints", {}).get("required_groups", [])
+assert {
+    tuple(item)
+    for group in groups
+    if group.get("summary") == "tell target"
+    for item in group.get("one_of", [])
+} == {("audience",), ("session-id",)}, groups
+assert any("--session-id" in item for item in form.get("examples", [])), form
+text = os.environ["TEXT"]
+assert "requires one tell target: <audience> OR --session-id" in text, text
+PY
+then
+    pass "tell help exposes audience or direct-session target alternatives"
+else
+    fail "tell help target alternatives drifted"
+fi
+
 # --- 7. aos listen (no channel) → MISSING_ARG on stderr ---
 if ERR=$(./aos listen 2>&1 >/dev/null); then
     fail "aos listen with no args should exit non-zero"


### PR DESCRIPTION
## Summary
- mark tell message audience as optional when --session-id is provided
- expose tell target alternatives through required_groups in rendered help
- add help and parser guards for direct-session tell targets

## Tests
- jq empty manifests/commands/aos-commands.json
- bash tests/help-contract.sh
- bash tests/external-parser-flags.sh
- node --test tests/schemas/aos-external-command-manifest-v0.test.mjs
- git diff --check
- bash tests/external-command-dispatch.sh

## Proof limits
- deterministic/static/parser proof only; no Level 4 live UI, native, or TCC proof run