### PR TITLE
Handle gate dismiss failures during settlement

### DIFF
--- a/packages/daemon/gate/index.js
+++ b/packages/daemon/gate/index.js
@@ -112,34 +112,35 @@ export function createGateService({
     const elapsedMs = Date.now() - entry.startedAt;
     try {
       await entry.receptor.dismiss(entry.handle);
-    } finally {
-      log('gate.resolved', { gate_id: id, resolution, elapsed_ms: elapsedMs });
-      if (recordStore) {
-        try {
-          await recordStore.append(createGateRecord({
-            request: entry.request,
-            receptorName: entry.receptor.constructor?.name ?? null,
-            presentedAt: entry.presentedAt,
-            resolvedAt,
-            elapsedMs,
-            resolution,
-            value,
-            error: rejectError,
-          }));
-        } catch (error) {
-          const recordError = createGateError(
-            GATE_ERROR_CODES.recordWriteFailed,
-            `failed to write gate record: ${error.message}`,
-            { cause: error },
-          );
-          if (rejectError) entry.reject(rejectError);
-          else entry.reject(recordError);
-          return;
-        }
-      }
-      if (rejectError) entry.reject(rejectError);
-      else entry.resolve(value);
+    } catch (error) {
+      log('gate.dismiss_failed', { gate_id: id, error: error instanceof Error ? error.message : String(error) });
     }
+    log('gate.resolved', { gate_id: id, resolution, elapsed_ms: elapsedMs });
+    if (recordStore) {
+      try {
+        await recordStore.append(createGateRecord({
+          request: entry.request,
+          receptorName: entry.receptor.constructor?.name ?? null,
+          presentedAt: entry.presentedAt,
+          resolvedAt,
+          elapsedMs,
+          resolution,
+          value,
+          error: rejectError,
+        }));
+      } catch (error) {
+        const recordError = createGateError(
+          GATE_ERROR_CODES.recordWriteFailed,
+          `failed to write gate record: ${error.message}`,
+          { cause: error },
+        );
+        if (rejectError) entry.reject(rejectError);
+        else entry.reject(recordError);
+        return;
+      }
+    }
+    if (rejectError) entry.reject(rejectError);
+    else entry.resolve(value);
   }
 
   const callbacks = {

--- a/tests/daemon/gate-service.test.mjs
+++ b/tests/daemon/gate-service.test.mjs
@@ -25,6 +25,7 @@ class ManualReceptor extends GateReceptor {
     super(callbacks);
     this.handles = [];
     this.dismissed = [];
+    this.dismissError = null;
   }
 
   async present(gateRequest) {
@@ -35,6 +36,7 @@ class ManualReceptor extends GateReceptor {
 
   async dismiss(handle) {
     this.dismissed.push(handle?.id);
+    if (this.dismissError) throw this.dismissError;
   }
 }
 
@@ -140,6 +142,33 @@ test('ask resolves no-answer envelope on service timeout', async () => {
   assert.deepEqual(await promise, { result: null, status: 'timeout' });
   assert.equal(service.pending.size, 0);
   assert.deepEqual(receptor.dismissed, ['gate-timeout']);
+});
+
+test('settle logs dismiss failures without rejecting the settlement task', async () => {
+  const harness = timeoutHarness();
+  const events = [];
+  let receptor;
+  const service = createGateService({
+    receptorFactory(callbacks) {
+      receptor = new ManualReceptor(callbacks);
+      return receptor;
+    },
+    logger(event) {
+      events.push(event);
+    },
+    ...harness,
+  });
+
+  const promise = service.ask(request('gate-dismiss-failure'));
+  await new Promise((resolve) => setImmediate(resolve));
+  receptor.dismissError = new Error('canvas already removed');
+
+  await assert.doesNotReject(() => service.resolve('gate-dismiss-failure', { decision: true }));
+  assert.deepEqual(await promise, { decision: true });
+  assert.equal(service.pending.size, 0);
+  assert.deepEqual(receptor.dismissed, ['gate-dismiss-failure']);
+  assert.equal(events.some((event) => event.event === 'gate.dismiss_failed'), true);
+  assert.equal(events.some((event) => event.event === 'gate.resolved'), true);
 });
 
 test('ask resolves no-answer envelope on human dismissal', async () => {


### PR DESCRIPTION
## Summary
- make gate receptor dismissal best-effort during settlement
- log dismiss failures without rejecting the fire-and-forget settlement task
- add a deterministic regression for canvas-already-removed dismissal failures

## Verification
- `node --test tests/daemon/gate-service.test.mjs`
- `git diff --check`

## DOX
- Read root `AGENTS.md`, `packages/AGENTS.md`, and `tests/AGENTS.md`; no DOX update needed because this preserves gate behavior and only hardens lifecycle cleanup.

## Notes
- Addresses the medium daemon gate `settle()` unhandled rejection lifecycle finding from the July 3 review packet.