### PR TITLE
Guard focus registry persistence

### DIFF
--- a/scripts/aos-focus-graph.mjs
+++ b/scripts/aos-focus-graph.mjs
@@ -175,11 +175,22 @@ function readRegistry() {
   if (!fs.existsSync(file)) return [];
   const raw = fs.readFileSync(file, 'utf8').trim();
   if (!raw) return [];
-  return JSON.parse(raw);
+  try {
+    const records = JSON.parse(raw);
+    if (!Array.isArray(records)) error(`Focus registry is schema-invalid: ${file}`, 'FOCUS_REGISTRY_INVALID');
+    return records;
+  } catch (parseError) {
+    if (parseError?.code === 'FOCUS_REGISTRY_INVALID') throw parseError;
+    error(`Focus registry is not valid JSON: ${file}`, 'FOCUS_REGISTRY_INVALID');
+  }
 }
 
 function writeRegistry(records) {
-  fs.writeFileSync(registryPath(), `${JSON.stringify(records, null, 2)}\n`);
+  const file = registryPath();
+  const dir = path.dirname(file);
+  const temp = path.join(dir, `.sessions.json.${process.pid}.${Date.now()}.tmp`);
+  fs.writeFileSync(temp, `${JSON.stringify(records, null, 2)}\n`);
+  fs.renameSync(temp, file);
 }
 
 function runPlaywright(session, verb, args = []) {
@@ -214,6 +225,10 @@ function addRegistryRecord(record) {
   writeRegistry(records);
 }
 
+function assertRegistryIDAvailable(id) {
+  if (readRegistry().some((item) => item.id === id)) error(`focus channel '${id}' already exists`, 'DUPLICATE_ID');
+}
+
 function removeRegistryRecord(id) {
   const records = readRegistry();
   if (!records.some((item) => item.id === id)) error(`focus channel '${id}' not found`, 'NOT_FOUND');
@@ -245,7 +260,13 @@ async function focusCreate(args) {
   const windowID = numberAfter(args, '--window');
   if (target && windowID !== undefined) error('--target and --window are mutually exclusive', 'INVALID_ARG');
   if (target) {
-    const url = new URL(target);
+    assertRegistryIDAvailable(id);
+    let url;
+    try {
+      url = new URL(target);
+    } catch {
+      error('invalid --target; expected browser://attach or browser://new', 'INVALID_ARG');
+    }
     if (url.protocol !== 'browser:' || !['attach', 'new'].includes(url.hostname)) {
       error('invalid --target; expected browser://attach or browser://new', 'INVALID_ARG');
     }

--- a/tests/browser/focus-browser.test.sh
+++ b/tests/browser/focus-browser.test.sh
@@ -26,9 +26,21 @@ fi
 grep -q '"code":[[:space:]]*"MISSING_ARG"' "$tmproot/graph-windows-display-missing.err" \
     || { echo "FAIL graph display missing code: $(cat "$tmproot/graph-windows-display-missing.err")" >&2; exit 1; }
 
+if ./aos focus create --id bad-target --target not-a-url 2>"$tmproot/focus-create-bad-target.err"; then
+    echo "FAIL malformed target: expected error" >&2; exit 1
+fi
+grep -q '"code":[[:space:]]*"INVALID_ARG"' "$tmproot/focus-create-bad-target.err" \
+    || { echo "FAIL malformed target code: $(cat "$tmproot/focus-create-bad-target.err")" >&2; exit 1; }
+
 # Case 1: create attach extension
 out=$(./aos focus create --id test-attach --target browser://attach --extension 2>&1)
 echo "$out" | grep -q '"status":[[:space:]]*"success"' || { echo "FAIL create: $out" >&2; exit 1; }
+
+if ./aos focus create --id test-attach --target browser://new 2>"$tmproot/focus-create-duplicate.err"; then
+    echo "FAIL duplicate id: expected error" >&2; exit 1
+fi
+grep -q '"code":[[:space:]]*"DUPLICATE_ID"' "$tmproot/focus-create-duplicate.err" \
+    || { echo "FAIL duplicate id code: $(cat "$tmproot/focus-create-duplicate.err")" >&2; exit 1; }
 
 # Case 2: list includes browser kind
 out=$(./aos focus list)
@@ -64,6 +76,14 @@ echo "$out" | grep -q '"status":[[:space:]]*"success"' || { echo "FAIL launched:
 out=$(./aos focus list)
 echo "$out" | jq -e '[.channels[]? // .data.channels[]? | select(.id == "test-attach")] | length == 0' >/dev/null \
     || { echo "FAIL remove: $out" >&2; exit 1; }
+
+printf '{not-json\n' > "$tmproot/repo/browser/sessions.json"
+if ./aos focus list 2>"$tmproot/focus-list-corrupt.err"; then
+    echo "FAIL corrupt registry: expected error" >&2; exit 1
+fi
+grep -q '"code":[[:space:]]*"FOCUS_REGISTRY_INVALID"' "$tmproot/focus-list-corrupt.err" \
+    || { echo "FAIL corrupt registry code: $(cat "$tmproot/focus-list-corrupt.err")" >&2; exit 1; }
+printf '[]\n' > "$tmproot/repo/browser/sessions.json"
 
 # Case 5: --target and --window mutually exclusive
 if ./aos focus create --id oops --target browser://new --window 12345 2>/dev/null; then


### PR DESCRIPTION
## Summary
- reject corrupt browser focus registry state with structured FOCUS_REGISTRY_INVALID errors
- write focus registry updates through a temp file plus rename
- validate malformed browser targets as INVALID_ARG
- reject duplicate browser focus IDs before launching Playwright

## Verification
- bash tests/browser/focus-browser.test.sh
- git diff --check

## DOX
- Read root AGENTS.md and scripts/AGENTS.md for the touched focus/graph command script. No DOX update needed: this preserves the existing command surface while hardening local registry persistence and validation.

## Notes
- This addresses the medium focus registry persistence finding and the adjacent malformed target validation issue from the July 3 review packet.