### PR TITLE
Align grand plan work record model

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -327,8 +327,18 @@ _Avoid_: accepted (schema term is `applied`), validation-result (diagnostic deta
   with Gates, Signals, Checkpoints, Guides, and Playbooks around that stack.
   `Recipe` means executable source-backed procedure; `docs/guides/` is the
   home for Markdown Guides/SOPs.
-- Phase 6 of `aos-grand-unification-plan.md` lists "save a work record" and "run verifier report" as Playbook steps - they are *harness obligations* around a Workflow-gated run, not Playbook-authored execution steps. Current `aos.step_descriptor` descriptors end at the single action + postcondition. Pending: plan revision.
-- Verifier Report shape — the plan lists `claims`, `verified`, `failed`, `unverified` as four parallel fields. Resolved direction (ADR-0003): use `claim_results[]` as the source of truth; if the four parallel fields persist, they are *derived indexes of Claim IDs*, not independent storage. When a Verifier Report is embedded in a Work Record it should not echo the full `claims` list (single source of truth); when reports travel standalone, they include a `claims_digest` for auditability. The v0 sketch keeps `claim_results[]` top-level and makes report indexes derived.
+- Phase 6 of `aos-grand-unification-plan.md` now treats browser runs as
+  Workflow-gated step evidence rather than Playbook-authored execution.
+  Emitting a Work Record and running the report-only verifier are harness
+  obligations around the run, not primitive step actions. Current
+  `aos.step_descriptor` descriptors end at the single action + postcondition.
+- Verifier Report shape — resolved direction (ADR-0003): use
+  `claim_results[]` as the source of truth, with `verified`, `failed`, and
+  `unverified` as derived indexes of Claim IDs, not independent storage. When a
+  Verifier Report is embedded in a Work Record it should not echo the full
+  `claims` list (single source of truth); when reports travel standalone, they
+  include a `claims_digest` for auditability. The v0 sketch keeps
+  `claim_results[]` top-level and makes report indexes derived.
 - Step descriptors need explicit syntax to *promote* a step Postcondition into a Work Record Claim for the gated harness bridge. The v0 Work Record examples show promoted run Claims referencing execution-map Postconditions.
 - `--anchor-browser` (and sibling `--anchor-window`, `--anchor-channel`) is a *role flag* whose value is a regular Target-with-Ref, not a parallel target dialect. The plan now says this explicitly; longer-term a generic `--anchor <target>` flag may consolidate them, but that is a future cleanup, not a plan rewrite. See ADR-0004.
 - `facets[].host` enum (`"browser" | "canvas" | "either"`) was considered and rejected as too coarse — a Facet may have *multiple Host implementations* with different entry points, target dialects, or fidelity. Resolved direction: `facets[].hosts[]` array of `{ kind, target_dialect, entry, ... }` records, with optional preference ordering. Initial sketch: `shared/schemas/aos-workbench-subject-vnext.md`.

--- a/docs/design/aos-grand-unification-plan.md
+++ b/docs/design/aos-grand-unification-plan.md
@@ -62,10 +62,8 @@ slices with repo evidence and clear exit criteria.
 - Define verifier report v0:
   - `status`
   - `confidence`
-  - `claims`
-  - `verified`
-  - `failed`
-  - `unverified`
+  - `claim_results[]`
+  - derived indexes: `verified`, `failed`, `unverified`
   - `evidence_refs`
   - `feedback`
 
@@ -162,26 +160,28 @@ slices with repo evidence and clear exit criteria.
 - Auto-feedback may draft findings; any replay/repair loop needs an explicit
   workflow gate.
 
-### Phase 6: Browser Playbooks
+### Phase 6: Browser Step Evidence And Workflow-Gated Runs
 
-- Add "AOS browser playbooks" as recorded, evidence-backed units, not raw macro
-  recordings.
-- A playbook step is:
+- Add browser step descriptors as recorded, evidence-backed units, not raw
+  macro recordings and not Playbook-authored execution.
+- A Workflow-gated harness step is:
   - re-see target
   - resolve semantic ref
   - check precondition
   - execute `aos do`
   - re-see
   - verify postcondition
+- Work Records and verifier reports are harness obligations around the run, not
+  step-authored primitive actions.
 - Keep raw `playwright-cli` traces, screenshots, video, and codegen as attached
   evidence or hints, not canonical truth.
-- First candidate playbook:
+- First candidate Workflow-gated browser run:
   - open browser-hosted wiki browser
   - locate Sigil subject
   - follow the Sigil radial menu facet/resource
   - inspect/edit one object transform
-  - save a work record
-  - run verifier report
+  - emit a Work Record through the harness
+  - run the report-only verifier profile
 
 ### Phase 7: AOS-Native Runtime Surfaces Stay Native
 

--- a/tests/execution-model-terminology-contract.test.mjs
+++ b/tests/execution-model-terminology-contract.test.mjs
@@ -94,6 +94,29 @@ test('current code and docs use Step Descriptor instead of Playbook Step substra
   );
 });
 
+test('grand unification plan keeps Work Records and verifier reports as harness obligations', async () => {
+  const plan = await text('docs/design/aos-grand-unification-plan.md');
+  const context = await text('CONTEXT.md');
+  const adr = await text('docs/adr/0013-aos-execution-model-v0.md');
+
+  assert.match(plan, /### Phase 6: Browser Step Evidence And Workflow-Gated Runs/);
+  assert.match(plan, /not Playbook-authored execution/);
+  assert.match(plan, /Work Records and verifier reports are harness obligations around the run/);
+  assert.match(plan, /First candidate Workflow-gated browser run/);
+  assert.match(plan, /emit a Work Record through the harness/);
+  assert.match(plan, /run the report-only verifier profile/);
+  assert.match(plan, /`claim_results\[\]`/);
+  assert.match(plan, /derived indexes: `verified`, `failed`, `unverified`/);
+  assert.match(context, /now treats browser runs as\s+Workflow-gated step evidence/);
+  assert.match(context, /use\s+`claim_results\[\]` as the source of truth/);
+  assert.match(adr, /neutral V0 sketch for one Workflow-gated step\/evidence bridge/);
+  assert.doesNotMatch(plan, /### Phase 6: Browser Playbooks/);
+  assert.doesNotMatch(plan, /A playbook step is/);
+  assert.doesNotMatch(plan, /save a work record/);
+  assert.doesNotMatch(plan, /run verifier report/);
+  assert.doesNotMatch(context, /Pending: plan revision/);
+});
+
 test('browser capture remains a projection, not a taxonomy source', async () => {
   const browser = await text('docs/design/browser-capture-ladder-projection.md');
   const adr = await text('docs/adr/0013-aos-execution-model-v0.md');


### PR DESCRIPTION
## Summary
- resolves the grand-unification plan verifier report shape to `claim_results[]` with derived status indexes
- recasts Phase 6 browser work as Workflow-gated step evidence, not Playbook-authored execution
- updates CONTEXT.md and adds a terminology regression guard for the resolved contract

## Verification
- node --test tests/execution-model-terminology-contract.test.mjs
- ./aos dev recommend --json --files docs/design/aos-grand-unification-plan.md CONTEXT.md tests/execution-model-terminology-contract.test.mjs
- bash tests/help-contract.sh
- bash tests/agent-workspace-contract-drift.sh
- git diff --check