### PR TITLE
Break canvas callback retain cycles on close

### DIFF
--- a/src/display/canvas.swift
+++ b/src/display/canvas.swift
@@ -484,6 +484,8 @@ window.__aosInitialFrame = [\(cgFrame.origin.x), \(cgFrame.origin.y), \(cgFrame.
     }
 
     func close() {
+        onMessage = nil
+        onTTLExpired = nil
         webView.configuration.userContentController.removeScriptMessageHandler(forName: "headsup")
         ttlTimer?.cancel()
         ttlTimer = nil

--- a/src/display/desktop-world-surface.swift
+++ b/src/display/desktop-world-surface.swift
@@ -276,9 +276,12 @@ final class DesktopWorldSurfaceCanvas: CanvasLike {
     }
 
     func close() {
+        onMessage = nil
+        onTTLExpired = nil
         ttlTimer?.cancel()
         ttlTimer = nil
         for segment in segments {
+            segment.messageHandler.onMessage = nil
             segment.webView.configuration.userContentController.removeScriptMessageHandler(forName: "headsup")
             segment.window.orderOut(nil)
             segment.window.close()

--- a/tests/canvas-close-callback-contract.test.mjs
+++ b/tests/canvas-close-callback-contract.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+function source(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+function functionBody(swiftSource, signature) {
+  const start = swiftSource.indexOf(signature);
+  return functionBodyAfter(swiftSource, signature, start);
+}
+
+function functionBodyAfter(swiftSource, signature, startAt) {
+  const start = swiftSource.indexOf(signature, startAt);
+  assert.notEqual(start, -1, `${signature} not found`);
+  const brace = swiftSource.indexOf('{', start);
+  assert.notEqual(brace, -1, `${signature} body not found`);
+  let depth = 0;
+  for (let i = brace; i < swiftSource.length; i += 1) {
+    if (swiftSource[i] === '{') depth += 1;
+    else if (swiftSource[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return swiftSource.slice(brace + 1, i);
+    }
+  }
+  throw new Error(`${signature} body did not close`);
+}
+
+test('single Canvas close clears retained callbacks before closing WebKit window', () => {
+  const body = functionBody(source('src/display/canvas.swift'), 'func close()');
+  const onMessage = body.indexOf('onMessage = nil');
+  const onTTLExpired = body.indexOf('onTTLExpired = nil');
+  const removeHandler = body.indexOf('removeScriptMessageHandler(forName: "headsup")');
+  const closeWindow = body.indexOf('window.close()');
+
+  assert.ok(onMessage >= 0, 'Canvas.close should clear the message callback');
+  assert.ok(onTTLExpired >= 0, 'Canvas.close should clear the TTL callback');
+  assert.ok(removeHandler > onMessage, 'Canvas.close should clear callbacks before removing WebKit handler');
+  assert.ok(closeWindow > removeHandler, 'Canvas.close should remove WebKit handler before closing window');
+});
+
+test('DesktopWorldSurfaceCanvas close clears retained callbacks and segment handlers', () => {
+  const swiftSource = source('src/display/desktop-world-surface.swift');
+  const classStart = swiftSource.indexOf('final class DesktopWorldSurfaceCanvas');
+  assert.notEqual(classStart, -1, 'DesktopWorldSurfaceCanvas class not found');
+  const body = functionBodyAfter(swiftSource, 'func close()', classStart);
+  const onMessage = body.indexOf('onMessage = nil');
+  const onTTLExpired = body.indexOf('onTTLExpired = nil');
+  const segmentHandler = body.indexOf('segment.messageHandler.onMessage = nil');
+  const segmentsCleared = body.indexOf('segments = []');
+
+  assert.ok(onMessage >= 0, 'DesktopWorldSurfaceCanvas.close should clear the retained message callback');
+  assert.ok(onTTLExpired >= 0, 'DesktopWorldSurfaceCanvas.close should clear the TTL callback');
+  assert.ok(segmentHandler > onMessage, 'DesktopWorldSurfaceCanvas.close should clear segment handlers after clearing root callback');
+  assert.ok(segmentsCleared > segmentHandler, 'DesktopWorldSurfaceCanvas.close should clear segments after handler teardown');
+});


### PR DESCRIPTION
## Summary
- clear retained Canvas callbacks before tearing down WebKit/window resources
- clear DesktopWorldSurfaceCanvas root callbacks and segment message handlers on close
- add a focused source-level regression test for callback teardown order

## Verification
- node --test tests/canvas-close-callback-contract.test.mjs
- bash tests/help-contract.sh
- bash build.sh --force --no-restart
- git diff --cached --check

## DOX
- Read root AGENTS.md, src/AGENTS.md, and src/daemon/AGENTS.md for the touched native display paths. No DOX update needed: this preserves the existing canvas lifecycle contract and does not change ownership, workflow, or public behavior.

## Notes
- `bash build.sh --force --no-restart` produced existing compiler warnings in `src/act/canvas-ref-targeting.swift` and deprecated speech APIs under `src/voice/`; no live daemon restart or Level 4 UI/TCC proof was run.