### PR TITLE
Bound content port config values

### DIFF
--- a/scripts/aos-config-command.mjs
+++ b/scripts/aos-config-command.mjs
@@ -309,7 +309,7 @@ function setConfigValue(config, key, value) {
   else if (key === 'content.port') {
     ensureContent(config);
     const parsed = Number(value);
-    if (!Number.isInteger(parsed) || parsed < 0) throw new Error('content.port must be a non-negative integer');
+    if (!Number.isInteger(parsed) || parsed < 0 || parsed > 65535) throw new Error('content.port must be an integer from 0 to 65535');
     config.content.port = parsed;
   } else if (key.startsWith('content.roots.')) {
     ensureContent(config);

--- a/tests/config-surface.sh
+++ b/tests/config-surface.sh
@@ -77,6 +77,21 @@ OUT="$(./aos config get content.port)"
 [ "$OUT" = "null" ] || fail "expected unset optional content.port=null, got '$OUT'"
 pass "config get returns null for known but unset optional values"
 
+OUT="$(./aos config set content.port 65535)"
+echo "$OUT" | grep -q '"port" : 65535' || fail "config set did not accept max content.port: $OUT"
+pass "config set accepts max content.port"
+
+if ./aos config set content.port 65536 2>"$STATE_ROOT/config-set-port.err"; then
+  fail "config set accepted out-of-range content.port"
+fi
+grep -q 'content.port must be an integer from 0 to 65535' "$STATE_ROOT/config-set-port.err" || {
+  cat "$STATE_ROOT/config-set-port.err"
+  fail "config set content.port range error did not explain UInt16 boundary"
+}
+OUT="$(./aos config get content.port)"
+[ "$OUT" = "65535" ] || fail "out-of-range content.port changed existing config: $OUT"
+pass "config set rejects out-of-range content.port without mutation"
+
 if ./aos config get voice.enabled --bogus 2>"$STATE_ROOT/config-get-bogus.err"; then
   fail "config get accepted unknown flag"
 fi


### PR DESCRIPTION
## Summary
- reject `content.port` values outside the Swift `UInt16` range
- keep the existing config value unchanged when an out-of-range port is rejected
- extend the isolated config surface regression for the max valid port and rejection path

## Verification
- `bash tests/config-surface.sh`
- `git diff --check`

## Notes
- Addresses the medium `content.port > 65535` daemon crash-loop finding from the July 3 review packet.

## DOX
- Read root `AGENTS.md`, `scripts/AGENTS.md`, and `tests/AGENTS.md`; no DOX update needed because this narrows an existing config validation contract and adds focused regression coverage.