### PR TITLE
Drain runProcess pipes before waiting

### DIFF
--- a/src/shared/helpers.swift
+++ b/src/shared/helpers.swift
@@ -272,6 +272,25 @@ struct ProcessOutput {
     let stderr: String
 }
 
+private final class ProcessPipeBuffer {
+    private let lock = NSLock()
+    private var data = Data()
+
+    func readToEnd(from handle: FileHandle) {
+        let output = handle.readDataToEndOfFile()
+        lock.lock()
+        data = output
+        lock.unlock()
+    }
+
+    func value() -> Data {
+        lock.lock()
+        let output = data
+        lock.unlock()
+        return output
+    }
+}
+
 @discardableResult
 func runProcess(_ executable: String, arguments: [String], environment: [String: String]? = nil) -> ProcessOutput {
     let process = Process()
@@ -288,19 +307,31 @@ func runProcess(_ executable: String, arguments: [String], environment: [String:
     }
     process.standardOutput = stdout
     process.standardError = stderr
+    let stdoutBuffer = ProcessPipeBuffer()
+    let stderrBuffer = ProcessPipeBuffer()
+    let pipeReaders = DispatchGroup()
 
     do {
         try process.run()
+        pipeReaders.enter()
+        DispatchQueue.global(qos: .utility).async {
+            stdoutBuffer.readToEnd(from: stdout.fileHandleForReading)
+            pipeReaders.leave()
+        }
+        pipeReaders.enter()
+        DispatchQueue.global(qos: .utility).async {
+            stderrBuffer.readToEnd(from: stderr.fileHandleForReading)
+            pipeReaders.leave()
+        }
         process.waitUntilExit()
+        pipeReaders.wait()
     } catch {
         return ProcessOutput(exitCode: 1, stdout: "", stderr: "\(error)")
     }
 
-    let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
-    let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
     return ProcessOutput(
         exitCode: process.terminationStatus,
-        stdout: String(data: stdoutData, encoding: .utf8) ?? "",
-        stderr: String(data: stderrData, encoding: .utf8) ?? ""
+        stdout: String(data: stdoutBuffer.value(), encoding: .utf8) ?? "",
+        stderr: String(data: stderrBuffer.value(), encoding: .utf8) ?? ""
     )
 }

--- a/tests/run-process-drain-contract.test.mjs
+++ b/tests/run-process-drain-contract.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+function source(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+function functionBody(swiftSource, signature) {
+  const start = swiftSource.indexOf(signature);
+  assert.notEqual(start, -1, `${signature} not found`);
+  const brace = swiftSource.indexOf('{', start);
+  assert.notEqual(brace, -1, `${signature} body not found`);
+  let depth = 0;
+  for (let i = brace; i < swiftSource.length; i += 1) {
+    if (swiftSource[i] === '{') depth += 1;
+    else if (swiftSource[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return swiftSource.slice(brace + 1, i);
+    }
+  }
+  throw new Error(`${signature} body did not close`);
+}
+
+test('runProcess drains stdout and stderr before waiting for child exit', () => {
+  const body = functionBody(source('src/shared/helpers.swift'), 'func runProcess(');
+  const group = body.indexOf('let pipeReaders = DispatchGroup()');
+  const run = body.indexOf('try process.run()');
+  const stdoutAsync = body.indexOf('stdoutBuffer.readToEnd');
+  const stderrAsync = body.indexOf('stderrBuffer.readToEnd');
+  const waitExit = body.indexOf('process.waitUntilExit()');
+  const waitReaders = body.indexOf('pipeReaders.wait()');
+  const oldPattern = body.indexOf('let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()');
+
+  assert.ok(group >= 0, 'runProcess should coordinate pipe readers with a DispatchGroup');
+  assert.ok(run >= 0, 'runProcess should still start the child process');
+  assert.ok(stdoutAsync > run, 'stdout drain should start after process launch');
+  assert.ok(stderrAsync > run, 'stderr drain should start after process launch');
+  assert.ok(waitExit > stdoutAsync, 'process exit wait should happen after stdout drain starts');
+  assert.ok(waitExit > stderrAsync, 'process exit wait should happen after stderr drain starts');
+  assert.ok(waitReaders > waitExit, 'runProcess should wait for pipe readers before decoding output');
+  assert.equal(oldPattern, -1, 'runProcess must not wait for exit before draining stdout');
+});


### PR DESCRIPTION
## Summary
- start stdout/stderr pipe drains immediately after process launch
- wait for process exit and reader completion before decoding output
- add a source-level regression preventing the wait-before-drain pattern

## Verification
- `node --test tests/run-process-drain-contract.test.mjs`
- `bash build.sh --no-restart`
- `git diff --check`

## DOX
- Read root `AGENTS.md`, `src/AGENTS.md`, and `tests/AGENTS.md`; no DOX update needed because this preserves the shared helper contract and adds only focused regression coverage.

## Notes
- Addresses the medium `runProcess` pipe deadlock finding from the July 3 review packet.