### PR TITLE
Clarify saved workspace wait diff boundary

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -182,6 +182,15 @@ commands require explicit workspace or snapshot ids. This keeps parallel agents
 from mutating hidden shared workspace state. Any future session-bound default
 must first define a multi-agent-safe contract.
 
+Current wait/diff/assertion boundary: saved workspaces do not expose
+`aos see capture --wait-for-change`, `aos see capture --until-stable`,
+`aos see refs --diff`, or `aos see assert`. Use `recommended_next_command` plus
+a fresh saved capture for re-perception, `aos show wait` only for canvas
+readiness, Recipe assertions only for command JSON checks, and Work Record
+postconditions for durable evidence checks. Future saved wait/diff/assert
+commands need manifest help, parser, schema/doc, and drift tests before public
+use.
+
 Capture modes are explicit:
 
 - `--mode ax`: tree-oriented refs where the backend can supply them.

--- a/shared/schemas/aos-agent-workspace-v0.md
+++ b/shared/schemas/aos-agent-workspace-v0.md
@@ -51,6 +51,18 @@ or snapshot ids. This avoids hidden global state across parallel agents. Any
 future session-bound default must define a multi-agent-safe contract before it
 becomes public.
 
+## Wait, Diff, And Assertion Boundary
+
+Current wait/diff/assertion boundary: saved workspaces do not expose
+`aos see capture --wait-for-change`, `aos see capture --until-stable`,
+`aos see refs --diff`, or `aos see assert`.
+
+Use `recommended_next_command` plus a fresh saved capture for re-perception,
+`aos show wait` only for canvas readiness, Recipe assertions only for command
+JSON checks, and Work Record postconditions for durable evidence checks. Future
+saved wait/diff/assert commands need manifest help, parser, schema/doc, and
+drift tests before public use.
+
 `capture.json` intentionally preserves the primitive output shape. The workspace
 schema validates the saved workspace files around that payload, not every
 primitive capture field.

--- a/skills/aos-agent-workspace/SKILL.md
+++ b/skills/aos-agent-workspace/SKILL.md
@@ -37,6 +37,12 @@ aos do focus ref:<snapshot-id>:r7 --workspace default --dry-run
   workspace exists, and `aos see workspace use <id>` is not a current command.
   Keep parallel agents isolated by passing explicit workspaces or setting the
   environment per process.
+- Current wait/diff/assertion boundary: saved workspaces do not expose
+  `aos see capture --wait-for-change`, `aos see capture --until-stable`,
+  `aos see refs --diff`, or `aos see assert`. Use
+  `recommended_next_command` plus a fresh saved capture for re-perception,
+  `aos show wait` only for canvas readiness, Recipe assertions only for command
+  JSON checks, and Work Record postconditions for durable evidence checks.
 - Prefer scoped refs: `ref:<snapshot-id>:<ref-id>`.
 - Use bare `ref:<ref-id>` only when one snapshot in the workspace contains that
   ref. If the command returns `REF_AMBIGUOUS`, use its candidate snapshots and

--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -227,6 +227,13 @@ for (const [label, text] of Object.entries({ schemaDoc, apiDoc, skill })) {
   assert.ok(prose.includes('No daemon-held current workspace exists'), `${label} must reject daemon-held current workspace state`);
   assert.ok(prose.includes('`aos see workspace use <id>` is not a current command'), `${label} must reject workspace use command as current contract`);
   assert.ok(/parallel agents|parallel-session/.test(prose), `${label} must tie workspace selection to multi-agent safety`);
+  assert.ok(prose.includes('Current wait/diff/assertion boundary'), `${label} must describe saved wait/diff/assertion boundary`);
+  for (const unsupported of ['aos see capture --wait-for-change', 'aos see capture --until-stable', 'aos see refs --diff', 'aos see assert']) {
+    assert.ok(text.includes(unsupported), `${label} must name unsupported saved workspace command ${unsupported}`);
+  }
+  assert.ok(text.includes('recommended_next_command'), `${label} must point re-perception to recommended_next_command`);
+  assert.ok(text.includes('aos show wait'), `${label} must keep show wait scoped to canvas readiness`);
+  assert.ok(prose.includes('Work Record postconditions'), `${label} must route durable evidence checks to Work Record postconditions`);
 }
 
 function skillFrontmatter(text) {
@@ -463,6 +470,16 @@ const workspaceUseForms = manifestJSON.commands.flatMap((command) => (command.fo
   || /\bworkspace use\b/.test(form.usage ?? '')
 )));
 assert.deepEqual(workspaceUseForms, [], 'manifest must not advertise a daemon-held workspace use command');
+const unsupportedSavedWorkspaceSeeForms = seeCommand.forms.filter((form) => (
+  /see-(refs-)?diff|see-assert|wait-for-change|until-stable/.test(form.id)
+  || /--wait-for-change|--until-stable|\bsee refs\b.*--diff|\bsee assert\b/.test(form.usage ?? '')
+  || (form.args ?? []).some((arg) => ['--wait-for-change', '--until-stable', '--diff'].includes(arg.token))
+));
+assert.deepEqual(
+  unsupportedSavedWorkspaceSeeForms.map((form) => form.id),
+  [],
+  'manifest must not advertise saved workspace wait/diff/assert commands before parser and schema support',
+);
 const captureForm = seeCommand.forms.find((form) => form.id === 'see-capture');
 const captureSaveForm = seeCommand.forms.find((form) => form.id === 'see-capture-save');
 assert.ok(captureForm, 'manifest missing see-capture form');


### PR DESCRIPTION
## Summary
- documents that saved workspaces do not currently expose `see capture --wait-for-change`, `see capture --until-stable`, `see refs --diff`, or `see assert`
- points agents to fresh saved captures, `show wait` for canvas readiness, Recipe assertions for command JSON, and Work Record postconditions for durable evidence checks
- adds drift coverage so the `see` manifest cannot advertise unsupported saved wait/diff/assert forms without parser/schema work

## Verification
- bash tests/agent-workspace-contract-drift.sh
- node -e help probe for unsupported saved wait/diff/assert forms
- ./aos dev recommend --json --files docs/api/aos.md shared/schemas/aos-agent-workspace-v0.md skills/aos-agent-workspace/SKILL.md tests/agent-workspace-contract-drift.sh
- bash tests/help-contract.sh
- node --test tests/schemas/*.test.mjs
- git diff --check