### PR TITLE
Use native AX bridge in desktop fixture

### DIFF
--- a/docs/design/fixtures/aos-work-records/desktop-workflow-demo-step.json
+++ b/docs/design/fixtures/aos-work-records/desktop-workflow-demo-step.json
@@ -10,14 +10,15 @@
   },
   "precondition": {
     "see": "AOS can inspect the foreground app and accessibility tree.",
-    "target": "ax:com.agent-os.launcher",
+    "target": "native AX selector bridge for com.agent-os.launcher",
     "state_id": "see_desktop000001"
   },
   "action": {
     "verb": "press",
-    "target": "ax:com.agent-os.launcher/workflow-entry-employer-brand",
+    "target": "native AX press via selector flags",
     "state_id": "see_desktop000001",
     "args": {
+      "bundle_id": "com.agent-os.launcher",
       "role": "AXButton",
       "title": "Employer Brand Competitor Audit"
     }
@@ -34,7 +35,8 @@
   },
   "execution_map": {
     "desktop": {
-      "target_grammar": "ax:<bundle-or-pid>/<ref>",
+      "target_grammar": "native AX selector flags such as --pid, --role, and title filters",
+      "target_model_vocabulary": "future first-class native AX refs remain reserved",
       "ax_candidates": [
         {
           "bundle_id": "com.agent-os.launcher",

--- a/tests/design/aos-work-record-fixtures.test.mjs
+++ b/tests/design/aos-work-record-fixtures.test.mjs
@@ -65,6 +65,19 @@ test('do_step examples preserve the four-layer work-record shape', () => {
   }
 });
 
+test('desktop work-record fixture uses current native AX selector bridge', () => {
+  const fixture = readJson('desktop-workflow-demo-step.json');
+  const desktop = fixture.execution_map.desktop;
+  const serialized = JSON.stringify(fixture);
+
+  assert.equal(fixture.precondition.target, 'native AX selector bridge for com.agent-os.launcher');
+  assert.equal(fixture.action.target, 'native AX press via selector flags');
+  assert.equal(fixture.action.args.bundle_id, 'com.agent-os.launcher');
+  assert.equal(desktop.target_grammar, 'native AX selector flags such as --pid, --role, and title filters');
+  assert.equal(desktop.target_model_vocabulary, 'future first-class native AX refs remain reserved');
+  assert.doesNotMatch(serialized, /ax:[^"]+/);
+});
+
 test('health fixture keeps retirement separate from historical evidence', () => {
   const fixture = readJson('recipe-health-retirement.json');
   assert.equal(fixture.type, 'aos.recipe_health_event');


### PR DESCRIPTION
## Summary
- update the desktop work-record design fixture to use native AX selector bridge wording instead of ax: target strings
- record bundle_id as an action selector argument
- add a fixture regression that rejects ax: target grammar in this live design example

## Verification
- node --test tests/design/aos-work-record-fixtures.test.mjs
- node --test tests/execution-model-terminology-contract.test.mjs
- ./aos dev recommend --json --files docs/design/fixtures/aos-work-records/desktop-workflow-demo-step.json tests/design/aos-work-record-fixtures.test.mjs
- bash tests/agent-workspace-contract-drift.sh
- bash tests/help-contract.sh
- git diff --check