### PR TITLE
Qualify design target bridge grammar

### DIFF
--- a/docs/design/aos-subject-model-compatibility-audit.md
+++ b/docs/design/aos-subject-model-compatibility-audit.md
@@ -156,16 +156,19 @@ Anchor Binding wording while preserving the current `--anchor-browser` CLI.
 
 At audit time, `docs/design/aos-work-records-and-self-healing-recipes.md` still
 gave the screen dialect as `screen:<frame-id>/<x,y>`. ADR-0006 and the grand
-plan use `screen:<state-id>/<x,y>` for coordinate fallback with a
-perception-state guard.
+plan now qualify current coordinate fallback as raw `x,y` plus optional
+`--state-id`; `screen:<state-id>/<x,y>` remains target-model/replay shorthand,
+not a current CLI target string.
 
 Migration direction:
 
-- update docs to `screen:<state-id>/<x,y>`;
+- update docs to current `x,y` plus `--state-id` bridge wording;
 - keep enforcement language honest: current AOS echoes/correlates state ids but
   does not reject stale coordinate actions yet.
 
-Cleanup status: the work-record design note now uses `screen:<state-id>/<x,y>`.
+Cleanup status: the work-record design note now qualifies screen coordinates
+and native AX as bridge/model vocabulary rather than current live target
+strings.
 
 ## 2026-05-06 Cutover Classification
 
@@ -180,7 +183,7 @@ Cleanup status: the work-record design note now uses `screen:<state-id>/<x,y>`.
 ## Recommended Migration Order
 
 1. Update docs-only drift that does not change behavior: navigation trail
-   wording, anchor role wording, and `screen:<state-id>/<x,y>`.
+   wording, anchor role wording, and screen coordinate bridge wording.
 2. Add schema sketches for Subject References, Facets, Hosts, Capabilities,
    operation contracts, Work Record origin/references, and verifier reports.
    Subject References, Facets, Hosts, Capabilities, and operation contracts now

--- a/docs/design/aos-work-records-and-self-healing-recipes.md
+++ b/docs/design/aos-work-records-and-self-healing-recipes.md
@@ -151,15 +151,18 @@ Examples:
 
 ```text
 browser:<session>/<ref>
-ax:<pid>/<ref>
 canvas:<canvas-id>/<state-scoped-ref>
-screen:<state-id>/<x,y>
+ref:<snapshot-id>:<ref-id>
+screen coordinate fallback: raw x,y plus --state-id (current CLI); screen:<state-id>/<x,y> is target-model/replay shorthand
+native AX: selector flags such as --pid and --role (current CLI); ax:<...> is reserved target-model vocabulary
 ```
 
-The exact grammar can harden later. The important point is that target strings
-are compact current-address handles while the execution map can carry richer
-target descriptors: owner namespace, durable target id, primitive actions,
-state, provenance, and machine-first stale-ref repair hints.
+The exact grammar can harden later. The important point is that direct target
+strings and saved refs stay compact current-address/provenance handles while
+the execution map can carry richer target descriptors: owner namespace, durable
+target id, primitive actions, state, provenance, and machine-first stale-ref
+repair hints. Screen coordinate and native AX bridges should be recorded as
+structured descriptors until they gain first-class live target strings.
 
 ## Playwright And Codegen
 

--- a/docs/design/pi-computer-use-lessons-for-aos-see-do.md
+++ b/docs/design/pi-computer-use-lessons-for-aos-see-do.md
@@ -48,13 +48,14 @@ Agents should prefer target refs emitted by `see` over screen coordinates. A
 coordinate action should carry the perception state that produced it and should
 be rejected or revalidated when that state is stale.
 
-This applies across target dialects:
+This applies across target handles and bridge forms:
 
 ```text
 browser:<session>/<ref>
-ax:<pid>/<ref>
 canvas:<canvas-id>/<ref>
-screen:<state-id>/<x,y>
+ref:<snapshot-id>:<ref-id>
+screen coordinate fallback: raw x,y plus --state-id (current CLI); screen:<state-id>/<x,y> is target-model/replay shorthand
+native AX: selector flags such as --pid and --role (current CLI); ax:<...> is reserved target-model vocabulary
 ```
 
 ### Perception State Ids

--- a/tests/execution-model-terminology-contract.test.mjs
+++ b/tests/execution-model-terminology-contract.test.mjs
@@ -151,6 +151,27 @@ test('grand unification plan qualifies screen and AX target-model vocabulary', a
   assert.doesNotMatch(plan, /`ax:<\.\.\.>`: future first-class macOS AX refs/);
 });
 
+test('design target examples keep screen and AX as bridge or model vocabulary', async () => {
+  const piLessons = await text('docs/design/pi-computer-use-lessons-for-aos-see-do.md');
+  const workRecords = await text('docs/design/aos-work-records-and-self-healing-recipes.md');
+  const compatibilityAudit = await text('docs/design/aos-subject-model-compatibility-audit.md');
+
+  for (const doc of [piLessons, workRecords]) {
+    assert.match(doc, /browser:<session>\/<ref>/);
+    assert.match(doc, /canvas:<canvas-id>\/<[^>]+>/);
+    assert.match(doc, /ref:<snapshot-id>:<ref-id>/);
+    assert.match(doc, /screen coordinate fallback: raw x,y plus --state-id \(current CLI\); screen:<state-id>\/<x,y> is target-model\/replay shorthand/);
+    assert.match(doc, /native AX: selector flags such as --pid and --role \(current CLI\); ax:<\.\.\.> is reserved target-model vocabulary/);
+    assert.doesNotMatch(doc, /^ax:<pid>\/<ref>$/m);
+    assert.doesNotMatch(doc, /^screen:<state-id>\/<x,y>$/m);
+  }
+
+  assert.match(compatibilityAudit, /current coordinate fallback as raw `x,y` plus optional\s+`--state-id`/);
+  assert.match(compatibilityAudit, /`screen:<state-id>\/<x,y>` remains target-model\/replay shorthand,\s+not a current CLI target string/);
+  assert.match(compatibilityAudit, /screen coordinate bridge wording/);
+  assert.doesNotMatch(compatibilityAudit, /update docs to `screen:<state-id>\/<x,y>`/);
+});
+
 test('voice and communication guidance keep say, voice, tell, and listen roles distinct', async () => {
   const architecture = await text('ARCHITECTURE.md');
   const aosApi = await text('docs/api/aos.md');


### PR DESCRIPTION
## Summary
- qualify Pi lessons and Work Record design target examples for saved refs, screen coordinate fallback, and native AX bridge forms
- update the compatibility audit status to point at current x,y plus --state-id wording instead of screen: as live CLI grammar
- add a terminology regression over those live design docs

## Verification
- node --test tests/execution-model-terminology-contract.test.mjs
- ./aos dev recommend --json --files docs/design/pi-computer-use-lessons-for-aos-see-do.md docs/design/aos-work-records-and-self-healing-recipes.md docs/design/aos-subject-model-compatibility-audit.md tests/execution-model-terminology-contract.test.mjs
- bash tests/agent-workspace-contract-drift.sh
- bash tests/help-contract.sh
- git diff --check