### PR TITLE
Fix Sigil selection and glTF fallback crashes

### DIFF
--- a/apps/sigil/renderer/live-modules/interaction-overlay.js
+++ b/apps/sigil/renderer/live-modules/interaction-overlay.js
@@ -636,6 +636,7 @@ function drawSelectionMode(ctx, overlay = {}, snapshot = {}, {
     for (const frame of overlay.frames || []) {
         const active = frame.active === true;
         const leaf = frame.leaf === true;
+        const time = Number(snapshot.time) || 0;
         drawFrame(ctx, frame, {
             stroke: frame.style?.stroke || (active ? 'rgba(94, 252, 210, 0.58)' : (leaf ? 'rgba(255, 224, 120, 0.48)' : 'rgba(170, 210, 255, 0.22)')),
             fill: frame.style?.fill ?? null,

--- a/apps/sigil/renderer/live-modules/radial-gesture-visuals.js
+++ b/apps/sigil/renderer/live-modules/radial-gesture-visuals.js
@@ -224,7 +224,7 @@ function disposeChildren(group) {
 function installFallbackGlyph(group, item, status, error = null) {
     const host = group.userData.modelHost || group;
     disposeChildren(host);
-    const fallback = createFallbackForItem(item);
+    const fallback = createFallbackGlyph();
     host.add(fallback);
     group.userData.baseRadius = glyphSceneRadius(fallback);
     group.userData.geometryStatus = status;
@@ -817,7 +817,7 @@ function disposeMaterial(material) {
 
 function disposeObject(object) {
     object.traverse((child) => {
-        if (child.geometry) child.geometry.dispose();
+        child.geometry?.dispose?.();
         disposeMaterial(child.material);
     });
 }

--- a/tests/renderer/interaction-overlay-lineage-layer.test.mjs
+++ b/tests/renderer/interaction-overlay-lineage-layer.test.mjs
@@ -85,3 +85,47 @@ test('Selection Mode lineage bar renders on a lower layer than the cursor scene'
     globalThis.window = originalWindow
   }
 })
+
+test('Selection Mode active frames draw without an unbound time reference', () => {
+  const appended = []
+  const originalDocument = globalThis.document
+  const originalWindow = globalThis.window
+
+  globalThis.document = {
+    body: {
+      appendChild(node) {
+        appended.push(node)
+      },
+    },
+    createElement(tag) {
+      assert.equal(tag, 'canvas')
+      return createCanvas()
+    },
+  }
+  globalThis.window = {
+    devicePixelRatio: 1,
+    innerWidth: 1280,
+    innerHeight: 720,
+    addEventListener() {},
+    removeEventListener() {},
+  }
+
+  try {
+    const overlay = createInteractionOverlay()
+    overlay.mount()
+    assert.doesNotThrow(() => overlay.draw({
+      time: 1.25,
+      selectionModeOverlay: {
+        active: true,
+        frames: [{
+          active: true,
+          rect: { x: 10, y: 20, w: 30, h: 40 },
+          style: {},
+        }],
+      },
+    }))
+  } finally {
+    globalThis.document = originalDocument
+    globalThis.window = originalWindow
+  }
+})

--- a/tests/renderer/radial-gesture-visuals.test.mjs
+++ b/tests/renderer/radial-gesture-visuals.test.mjs
@@ -507,6 +507,33 @@ test('closing radial visuals reverse their ingress animation before disappearing
   assert.equal(visuals.group.visible, false)
 })
 
+test('glTF radial item missing source installs fallback glyph without throwing', () => {
+  const scene = new Object3D()
+  const visuals = createSigilRadialGestureVisuals({
+    scene,
+    projectPoint: (point) => new Vector3(point.x, point.y, 0),
+    projectRadius: () => 0.3,
+  })
+
+  assert.doesNotThrow(() => visuals.update({
+    phase: 'radial',
+    menuProgress: 1,
+    origin: { x: 0, y: 0 },
+    pointer: { x: 0, y: 0 },
+    items: [{
+      id: 'missing-model',
+      center: { x: 100, y: 0 },
+      hitRadius: 20,
+      visualRadius: 20,
+      geometry: { type: 'gltf' },
+    }],
+  }, { time: 0 }))
+
+  const glyph = visuals.group.children[0]
+  assert.equal(glyph.userData.geometryStatus, 'missing-src')
+  assert.ok(glyph.children.length > 0)
+})
+
 test('Sigil radial item modules own fallback glyph creation hooks', async () => {
   const { resolveSigilRadialItemModule } = await import('../../apps/sigil/renderer/radial-menu/item-registry.js')
   const moduleDef = resolveSigilRadialItemModule({ id: 'avatar-controls' })


### PR DESCRIPTION
## Summary
- bind selection frame draw time from the current snapshot before passing it into frame rendering
- use the existing fallback glyph factory for failed/missing glTF radial item geometry
- guard optional geometry disposal during fallback replacement
- add renderer regressions for active selection-frame drawing and missing glTF source fallback

## Review blockers
Addresses high findings #3 and #4 from `/Users/Michael/Code/tmp/agent-os-code-review-2026-07-03.md`: selection-mode active frame rendering threw an unbound `time` ReferenceError, and glTF fallback recovery called a nonexistent `createFallbackForItem` helper.

## Verification
- `node --test tests/renderer/interaction-overlay-lineage-layer.test.mjs`
- `node --test tests/renderer/radial-gesture-visuals.test.mjs`
- `node --test tests/renderer/sigil-selection-mode-runtime.test.mjs tests/renderer/sigil-selection-mode-performance.test.mjs tests/renderer/radial-gesture-menu.test.mjs`
- `git diff --check`

## DOX
Read root `AGENTS.md`, `apps/AGENTS.md`, and `apps/sigil/AGENTS.md`. No DOX files changed because this is a Sigil renderer bug fix under existing app ownership and verification guidance.

## Live proof
Not run. This is covered by deterministic renderer tests and does not require Level 4 real-input/TCC proof.