### PR TITLE
Fix host tool-result message shape

### DIFF
--- a/packages/host/src/agent-loop.ts
+++ b/packages/host/src/agent-loop.ts
@@ -133,9 +133,11 @@ export class AgentLoop {
         toolResultBlocks.push({
           type: 'tool_result',
           tool_use_id: tc.toolCallId,
+          tool_name: tc.toolName,
           content: typeof result.content === 'string'
             ? result.content
             : JSON.stringify(result.content),
+          is_error: result.isError,
         });
         yield {
           type: 'tool-result',
@@ -144,8 +146,7 @@ export class AgentLoop {
         };
       }
 
-      // Persist tool results as user message (Anthropic expects tool_result in user turn)
-      this.store.appendMessage(sessionId, 'user', toolResultBlocks);
+      this.store.appendMessage(sessionId, 'tool', toolResultBlocks);
 
       // Rebuild messages for next iteration
       messages = this.buildMessages(sessionId);

--- a/packages/host/src/provider/anthropic.ts
+++ b/packages/host/src/provider/anthropic.ts
@@ -1,11 +1,73 @@
 // packages/host/src/provider/anthropic.ts
 import { streamText, jsonSchema } from 'ai';
-import type { CoreMessage } from 'ai';
+import type { CoreAssistantMessage, CoreMessage, CoreToolMessage, CoreUserMessage } from 'ai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import type {
   ProviderAdapter, ProviderMessage, ProviderConfig,
   ToolDefinition, StreamEvent, JSONValue,
 } from '../types.ts';
+
+export function toAnthropicCoreMessages(messages: ProviderMessage[]): CoreMessage[] {
+  return messages.map((msg, index) => {
+    if (msg.role === 'tool' || msg.content.every(block => block.type === 'tool_result')) {
+      return {
+        role: 'tool',
+        content: msg.content.flatMap(block => {
+          if (block.type !== 'tool_result') return [];
+          return [{
+            type: 'tool-result' as const,
+            toolCallId: block.tool_use_id,
+            toolName: block.tool_name ?? inferToolName(messages, index, block.tool_use_id),
+            result: block.content,
+            isError: block.is_error,
+          }];
+        }),
+      } satisfies CoreToolMessage;
+    }
+
+    if (msg.role === 'assistant') {
+      const content: CoreAssistantMessage['content'] = [];
+      for (const block of msg.content) {
+        if (block.type === 'text') {
+          content.push({ type: 'text', text: block.text });
+        } else if (block.type === 'tool_use') {
+          content.push({
+            type: 'tool-call',
+            toolCallId: block.id,
+            toolName: block.name,
+            args: block.input as Record<string, unknown>,
+          });
+        }
+      }
+      return {
+        role: 'assistant',
+        content,
+      } satisfies CoreAssistantMessage;
+    }
+
+    const content: CoreUserMessage['content'] = [];
+    for (const block of msg.content) {
+      if (block.type === 'text') {
+        content.push({ type: 'text', text: block.text });
+      }
+    }
+    return {
+      role: 'user',
+      content,
+    } satisfies CoreUserMessage;
+  });
+}
+
+function inferToolName(messages: ProviderMessage[], beforeIndex: number, toolCallId: string): string {
+  for (let i = beforeIndex - 1; i >= 0; i--) {
+    for (const block of messages[i]?.content ?? []) {
+      if (block.type === 'tool_use' && block.id === toolCallId) {
+        return block.name;
+      }
+    }
+  }
+  return 'unknown_tool';
+}
 
 export class AnthropicAdapter implements ProviderAdapter {
   readonly id = 'anthropic';
@@ -19,25 +81,7 @@ export class AnthropicAdapter implements ProviderAdapter {
   }): AsyncIterable<StreamEvent> {
     const { messages, tools, system, config } = params;
 
-    // Convert our message format to Vercel AI SDK format
-    const aiMessages = messages.map(msg => ({
-      role: msg.role,
-      content: msg.content.map(block => {
-        if (block.type === 'text') return { type: 'text' as const, text: block.text };
-        if (block.type === 'tool_use') return {
-          type: 'tool-call' as const,
-          toolCallId: block.id,
-          toolName: block.name,
-          args: block.input as Record<string, unknown>,
-        };
-        if (block.type === 'tool_result') return {
-          type: 'tool-result' as const,
-          toolCallId: block.tool_use_id,
-          result: block.content,
-        };
-        return { type: 'text' as const, text: '' };
-      }),
-    }));
+    const aiMessages = toAnthropicCoreMessages(messages);
 
     // Convert tool definitions to Vercel AI SDK format.
     // The SDK requires `parameters` (not `inputSchema`) wrapping the JSON schema

--- a/packages/host/src/session-store.ts
+++ b/packages/host/src/session-store.ts
@@ -28,14 +28,45 @@ export class SessionStore {
       CREATE TABLE IF NOT EXISTS messages (
         id TEXT PRIMARY KEY,
         session_id TEXT NOT NULL REFERENCES sessions(id),
-        role TEXT NOT NULL CHECK(role IN ('user', 'assistant')),
+        role TEXT NOT NULL CHECK(role IN ('user', 'assistant', 'tool')),
+        content TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        token_count INTEGER
+      );
+    `);
+
+    this.migrateMessagesRoleConstraint();
+
+    this.db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_messages_session
+        ON messages(session_id, created_at);
+    `);
+  }
+
+  private migrateMessagesRoleConstraint(): void {
+    const row = this.db.prepare(`
+      SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'messages'
+    `).get() as { sql?: string } | undefined;
+    if (!row?.sql || row.sql.includes("'tool'")) return;
+
+    this.db.exec(`
+      DROP INDEX IF EXISTS idx_messages_session;
+
+      CREATE TABLE messages_new (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL REFERENCES sessions(id),
+        role TEXT NOT NULL CHECK(role IN ('user', 'assistant', 'tool')),
         content TEXT NOT NULL,
         created_at TEXT NOT NULL,
         token_count INTEGER
       );
 
-      CREATE INDEX IF NOT EXISTS idx_messages_session
-        ON messages(session_id, created_at);
+      INSERT INTO messages_new (id, session_id, role, content, created_at, token_count)
+      SELECT id, session_id, role, content, created_at, token_count
+      FROM messages;
+
+      DROP TABLE messages;
+      ALTER TABLE messages_new RENAME TO messages;
     `);
   }
 
@@ -89,7 +120,7 @@ export class SessionStore {
 
   appendMessage(
     sessionId: string,
-    role: 'user' | 'assistant',
+    role: 'user' | 'assistant' | 'tool',
     content: unknown[],
     tokenCount?: number
   ): StoredMessage {

--- a/packages/host/src/types.ts
+++ b/packages/host/src/types.ts
@@ -83,7 +83,7 @@ export interface SessionConfig {
 export interface StoredMessage {
   id: string;
   sessionId: string;
-  role: 'user' | 'assistant';
+  role: 'user' | 'assistant' | 'tool';
   content: string; // JSON-serialized content blocks
   createdAt: string;
   tokenCount?: number;
@@ -98,14 +98,14 @@ export interface ProviderConfig {
 }
 
 export interface ProviderMessage {
-  role: 'user' | 'assistant';
+  role: 'user' | 'assistant' | 'tool';
   content: ProviderContentBlock[];
 }
 
 export type ProviderContentBlock =
   | { type: 'text'; text: string }
   | { type: 'tool_use'; id: string; name: string; input: JSONValue }
-  | { type: 'tool_result'; tool_use_id: string; content: string };
+  | { type: 'tool_result'; tool_use_id: string; tool_name?: string; content: string; is_error?: boolean };
 
 export interface ProviderAdapter {
   id: string;

--- a/packages/host/test/agent-loop.test.ts
+++ b/packages/host/test/agent-loop.test.ts
@@ -110,6 +110,18 @@ describe('AgentLoop', () => {
 
     const textDeltas = events.filter(e => e.type === 'text-delta');
     assert.ok(textDeltas.length > 0);
+
+    const messages = store.getMessages(session.id);
+    const toolMessage = messages.find(message => message.role === 'tool');
+    assert.ok(toolMessage);
+    assert.deepEqual(JSON.parse(toolMessage.content), [
+      {
+        type: 'tool_result',
+        tool_use_id: 'tc1',
+        tool_name: 'echo',
+        content: 'echoed: test',
+      },
+    ]);
   });
 
   it('denies tool calls without permission', async () => {

--- a/packages/host/test/provider/anthropic.test.ts
+++ b/packages/host/test/provider/anthropic.test.ts
@@ -1,7 +1,7 @@
 // packages/host/test/provider/anthropic.test.ts
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
-import { AnthropicAdapter } from '../../src/provider/anthropic.ts';
+import { AnthropicAdapter, toAnthropicCoreMessages } from '../../src/provider/anthropic.ts';
 import type { StreamEvent } from '../../src/types.ts';
 
 describe('AnthropicAdapter', () => {
@@ -18,6 +18,55 @@ describe('AnthropicAdapter', () => {
   it('has correct id', () => {
     const a = new AnthropicAdapter();
     assert.equal(a.id, 'anthropic');
+  });
+
+  it('converts tool results to AI SDK tool messages with tool names', () => {
+    const messages = toAnthropicCoreMessages([
+      { role: 'user', content: [{ type: 'text', text: 'echo test' }] },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'tc1', name: 'echo', input: { text: 'test' } },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          { type: 'tool_result', tool_use_id: 'tc1', tool_name: 'echo', content: 'echoed: test' },
+        ],
+      },
+    ]);
+
+    assert.equal(messages[2].role, 'tool');
+    assert.deepEqual(messages[2].content, [
+      {
+        type: 'tool-result',
+        toolCallId: 'tc1',
+        toolName: 'echo',
+        result: 'echoed: test',
+        isError: undefined,
+      },
+    ]);
+  });
+
+  it('infers tool names for legacy stored user-role tool results', () => {
+    const messages = toAnthropicCoreMessages([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'tc1', name: 'read_file', input: { path: '/tmp/test.txt' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'tc1', content: 'contents' },
+        ],
+      },
+    ]);
+
+    assert.equal(messages[1].role, 'tool');
+    assert.equal(messages[1].content[0].toolName, 'read_file');
   });
 
   it('streams a simple text response', async () => {

--- a/packages/host/test/session-store.test.ts
+++ b/packages/host/test/session-store.test.ts
@@ -1,6 +1,7 @@
 // packages/host/test/session-store.test.ts
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
 import { SessionStore } from '../src/session-store.ts';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -80,6 +81,53 @@ describe('SessionStore', () => {
       store.appendMessage(session.id, 'user', [{ type: 'text', text: 'hello' }], 10);
       const messages = store.getMessages(session.id);
       assert.equal(messages[0].tokenCount, 10);
+    });
+
+    it('stores tool role messages', () => {
+      const session = store.createSession({});
+      store.appendMessage(session.id, 'tool', [
+        { type: 'tool_result', tool_use_id: 'tc1', tool_name: 'echo', content: 'ok' },
+      ]);
+
+      const messages = store.getMessages(session.id);
+      assert.equal(messages.length, 1);
+      assert.equal(messages[0].role, 'tool');
+    });
+
+    it('migrates existing message tables to allow tool role messages', () => {
+      store.close();
+      try { fs.unlinkSync(dbPath); } catch {}
+
+      const db = new Database(dbPath);
+      db.exec(`
+        CREATE TABLE sessions (
+          id TEXT PRIMARY KEY,
+          provider TEXT NOT NULL DEFAULT 'anthropic',
+          model TEXT NOT NULL DEFAULT 'claude-sonnet-4-20250514',
+          system TEXT,
+          tool_profile TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        );
+        CREATE TABLE messages (
+          id TEXT PRIMARY KEY,
+          session_id TEXT NOT NULL REFERENCES sessions(id),
+          role TEXT NOT NULL CHECK(role IN ('user', 'assistant')),
+          content TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          token_count INTEGER
+        );
+      `);
+      db.close();
+
+      store = new SessionStore(dbPath);
+      const session = store.createSession({});
+      store.appendMessage(session.id, 'tool', [
+        { type: 'tool_result', tool_use_id: 'tc1', tool_name: 'echo', content: 'ok' },
+      ]);
+
+      const messages = store.getMessages(session.id);
+      assert.equal(messages[0].role, 'tool');
     });
 
     it('returns empty array for session with no messages', () => {


### PR DESCRIPTION
## Summary
- persist host tool results as `role: tool` messages with the originating `tool_name`
- convert host provider messages into AI SDK `CoreToolMessage` parts that include the required `toolName`
- migrate existing session DB message tables so stored histories can accept `tool` role messages while preserving legacy user-role tool-result readback

## Review blocker
Addresses critical finding #1 from `/Users/Michael/Code/tmp/agent-os-code-review-2026-07-03.md`: tool-using host turns failed because AI SDK v4 expects tool results in a tool-role message with `toolName`.

## Verification
- `npm rebuild better-sqlite3` in `packages/host` to refresh the local native binding for this Node ABI before running DB-backed tests
- `npm run check` in `packages/host`
- `npm test` in `packages/host` (67 passing)
- `git diff --check`

## DOX
Read root `AGENTS.md` and `packages/AGENTS.md`. No DOX files changed because this updates host internals and compatibility behavior without changing package ownership, workflow rules, or verification contracts.

## Live proof
Not run. This is covered by deterministic host unit/type tests and does not require Level 4 live UI/native/TCC proof.