### PR TITLE
Align work record step evidence bridge

### DIFF
--- a/docs/design/aos-work-records-and-self-healing-recipes.md
+++ b/docs/design/aos-work-records-and-self-healing-recipes.md
@@ -135,10 +135,11 @@ target identity.
 The first AOS action capture slice is intentionally saved-evidence only. A
 single source records before perception, the AOS `do` result, and after
 perception, then `buildWorkRecordV0FromAosActionEvidence()` normalizes that
-source into Work Record v0. This is enough to make the shape a Playbook-step
-substrate: a future Playbook harness can run the same `see -> resolve -> do ->
-see` loop and hand the saved evidence envelope to the builder. The Work Record
-still records what happened; the Playbook remains the reusable plan. No
+source into Work Record v0. This is enough for a Workflow-gated step/evidence
+bridge: a harness can run the same `see -> resolve -> do -> see` loop and hand
+the saved evidence envelope to the builder. Work Records and verifier reports
+are harness obligations around the run, not step-authored primitive actions.
+Playbooks remain method guidance rather than the execution substrate. No
 autonomous replay, ref repair, or broad recorder command is implied by this
 capture slice.
 

--- a/tests/execution-model-terminology-contract.test.mjs
+++ b/tests/execution-model-terminology-contract.test.mjs
@@ -97,6 +97,7 @@ test('current code and docs use Step Descriptor instead of Playbook Step substra
 test('grand unification plan keeps Work Records and verifier reports as harness obligations', async () => {
   const plan = await text('docs/design/aos-grand-unification-plan.md');
   const context = await text('CONTEXT.md');
+  const workRecords = await text('docs/design/aos-work-records-and-self-healing-recipes.md');
   const adr = await text('docs/adr/0013-aos-execution-model-v0.md');
 
   assert.match(plan, /### Phase 6: Browser Step Evidence And Workflow-Gated Runs/);
@@ -109,11 +110,16 @@ test('grand unification plan keeps Work Records and verifier reports as harness 
   assert.match(plan, /derived indexes: `verified`, `failed`, `unverified`/);
   assert.match(context, /now treats browser runs as\s+Workflow-gated step evidence/);
   assert.match(context, /use\s+`claim_results\[\]` as the source of truth/);
+  assert.match(workRecords, /Workflow-gated step\/evidence\s+bridge/);
+  assert.match(workRecords, /Work Records and verifier reports\s+are harness obligations around the run/);
+  assert.match(workRecords, /Playbooks remain method guidance rather than the execution substrate/);
   assert.match(adr, /neutral V0 sketch for one Workflow-gated step\/evidence bridge/);
   assert.doesNotMatch(plan, /### Phase 6: Browser Playbooks/);
   assert.doesNotMatch(plan, /A playbook step is/);
   assert.doesNotMatch(plan, /save a work record/);
   assert.doesNotMatch(plan, /run verifier report/);
+  assert.doesNotMatch(workRecords, /Playbook-step substrate/);
+  assert.doesNotMatch(workRecords, /future Playbook harness/);
   assert.doesNotMatch(context, /Pending: plan revision/);
 });
 


### PR DESCRIPTION
## Summary
- replaces active Work Record design wording that described saved action evidence as a Playbook-step substrate
- aligns it with the Workflow-gated step/evidence bridge and harness-obligation model
- extends the terminology regression test to cover this active design doc

## Verification
- node --test tests/execution-model-terminology-contract.test.mjs
- rg stale phrase scan over Work Record / grand plan / context terminology docs
- ./aos dev recommend --json --files docs/design/aos-work-records-and-self-healing-recipes.md tests/execution-model-terminology-contract.test.mjs
- git diff --check