### PR TITLE
Allow JSON browser anchor resolution

### DIFF
--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -10028,10 +10028,18 @@
               "required" : true,
               "summary" : "Browser target (browser:<session>[\/<ref>])",
               "value_type" : "string"
+            },
+            {
+              "id" : "json",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Emit machine-readable anchor resolution",
+              "token" : "--json",
+              "value_type" : "bool"
             }
           ],
           "examples" : [
-            "aos browser _resolve-anchor browser:todo\/e21"
+            "aos browser _resolve-anchor browser:todo\/e21 --json"
           ],
           "execution" : {
             "auto_starts_daemon" : false,
@@ -10047,9 +10055,9 @@
             "default_mode" : "json",
             "error_mode" : "json_stderr",
             "streaming" : false,
-            "supports_json_flag" : false
+            "supports_json_flag" : true
           },
-          "usage" : "aos browser _resolve-anchor <target>"
+          "usage" : "aos browser _resolve-anchor <target> [--json]"
         }
       ],
       "path" : [

--- a/scripts/aos-browser-internal.mjs
+++ b/scripts/aos-browser-internal.mjs
@@ -342,8 +342,9 @@ function boundsViaEval(session, ref) {
 }
 
 function resolveAnchorCommand(args) {
-  requireExactArgs(args, 'Usage: aos browser _resolve-anchor <target>');
-  const input = args[0];
+  const positional = args.filter((arg) => arg !== '--json');
+  requireExactArgs(positional, 'Usage: aos browser _resolve-anchor <target> [--json]');
+  const input = positional[0];
   const target = parseBrowserTarget(input);
   const record = readRegistry().find((item) => item.id === target.session);
   if (!record) error(`browser session '${target.session}' not registered`, 'NOT_FOUND');

--- a/tests/browser/anchor-resolver.test.sh
+++ b/tests/browser/anchor-resolver.test.sh
@@ -33,7 +33,7 @@ echo "$out" | grep -q "NOT_FOUND" || { echo "FAIL not-found code: $out" >&2; exi
 
 # Case 3: local session with winID → static offset (rect from fake eval)
 ./aos browser _registry add --id=local-sess --mode=attach --attach-kind=extension --browser-window-id=99999 >/dev/null
-out=$(./aos browser _resolve-anchor "browser:local-sess/e2" 2>&1)
+out=$(./aos browser _resolve-anchor "browser:local-sess/e2" --json 2>&1)
 echo "$out" | jq -e '.anchor_window == 99999' >/dev/null \
     || { echo "FAIL local anchor_window: $out" >&2; exit 1; }
 echo "$out" | jq -e '.offset | length == 4' >/dev/null \


### PR DESCRIPTION
Summary:
- allow internal `aos browser _resolve-anchor <target> --json` used by `show create --anchor-browser`
- advertise the JSON flag in the command manifest
- extend fake browser resolver coverage

Verification:
- `bash tests/browser/show-anchor.test.sh`
- `bash tests/browser/anchor-resolver.test.sh`
- `node --test tests/schemas/aos-external-command-manifest-v0.test.mjs`
- `bash tests/help-contract.sh`
- `./aos dev recommend --json --files scripts/aos-browser-internal.mjs manifests/commands/aos-commands.json tests/browser/anchor-resolver.test.sh`
- `git diff --check`
- `bash tests/external-command-dispatch.sh`
- `bash tests/external-parser-flags.sh`
- `node --test tests/aos-dev-gh-help-parity.test.mjs`
- `node --test tests/schemas/dev-workflow-rules.test.mjs tests/schemas/dev-active-profile.test.mjs tests/schemas/dev-workflow-profiles.test.mjs`
- `bash tests/dev-workflow-router.sh`
- `bash tests/dev-audit.sh`
- `bash tests/dev-situation.sh`
- `bash tests/dev-drift-lint.sh`
- fake browser batch: `for t in tests/browser/see-capture.test.sh tests/browser/snapshot-parser.test.sh tests/browser/focus-browser.test.sh tests/browser/dom-element-target.test.sh tests/browser/registry.test.sh tests/browser/anchor-resolver.test.sh tests/browser/do-fill.test.sh tests/browser/do-navigate.test.sh tests/browser/do-existing-verbs.test.sh tests/browser/eval-parser.test.sh tests/browser/target-parser.test.sh tests/browser/registry-introspection.test.sh tests/browser/process.test.sh tests/browser/show-anchor.test.sh tests/browser/version-check.test.sh; do bash "$t"; done`

Live proof: Not applicable; fake browser/static command-contract test only. No Level 4 native/TCC proof required.