### PR TITLE
Reap stale workspace mutation locks

### DIFF
--- a/scripts/lib/agent-workspace/store.mjs
+++ b/scripts/lib/agent-workspace/store.mjs
@@ -425,6 +425,32 @@ export function workspaceLockState(dir) {
   return { status: 'locked', path: lockDir, owner };
 }
 
+function ownerPID(lockDir) {
+  try {
+    const owner = JSON.parse(fs.readFileSync(path.join(lockDir, 'owner.json'), 'utf8'));
+    const pid = Number(owner?.pid);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function processIsGone(pid) {
+  try {
+    process.kill(pid, 0);
+    return false;
+  } catch (error) {
+    return error?.code === 'ESRCH';
+  }
+}
+
+function reapStaleWorkspaceLock(lockDir) {
+  const pid = ownerPID(lockDir);
+  if (!pid || !processIsGone(pid)) return false;
+  fs.rmSync(lockDir, { recursive: true, force: true });
+  return true;
+}
+
 export function withWorkspaceLock(workspace, callback, env = process.env, { create = false } = {}) {
   const dir = assertUnderWorkspacesRoot(workspaceDir(workspace, env), env);
   if (create) {
@@ -439,15 +465,25 @@ export function withWorkspaceLock(workspace, callback, env = process.env, { crea
     lockHeld = true;
   } catch (error) {
     if (error?.code === 'EEXIST') {
-      exitAgentWorkspaceError(`Workspace '${workspace}' is locked for mutation: ${lockDir}`, 'AGENT_WORKSPACE_LOCKED', {
-        workspace_id: workspace,
-        lock_path: lockDir,
-      });
-    }
-    if (error?.code === 'ENOENT') {
+      if (reapStaleWorkspaceLock(lockDir)) {
+        try {
+          fs.mkdirSync(lockDir);
+          lockHeld = true;
+        } catch (retryError) {
+          if (retryError?.code !== 'EEXIST') throw retryError;
+        }
+      }
+      if (!lockHeld) {
+        exitAgentWorkspaceError(`Workspace '${workspace}' is locked for mutation: ${lockDir}`, 'AGENT_WORKSPACE_LOCKED', {
+          workspace_id: workspace,
+          lock_path: lockDir,
+        });
+      }
+    } else if (error?.code === 'ENOENT') {
       exitAgentWorkspaceError(`Workspace '${workspace}' not found`, 'WORKSPACE_NOT_FOUND');
+    } else {
+      throw error;
     }
-    throw error;
   }
   try {
     writeJSONAtomic(path.join(lockDir, 'owner.json'), {

--- a/tests/agent-workspace-cleanup.sh
+++ b/tests/agent-workspace-cleanup.sh
@@ -39,6 +39,18 @@ fi
 expect_error_code "AGENT_WORKSPACE_LOCKED" "$LOCKED_DELETE_ERR"
 rm -rf "$WORKSPACE_PATH/.write-lock"
 
+mkdir "$WORKSPACE_PATH/.write-lock"
+cat >"$WORKSPACE_PATH/.write-lock/owner.json" <<'JSON'
+{"pid":999999999,"owner":"stale-test"}
+JSON
+STALE_LOCK_CAPTURE="$TMP_DIR/stale-lock-capture.json"
+./aos see capture browser:todo --save --mode ax --workspace ws1 --name stale-lock-save >"$STALE_LOCK_CAPTURE"
+jq -e '.status == "success" and .workspace_id == "ws1" and .snapshot_id == "stale-lock-save"' "$STALE_LOCK_CAPTURE" >/dev/null \
+    || fail "save did not recover from stale workspace lock: $(cat "$STALE_LOCK_CAPTURE")"
+[[ ! -e "$WORKSPACE_PATH/.write-lock" ]] \
+    || fail "stale workspace lock was not cleaned after recovered save"
+./aos see snapshot delete stale-lock-save --workspace ws1 --i-understand-local-artifacts --json >"$TMP_DIR/stale-lock-delete.json"
+
 SNAPS="$TMP_DIR/snapshots.json"
 ./aos see snapshots --workspace ws1 --json >"$SNAPS"
 jq -e '


### PR DESCRIPTION
## Summary
- detect stale workspace write locks whose recorded owner PID no longer exists
- remove stale lock directories and retry acquisition before mutating workspace state
- keep malformed, missing-owner, active, and permission-denied locks fail-closed
- add cleanup regression coverage for stale-lock recovery

## Verification
- bash tests/agent-workspace-cleanup.sh
- git diff --check

## DOX
- Read root AGENTS.md, scripts/AGENTS.md, and scripts/lib/agent-workspace/AGENTS.md for the touched saved-workspace store path. No DOX update needed: this preserves the workspace mutation-lock contract while adding dead-owner recovery.

## Notes
- This addresses the medium stale `.write-lock` data-loss/liveness finding from the July 3 review packet.