### PR TITLE
Align say help with direct TTS role

### DIFF
--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -4194,7 +4194,7 @@
       "path" : [
         "say"
       ],
-      "summary" : "Voice — speak text aloud (sugar for tell human)"
+      "summary" : "Voice — direct TTS convenience aligned with tell human"
     },
     {
       "forms" : [

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -291,6 +291,8 @@ if echo "$OUT" | grep -q '"token" : "--voice-slot"' &&
    echo "$OUT" | grep -q '"token" : "--language"' &&
    echo "$OUT" | grep -q '"token" : "--gender"' &&
    echo "$OUT" | grep -q '"token" : "--quality-tier"' &&
+   echo "$OUT" | grep -q 'direct TTS convenience aligned with tell human' &&
+   ! echo "$OUT" | grep -qi 'sugar for tell human' &&
    echo "$OUT" | grep -q 'aos say \[--voice id\] \[--voice-slot n\] \[--language value\] \[--gender value\] \[--quality-tier value\] \[--rate wpm\] <text>' &&
    echo "$OUT" | grep -q 'resolved after filters'; then
     pass "say help exposes filtered voice-slot selection"


### PR DESCRIPTION
## Summary
- replace the `aos say` help summary wording from sugar to direct TTS convenience
- add a help-contract guard for the direct TTS wording and against the old sugar phrase

## Tests
- ./aos help say | rg "direct TTS|sugar|tell human"
- bash tests/help-contract.sh
- bash tests/external-command-dispatch.sh
- node --test tests/schemas/aos-external-command-manifest-v0.test.mjs
- git diff --check

## Proof limits
- deterministic/static/help proof only; no Level 4 live UI, native, or TCC proof run