### PR TITLE
Guard terminal stdin writes after exit

### DIFF
--- a/packages/toolkit/components/agent-terminal/bridge-server.mjs
+++ b/packages/toolkit/components/agent-terminal/bridge-server.mjs
@@ -13,7 +13,9 @@ import {
 import {
   appendProcessStderr,
   boundedInt,
+  childStdinOpen,
   createTerminalSessionManager,
+  writeChildStdin,
 } from './terminal-session-manager.mjs';
 
 function envValue(name, fallback) {
@@ -251,4 +253,4 @@ if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
   startServer();
 }
 
-export { appendProcessStderr, startServer };
+export { appendProcessStderr, childStdinOpen, startServer, writeChildStdin };

--- a/packages/toolkit/components/agent-terminal/terminal-session-manager.mjs
+++ b/packages/toolkit/components/agent-terminal/terminal-session-manager.mjs
@@ -84,6 +84,30 @@ function appendProcessStderr(record, chunk) {
   if (remaining) appendProcessOutput(record, `${remaining}\n`);
 }
 
+function childStdinOpen(child) {
+  return child?.stdin
+    && !child.stdin.destroyed
+    && !child.stdin.writableEnded
+    && !child.stdin.closed
+    && child.exitCode == null
+    && child.signalCode == null;
+}
+
+function writeChildStdin(child, data) {
+  const payload = Buffer.isBuffer(data) ? data : Buffer.from(String(data), 'utf8');
+  if (!childStdinOpen(child)) {
+    return { bytes: payload.length, accepted: false };
+  }
+  try {
+    return {
+      bytes: payload.length,
+      accepted: child.stdin.write(payload),
+    };
+  } catch {
+    return { bytes: payload.length, accepted: false };
+  }
+}
+
 function wsFrame(data, opcode = 1) {
   const payload = Buffer.isBuffer(data) ? data : Buffer.from(String(data), 'utf8');
   const header = [];
@@ -230,6 +254,7 @@ function createTerminalSessionManager(options = {}) {
     sessionCommands.set(session, { command: shellCommand, cwd: cwd || defaultCwd });
     child.stdout.on('data', chunk => appendProcessOutput(record, chunk));
     child.stderr.on('data', chunk => appendProcessStderr(record, chunk));
+    child.stdin.on('error', () => {});
     child.on('exit', (code, signal) => {
       record.exited = true;
       const message = `\n[process exited: ${signal || (code ?? 0)}]\n`;
@@ -341,12 +366,11 @@ function createTerminalSessionManager(options = {}) {
   }
 
   function writeProcessStdin(record, data) {
-    const payload = Buffer.isBuffer(data) ? data : Buffer.from(String(data), 'utf8');
-    const accepted = record.child.stdin.write(payload);
-    return {
-      bytes: payload.length,
-      accepted,
-    };
+    if (!record || record.exited) {
+      const payload = Buffer.isBuffer(data) ? data : Buffer.from(String(data), 'utf8');
+      return { bytes: payload.length, accepted: false };
+    }
+    return writeChildStdin(record.child, data);
   }
 
   function writeProcessControl(record, message) {
@@ -529,7 +553,11 @@ function createTerminalSessionManager(options = {}) {
             }
             continue;
           }
-          record.child.stdin.write(frame.payload);
+          if (record.exited) {
+            socket.end();
+            return;
+          }
+          writeProcessStdin(record, frame.payload);
         }
       }
     });
@@ -603,6 +631,7 @@ function createTerminalSessionManager(options = {}) {
         socket.end();
       }
     });
+    child.stdin.on('error', () => {});
 
     socket.on('data', chunk => {
       incoming = Buffer.concat([incoming, chunk]);
@@ -619,7 +648,7 @@ function createTerminalSessionManager(options = {}) {
         }
         if (frame.opcode === 1 || frame.opcode === 2) {
           if (frame.opcode === 1 && handleControlFrame(frame.payload.toString('utf8'))) continue;
-          child.stdin.write(frame.payload);
+          writeChildStdin(child, frame.payload);
         }
       }
     });
@@ -659,4 +688,6 @@ export {
   appendProcessStderr,
   boundedInt,
   createTerminalSessionManager,
+  childStdinOpen,
+  writeChildStdin,
 };

--- a/tests/sigil-agent-terminal-server.test.mjs
+++ b/tests/sigil-agent-terminal-server.test.mjs
@@ -5,7 +5,11 @@ import fs from 'node:fs';
 import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
-import { appendProcessStderr } from '../packages/toolkit/components/agent-terminal/bridge-server.mjs';
+import {
+  appendProcessStderr,
+  childStdinOpen,
+  writeChildStdin,
+} from '../packages/toolkit/components/agent-terminal/bridge-server.mjs';
 
 const toolkitBridgeServer = 'packages/toolkit/components/agent-terminal/bridge-server.mjs';
 const toolkitPtyProxy = 'packages/toolkit/components/agent-terminal/pty-proxy.py';
@@ -322,6 +326,46 @@ describe('Sigil Agent Terminal bridge', () => {
     assert.deepEqual(snapshot.terminal, { cols: 80, rows: 24 });
     assert.match(snapshot.text, new RegExp(escapeRegExp(marker)));
     assert.match(snapshot.text, /\[process exited:/);
+  });
+
+  it('rejects writes to exited or broken child stdin without throwing', () => {
+    const exitedChild = {
+      exitCode: 0,
+      signalCode: null,
+      stdin: {
+        destroyed: false,
+        writableEnded: false,
+        closed: false,
+        write() {
+          throw new Error('should not write after exit');
+        },
+      },
+    };
+    assert.equal(childStdinOpen(exitedChild), false);
+    assert.deepEqual(writeChildStdin(exitedChild, 'late-input'), {
+      bytes: Buffer.byteLength('late-input'),
+      accepted: false,
+    });
+
+    const brokenChild = {
+      exitCode: null,
+      signalCode: null,
+      stdin: {
+        destroyed: false,
+        writableEnded: false,
+        closed: false,
+        write() {
+          const error = new Error('write EPIPE');
+          error.code = 'EPIPE';
+          throw error;
+        },
+      },
+    };
+    assert.equal(childStdinOpen(brokenChild), true);
+    assert.deepEqual(writeChildStdin(brokenChild, Buffer.from('queued-key')), {
+      bytes: Buffer.byteLength('queued-key'),
+      accepted: false,
+    });
   });
 
   it('submits process-driver /input text with Enter to the PTY', async () => {


### PR DESCRIPTION
## Summary
- route terminal child stdin writes through a closed-pipe-aware helper
- avoid direct WebSocket writes to exited or broken process stdin
- attach stdin error listeners so EPIPE-style stream errors do not crash the shared bridge
- cover exited and throwing stdin writes in the agent-terminal server test suite

## Verification
- node --test tests/sigil-agent-terminal-server.test.mjs
- git diff --check

## DOX
- Read root AGENTS.md, packages/AGENTS.md, and packages/toolkit/AGENTS.md for the touched toolkit component path. No DOX update needed: this preserves the existing agent-terminal bridge contract and does not change ownership, public routing, or workflow.

## Notes
- No live terminal UI/TCC proof was run; this is a process-bridge lifecycle fix covered by local Node tests.