### PR TITLE
Guard config writes from corrupt state

### DIFF
--- a/scripts/aos-config-command.mjs
+++ b/scripts/aos-config-command.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
 import { homedir } from 'node:os';
 
 const DEFAULT_CONFIG = {
@@ -99,17 +99,30 @@ function clone(value) {
 }
 
 async function loadConfig() {
+  const path = configPath();
   try {
-    return JSON.parse(await readFile(configPath(), 'utf8'));
-  } catch {
-    return clone(DEFAULT_CONFIG);
+    return JSON.parse(await readFile(path, 'utf8'));
+  } catch (loadError) {
+    if (loadError?.code === 'ENOENT') return clone(DEFAULT_CONFIG);
+    if (loadError instanceof SyntaxError) {
+      error(`Config file is not valid JSON: ${path}`, 'CONFIG_INVALID');
+    }
+    error(`Unable to read config file: ${path}`, 'CONFIG_READ_FAILED');
   }
 }
 
 async function saveConfig(config) {
   const path = configPath();
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, `${JSON.stringify(config, null, 2)}\n`);
+  const dir = dirname(path);
+  const tempPath = join(dir, `.${basename(path)}.${process.pid}.${Date.now()}.tmp`);
+  await mkdir(dir, { recursive: true });
+  try {
+    await writeFile(tempPath, `${JSON.stringify(config, null, 2)}\n`);
+    await rename(tempPath, path);
+  } catch (saveError) {
+    await rm(tempPath, { force: true }).catch(() => {});
+    error(`Unable to write config file: ${saveError.message}`, 'CONFIG_WRITE_FAILED');
+  }
 }
 
 function ensureVoicePolicies(config) {

--- a/tests/config-surface.sh
+++ b/tests/config-surface.sh
@@ -130,4 +130,21 @@ grep -q '"error": "Unknown argument: extra"' "$STATE_ROOT/config-set-extra.err" 
 }
 pass "config set rejects extra positional args with JSON error"
 
+CORRUPT_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/aos-config-corrupt.XXXXXX")"
+mkdir -p "$CORRUPT_ROOT/repo"
+printf '{not-json\n' >"$CORRUPT_ROOT/repo/config.json"
+if AOS_STATE_ROOT="$CORRUPT_ROOT" ./aos config set voice.enabled false >"$CORRUPT_ROOT/config-set-corrupt.out" 2>"$CORRUPT_ROOT/config-set-corrupt.err"; then
+  fail "config set accepted corrupt existing config"
+fi
+grep -q '"code": "CONFIG_INVALID"' "$CORRUPT_ROOT/config-set-corrupt.err" || {
+  cat "$CORRUPT_ROOT/config-set-corrupt.err"
+  fail "config set corrupt config did not use CONFIG_INVALID"
+}
+grep -q '{not-json' "$CORRUPT_ROOT/repo/config.json" || {
+  cat "$CORRUPT_ROOT/repo/config.json"
+  fail "config set corrupt config overwrote the existing file"
+}
+rm -rf "$CORRUPT_ROOT"
+pass "config set refuses to overwrite corrupt existing config"
+
 echo "config-surface: all checks passed"


### PR DESCRIPTION
## Summary
- treat missing config as defaults, but reject malformed existing config with CONFIG_INVALID
- write config updates through a temp file plus rename instead of overwriting in place
- add config-surface coverage proving corrupt existing config is not replaced by defaults

## Verification
- bash tests/config-surface.sh
- git diff --check
- ./aos help --json
- ./aos help see --json
- ./aos help do --json
- ./aos help show --json

## DOX
- Read root AGENTS.md and scripts/AGENTS.md for the touched script command surface. No DOX update needed: this preserves the existing config command contract while hardening persistence behavior.

## Notes
- This addresses the medium data-loss-on-interrupt config finding from the July 3 review packet.