### PR TITLE
Clarify agent workspace selection boundary

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -173,6 +173,15 @@ Saved capture writes are staged under `snapshots/.staging/`, marked with
 Readback and `index.json` rebuilds only use committed snapshots, so partial or
 staged writes do not become valid workspace state.
 
+Workspace selection is command-scoped. For saved workspace reads and actions,
+`--workspace <id>` wins; otherwise `AOS_AGENT_WORKSPACE` selects a workspace;
+otherwise AOS uses `default`. No daemon-held current workspace exists, and
+`aos see workspace use <id>` is not a current command. `aos see workspaces`
+lists all local workspaces without consulting `AOS_AGENT_WORKSPACE`; cleanup
+commands require explicit workspace or snapshot ids. This keeps parallel agents
+from mutating hidden shared workspace state. Any future session-bound default
+must first define a multi-agent-safe contract.
+
 Capture modes are explicit:
 
 - `--mode ax`: tree-oriented refs where the backend can supply them.

--- a/shared/schemas/aos-agent-workspace-v0.md
+++ b/shared/schemas/aos-agent-workspace-v0.md
@@ -38,6 +38,19 @@ Mutating commands may create a transient `.write-lock/` directory under the
 workspace. This is local contention control state, not part of the persisted
 schema contract.
 
+## Workspace Selection
+
+Workspace selection is command-scoped. For saved workspace reads and actions,
+`--workspace <id>` wins; otherwise `AOS_AGENT_WORKSPACE` selects a workspace;
+otherwise AOS uses `default`.
+
+No daemon-held current workspace exists, and `aos see workspace use <id>` is not
+a current command. `aos see workspaces` lists all local workspaces without
+consulting `AOS_AGENT_WORKSPACE`; cleanup commands require explicit workspace
+or snapshot ids. This avoids hidden global state across parallel agents. Any
+future session-bound default must define a multi-agent-safe contract before it
+becomes public.
+
 `capture.json` intentionally preserves the primitive output shape. The workspace
 schema validates the saved workspace files around that payload, not every
 primitive capture field.

--- a/skills/aos-agent-workspace/SKILL.md
+++ b/skills/aos-agent-workspace/SKILL.md
@@ -32,6 +32,11 @@ aos do focus ref:<snapshot-id>:r7 --workspace default --dry-run
 - A saved capture source can be a positional target such as `browser:work` or a
   source flag such as `--region <rect>`, `--canvas <id>`, or `--channel <id>`.
   `--save` is the state mutation boundary.
+- Workspace selection is command-scoped: `--workspace <id>` overrides
+  `AOS_AGENT_WORKSPACE`; absent both, AOS uses `default`. No daemon-held current
+  workspace exists, and `aos see workspace use <id>` is not a current command.
+  Keep parallel agents isolated by passing explicit workspaces or setting the
+  environment per process.
 - Prefer scoped refs: `ref:<snapshot-id>:<ref-id>`.
 - Use bare `ref:<ref-id>` only when one snapshot in the workspace contains that
   ref. If the command returns `REF_AMBIGUOUS`, use its candidate snapshots and

--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -27,6 +27,7 @@ import {
   SAVED_REF_V0_ACTIONS_BY_BACKEND,
   savedRefBackendSupportsRealMutation,
 } from './scripts/lib/agent-workspace/contracts.mjs';
+import { workspaceID } from './scripts/lib/agent-workspace/core.mjs';
 
 const schema = JSON.parse(fs.readFileSync('shared/schemas/aos-agent-workspace-v0.schema.json', 'utf8'));
 const defs = schema.$defs;
@@ -48,6 +49,14 @@ const workspaceIndexSnapshotRequired = defs.workspace_index.properties.snapshots
 assert.ok(workspaceIndexSnapshotRequired.includes('capture_target'), 'workspace index snapshots must expose compact capture target readback');
 assert.ok(workspaceIndexSnapshotRequired.includes('query'), 'workspace index snapshots must expose compact saved query readback');
 assert.ok(defs.snapshot_record.required.includes('query'), 'snapshot records must persist nullable saved query readback');
+assert.equal(workspaceID(null, {}), 'default', 'workspace fallback must be command-local default');
+assert.equal(workspaceID(undefined, { AOS_AGENT_WORKSPACE: 'env-ws' }), 'env-ws', 'AOS_AGENT_WORKSPACE must supply command-local workspace default');
+assert.equal(workspaceID('flag-ws', { AOS_AGENT_WORKSPACE: 'env-ws' }), 'flag-ws', '--workspace must override AOS_AGENT_WORKSPACE');
+assert.throws(
+  () => workspaceID(null, { AOS_AGENT_WORKSPACE: 'bad/id' }),
+  { name: 'AgentWorkspaceError', code: 'INVALID_ID' },
+  'AOS_AGENT_WORKSPACE default must stay validated like an explicit workspace id',
+);
 
 for (const [backend, actions] of Object.entries(SAVED_REF_V0_ACTIONS_BY_BACKEND)) {
   for (const action of actions) {
@@ -209,6 +218,16 @@ const manifest = fs.readFileSync('manifests/commands/aos-commands.json', 'utf8')
 const manifestJSON = JSON.parse(manifest);
 const swiftAXModel = fs.readFileSync('src/perceive/models.swift', 'utf8');
 const swiftAXTraversal = fs.readFileSync('src/perceive/ax.swift', 'utf8');
+
+for (const [label, text] of Object.entries({ schemaDoc, apiDoc, skill })) {
+  const prose = text.replace(/\s+/g, ' ');
+  assert.ok(prose.includes('Workspace selection is command-scoped'), `${label} must describe command-scoped workspace selection`);
+  assert.ok(text.includes('AOS_AGENT_WORKSPACE'), `${label} must describe the environment workspace default`);
+  assert.ok(prose.includes('`--workspace <id>`') && prose.includes('AOS uses `default`'), `${label} must document flag/env/default precedence`);
+  assert.ok(prose.includes('No daemon-held current workspace exists'), `${label} must reject daemon-held current workspace state`);
+  assert.ok(prose.includes('`aos see workspace use <id>` is not a current command'), `${label} must reject workspace use command as current contract`);
+  assert.ok(/parallel agents|parallel-session/.test(prose), `${label} must tie workspace selection to multi-agent safety`);
+}
 
 function skillFrontmatter(text) {
   assert.ok(text.startsWith('---\n'), 'skill must start with YAML frontmatter');
@@ -439,6 +458,11 @@ assert.ok(!doNativeDragForm.usage.includes('canvas:<canvas-id>'), 'native coordi
 
 const seeCommand = manifestJSON.commands.find((command) => JSON.stringify(command.path) === JSON.stringify(['see']));
 assert.ok(seeCommand, 'manifest missing see command');
+const workspaceUseForms = manifestJSON.commands.flatMap((command) => (command.forms ?? []).filter((form) => (
+  form.id === 'see-workspace-use'
+  || /\bworkspace use\b/.test(form.usage ?? '')
+)));
+assert.deepEqual(workspaceUseForms, [], 'manifest must not advertise a daemon-held workspace use command');
 const captureForm = seeCommand.forms.find((form) => form.id === 'see-capture');
 const captureSaveForm = seeCommand.forms.find((form) => form.id === 'see-capture-save');
 assert.ok(captureForm, 'manifest missing see-capture form');


### PR DESCRIPTION
## Summary
- documents workspace selection as command-scoped across API, schema doc, and the saved-workspace skill
- states flag/env/default precedence and rejects daemon-held `workspace use` state as current contract
- adds drift coverage for resolver behavior, docs/skill wording, and manifest absence of a workspace-use form

## Verification
- bash tests/agent-workspace-contract-drift.sh
- ./aos dev recommend --json --files docs/api/aos.md shared/schemas/aos-agent-workspace-v0.md skills/aos-agent-workspace/SKILL.md tests/agent-workspace-contract-drift.sh
- bash tests/help-contract.sh
- node --test tests/schemas/*.test.mjs
- git diff --check