### PR TITLE
Constrain gateway script registry names

### DIFF
--- a/packages/gateway/src/scripts.ts
+++ b/packages/gateway/src/scripts.ts
@@ -14,14 +14,27 @@ export interface ScriptMeta {
   note?: string;
 }
 
+const SCRIPT_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
 export class ScriptRegistry {
-  constructor(private dir: string) {
+  private dir: string;
+
+  constructor(dir: string) {
+    this.dir = dir;
     mkdirSync(dir, { recursive: true });
   }
 
+  private safeName(name: string): string {
+    if (typeof name !== 'string' || !SCRIPT_NAME_PATTERN.test(name)) {
+      throw new Error('Invalid script name. Use letters, numbers, dots, underscores, or dashes.');
+    }
+    return name;
+  }
+
   save(name: string, script: string, meta: ScriptMeta, overwrite = false, sessionId?: string) {
-    const scriptPath = join(this.dir, `${name}.ts`);
-    const metaPath = join(this.dir, `${name}.meta.json`);
+    const safeName = this.safeName(name);
+    const scriptPath = join(this.dir, `${safeName}.ts`);
+    const metaPath = join(this.dir, `${safeName}.meta.json`);
 
     if (existsSync(scriptPath) && !overwrite) {
       throw new Error(`Script "${name}" already exists. Use overwrite: true to update.`);
@@ -38,7 +51,7 @@ export class ScriptRegistry {
       changelog = existing.changelog ?? [];
       createdAt = existing.createdAt ?? createdAt;
       createdBy = existing.createdBy ?? createdBy;
-      renameSync(scriptPath, join(this.dir, `${name}.prev.ts`));
+      renameSync(scriptPath, join(this.dir, `${safeName}.prev.ts`));
     }
 
     const now = new Date().toISOString();
@@ -49,7 +62,7 @@ export class ScriptRegistry {
     if (changelog.length > 20) changelog = changelog.slice(-20);
 
     const metaJson = {
-      name, description: meta.description, intent: meta.intent,
+      name: safeName, description: meta.description, intent: meta.intent,
       portable: meta.portable ?? true, version,
       parameters: meta.parameters,
       createdBy, createdAt,
@@ -62,7 +75,8 @@ export class ScriptRegistry {
   }
 
   load(name: string): string {
-    const p = join(this.dir, `${name}.ts`);
+    const safeName = this.safeName(name);
+    const p = join(this.dir, `${safeName}.ts`);
     if (!existsSync(p)) throw new Error(`Script "${name}" not found.`);
     return readFileSync(p, 'utf-8');
   }

--- a/packages/gateway/test/scripts.test.ts
+++ b/packages/gateway/test/scripts.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { ScriptRegistry } from '../src/scripts.js';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -47,5 +47,19 @@ describe('ScriptRegistry', () => {
     const filtered = registry.list({ intent: 'perception' });
     assert.ok(filtered.some(s => s.name === 'percep'));
     assert.ok(!filtered.some(s => s.intent !== 'perception'));
+  });
+
+  it('rejects traversal and absolute script names without writing outside the script dir', () => {
+    const outside = join(dir, '..', 'escape.ts');
+
+    assert.throws(() => {
+      registry.save('../escape', 'return 1;', { description: 'bad', intent: 'mixed' });
+    }, /Invalid script name/);
+    assert.throws(() => {
+      registry.save('/tmp/escape', 'return 1;', { description: 'bad', intent: 'mixed' });
+    }, /Invalid script name/);
+    assert.throws(() => registry.load('../escape'), /Invalid script name/);
+
+    assert.equal(existsSync(outside), false);
   });
 });

--- a/tests/gateway-script-registry-paths.test.mjs
+++ b/tests/gateway-script-registry-paths.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+import { ScriptRegistry } from '../packages/gateway/src/scripts.ts';
+
+test('gateway ScriptRegistry rejects traversal names without writing outside scripts dir', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'aos-gateway-scripts-'));
+  const registry = new ScriptRegistry(dir);
+  const outside = path.join(dir, '..', 'escape.ts');
+
+  try {
+    assert.throws(() => {
+      registry.save('../escape', 'return 1;', { description: 'bad', intent: 'mixed' });
+    }, /Invalid script name/);
+    assert.throws(() => {
+      registry.save('/tmp/escape', 'return 1;', { description: 'bad', intent: 'mixed' });
+    }, /Invalid script name/);
+    assert.throws(() => registry.load('../escape'), /Invalid script name/);
+
+    assert.equal(existsSync(outside), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- reject gateway script names outside a simple file-name alphabet before save/load
- keep saved metadata on the sanitized script name
- add negative traversal/absolute-name tests for the package test and a plain Node root regression

## Verification
- `node --test --experimental-strip-types tests/gateway-script-registry-paths.test.mjs`
- `cd packages/gateway && npm run build`
- `git diff --check`

## Notes
- `cd packages/gateway && node --test --loader ts-node/esm test/scripts.test.ts` currently fails before test bodies under Node v24.16.0 with the existing package `ts-node/esm` loader, matching the earlier unrelated `doctor.test.ts` probe. The runnable root regression imports the source with Node strip-types mode.
- Addresses the medium gateway scripts path traversal finding from the July 3 review packet.

## DOX
- Read root `AGENTS.md`, `packages/AGENTS.md`, and `tests/AGENTS.md`; no DOX update needed because this fixes an internal gateway security boundary and adds focused regression coverage.