### PR TITLE
Guard session click counts

### DIFF
--- a/src/act/actions.swift
+++ b/src/act/actions.swift
@@ -126,6 +126,11 @@ func handleMove(_ req: ActionRequest, state: SessionState) -> ActionResponse {
 func handleClick(_ req: ActionRequest, state: SessionState) -> ActionResponse {
     let start = Date()
     let profile = state.profile
+    let clickCount = req.count ?? 1
+
+    guard clickCount > 0 else {
+        return errorResponse("click", state: state, message: "Click count must be greater than zero", code: "INVALID_COUNT")
+    }
 
     // Resolve click position: explicit coords, channel element, or current cursor
     let clickPoint: CGPoint
@@ -157,7 +162,6 @@ func handleClick(_ req: ActionRequest, state: SessionState) -> ActionResponse {
     let downType: CGEventType = isRight ? .rightMouseDown : .leftMouseDown
     let upType: CGEventType = isRight ? .rightMouseUp : .leftMouseUp
     let cgButton: CGMouseButton = isRight ? .right : .left
-    let clickCount = req.count ?? 1
 
     let source = CGEventSource(stateID: .hidSystemState)
     let flags = currentFlags(state)

--- a/tests/click-count-contract.test.mjs
+++ b/tests/click-count-contract.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+function source(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+function functionBody(swiftSource, signature) {
+  const start = swiftSource.indexOf(signature);
+  assert.notEqual(start, -1, `${signature} not found`);
+  const brace = swiftSource.indexOf('{', start);
+  assert.notEqual(brace, -1, `${signature} body not found`);
+  let depth = 0;
+  for (let i = brace; i < swiftSource.length; i += 1) {
+    if (swiftSource[i] === '{') depth += 1;
+    else if (swiftSource[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return swiftSource.slice(brace + 1, i);
+    }
+  }
+  throw new Error(`${signature} body did not close`);
+}
+
+test('handleClick rejects non-positive counts before posting click events', () => {
+  const body = functionBody(source('src/act/actions.swift'), 'func handleClick(');
+  const clickCount = body.indexOf('let clickCount = req.count ?? 1');
+  const invalidCount = body.indexOf('guard clickCount > 0 else');
+  const invalidCode = body.indexOf('code: "INVALID_COUNT"');
+  const eventSource = body.indexOf('CGEventSource(stateID: .hidSystemState)');
+  const clickRange = body.indexOf('for i in 1...clickCount');
+
+  assert.ok(clickCount >= 0, 'handleClick should normalize missing count to one');
+  assert.ok(invalidCount > clickCount, 'handleClick should validate the normalized count');
+  assert.ok(invalidCode > invalidCount, 'invalid click counts should return a structured error');
+  assert.ok(eventSource > invalidCode, 'invalid count should be rejected before any CGEvent source is created');
+  assert.ok(clickRange > invalidCode, 'invalid count should be rejected before the trapping range loop');
+});


### PR DESCRIPTION
## Summary
- reject non-positive session click counts before coordinate resolution or CGEvent creation
- return a structured INVALID_COUNT error instead of trapping in `1...clickCount`
- add a focused source-level regression test for the handler guard order

## Verification
- node --test tests/click-count-contract.test.mjs
- bash build.sh --no-restart
- AOS_BYPASS_PREFLIGHT=1 ./aos __do session with `count:0` followed by `end` returned INVALID_COUNT and kept the session alive
- bash tests/help-contract.sh
- git diff --check

## DOX
- Read root AGENTS.md and src/AGENTS.md for the touched native action path. No DOX update needed: this preserves the existing session handler contract that malformed input returns errors without killing the session.

## Notes
- `bash build.sh --no-restart` produced existing compiler warnings in `src/act/canvas-ref-targeting.swift` and deprecated speech APIs under `src/voice/`. No live daemon restart or Level 4 UI/TCC proof was run.