### PR TITLE
Clarify saved ref glossary contract

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -188,6 +188,20 @@ canvas targets and the target-model shape for other ref-addressed resolvers as
 they converge.
 _Avoid_: full target (ambiguous), qualified ref.
 
+**Saved Ref**:
+The primary model-facing handle for a persisted perception ref in an agent
+workspace: `ref:<snapshot-id>:<ref-id>`. Saved Refs are produced by
+`aos see capture --save` and read back with `aos see refs`; use them for normal
+observe-act loops. A Saved Ref names a workspace snapshot record, including
+backend, conformance, supported action matrix, and original ref data, and must
+revalidate or reacquire the current target before mutation. It is not a live
+Target-with-Ref: saved browser refs may dispatch through a current
+`browser:<session>/<ref>` target after validation, canvas refs may resolve
+through current canvas semantic refs, stable native AX refs may bridge to
+direct AX flags, and unsupported or volatile refs fail closed. Bare
+`ref:<ref-id>` is permitted only when unambiguous inside the workspace.
+_Avoid_: saved target, locator, permanent object id, direct target.
+
 **Semantic Target**:
 A discovered candidate emitted by perception, typically from `aos see ... --xray`. A structured record carrying ref, name, role, bounds, state, AOS ownership metadata, etc. Not a new address grammar — Semantic Targets *contain* Refs and report what's resolvable inside a Target.
 _Avoid_: hit, candidate, probe result.
@@ -270,7 +284,8 @@ _Avoid_: accepted (schema term is `applied`), validation-result (diagnostic deta
 - Within a Work Record: the **intent spine** is durable, the **execution map** is repairable, **evidence** is immutable, **Verifier Health** can be re-evaluated.
 - **Claims** belong to the intent spine; **Postconditions** belong to the execution map. A Claim references zero or more Postconditions; a Postcondition can exist as a step-local gate without being referenced by any Claim.
 - The verifier produces one **Claim Result** per Claim by evaluating the Claim's referenced Postconditions against captured Evidence; aggregated Claim Results determine the run's **Verifier Health**.
-- A **Target-with-Ref** is the model unit of address for ref-addressed `aos see`/`aos do`/`aos show` operations. Live CLI forms currently expose it for browser and canvas targets. An **Anchor** is one role a Target-with-Ref can play (placement reference for `show`); on resolution it becomes an **Anchor Binding** in the display subsystem.
+- A **Target-with-Ref** is the live direct model unit of address for ref-addressed `aos see`/direct `aos do`/`aos show` operations. Live CLI forms currently expose it for browser and canvas targets. An **Anchor** is one role a Target-with-Ref can play (placement reference for `show`); on resolution it becomes an **Anchor Binding** in the display subsystem.
+- A **Saved Ref** (`ref:<snapshot-id>:<ref-id>`) is the preferred model-facing handle for saved perception workspaces and normal `see --save` -> `do` loops. Saved Refs are separate from direct Target-with-Ref address grammar: they carry snapshot/workspace/conformance/action-matrix data and must revalidate, reacquire, or fail closed before dispatching through browser, canvas, or native bridge actions.
 - Refs are dialect-specific: `browser` and `canvas` live CLI targets carry Refs, and AX model targets identify elements by AX path/filters. Screen coordinate actions carry raw coordinates plus `--state-id` instead.
 - A **Subject** is host-neutral. A **Facet** declares one or more **Hosts** it supports; opening a Facet means picking one of its Hosts and addressing the resulting render through that Host's Target dialect.
 - **Browser-First** is a posture for wiki/editor/artifact Facets; **AOS-Native** is a *requirement* for Facets that depend on AOS runtime privileges. Most Facets fall in between and can declare multiple Hosts.

--- a/shared/schemas/aos-agent-workspace-v0.md
+++ b/shared/schemas/aos-agent-workspace-v0.md
@@ -176,7 +176,7 @@ verification step. After a dry-run returns a safe status such as `reacquired`,
 `resolved`, or `direct_ax_ready`, dispatch by rerunning the exact saved-ref
 command without `--dry-run`; do not remove `--dry-run` for
 validation-required, blocked, unsupported, or low-confidence refs. Refresh
-recommendations point back to the originating saved target and mode:
+recommendations point back to the originating capture target and mode:
 
 ```bash
 aos see capture <capture_target> --save --workspace <workspace> --mode <capture_mode>

--- a/tests/execution-model-terminology-contract.test.mjs
+++ b/tests/execution-model-terminology-contract.test.mjs
@@ -117,6 +117,27 @@ test('browser target guidance prefers saved refs and keeps direct refs volatile'
   assert.doesNotMatch(browserSkill, /docs\/superpowers\/specs\/2026-04-24-playwright-browser-adapter-design\.md/);
 });
 
+test('context glossary distinguishes saved refs from live target refs', async () => {
+  const context = await text('CONTEXT.md');
+  const aosApi = await text('docs/api/aos.md');
+  const workspaceSchema = await text('shared/schemas/aos-agent-workspace-v0.md');
+
+  assert.match(context, /\*\*Saved Ref\*\*:/);
+  assert.match(context, /`ref:<snapshot-id>:<ref-id>`/);
+  assert.match(context, /primary model-facing handle/);
+  assert.match(context, /workspace snapshot record/);
+  assert.match(context, /revalidate or reacquire the current target before mutation/);
+  assert.match(context, /not a live\s+Target-with-Ref/);
+  assert.match(context, /Bare\s+`ref:<ref-id>` is permitted only when unambiguous inside the workspace/);
+  assert.match(context, /separate from direct Target-with-Ref address grammar/);
+  assert.match(context, /snapshot\/workspace\/conformance\/action-matrix data/);
+  assert.match(aosApi, /Saved refs use `ref:<snapshot-id>:<ref-id>`/);
+  assert.match(workspaceSchema, /Saved refs are scoped to a snapshot/);
+  assert.match(workspaceSchema, /originating capture target and mode/);
+  assert.doesNotMatch(workspaceSchema, /originating saved target/);
+  assert.doesNotMatch(context, /Saved Ref[\s\S]{0,500}is the live wire form/);
+});
+
 test('voice and communication guidance keep say, voice, tell, and listen roles distinct', async () => {
   const architecture = await text('ARCHITECTURE.md');
   const aosApi = await text('docs/api/aos.md');


### PR DESCRIPTION
## Summary
- add Saved Ref as a first-class CONTEXT glossary term for ref:<snapshot-id>:<ref-id>
- distinguish saved workspace handles from live Target-with-Ref direct target grammar
- rename schema wording from originating saved target to originating capture target and guard it in the terminology test

## Verification
- node --test tests/execution-model-terminology-contract.test.mjs
- bash tests/agent-workspace-contract-drift.sh
- bash tests/help-contract.sh
- ./aos dev recommend --json --files CONTEXT.md shared/schemas/aos-agent-workspace-v0.md tests/execution-model-terminology-contract.test.mjs
- node --test tests/schemas/*.test.mjs
- git diff --check