### PR TITLE
Reject host client calls on socket close

### DIFF
--- a/packages/host/src/sdk-client.ts
+++ b/packages/host/src/sdk-client.ts
@@ -17,15 +17,40 @@ export class HostClient {
     this.socketPath = socketPath;
   }
 
+  private rejectPending(error: Error): void {
+    for (const handler of this.pending.values()) {
+      handler.reject(error);
+    }
+    this.pending.clear();
+  }
+
   connect(): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.socket = net.createConnection(this.socketPath);
+      const socket = net.createConnection(this.socketPath);
+      this.socket = socket;
       let buffer = '';
 
-      this.socket.on('connect', resolve);
-      this.socket.once('error', reject);
+      const onConnectError = (error: Error) => {
+        if (this.socket === socket) this.socket = null;
+        reject(error);
+      };
 
-      this.socket.on('data', (data) => {
+      socket.once('error', onConnectError);
+      socket.once('connect', () => {
+        socket.off('error', onConnectError);
+        resolve();
+      });
+
+      socket.on('error', (error) => {
+        this.rejectPending(error);
+      });
+
+      socket.on('close', () => {
+        this.rejectPending(new Error('Host socket closed'));
+        if (this.socket === socket) this.socket = null;
+      });
+
+      socket.on('data', (data) => {
         buffer += data.toString();
         const lines = buffer.split('\n');
         buffer = lines.pop() ?? '';
@@ -53,6 +78,7 @@ export class HostClient {
   }
 
   disconnect(): void {
+    this.rejectPending(new Error('Host socket disconnected'));
     this.socket?.destroy();
     this.socket = null;
   }

--- a/packages/host/test/sdk-client.test.ts
+++ b/packages/host/test/sdk-client.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { HostClient } from '../src/sdk-client.ts';
+
+function nextTick(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('HostClient', () => {
+  const sockets: net.Server[] = [];
+  const connections: net.Socket[] = [];
+  const paths: string[] = [];
+
+  afterEach(async () => {
+    for (const socket of connections.splice(0)) {
+      socket.destroy();
+    }
+    await Promise.all(sockets.splice(0).map((server) => new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    })));
+    for (const socketPath of paths.splice(0)) {
+      try { fs.unlinkSync(socketPath); } catch {}
+    }
+  });
+
+  it('rejects pending calls when the socket closes without a response', async () => {
+    const socketPath = path.join(os.tmpdir(), `aos-host-client-${process.pid}-${Date.now()}.sock`);
+    paths.push(socketPath);
+
+    const server = net.createServer((socket) => {
+      connections.push(socket);
+      socket.once('data', () => socket.destroy());
+    });
+    sockets.push(server);
+    await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+    const client = new HostClient(socketPath);
+    await client.connect();
+    const pending = client.listTools();
+    await nextTick();
+
+    await assert.rejects(
+      () => pending,
+      /Host socket closed/,
+    );
+  });
+
+  it('rejects pending calls on explicit disconnect', async () => {
+    const socketPath = path.join(os.tmpdir(), `aos-host-client-disconnect-${process.pid}-${Date.now()}.sock`);
+    paths.push(socketPath);
+
+    const server = net.createServer((socket) => {
+      connections.push(socket);
+    });
+    sockets.push(server);
+    await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+
+    const client = new HostClient(socketPath);
+    await client.connect();
+    const pending = client.listSessions();
+    client.disconnect();
+
+    await assert.rejects(
+      () => pending,
+      /Host socket disconnected/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- reject all pending HostClient calls when the socket errors or closes after connect
- reject pending calls on explicit disconnect
- add package-local socket lifecycle regressions for close-without-response and disconnect

## Verification
- `node --test --experimental-strip-types packages/host/test/sdk-client.test.ts`
- `cd packages/host && npm run check`
- `git diff --check`

## DOX
- Read root `AGENTS.md`, `packages/AGENTS.md`, and `tests/AGENTS.md`; no DOX update needed because this preserves the host client contract and hardens socket lifecycle behavior.

## Notes
- Addresses the medium host `sdk-client.ts` socket close/error pending-promise hang from the July 3 review packet.