### PR TITLE
Avoid double-closing event stream fds

### DIFF
--- a/shared/swift/ipc/event-stream.swift
+++ b/shared/swift/ipc/event-stream.swift
@@ -78,6 +78,14 @@ class DaemonEventStream {
         if currentFD >= 0 { close(currentFD) }
     }
 
+    private func clearConnectedFD(_ expectedFD: Int32) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard fd == expectedFD else { return false }
+        fd = -1
+        return true
+    }
+
     var isRunning: Bool {
         lock.lock()
         defer { lock.unlock() }
@@ -121,8 +129,9 @@ class DaemonEventStream {
 
             guard session.sendAndReceive(subscribeMessage) != nil else {
                 fputs("event-stream: subscribe failed, retrying...\n", stderr)
-                close(sockFD)
-                lock.lock(); fd = -1; lock.unlock()
+                if clearConnectedFD(sockFD) {
+                    close(sockFD)
+                }
                 usleep(UInt32(backoff * 1_000_000))
                 continue  // defer fires here: session.fd = -1 (already -1 is fine)
             }
@@ -141,10 +150,9 @@ class DaemonEventStream {
             readLoop(sockFD)
 
             // Connection lost
-            close(sockFD)
-            lock.lock()
-            fd = -1
-            lock.unlock()
+            if clearConnectedFD(sockFD) {
+                close(sockFD)
+            }
 
             onDisconnect?()
             fputs("event-stream: connection lost, reconnecting...\n", stderr)

--- a/tests/event-stream-fd-ownership-contract.test.mjs
+++ b/tests/event-stream-fd-ownership-contract.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+function source(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+function methodBody(swiftSource, signature) {
+  const start = swiftSource.indexOf(signature);
+  assert.notEqual(start, -1, `${signature} not found`);
+  const brace = swiftSource.indexOf('{', start);
+  assert.notEqual(brace, -1, `${signature} body not found`);
+  let depth = 0;
+  for (let i = brace; i < swiftSource.length; i += 1) {
+    if (swiftSource[i] === '{') depth += 1;
+    else if (swiftSource[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return swiftSource.slice(brace + 1, i);
+    }
+  }
+  throw new Error(`${signature} body did not close`);
+}
+
+test('DaemonEventStream subscriber loop only closes fd it still owns', () => {
+  const swift = source('shared/swift/ipc/event-stream.swift');
+  const helper = methodBody(swift, 'private func clearConnectedFD(');
+  const loop = methodBody(swift, 'private func subscriberLoop()');
+  const stop = methodBody(swift, 'func stop()');
+
+  assert.match(helper, /guard fd == expectedFD else \{ return false \}/);
+  assert.match(helper, /fd = -1/);
+
+  assert.match(stop, /let currentFD = fd/);
+  assert.match(stop, /fd = -1/);
+  assert.match(stop, /close\(currentFD\)/);
+
+  assert.match(loop, /if clearConnectedFD\(sockFD\) \{\s*close\(sockFD\)\s*\}/);
+  assert.doesNotMatch(loop, /\/\/ Connection lost\s*close\(sockFD\)/);
+  assert.doesNotMatch(loop, /lock\.lock\(\);\s*fd = -1;\s*lock\.unlock\(\)/);
+});


### PR DESCRIPTION
## Summary
- add an event-stream fd ownership helper that clears only the currently registered fd
- avoid closing `sockFD` after `stop()` has already cleared and closed it
- cover the lifecycle contract with a focused source-level regression

## Verification
- `node --test tests/event-stream-fd-ownership-contract.test.mjs`
- `bash build.sh --no-restart --force` (passes; existing Swift warnings remain in canvas targeting and deprecated speech APIs)
- `git diff --check`

## DOX
- Read root `AGENTS.md`, `shared/AGENTS.md`, and `tests/AGENTS.md`; no DOX update needed because this preserves the shared IPC helper contract and adds focused regression coverage.

## Notes
- Addresses the medium double-close subscriber fd lifecycle finding from the July 3 review packet.