### PR TITLE
Guard surface inspector pin loops

### DIFF
--- a/packages/toolkit/workbench/surface-inspector-annotations.js
+++ b/packages/toolkit/workbench/surface-inspector-annotations.js
@@ -123,7 +123,9 @@ function activeSurfaceInspectorFramePath(state = {}) {
   const pinsById = new Map(activeSurfaceInspectorPins(state).map((pin) => [pin.id, pin]))
   let cursor = pinsById.get(state.active_frame_id)
   const path = []
-  while (cursor) {
+  const visited = new Set()
+  while (cursor && !visited.has(cursor.id)) {
+    visited.add(cursor.id)
     path.unshift(cursor)
     cursor = cursor.parent_pin_id ? pinsById.get(cursor.parent_pin_id) : null
   }
@@ -570,9 +572,10 @@ export function recordSurfaceInspectorAnnotationSnapshotSuccess(state, options =
 export function pinSurfaceInspectorFrame(state, node = {}, options = {}) {
   const next = createSurfaceInspectorAnnotationState(state)
   const subjectPath = subjectPathFromNode(node)
-  const parentPinId = (options.parent_pin_id ?? next.active_frame_id) || null
+  const requestedParentPinId = (options.parent_pin_id ?? next.active_frame_id) || null
   const rootId = text(options.root_id || node.root_id || node.display_id || node.root_label, 'main')
   const id = text(options.id, stableId('pin', [rootId, ...subjectPath]))
+  const parentPinId = requestedParentPinId === id ? null : requestedParentPinId
   const existingIndex = next.pins.findIndex((pin) => pin.id === id)
   const pin = normalizePinRecord({
     id,
@@ -657,7 +660,9 @@ export function jumpSurfaceInspectorAnnotationScope(state, pinId = '') {
   if (!pin) return next
   const stack = []
   let cursor = pin
-  while (cursor) {
+  const visited = new Set()
+  while (cursor && !visited.has(cursor.id)) {
+    visited.add(cursor.id)
     stack.unshift(scopeFrameFromPin(cursor))
     cursor = cursor.parent_pin_id ? pinsById.get(cursor.parent_pin_id) : null
   }
@@ -913,7 +918,9 @@ export function computeSurfaceInspectorActiveEdge(state) {
   if (!active) return { edge_id: '', frame_path: [], comments: [] }
   const path = []
   let cursor = active
-  while (cursor) {
+  const visited = new Set()
+  while (cursor && !visited.has(cursor.id)) {
+    visited.add(cursor.id)
     path.unshift(cursor)
     cursor = cursor.parent_pin_id ? pinById.get(cursor.parent_pin_id) : null
   }
@@ -951,10 +958,13 @@ export function buildSurfaceInspectorAnnotationTreeRows(state) {
   const collapseAnchorChain = (pin) => {
     const chain = [pin]
     let cursor = pin
+    const visited = new Set([pin.id])
     while ((commentsByPin.get(cursor.id) || []).length === 0) {
       const children = (childrenByParent.get(cursor.id) || []).filter((child) => child.status !== 'removed').sort(pinSort)
       if (children.length !== 1) break
+      if (visited.has(children[0].id)) break
       cursor = children[0]
+      visited.add(cursor.id)
       chain.push(cursor)
     }
     return chain

--- a/tests/toolkit/surface-inspector-annotations.test.mjs
+++ b/tests/toolkit/surface-inspector-annotations.test.mjs
@@ -485,6 +485,37 @@ test('active edge selection computes frame path and opacity ladder', () => {
   assert.deepEqual(edge.comments.map((comment) => comment.id), ['comment-leaf'])
 })
 
+test('re-pinning the active frame does not create a self-parent loop', () => {
+  let state = setSurfaceInspectorAnnotationMode(createSurfaceInspectorAnnotationState(), true)
+  const target = node('root', ['main', 'root'])
+  state = pinSurfaceInspectorFrame(state, target, { id: 'pin-root' })
+  state = pinSurfaceInspectorFrame(state, target, { id: 'pin-root' })
+
+  assert.equal(state.pins.length, 1)
+  assert.equal(state.pins[0].id, 'pin-root')
+  assert.equal(state.pins[0].parent_pin_id, null)
+  const edge = computeSurfaceInspectorActiveEdge(state)
+  assert.deepEqual(edge.frame_path.map((pin) => pin.id), ['pin-root'])
+})
+
+test('malformed self-parent pins do not hang active-edge or scope traversal', () => {
+  let state = setSurfaceInspectorAnnotationMode(createSurfaceInspectorAnnotationState(), true)
+  state = pinSurfaceInspectorFrame(state, node('loop', ['main', 'loop']), { id: 'pin-loop' })
+  state = {
+    ...state,
+    pins: state.pins.map((pin) => ({ ...pin, parent_pin_id: pin.id })),
+  }
+
+  const edge = computeSurfaceInspectorActiveEdge(state)
+  assert.deepEqual(edge.frame_path.map((pin) => pin.id), ['pin-loop'])
+
+  const jumped = jumpSurfaceInspectorAnnotationScope(state, 'pin-loop')
+  assert.deepEqual(jumped.annotation_scope_stack.map((frame) => frame.pin_id), ['pin-loop'])
+
+  const session = surfaceInspectorAnnotationStateToSession(state)
+  assert.equal(session.preview_scope_stack.length, 1)
+})
+
 test('unpin/prune requires confirmation when descendants or comments exist', () => {
   let state = setSurfaceInspectorAnnotationMode(createSurfaceInspectorAnnotationState(), true)
   state = pinSurfaceInspectorFrame(state, node('root'), { id: 'pin-root' })


### PR DESCRIPTION
## Summary
- prevent re-pinning the active deterministic frame from assigning itself as parent
- add visited guards to active frame path, scope jump, active edge, and collapsed tree traversal
- cover re-pin self-parent and malformed legacy self-loop state in annotation tests

## Verification
- node --test tests/toolkit/surface-inspector-annotations.test.mjs
- git diff --check

## DOX
- Read root AGENTS.md, packages/AGENTS.md, and packages/toolkit/AGENTS.md for the touched toolkit workbench path. No DOX update needed: this preserves the existing surface-inspector annotation model while hardening malformed lifecycle state.

## Notes
- No live UI proof was run; this is deterministic workbench state logic covered by local Node tests.