### PR TITLE
Write checkpoint annotations atomically

### DIFF
--- a/scripts/workbench-human-checkpoint-annotate.mjs
+++ b/scripts/workbench-human-checkpoint-annotate.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import {
   addMarkdownWorkbenchAnnotation,
   clearMarkdownWorkbenchAnnotations,
@@ -64,34 +64,57 @@ function readAnnotationsFromFile(filePath) {
 
 function writeRecord(record, output) {
   const json = `${JSON.stringify(record, null, 2)}\n`;
-  if (output) fs.writeFileSync(path.resolve(repoRoot, output), json);
+  if (output) writeFileAtomic(path.resolve(repoRoot, output), json);
   else process.stdout.write(json);
 }
 
-const args = parseArgs(process.argv.slice(2));
-if (args.help || !args.checkpoint) {
-  usage();
-  process.exit(args.help ? 0 : 1);
-}
-
-let checkpoint = JSON.parse(fs.readFileSync(path.resolve(repoRoot, args.checkpoint), 'utf8'));
-
-if (args.clear) checkpoint = clearMarkdownWorkbenchAnnotations(checkpoint, { actor: 'operator-cli' });
-
-for (const raw of args.annotationJson) {
-  checkpoint = addMarkdownWorkbenchAnnotation(checkpoint, JSON.parse(raw));
-}
-for (const filePath of args.annotationFiles.filter(Boolean)) {
-  for (const annotation of readAnnotationsFromFile(filePath)) {
-    checkpoint = addMarkdownWorkbenchAnnotation(checkpoint, annotation);
+export function writeFileAtomic(filePath, contents) {
+  const target = path.resolve(filePath);
+  const dir = path.dirname(target);
+  const temp = path.join(dir, `.${path.basename(target)}.${process.pid}.${Date.now()}.tmp`);
+  try {
+    fs.writeFileSync(temp, contents);
+    fs.renameSync(temp, target);
+  } catch (error) {
+    try {
+      fs.rmSync(temp, { force: true });
+    } catch {
+      // Preserve the original write failure.
+    }
+    throw error;
   }
 }
-for (const id of args.resolve.filter(Boolean)) {
-  checkpoint = resolveMarkdownWorkbenchAnnotation(checkpoint, id, 'resolved');
-}
-for (const id of args.reject.filter(Boolean)) {
-  checkpoint = resolveMarkdownWorkbenchAnnotation(checkpoint, id, 'rejected');
-}
-if (args.commit) checkpoint = commitMarkdownWorkbenchAnnotations(checkpoint);
 
-writeRecord(checkpoint, args.output);
+function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (args.help || !args.checkpoint) {
+    usage();
+    process.exit(args.help ? 0 : 1);
+  }
+
+  let checkpoint = JSON.parse(fs.readFileSync(path.resolve(repoRoot, args.checkpoint), 'utf8'));
+
+  if (args.clear) checkpoint = clearMarkdownWorkbenchAnnotations(checkpoint, { actor: 'operator-cli' });
+
+  for (const raw of args.annotationJson) {
+    checkpoint = addMarkdownWorkbenchAnnotation(checkpoint, JSON.parse(raw));
+  }
+  for (const filePath of args.annotationFiles.filter(Boolean)) {
+    for (const annotation of readAnnotationsFromFile(filePath)) {
+      checkpoint = addMarkdownWorkbenchAnnotation(checkpoint, annotation);
+    }
+  }
+  for (const id of args.resolve.filter(Boolean)) {
+    checkpoint = resolveMarkdownWorkbenchAnnotation(checkpoint, id, 'resolved');
+  }
+  for (const id of args.reject.filter(Boolean)) {
+    checkpoint = resolveMarkdownWorkbenchAnnotation(checkpoint, id, 'rejected');
+  }
+  if (args.commit) checkpoint = commitMarkdownWorkbenchAnnotations(checkpoint);
+
+  writeRecord(checkpoint, args.output);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main();
+}

--- a/tests/workbench-human-checkpoint-annotate.test.mjs
+++ b/tests/workbench-human-checkpoint-annotate.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import { writeFileAtomic } from '../scripts/workbench-human-checkpoint-annotate.mjs';
+
+test('checkpoint annotate atomic writer replaces files through a temporary sibling', () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'aos-checkpoint-annotate-'));
+  try {
+    const file = path.join(root, 'checkpoint.json');
+    writeFileSync(file, '{"status":"old"}\n');
+
+    writeFileAtomic(file, '{"status":"new"}\n');
+
+    assert.equal(readFileSync(file, 'utf8'), '{"status":"new"}\n');
+    assert.deepEqual(readdirSync(root).sort(), ['checkpoint.json']);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('checkpoint annotate atomic writer preserves original file when rename fails', () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'aos-checkpoint-annotate-'));
+  const originalRename = fs.renameSync;
+  try {
+    const file = path.join(root, 'checkpoint.json');
+    writeFileSync(file, '{"status":"old"}\n');
+    fs.renameSync = () => {
+      throw new Error('simulated rename failure');
+    };
+
+    assert.throws(() => writeFileAtomic(file, '{"status":"new"}\n'), /simulated rename failure/);
+
+    assert.equal(readFileSync(file, 'utf8'), '{"status":"old"}\n');
+    assert.deepEqual(readdirSync(root).sort(), ['checkpoint.json']);
+  } finally {
+    fs.renameSync = originalRename;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('checkpoint annotate script can be imported without running the CLI', () => {
+  const result = spawnSync(process.execPath, ['-e', `
+    import('./scripts/workbench-human-checkpoint-annotate.mjs')
+      .then((module) => {
+        if (typeof module.writeFileAtomic !== 'function') process.exit(2);
+      })
+      .catch(() => process.exit(1));
+  `], {
+    cwd: path.resolve(import.meta.dirname, '..'),
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+});


### PR DESCRIPTION
## Summary
- write checkpoint annotation outputs through a same-directory temporary file plus rename
- keep the original checkpoint intact if replacement fails
- wrap the CLI entrypoint so the atomic writer can be imported and tested directly

## Verification
- node --test tests/workbench-human-checkpoint-annotate.test.mjs
- manual CLI smoke: in-place `workbench-human-checkpoint-annotate.mjs --checkpoint X --output X` on a valid checkpoint
- git diff --check

## DOX
- Read root AGENTS.md and scripts/AGENTS.md for the touched script command surface. No DOX update needed: this preserves the checkpoint annotation workflow while hardening persistence behavior.

## Notes
- This addresses the medium non-atomic checkpoint overwrite finding from the July 3 review packet.