### PR TITLE
Refresh browser target gap notes

### DIFF
--- a/docs/design/see-do-grammar-trace-connections.md
+++ b/docs/design/see-do-grammar-trace-connections.md
@@ -237,16 +237,15 @@ follow page scroll, zoom, navigation, or DOM mutation. The agent must re-anchor.
 - Browser adapter docs say no workflow recording/replay/codegen wrapper exists
   in v1, while workbench notes point to that as future subject/artifact work.
   These are compatible, but the distinction should stay explicit.
-- Gateway scripts cannot currently use browser refs through the typed SDK.
-  A future "gather web source artifacts" worker would either shell out to
-  `./aos`/`playwright-cli` directly or need SDK/browser additions.
-- `docs/api/aos.md` does not document browser target usage even though
-  `ARCHITECTURE.md`, help metadata, and implementation do.
-- `aos help see --json` exposes `browser.adapter` as a capability but the
-  target discovery/examples do not show `browser:<session>`.
-- Existing `do` help shows browser-only `fill`/`navigate`, but the browser
-  forms of existing verbs such as `click browser:<session>/<ref>` are not clear
-  in usage examples.
+- The public CLI now documents browser targets through `docs/api/aos.md`,
+  `aos see capture browser:<session> --save`, and direct `aos do` browser forms
+  such as `click`, `fill`, `hover`, `scroll`, `drag`, and `navigate`.
+  Collection workers should prefer saved refs for normal loops and use direct
+  `browser:<session>/<ref>` targets as current diagnostic/provenance handles.
+- Gateway scripts still should not assume typed SDK parity with CLI browser
+  refs. A future "gather web source artifacts" worker should either shell out to
+  `./aos`, use a named raw Playwright escape hatch, or add an explicit
+  SDK/browser capability with matching help and tests.
 - The implementation plan described internal browser debug helpers as omitted
   from help unless verbose, but the command registry has no internal/verbose
   field and `aos help browser --json` exposes them.

--- a/tests/execution-model-terminology-contract.test.mjs
+++ b/tests/execution-model-terminology-contract.test.mjs
@@ -135,14 +135,22 @@ test('browser capture remains a projection, not a taxonomy source', async () => 
 test('browser target guidance prefers saved refs and keeps direct refs volatile', async () => {
   const architecture = await text('ARCHITECTURE.md');
   const browserSkill = await text('skills/browser-adapter/SKILL.md');
-  const maintained = `${architecture}\n${browserSkill}`;
+  const seeDo = await text('docs/design/see-do-grammar-trace-connections.md');
+  const maintained = `${architecture}\n${browserSkill}\n${seeDo}`;
 
   assert.match(architecture, /For normal observe-act loops, agents capture `aos see capture browser:<session> --save --mode som --workspace <id>`/);
   assert.match(architecture, /saved-ref dispatch validates the current browser target/);
   assert.match(browserSkill, /`ref:<snapshot-id>:<ref>` — the preferred observe-act target for normal browser work/);
   assert.match(browserSkill, /Direct browser refs are volatile/);
+  assert.match(seeDo, /public CLI now documents browser targets through `docs\/api\/aos\.md`/);
+  assert.match(seeDo, /Collection workers should prefer saved refs for normal loops/);
+  assert.match(seeDo, /direct\s+`browser:<session>\/<ref>` targets as current diagnostic\/provenance handles/);
+  assert.match(seeDo, /should not assume typed SDK parity with CLI browser\s+refs/);
   assert.match(browserSkill, /docs\/archive\/superpowers\/specs\/2026-04-24-playwright-browser-adapter-design\.md/);
   assert.doesNotMatch(maintained, /refs come from `aos see capture browser:<session> --xray`/);
+  assert.doesNotMatch(seeDo, /`docs\/api\/aos\.md` does not document browser target usage/);
+  assert.doesNotMatch(seeDo, /target discovery\/examples do not show `browser:<session>`/);
+  assert.doesNotMatch(seeDo, /browser\s+forms of existing verbs .* are not clear/);
   assert.doesNotMatch(browserSkill, /docs\/superpowers\/specs\/2026-04-24-playwright-browser-adapter-design\.md/);
 });
 


### PR DESCRIPTION
## Summary
- updates see/do grammar gap notes to reflect current browser target API and help coverage
- keeps the real remaining gap scoped to typed gateway/SDK parity for browser refs
- extends terminology drift coverage so stale API/help browser-target claims do not return

## Verification
- node --test tests/execution-model-terminology-contract.test.mjs
- rg stale browser-target gap scan over the design note and test
- ./aos dev recommend --json --files docs/design/see-do-grammar-trace-connections.md tests/execution-model-terminology-contract.test.mjs
- git diff --check