### PR TITLE
Fix decision gate tab focus trap

### DIFF
--- a/packages/toolkit/components/decision-gate/index.js
+++ b/packages/toolkit/components/decision-gate/index.js
@@ -196,8 +196,7 @@ export function createDecisionGate(container, options = {}) {
       return;
     }
     if (event.key === 'Tab') {
-      const focusable = root
-        .querySelectorAll('button,input,select,textarea,[tabindex]')
+      const focusable = Array.from(root.querySelectorAll('button,input,select,textarea,[tabindex]'))
         .filter((element) => !element.disabled && !hasHiddenAncestor(element, root));
       if (!focusable.length) return;
       const currentIndex = focusable.indexOf(doc.activeElement);

--- a/tests/toolkit/decision-gate.test.mjs
+++ b/tests/toolkit/decision-gate.test.mjs
@@ -51,6 +51,22 @@ function flushAsyncSubmit() {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
+function nodeListLike(items) {
+  const list = {
+    length: items.length,
+    item(index) {
+      return items[index] || null;
+    },
+    *[Symbol.iterator]() {
+      yield* items;
+    },
+  };
+  items.forEach((item, index) => {
+    list[index] = item;
+  });
+  return list;
+}
+
 test('renders title', () => {
   const { container } = mount(baseRequest({ prompt: { title: 'Pick a path', body: null } }));
 
@@ -214,6 +230,9 @@ test('Escape resolves no-answer envelope', () => {
 
 test('Tab cycles through fields and action buttons', () => {
   const { container, document } = mount(baseRequest({ ui: { variant: 'freetext' } }));
+  const root = container.children[0];
+  const querySelectorAll = root.querySelectorAll.bind(root);
+  root.querySelectorAll = (selector) => nodeListLike(querySelectorAll(selector));
   const dismiss = container.querySelector('.aos-gate-dismiss');
   const submit = container.querySelector('.aos-gate-submit');
 


### PR DESCRIPTION
## Summary
- convert the decision-gate focusable NodeList with Array.from before filtering/index lookup
- update the Tab-cycle regression to use a browser-like NodeList without Array methods

## Verification
- node --test tests/toolkit/decision-gate.test.mjs
- git diff --check

## DOX
- Read root AGENTS.md, packages/AGENTS.md, and packages/toolkit/AGENTS.md for the touched toolkit component path. No DOX update needed: this preserves the existing decision-gate keyboard contract.

## Notes
- No live UI proof was run; this is deterministic DOM focus logic covered by local Node tests.