### PR TITLE
Split do drag API table tiers

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -808,9 +808,9 @@ Primary public verbs:
 
 | Subcommand | Purpose |
 | --- | --- |
-| `click` | click coordinates, browser refs, or AOS canvas semantic refs |
+| `click` | click coordinates, saved refs, direct browser targets, or AOS canvas semantic refs |
 | `hover` | move cursor |
-| `drag` | drag between coordinates, browser refs, or AOS canvas semantic refs |
+| `drag` | saved/browser two-endpoint drag, direct canvas semantic drag (`--by` / `--to-value`), or native coordinate drag |
 | `scroll` | scroll at a point |
 | `type` | type text |
 | `key` | key combo |

--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -413,6 +413,9 @@ const doNativeDragForm = doCommand.forms.find((form) => form.id === 'do-drag-nat
 assert.ok(doDragForm, 'manifest missing saved-ref/browser do-drag form');
 assert.ok(doCanvasDragForm, 'manifest missing direct canvas do-drag form');
 assert.ok(doNativeDragForm, 'manifest missing native coordinate do-drag form');
+assert.ok(apiDoc.includes('| `click` | click coordinates, saved refs, direct browser targets, or AOS canvas semantic refs |'), 'API do table must name saved refs and direct browser targets for click');
+assert.ok(apiDoc.includes('| `drag` | saved/browser two-endpoint drag, direct canvas semantic drag (`--by` / `--to-value`), or native coordinate drag |'), 'API do table must split drag grammar tiers');
+assert.ok(!apiDoc.includes('| `drag` | drag between coordinates, browser refs, or AOS canvas semantic refs |'), 'API do table must not collapse drag grammar tiers');
 assert.ok(!doDragForm.usage.includes('--speed'), 'saved-ref drag usage must not advertise native-only --speed');
 assert.ok(!doDragForm.args.some((arg) => arg.token === '--speed'), 'saved-ref drag args must not advertise native-only --speed');
 assert.ok(!doDragForm.usage.includes('--by'), 'saved-ref drag usage must not advertise direct-canvas --by');


### PR DESCRIPTION
## Summary
- update the public `aos do` API table so `click` names saved refs and direct browser targets
- split `drag` wording into saved/browser two-endpoint drag, direct canvas semantic drag, and native coordinate drag
- add a contract-drift guard so the API table cannot collapse the drag grammars again

## Tests
- bash tests/agent-workspace-contract-drift.sh
- bash tests/help-contract.sh
- ./aos dev recommend --json --files docs/api/aos.md tests/agent-workspace-contract-drift.sh
- git diff --check

## Proof limits
- deterministic/static docs/help proof only; no Level 4 live UI, native, or TCC proof run