### PR TITLE
Clarify work record action targets

### DIFF
--- a/docs/api/toolkit/workbench.md
+++ b/docs/api/toolkit/workbench.md
@@ -1407,11 +1407,14 @@ capture builders. `buildWorkRecordV0FromCommandEvidence()` turns one bounded
 repo command evidence source into a completed Work Record v0.
 `buildWorkRecordV0FromAosActionEvidence()` does the same for one saved AOS
 `see -> do -> see` action evidence source, preserving before perception, action
-metadata, after perception, target dialect, Target-with-Ref, State IDs where
-available, immutable evidence refs, Claims, Postconditions, Claim Results, a
-Verifier Report, and Health. This is report-only substrate for later browser,
-canvas, or Step descriptors; it does not add replay, repair, or a broad CLI
-command surface.
+metadata, after perception, target dialect, selected action target, State IDs
+where available, immutable evidence refs, Claims, Postconditions, Claim
+Results, a Verifier Report, and Health. Direct browser/canvas evidence may use
+a Target-with-Ref, saved-ref evidence should preserve the Saved Ref plus
+resolved underlying target, and native AX evidence should preserve its selector
+bridge descriptor. This is report-only substrate for later browser, canvas, or
+Step descriptors; it does not add replay, repair, or a broad CLI command
+surface.
 
 `packages/toolkit/workbench/browser-evidence-capture.js` exposes Browser
 Evidence Capture V0 for local fixture-backed evidence capture. It accepts a local

--- a/shared/schemas/aos-work-record-v0.md
+++ b/shared/schemas/aos-work-record-v0.md
@@ -304,8 +304,11 @@ The second producer is also narrow:
 `buildWorkRecordV0FromAosActionEvidence()` turns one saved AOS action evidence
 source into the same completed v0 shape. Its source records one
 `see -> do -> see` slice with before perception, AOS action metadata, after
-perception, target dialect, Target-with-Ref, State IDs where available, and
-immutable artifact refs. The builder stores the selected action target in
+perception, target dialect, selected action target, State IDs where available,
+and immutable artifact refs. Direct browser/canvas evidence may store a
+Target-with-Ref, saved-ref evidence should preserve the Saved Ref plus resolved
+underlying target, and native AX evidence should preserve its selector bridge
+descriptor. The builder stores the selected action target in
 `execution_map.steps[].action`, stores before/action/after receipts in
 `evidence[]`, and ties the post-action Postcondition to the after-perception
 evidence.
@@ -323,9 +326,10 @@ The Step Descriptor bridge keeps that split explicit:
 `aos.step_descriptor` descriptor with one saved AOS action evidence source. The
 gated harness or containing Workflow contributes `origin.kind: "workflow"` and
 `origin.ref`; the step descriptor contributes target-resolution metadata, step
-repair hints, workflow gate refs, and claim-promotion metadata. The action evidence still contributes the
-immutable before/action/after receipts, State IDs, selected Target-with-Ref,
-Claim Results, Verifier Report, and Health. This bridge does not make Playbook
+repair hints, workflow gate refs, and claim-promotion metadata. The action
+evidence still contributes the immutable before/action/after receipts, State
+IDs, selected action target, Claim Results, Verifier Report, and Health. This
+bridge does not make Playbook
 the executable substrate and does not execute or replay the descriptor.
 
 The first harness layer above that bridge is
@@ -341,7 +345,9 @@ module API above the daemon instead of a broad public CLI. Its boundary is:
   evidence. The harness rejects missing or undeclared gates before action code
   runs.
 - **Work Record evidence:** immutable before/action/after receipts and the
-  selected Target-with-Ref for what actually happened during the run.
+  selected action target for what actually happened during the run. A selected
+  action target may be a direct Target-with-Ref, a Saved Ref with resolved
+  underlying target metadata, or a native bridge descriptor.
 - **Verifier diagnostics:** report-only classifications such as target/ref
   drift, precondition failure, action failure, postcondition failure, evidence
   ref drift, and State ID inconsistency. Diagnostics do not mutate the Work

--- a/tests/execution-model-terminology-contract.test.mjs
+++ b/tests/execution-model-terminology-contract.test.mjs
@@ -172,6 +172,23 @@ test('design target examples keep screen and AX as bridge or model vocabulary', 
   assert.doesNotMatch(compatibilityAudit, /update docs to `screen:<state-id>\/<x,y>`/);
 });
 
+test('work record action evidence docs preserve selected action target vocabulary', async () => {
+  const schemaDoc = await text('shared/schemas/aos-work-record-v0.md');
+  const workbenchApi = await text('docs/api/toolkit/workbench.md');
+
+  for (const doc of [schemaDoc, workbenchApi]) {
+    assert.match(doc, /target dialect, selected action target, State IDs/);
+    assert.match(doc, /Direct browser\/canvas evidence may (?:store|use)\s+a\s+Target-with-Ref/);
+    assert.match(doc, /saved-ref evidence should preserve the Saved Ref plus\s+resolved\s+underlying target/);
+    assert.match(doc, /native AX evidence should preserve its selector\s+bridge\s+descriptor/);
+    assert.doesNotMatch(doc, /target dialect, Target-with-Ref, State IDs/);
+  }
+
+  assert.match(schemaDoc, /selected action target for what actually happened during the run/);
+  assert.match(schemaDoc, /may be a direct Target-with-Ref, a Saved Ref with resolved\s+underlying target metadata, or a native bridge descriptor/);
+  assert.doesNotMatch(schemaDoc, /selected Target-with-Ref/);
+});
+
 test('voice and communication guidance keep say, voice, tell, and listen roles distinct', async () => {
   const architecture = await text('ARCHITECTURE.md');
   const aosApi = await text('docs/api/aos.md');


### PR DESCRIPTION
## Summary
- update Work Record contract docs from Target-with-Ref-only action evidence to selected action target vocabulary
- name direct Target-with-Ref, Saved Ref plus resolved target, and native AX bridge descriptor as evidence shapes
- add a terminology regression for the shared schema doc and toolkit API doc

## Verification
- node --test tests/execution-model-terminology-contract.test.mjs
- node --test tests/schemas/*.test.mjs
- ./aos dev recommend --json --files shared/schemas/aos-work-record-v0.md docs/api/toolkit/workbench.md tests/execution-model-terminology-contract.test.mjs
- bash tests/agent-workspace-contract-drift.sh
- bash tests/help-contract.sh
- git diff --check