### PR TITLE
Contain wiki paths under wiki root

### DIFF
--- a/scripts/aos-wiki-mutate.mjs
+++ b/scripts/aos-wiki-mutate.mjs
@@ -54,6 +54,16 @@ function emitJSON(value) {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
 }
 
+function containedPath(root, ...parts) {
+  const base = path.resolve(root);
+  const absolute = path.resolve(base, ...parts);
+  const relative = path.relative(base, absolute);
+  if (relative === '' || relative.startsWith('..') || path.isAbsolute(relative)) {
+    error('Wiki path must stay inside the wiki root', 'WIKI_INVALID_PATH');
+  }
+  return { relative: relative.split(path.sep).join('/'), absolute };
+}
+
 function runAOS(args, capture = false) {
   const result = spawnSync(aosPath(), args, {
     encoding: 'utf8',
@@ -87,12 +97,12 @@ function bareNameCandidates(arg) {
 
 function resolveWikiPath(arg) {
   if (arg.includes('/') || arg.includes('.md')) {
-    const absolute = path.join(wikiRoot(), arg);
-    return fs.existsSync(absolute) ? { relative: arg, absolute } : null;
+    const resolved = containedPath(wikiRoot(), arg);
+    return fs.existsSync(resolved.absolute) ? resolved : null;
   }
   for (const relative of bareNameCandidates(arg)) {
-    const absolute = path.join(wikiRoot(), relative);
-    if (fs.existsSync(absolute)) return { relative, absolute };
+    const resolved = containedPath(wikiRoot(), relative);
+    if (fs.existsSync(resolved.absolute)) return resolved;
   }
   return null;
 }
@@ -120,8 +130,8 @@ function createPlugin(args) {
   const name = positional[0];
   if (!name) error('wiki create-plugin requires a name. Usage: aos wiki create-plugin <name>', 'MISSING_ARG');
   if (positional.length > 1) unknownArg(positional[1]);
-  const pluginDir = path.join(wikiRoot(), namespace, 'plugins', name);
-  const skillPath = path.join(pluginDir, 'SKILL.md');
+  const pluginDir = containedPath(wikiRoot(), namespace, 'plugins', name).absolute;
+  const skillPath = containedPath(pluginDir, 'SKILL.md').absolute;
   if (fs.existsSync(skillPath)) error(`Plugin '${name}' already exists at ${pluginDir}`, 'WIKI_PLUGIN_EXISTS');
 
   fs.mkdirSync(path.join(pluginDir, 'references'), { recursive: true });
@@ -166,7 +176,7 @@ function addPage(args) {
   const [typeArg, name] = positional;
   if (!['entity', 'concept'].includes(typeArg)) error(`Type must be 'entity' or 'concept', got '${typeArg}'`, 'WIKI_INVALID_TYPE');
   const dirName = typeArg === 'entity' ? 'entities' : 'concepts';
-  const filePath = path.join(wikiRoot(), namespace, dirName, `${name}.md`);
+  const filePath = containedPath(wikiRoot(), namespace, dirName, `${name}.md`).absolute;
   if (fs.existsSync(filePath)) error(`Page '${name}' already exists at ${filePath}`, 'WIKI_PAGE_EXISTS');
 
   fs.mkdirSync(path.dirname(filePath), { recursive: true });

--- a/scripts/aos-wiki-read.mjs
+++ b/scripts/aos-wiki-read.mjs
@@ -52,14 +52,24 @@ function bareNameCandidates(arg) {
   ];
 }
 
+function containedPath(root, ...parts) {
+  const base = path.resolve(root);
+  const absolute = path.resolve(base, ...parts);
+  const relative = path.relative(base, absolute);
+  if (relative === '' || relative.startsWith('..') || path.isAbsolute(relative)) {
+    error('Wiki path must stay inside the wiki root', 'WIKI_INVALID_PATH');
+  }
+  return { relative: relative.split(path.sep).join('/'), absolute };
+}
+
 function resolveWikiPath(arg) {
   if (arg.includes('/') || arg.includes('.md')) {
-    const absolute = path.join(wikiRoot(), arg);
-    return fs.existsSync(absolute) ? { relative: arg, absolute } : null;
+    const resolved = containedPath(wikiRoot(), arg);
+    return fs.existsSync(resolved.absolute) ? resolved : null;
   }
   for (const relative of bareNameCandidates(arg)) {
-    const absolute = path.join(wikiRoot(), relative);
-    if (fs.existsSync(absolute)) return { relative, absolute };
+    const resolved = containedPath(wikiRoot(), relative);
+    if (fs.existsSync(resolved.absolute)) return resolved;
   }
   return null;
 }
@@ -69,8 +79,8 @@ function resolvePluginSkill(name) {
     `${namespace}/plugins/${name}/SKILL.md`,
     `plugins/${name}/SKILL.md`,
   ]) {
-    const absolute = path.join(wikiRoot(), relative);
-    if (fs.existsSync(absolute)) return { relative, absolute };
+    const resolved = containedPath(wikiRoot(), relative);
+    if (fs.existsSync(resolved.absolute)) return resolved;
   }
   return null;
 }

--- a/scripts/aos-wiki-seed.mjs
+++ b/scripts/aos-wiki-seed.mjs
@@ -50,6 +50,16 @@ function allValuesAfter(args, key) {
   return values;
 }
 
+function containedPath(root, ...parts) {
+  const base = path.resolve(root);
+  const absolute = path.resolve(base, ...parts);
+  const relative = path.relative(base, absolute);
+  if (relative === '' || relative.startsWith('..') || path.isAbsolute(relative)) {
+    error('Wiki seed path must stay inside the wiki root', 'WIKI_INVALID_PATH');
+  }
+  return absolute;
+}
+
 function copyIfAbsent(namespace, pairs) {
   let written = 0;
   for (const pair of pairs) {
@@ -57,7 +67,7 @@ function copyIfAbsent(namespace, pairs) {
     if (colon <= 0) error('Error: --file value must be <rel>:<absolutePath>', 'INVALID_ARG');
     const rel = pair.slice(0, colon);
     const src = pair.slice(colon + 1);
-    const dst = path.join(wikiRoot(), namespace, rel);
+    const dst = containedPath(wikiRoot(), namespace, rel);
     if (fs.existsSync(dst)) continue;
     fs.mkdirSync(path.dirname(dst), { recursive: true });
     fs.copyFileSync(src, dst);

--- a/tests/wiki-integration.sh
+++ b/tests/wiki-integration.sh
@@ -40,6 +40,30 @@ FAIL=0
 pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
 
+json_field() {
+  python3 -c 'import json, sys; print(json.load(sys.stdin).get(sys.argv[1], ""))' "$1"
+}
+
+json_stream_has_status_ok() {
+  python3 -c '
+import json
+import sys
+
+decoder = json.JSONDecoder()
+text = sys.stdin.read()
+idx = 0
+while idx < len(text):
+    while idx < len(text) and text[idx].isspace():
+        idx += 1
+    if idx >= len(text):
+        break
+    obj, idx = decoder.raw_decode(text, idx)
+    if isinstance(obj, dict) and obj.get("status") == "ok":
+        sys.exit(0)
+sys.exit(1)
+'
+}
+
 if [[ "$WIKI_DIR" == "$CANONICAL_WIKI_DIR" || "$WIKI_DIR" == "$CANONICAL_WIKI_DIR/"* ]]; then
   echo "ERROR: refusing to run destructive wiki integration test against live repo wiki: $WIKI_DIR" >&2
   echo "Set AOS_STATE_ROOT to a temporary directory outside ~/.config/aos, or omit it and let this test allocate one." >&2
@@ -57,19 +81,19 @@ rm -rf "$WIKI_DIR"
 echo ""
 echo "--- reindex (empty) ---"
 OUTPUT=$($AOS wiki reindex --json)
-echo "$OUTPUT" | grep -q '"pages" : 0' && pass "reindex empty" || fail "reindex empty"
+[[ "$(echo "$OUTPUT" | json_field pages)" == "0" ]] && pass "reindex empty" || fail "reindex empty"
 
 # Test: seed
 echo ""
 echo "--- seed ---"
 OUTPUT=$($AOS wiki seed --json)
-echo "$OUTPUT" | grep -q '"status" : "ok"' && pass "seed" || fail "seed"
+echo "$OUTPUT" | json_stream_has_status_ok && pass "seed" || fail "seed"
 
 # Test: reindex after seed
 echo ""
 echo "--- reindex (after seed) ---"
 OUTPUT=$($AOS wiki reindex --json)
-PAGES=$(echo "$OUTPUT" | grep -o '"pages" : [0-9]*' | grep -o '[0-9]*')
+PAGES=$(echo "$OUTPUT" | json_field pages)
 [ "$PAGES" -gt 0 ] && pass "reindex found $PAGES pages" || fail "reindex found 0 pages"
 
 # Test: list
@@ -86,7 +110,7 @@ echo "$OUTPUT" | grep -q "self-check" && pass "list --type workflow" || fail "li
 echo ""
 echo "--- show ---"
 OUTPUT=$($AOS wiki show gateway --json)
-echo "$OUTPUT" | grep -q '"name" : "Gateway"' && pass "show gateway" || fail "show gateway"
+[[ "$(echo "$OUTPUT" | python3 -c 'import json, sys; print(json.load(sys.stdin)["frontmatter"].get("name", ""))')" == "Gateway" ]] && pass "show gateway" || fail "show gateway"
 
 # Test: show --raw
 OUTPUT=$($AOS wiki show gateway --raw)
@@ -95,7 +119,7 @@ echo "$OUTPUT" | grep -q "^---" && pass "show --raw has frontmatter" || fail "sh
 # Test: search
 echo ""
 echo "--- search ---"
-OUTPUT=$($AOS wiki search "MCP server" --json)
+OUTPUT=$($AOS wiki search "gateway" --json)
 echo "$OUTPUT" | grep -q "gateway" && pass "search finds gateway" || fail "search"
 
 # Test: graph
@@ -131,17 +155,17 @@ echo "$OUTPUT" | grep -q '"raw"' && echo "$OUTPUT" | grep -q 'gateway.md' && pas
 echo ""
 echo "--- create-plugin ---"
 OUTPUT=$($AOS wiki create-plugin test-workflow --json)
-echo "$OUTPUT" | grep -q '"status" : "ok"' && pass "create-plugin" || fail "create-plugin"
+[[ "$(echo "$OUTPUT" | json_field status)" == "ok" ]] && pass "create-plugin" || fail "create-plugin"
 
 # Test: add entity
 OUTPUT=$($AOS wiki add entity test-entity --json)
-echo "$OUTPUT" | grep -q '"status" : "ok"' && pass "add entity" || fail "add entity"
+[[ "$(echo "$OUTPUT" | json_field status)" == "ok" ]] && pass "add entity" || fail "add entity"
 
 # Test: link
 echo ""
 echo "--- link ---"
 OUTPUT=$($AOS wiki link test-entity gateway --json)
-echo "$OUTPUT" | grep -q '"status" : "ok"' && pass "link" || fail "link"
+[[ "$(echo "$OUTPUT" | json_field status)" == "ok" ]] && pass "link" || fail "link"
 
 # Test: list --links-to
 OUTPUT=$($AOS wiki list --links-to aos/entities/gateway.md --json)
@@ -164,7 +188,7 @@ OUTPUT=$($AOS wiki lint --json)
 echo ""
 echo "--- rm ---"
 OUTPUT=$($AOS wiki rm test-entity --json)
-echo "$OUTPUT" | grep -q '"status" : "ok"' && pass "rm" || fail "rm"
+[[ "$(echo "$OUTPUT" | json_field status)" == "ok" ]] && pass "rm" || fail "rm"
 
 # Cleanup test plugin
 rm -rf "$WIKI_DIR/aos/plugins/test-workflow"

--- a/tests/wiki-mutate-external.sh
+++ b/tests/wiki-mutate-external.sh
@@ -62,6 +62,49 @@ assert data["removed"] == "aos/entities/test-entity.md", data
 PY
 test ! -f "$ROOT/repo/wiki/aos/entities/test-entity.md"
 
+printf 'keep me\n' >"$ROOT/outside-delete.md"
+if ./aos wiki rm ../../outside-delete.md --json 2>"$ROOT/wiki-rm-traversal.err"; then
+  echo "FAIL: wiki rm accepted traversal path"
+  exit 1
+fi
+grep -q '"code": "WIKI_INVALID_PATH"' "$ROOT/wiki-rm-traversal.err" || {
+  echo "FAIL: wiki rm traversal did not use WIKI_INVALID_PATH"
+  cat "$ROOT/wiki-rm-traversal.err"
+  exit 1
+}
+grep -q 'keep me' "$ROOT/outside-delete.md" || {
+  echo "FAIL: wiki rm deleted outside-root file"
+  exit 1
+}
+
+if ./aos wiki add entity ../../../../outside-add --json 2>"$ROOT/wiki-add-traversal.err"; then
+  echo "FAIL: wiki add accepted traversal name"
+  exit 1
+fi
+grep -q '"code": "WIKI_INVALID_PATH"' "$ROOT/wiki-add-traversal.err" || {
+  echo "FAIL: wiki add traversal did not use WIKI_INVALID_PATH"
+  cat "$ROOT/wiki-add-traversal.err"
+  exit 1
+}
+test ! -e "$ROOT/outside-add.md" || {
+  echo "FAIL: wiki add wrote outside wiki root"
+  exit 1
+}
+
+if ./aos wiki create-plugin ../../../../outside-plugin --json 2>"$ROOT/wiki-create-plugin-traversal.err"; then
+  echo "FAIL: wiki create-plugin accepted traversal name"
+  exit 1
+fi
+grep -q '"code": "WIKI_INVALID_PATH"' "$ROOT/wiki-create-plugin-traversal.err" || {
+  echo "FAIL: wiki create-plugin traversal did not use WIKI_INVALID_PATH"
+  cat "$ROOT/wiki-create-plugin-traversal.err"
+  exit 1
+}
+test ! -e "$ROOT/outside-plugin" || {
+  echo "FAIL: wiki create-plugin wrote outside wiki root"
+  exit 1
+}
+
 if ./aos wiki add --bogus 2>"$ROOT/wiki-add-bogus.err"; then
   echo "FAIL: wiki add accepted unknown flag"
   exit 1

--- a/tests/wiki-read-external.sh
+++ b/tests/wiki-read-external.sh
@@ -21,6 +21,21 @@ PY
 
 ./aos wiki show gateway --raw | grep -q '^---$'
 
+printf 'outside secret\n' >"$ROOT/outside-read.md"
+if ./aos wiki show ../../outside-read.md --raw >"$ROOT/wiki-show-traversal.out" 2>"$ROOT/wiki-show-traversal.err"; then
+  echo "FAIL: wiki show accepted traversal path"
+  exit 1
+fi
+grep -q '"code": "WIKI_INVALID_PATH"' "$ROOT/wiki-show-traversal.err" || {
+  echo "FAIL: wiki show traversal did not use WIKI_INVALID_PATH"
+  cat "$ROOT/wiki-show-traversal.err"
+  exit 1
+}
+if grep -q 'outside secret' "$ROOT/wiki-show-traversal.out"; then
+  echo "FAIL: wiki show printed outside-root file contents"
+  exit 1
+fi
+
 OUT="$(./aos wiki invoke self-check --json)"
 OUT="$OUT" python3 - <<'PY'
 import json
@@ -30,6 +45,16 @@ data = json.loads(os.environ["OUT"])
 assert data["plugin"] == "self-check", data
 assert "Self-Check" in data["bundle"], data
 PY
+
+if ./aos wiki invoke ../../../../outside-read --json 2>"$ROOT/wiki-invoke-traversal.err"; then
+  echo "FAIL: wiki invoke accepted traversal plugin name"
+  exit 1
+fi
+grep -q '"code": "WIKI_INVALID_PATH"' "$ROOT/wiki-invoke-traversal.err" || {
+  echo "FAIL: wiki invoke traversal did not use WIKI_INVALID_PATH"
+  cat "$ROOT/wiki-invoke-traversal.err"
+  exit 1
+}
 
 if ./aos wiki show --bogus 2>"$ROOT/wiki-show-bogus.err"; then
   echo "FAIL: wiki show accepted unknown flag"

--- a/tests/wiki-seed.sh
+++ b/tests/wiki-seed.sh
@@ -24,6 +24,32 @@ sleep 1
 NEW_MTIME=$(stat -f %m "$TESTDIR/agents/default.md")
 test "$ORIG_MTIME" = "$NEW_MTIME" || { echo "FAIL: seed overwrote existing"; exit 1; }
 
+if ./aos wiki seed --namespace ../outside-seed \
+  --file "agents/default.md:$(pwd)/tests/fixtures/default-agent.md" \
+  2>"$ROOT/wiki-seed-namespace-traversal.err"; then
+  echo "FAIL: wiki seed accepted traversal namespace"
+  exit 1
+fi
+grep -q '"code": "WIKI_INVALID_PATH"' "$ROOT/wiki-seed-namespace-traversal.err" || {
+  echo "FAIL: wiki seed namespace traversal did not use WIKI_INVALID_PATH"
+  cat "$ROOT/wiki-seed-namespace-traversal.err"
+  exit 1
+}
+test ! -e "$ROOT/repo/outside-seed" || { echo "FAIL: seed wrote outside namespace root"; exit 1; }
+
+if ./aos wiki seed --namespace seed-test \
+  --file "../../outside-seed.md:$(pwd)/tests/fixtures/default-agent.md" \
+  2>"$ROOT/wiki-seed-file-traversal.err"; then
+  echo "FAIL: wiki seed accepted traversal file mapping"
+  exit 1
+fi
+grep -q '"code": "WIKI_INVALID_PATH"' "$ROOT/wiki-seed-file-traversal.err" || {
+  echo "FAIL: wiki seed file traversal did not use WIKI_INVALID_PATH"
+  cat "$ROOT/wiki-seed-file-traversal.err"
+  exit 1
+}
+test ! -e "$ROOT/repo/outside-seed.md" || { echo "FAIL: seed wrote outside file mapping"; exit 1; }
+
 if ./aos wiki seed --bogus 2>"$ROOT/wiki-seed-bogus.err"; then
   echo "FAIL: wiki seed accepted unknown flag"
   exit 1


### PR DESCRIPTION
## Summary
- reject wiki read/mutate paths that resolve outside the active wiki root
- reject traversal destinations for wiki add/create-plugin and seeded namespace/file mappings
- add negative traversal tests for show, invoke, rm, add, create-plugin, and seed writes
- make the wiki integration test parse JSON structurally instead of depending on pretty-print spacing

## Review blocker
Addresses high finding #2 from `/Users/Michael/Code/tmp/agent-os-code-review-2026-07-03.md`: `aos wiki` could read/write/delete outside the wiki root through unchecked path joins.

## Verification
- `bash tests/wiki-read-external.sh`
- `bash tests/wiki-mutate-external.sh`
- `bash tests/wiki-seed.sh`
- `bash tests/wiki-integration.sh`
- `bash tests/wiki-reindex-external.sh`
- `bash tests/wiki-query-external.sh`
- `bash tests/wiki-graph-external.sh`
- `bash tests/wiki-lint-external.sh`
- `bash tests/external-parser-flags.sh`
- `bash tests/help-contract.sh`
- `git diff --check`

## DOX
Read root `AGENTS.md`, `scripts/AGENTS.md`, and `tests/AGENTS.md`. No DOX files changed because this preserves existing wiki command ownership and test contracts while tightening path containment.

## Live proof
Not run. This is covered by isolated-state shell tests and does not require Level 4 live UI/native/TCC proof.