### PR TITLE
Qualify plan target grammar

### DIFF
--- a/docs/design/aos-grand-unification-plan.md
+++ b/docs/design/aos-grand-unification-plan.md
@@ -41,8 +41,12 @@ slices with repo evidence and clear exit criteria.
 - Keep target dialects explicit:
   - `browser:<session>/<ref>`: Playwright-backed DOM/ARIA targets.
   - `canvas:<canvas-id>/<ref>`: AOS canvas semantic targets.
-  - `screen:<state-id>/<x,y>`: coordinate fallback with state guard.
-  - `ax:<...>`: future first-class macOS AX refs.
+  - Screen coordinate fallback: current CLI actions use raw `x,y` plus optional
+    `--state-id`; `screen:<state-id>/<x,y>` remains target-model/replay
+    vocabulary, not a current CLI target string.
+  - Native AX: current CLI actions select elements through flags such as
+    `--pid` and `--role`; `ax:<...>` remains future first-class target-model
+    vocabulary, not a current CLI target string.
 - Evolve `aos.workbench.subject` in a compatible way:
   - Add optional `links`, `facets`, `edit_targets`, and `verification` fields
     after design/schema tests prove the shape.

--- a/tests/execution-model-terminology-contract.test.mjs
+++ b/tests/execution-model-terminology-contract.test.mjs
@@ -138,6 +138,19 @@ test('context glossary distinguishes saved refs from live target refs', async ()
   assert.doesNotMatch(context, /Saved Ref[\s\S]{0,500}is the live wire form/);
 });
 
+test('grand unification plan qualifies screen and AX target-model vocabulary', async () => {
+  const plan = await text('docs/design/aos-grand-unification-plan.md');
+
+  assert.match(plan, /`browser:<session>\/<ref>`: Playwright-backed DOM\/ARIA targets/);
+  assert.match(plan, /`canvas:<canvas-id>\/<ref>`: AOS canvas semantic targets/);
+  assert.match(plan, /Screen coordinate fallback: current CLI actions use raw `x,y` plus optional\s+`--state-id`/);
+  assert.match(plan, /`screen:<state-id>\/<x,y>` remains target-model\/replay\s+vocabulary, not a current CLI target string/);
+  assert.match(plan, /Native AX: current CLI actions select elements through flags such as\s+`--pid` and `--role`/);
+  assert.match(plan, /`ax:<\.\.\.>` remains future first-class target-model\s+vocabulary, not a current CLI target string/);
+  assert.doesNotMatch(plan, /`screen:<state-id>\/<x,y>`: coordinate fallback with state guard/);
+  assert.doesNotMatch(plan, /`ax:<\.\.\.>`: future first-class macOS AX refs/);
+});
+
 test('voice and communication guidance keep say, voice, tell, and listen roles distinct', async () => {
   const architecture = await text('ARCHITECTURE.md');
   const aosApi = await text('docs/api/aos.md');


### PR DESCRIPTION
## Summary
- qualify the grand-unification plan target list for current screen coordinate and native AX CLI behavior
- preserve browser and canvas as the live direct target examples
- add a terminology regression so the plan cannot re-advertise screen:/ax: as current CLI target strings

## Verification
- node --test tests/execution-model-terminology-contract.test.mjs
- ./aos dev recommend --json --files docs/design/aos-grand-unification-plan.md tests/execution-model-terminology-contract.test.mjs
- bash tests/agent-workspace-contract-drift.sh
- bash tests/help-contract.sh
- git diff --check