### PR TITLE
Clarify browser direct route contract

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -830,8 +830,8 @@ Primary public verbs:
 | `hover` | saved/browser hover or coordinate hover |
 | `drag` | saved/browser two-endpoint drag, direct canvas semantic drag (`--by` / `--to-value`), or native coordinate drag |
 | `scroll` | saved/browser scroll with `dx,dy`, or coordinate scroll with `--dx` / `--dy` |
-| `type` | literal native text input, not a saved-ref target form |
-| `key` | literal native key combo, not a saved-ref target form |
+| `type` | literal native text input or direct browser target text; no saved-ref action |
+| `key` | literal native key combo or direct browser target key press; no saved-ref action |
 | `press` | saved native AX press or direct `--pid` / `--role` AX press |
 | `set-value` | saved refs, direct AX, or AOS canvas semantic set-value |
 | `focus` | saved native AX focus or direct `--pid` / `--role` AX focus |
@@ -859,6 +859,12 @@ drag refs can dispatch only after page, frame, navigation, and element
 validation pass. Saved-ref grammar rejects missing, invalid, extra, or unknown
 action arguments and flags with `MISSING_ARG`, `INVALID_ARG`, `UNKNOWN_ARG`, or
 `UNKNOWN_FLAG`.
+Direct browser `type` and `key` are current-host routes when the first action
+argument is `browser:<session>/<ref>` or `browser:<session>`. They live in the
+external command manifest and route to Playwright; they are not saved-ref
+actions. Saved-ref `type` and `key` attempts with `--workspace` or `--snapshot`
+fail closed through the saved-ref resolver until browser keyboard semantics are
+promoted through the action matrix.
 Refs with `confidence: low` are readback-only for saved-ref mutation and fail
 closed with `REF_UNSUPPORTED` and `reason: low_confidence_target` before dry-run
 validation or dispatch. Non-dry-run mutation refuses unsafe resolution classes or

--- a/docs/design/see-do-grammar-trace-connections.md
+++ b/docs/design/see-do-grammar-trace-connections.md
@@ -207,16 +207,24 @@ browser:<session>
 browser:<session>/<ref>
 ```
 
-Refs come from `aos see capture browser:<session> --xray`, which parses
-Playwright snapshot markdown into AOS `AXElementJSON` records. Browser xray has
-refs but usually no bounds; `--label` fetches bounds with one eval call per ref.
+Saved browser refs come from
+`aos see capture browser:<session> --save --mode som --workspace <id>` plus
+`aos see refs`; saved-ref dispatch then refreshes current browser perception
+and routes through the underlying direct `browser:<session>/<ref>` target after
+validation. Low-level browser xray remains the current-ref producer underneath:
+`aos see capture browser:<session> --xray` parses Playwright snapshot markdown
+into AOS `AXElementJSON` records. Browser xray has refs but usually no bounds;
+`--label` fetches bounds with one eval call per ref.
 
-The `do` side dispatches existing verbs such as click, hover, drag, scroll,
-type, and key to Playwright when the first target is `browser:...`. Browser-only
-`do fill` and `do navigate` are implemented as small AOS verbs over
-Playwright's `fill` and `goto`. Anything not wrapped, such as tracing, codegen,
-tab operations, check/select/upload, reload/back, and arbitrary page scripts,
-remains a raw `playwright-cli` escape hatch.
+The external command manifest conditionally dispatches direct browser forms for
+click, hover, drag, scroll, type, and key when the first target starts with
+`browser:`. Browser-only `do fill` and `do navigate` are implemented as small
+AOS verbs over Playwright's `fill` and `goto`; `fill` also has saved-ref
+support, while saved-ref `type` and `key` remain explicitly unsupported until
+the browser keyboard grammar is promoted through the saved-ref matrix. Anything
+not wrapped, such as tracing, codegen, tab operations, check/select/upload,
+reload/back, and arbitrary page scripts, remains a raw `playwright-cli` escape
+hatch.
 
 For `show`, `--anchor-browser browser:<session>/<ref>` is the current CLI role
 flag for using a browser Target-with-Ref as an Anchor. The CLI resolves that
@@ -239,16 +247,18 @@ follow page scroll, zoom, navigation, or DOM mutation. The agent must re-anchor.
   These are compatible, but the distinction should stay explicit.
 - The public CLI now documents browser targets through `docs/api/aos.md`,
   `aos see capture browser:<session> --save`, and direct `aos do` browser forms
-  such as `click`, `fill`, `hover`, `scroll`, `drag`, and `navigate`.
-  Collection workers should prefer saved refs for normal loops and use direct
-  `browser:<session>/<ref>` targets as current diagnostic/provenance handles.
+  such as `click`, `fill`, `hover`, `scroll`, `drag`, `type`, `key`, and
+  `navigate`. Collection workers should prefer saved refs for normal loops and
+  use direct `browser:<session>/<ref>` targets as current
+  diagnostic/provenance handles.
 - Gateway scripts still should not assume typed SDK parity with CLI browser
   refs. A future "gather web source artifacts" worker should either shell out to
   `./aos`, use a named raw Playwright escape hatch, or add an explicit
   SDK/browser capability with matching help and tests.
 - The implementation plan described internal browser debug helpers as omitted
-  from help unless verbose, but the command registry has no internal/verbose
-  field and `aos help browser --json` exposes them.
+  from help unless verbose. The current contract expresses that through
+  `consumer_discovery: false`: root consumer help omits the browser debug group,
+  while `aos help browser --json` remains directly resolvable for maintainers.
 - Static browser anchoring is thinner than the plan's content-inset strategy:
   `src/browser/anchor-resolver.swift` currently uses viewport coords plus
   window id and notes that Chrome content-view inset calibration is deferred.

--- a/skills/browser-adapter/SKILL.md
+++ b/skills/browser-adapter/SKILL.md
@@ -62,6 +62,10 @@ aos do key browser:work Enter
 aos do navigate browser:work https://example.com
 ```
 
+Direct browser `type` and `key` are current-host routes from the external
+command manifest. Saved-ref `type` and `key` are not supported; use saved refs
+for click, fill, hover, scroll, and drag after dry-run validation.
+
 **Label elements visually.**
 
 ```bash

--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -444,8 +444,8 @@ assert.ok(apiDoc.includes('| `hover` | saved/browser hover or coordinate hover |
 assert.ok(apiDoc.includes('| `drag` | saved/browser two-endpoint drag, direct canvas semantic drag (`--by` / `--to-value`), or native coordinate drag |'), 'API do table must split drag grammar tiers');
 assert.ok(!apiDoc.includes('| `drag` | drag between coordinates, browser refs, or AOS canvas semantic refs |'), 'API do table must not collapse drag grammar tiers');
 assert.ok(apiDoc.includes('| `scroll` | saved/browser scroll with `dx,dy`, or coordinate scroll with `--dx` / `--dy` |'), 'API do table must split saved/browser and coordinate scroll tiers');
-assert.ok(apiDoc.includes('| `type` | literal native text input, not a saved-ref target form |'), 'API do table must keep type out of saved-ref target forms');
-assert.ok(apiDoc.includes('| `key` | literal native key combo, not a saved-ref target form |'), 'API do table must keep key out of saved-ref target forms');
+assert.ok(apiDoc.includes('| `type` | literal native text input or direct browser target text; no saved-ref action |'), 'API do table must keep type out of saved-ref actions while naming the direct browser route');
+assert.ok(apiDoc.includes('| `key` | literal native key combo or direct browser target key press; no saved-ref action |'), 'API do table must keep key out of saved-ref actions while naming the direct browser route');
 assert.ok(apiDoc.includes('| `press` | saved native AX press or direct `--pid` / `--role` AX press |'), 'API do table must split saved native AX and direct AX press');
 assert.ok(apiDoc.includes('| `set-value` | saved refs, direct AX, or AOS canvas semantic set-value |'), 'API do table must name saved refs, direct AX, and canvas set-value');
 assert.ok(apiDoc.includes('| `focus` | saved native AX focus or direct `--pid` / `--role` AX focus |'), 'API do table must split saved native AX and direct AX focus');

--- a/tests/execution-model-terminology-contract.test.mjs
+++ b/tests/execution-model-terminology-contract.test.mjs
@@ -134,20 +134,35 @@ test('browser capture remains a projection, not a taxonomy source', async () => 
 
 test('browser target guidance prefers saved refs and keeps direct refs volatile', async () => {
   const architecture = await text('ARCHITECTURE.md');
+  const aosApi = await text('docs/api/aos.md');
   const browserSkill = await text('skills/browser-adapter/SKILL.md');
   const seeDo = await text('docs/design/see-do-grammar-trace-connections.md');
-  const maintained = `${architecture}\n${browserSkill}\n${seeDo}`;
+  const externalManifest = JSON.parse(await text('manifests/commands/aos-external-commands.json'));
+  const maintained = `${architecture}\n${aosApi}\n${browserSkill}\n${seeDo}`;
 
   assert.match(architecture, /For normal observe-act loops, agents capture `aos see capture browser:<session> --save --mode som --workspace <id>`/);
   assert.match(architecture, /saved-ref dispatch validates the current browser target/);
+  assert.match(aosApi, /Direct browser `type` and `key` are current-host routes/);
+  assert.match(aosApi, /Saved-ref `type` and `key` attempts[\s\S]*fail closed through the saved-ref resolver/);
   assert.match(browserSkill, /`ref:<snapshot-id>:<ref>` — the preferred observe-act target for normal browser work/);
   assert.match(browserSkill, /Direct browser refs are volatile/);
+  assert.match(browserSkill, /Direct browser `type` and `key` are current-host routes/);
   assert.match(seeDo, /public CLI now documents browser targets through `docs\/api\/aos\.md`/);
   assert.match(seeDo, /Collection workers should prefer saved refs for normal loops/);
-  assert.match(seeDo, /direct\s+`browser:<session>\/<ref>` targets as current diagnostic\/provenance handles/);
+  assert.match(seeDo, /direct\s+`browser:<session>\/<ref>` targets as current\s+diagnostic\/provenance handles/);
+  assert.match(seeDo, /external command manifest conditionally dispatches direct browser forms for\nclick, hover, drag, scroll, type, and key/);
   assert.match(seeDo, /should not assume typed SDK parity with CLI browser\s+refs/);
   assert.match(browserSkill, /docs\/archive\/superpowers\/specs\/2026-04-24-playwright-browser-adapter-design\.md/);
-  assert.doesNotMatch(maintained, /refs come from `aos see capture browser:<session> --xray`/);
+  for (const action of ['type', 'key']) {
+    assert.ok(
+      externalManifest.commands.some((command) =>
+        command.path?.join(' ') === `do ${action}`
+        && command.argv_prefix?.join(' ') === `node scripts/aos-do-browser.mjs ${action}`
+        && command.when?.prefix === 'browser:'),
+      `missing direct browser external route for do ${action}`,
+    );
+  }
+  assert.doesNotMatch(maintained, /refs come from `aos see capture browser:<session> --xray`/i);
   assert.doesNotMatch(seeDo, /`docs\/api\/aos\.md` does not document browser target usage/);
   assert.doesNotMatch(seeDo, /target discovery\/examples do not show `browser:<session>`/);
   assert.doesNotMatch(seeDo, /browser\s+forms of existing verbs .* are not clear/);


### PR DESCRIPTION
## Summary
- clarify saved browser refs versus low-level browser xray current refs
- document direct browser type/key as external-manifest current-host routes, while keeping saved-ref type/key unsupported
- update browser adapter skill and drift tests so stale xray-as-saved-ref wording cannot return

## Verification
- ./aos dev recommend --json --files docs/api/aos.md docs/design/see-do-grammar-trace-connections.md skills/browser-adapter/SKILL.md tests/agent-workspace-contract-drift.sh tests/execution-model-terminology-contract.test.mjs
- node --test tests/execution-model-terminology-contract.test.mjs
- bash tests/help-contract.sh
- bash tests/external-command-dispatch.sh
- bash tests/agent-workspace-contract-drift.sh
- git diff --check

## Live proof
- Not applicable; docs and deterministic contract tests only. No Level 4 native/TCC proof required.