### PR TITLE
Reject gateway SDK calls on socket close

### DIFF
--- a/packages/gateway/sdk/aos-sdk.js
+++ b/packages/gateway/sdk/aos-sdk.js
@@ -7,6 +7,13 @@ let _conn = null;
 let _reqId = 0;
 const _pending = new Map();
 
+function rejectPending(error) {
+  for (const pending of _pending.values()) {
+    pending.reject(error);
+  }
+  _pending.clear();
+}
+
 function getConnection() {
   if (_conn) return _conn;
   const sockPath = globalThis.__aos_config?.gatewaySocket;
@@ -21,20 +28,33 @@ function getConnection() {
       buffer = buffer.slice(idx + 1);
       try {
         const resp = JSON.parse(line);
-        const resolve = _pending.get(resp.id);
-        if (resolve) { _pending.delete(resp.id); resolve(resp.result); }
+        const pending = _pending.get(resp.id);
+        if (pending) {
+          _pending.delete(resp.id);
+          pending.resolve(resp.result);
+        }
       } catch {}
     }
+  });
+  _conn.on('error', (error) => {
+    rejectPending(error);
+  });
+  _conn.on('close', () => {
+    rejectPending(new Error('AOS SDK socket closed'));
+    _conn = null;
   });
   return _conn;
 }
 
 function call(domain, method, params) {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const id = String(++_reqId);
-    _pending.set(id, resolve);
+    _pending.set(id, { resolve, reject });
     const conn = getConnection();
-    conn.write(JSON.stringify({ id, domain, method, params }) + '\n');
+    conn.write(JSON.stringify({ id, domain, method, params }) + '\n', (error) => {
+      if (!error) return;
+      if (_pending.delete(id)) reject(error);
+    });
   });
 }
 
@@ -73,4 +93,8 @@ const aos = {
 
 globalThis.aos = aos;
 globalThis.__aos_call = call;
-globalThis.__aos_cleanup = () => { if (_conn) _conn.destroy(); };
+globalThis.__aos_cleanup = () => {
+  rejectPending(new Error('AOS SDK cleanup'));
+  if (_conn) _conn.destroy();
+  _conn = null;
+};

--- a/tests/gateway-sdk-socket-lifecycle.test.mjs
+++ b/tests/gateway-sdk-socket-lifecycle.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+const repoRoot = path.resolve(import.meta.dirname, '..');
+const sdkPath = path.join(repoRoot, 'packages/gateway/sdk/aos-sdk.js');
+
+function runNode(scriptPath, timeoutMs = 2000) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [scriptPath], { timeout: timeoutMs });
+    let stderr = '';
+    child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+    child.on('error', reject);
+    child.on('close', (code, signal) => {
+      if (code === 0) resolve({ stderr });
+      else reject(new Error(`node exited code=${code} signal=${signal} stderr=${stderr}`));
+    });
+  });
+}
+
+test('gateway SDK rejects pending calls when the socket closes without a response', async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'aos-gateway-sdk-'));
+  const socketPath = path.join(dir, 'gateway.sock');
+  const resultPath = path.join(dir, 'result.json');
+  const scriptPath = path.join(dir, 'sdk-close-test.cjs');
+  const sdkSource = readFileSync(sdkPath, 'utf8');
+  const server = createServer((socket) => {
+    socket.once('data', () => socket.destroy());
+  });
+
+  try {
+    await new Promise((resolve) => server.listen(socketPath, resolve));
+    writeFileSync(scriptPath, `
+globalThis.__aos_config = { gatewaySocket: ${JSON.stringify(socketPath)} };
+${sdkSource}
+(async () => {
+  try {
+    await globalThis.aos.doctor();
+    require('node:fs').writeFileSync(${JSON.stringify(resultPath)}, JSON.stringify({ ok: true }));
+  } catch (error) {
+    require('node:fs').writeFileSync(${JSON.stringify(resultPath)}, JSON.stringify({ ok: false, error: error.message }));
+  } finally {
+    globalThis.__aos_cleanup?.();
+  }
+})();
+`);
+
+    await runNode(scriptPath);
+
+    assert.deepEqual(JSON.parse(readFileSync(resultPath, 'utf8')), {
+      ok: false,
+      error: 'AOS SDK socket closed',
+    });
+  } finally {
+    await new Promise((resolve) => server.close(() => resolve()));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- reject all pending injected gateway SDK calls when the socket errors or closes
- clear the cached SDK connection after close and cleanup
- add a plain Node regression that embeds the real SDK and verifies close-without-response settles

## Verification
- `node --test tests/gateway-sdk-socket-lifecycle.test.mjs`
- `cd packages/gateway && npm run build`
- `git diff --check`

## Notes
- `cd packages/gateway && node --test --loader ts-node/esm test/doctor.test.ts` currently fails before test bodies under Node v24.16.0 with the existing `ts-node/esm` loader, so the focused regression avoids that loader and exercises the actual injected SDK source in a `.cjs` wrapper.
- Addresses the medium gateway SDK socket close/error pending-promise hang from the July 3 review packet.

## DOX
- Read root `AGENTS.md`, `packages/AGENTS.md`, and `tests/AGENTS.md`; no DOX update needed because this preserves the gateway SDK contract and hardens socket lifecycle behavior.