### PR TITLE
Validate native action profile flags

### DIFF
--- a/src/act/act-cli.swift
+++ b/src/act/act-cli.swift
@@ -91,6 +91,30 @@ private func playbackMode(args: [String]) -> String {
     }
 }
 
+private func positiveIntArg(_ args: [String], _ flag: String) -> Int? {
+    guard let raw = getArg(args, flag) else { return nil }
+    guard let parsed = parseInt(raw), parsed > 0 else {
+        exitError("\(flag) requires a positive integer", code: "INVALID_ARG")
+    }
+    return parsed
+}
+
+private func positiveDoubleArg(_ args: [String], _ flag: String) -> Double? {
+    guard let raw = getArg(args, flag) else { return nil }
+    guard let parsed = parseDouble(raw), parsed > 0, parsed.isFinite else {
+        exitError("\(flag) requires a positive number", code: "INVALID_ARG")
+    }
+    return parsed
+}
+
+private func varianceArg(_ args: [String], _ flag: String) -> Double? {
+    guard let raw = getArg(args, flag) else { return nil }
+    guard let parsed = parseDouble(raw), parsed >= 0, parsed <= 1, parsed.isFinite else {
+        exitError("\(flag) requires a number from 0 to 1", code: "INVALID_ARG")
+    }
+    return parsed
+}
+
 private func printCanvasTargetActionResult(
     action: String,
     backend: String = "canvas",
@@ -450,7 +474,7 @@ func cliClick(args: [String]) {
     let isDouble = hasFlag(args, "--double")
 
     // Override click dwell from CLI flag
-    if let dwellMs = parseInt(getArg(args, "--dwell")) {
+    if let dwellMs = positiveIntArg(args, "--dwell") {
         state.profile.timing.click_dwell = DelayRange(min: dwellMs, max: dwellMs)
     }
 
@@ -498,7 +522,7 @@ private func cliClickCanvasRef(targetString: String, args: [String]) {
     }
 
     let state = cliSessionState(args: args)
-    if let dwellMs = parseInt(getArg(args, "--dwell")) {
+    if let dwellMs = positiveIntArg(args, "--dwell") {
         state.profile.timing.click_dwell = DelayRange(min: dwellMs, max: dwellMs)
     }
 
@@ -563,7 +587,7 @@ func cliDrag(args: [String]) {
     }
 
     // Override drag speed from CLI flags
-    if let speedPxPerSec = parseDouble(getArg(args, "--speed")) {
+    if let speedPxPerSec = positiveDoubleArg(args, "--speed") {
         state.profile.mouse.pixels_per_second = speedPxPerSec
     }
 
@@ -798,12 +822,12 @@ func cliType(args: [String]) {
     }
 
     // Override typing cadence from CLI flags
-    if let delayMs = parseDouble(getArg(args, "--delay")) {
+    if let delayMs = positiveDoubleArg(args, "--delay") {
         // delay is ms per character -> derive WPM: chars/sec = 1000/delay, WPM = chars_per_sec * 60 / 5
-        let charsPerSec = 1000.0 / max(1.0, delayMs)
+        let charsPerSec = 1000.0 / delayMs
         state.profile.timing.typing_cadence.wpm = max(1, Int(charsPerSec * 60.0 / 5.0))
     }
-    if let variance = parseDouble(getArg(args, "--variance")) {
+    if let variance = varianceArg(args, "--variance") {
         state.profile.timing.typing_cadence.variance = variance
     }
 

--- a/tests/external-parser-flags.sh
+++ b/tests/external-parser-flags.sh
@@ -189,6 +189,16 @@ if ! grep -Eq '"code"[[:space:]]*:[[:space:]]*"INVALID_ARG"' "$err"; then
   cat "$err" >&2
   exit 1
 fi
+err="$STATE_ROOT/do-native-click-dwell-negative.err"
+if ./aos do click 10,10 --dwell -1 --dry-run 2>"$err"; then
+  echo "FAIL: do native click accepted negative --dwell value" >&2
+  exit 1
+fi
+if ! grep -Eq '"code"[[:space:]]*:[[:space:]]*"INVALID_ARG"' "$err"; then
+  echo "FAIL: do native click negative --dwell value did not use INVALID_ARG" >&2
+  cat "$err" >&2
+  exit 1
+fi
 err="$STATE_ROOT/do-native-drag-speed-invalid.err"
 if ./aos do drag 10,10 20,20 --speed fast --dry-run 2>"$err"; then
   echo "FAIL: do native drag accepted invalid --speed value" >&2
@@ -196,6 +206,26 @@ if ./aos do drag 10,10 20,20 --speed fast --dry-run 2>"$err"; then
 fi
 if ! grep -Eq '"code"[[:space:]]*:[[:space:]]*"INVALID_ARG"' "$err"; then
   echo "FAIL: do native drag invalid --speed value did not use INVALID_ARG" >&2
+  cat "$err" >&2
+  exit 1
+fi
+err="$STATE_ROOT/do-native-drag-speed-zero.err"
+if ./aos do drag 10,10 20,20 --speed 0 --dry-run 2>"$err"; then
+  echo "FAIL: do native drag accepted zero --speed value" >&2
+  exit 1
+fi
+if ! grep -Eq '"code"[[:space:]]*:[[:space:]]*"INVALID_ARG"' "$err"; then
+  echo "FAIL: do native drag zero --speed value did not use INVALID_ARG" >&2
+  cat "$err" >&2
+  exit 1
+fi
+err="$STATE_ROOT/do-native-type-variance-negative.err"
+if ./aos do type hello --variance -0.5 --dry-run 2>"$err"; then
+  echo "FAIL: do native type accepted negative --variance value" >&2
+  exit 1
+fi
+if ! grep -Eq '"code"[[:space:]]*:[[:space:]]*"INVALID_ARG"' "$err"; then
+  echo "FAIL: do native type negative --variance value did not use INVALID_ARG" >&2
   cat "$err" >&2
   exit 1
 fi


### PR DESCRIPTION
Summary:
- validate native coordinate action profile flags before dry-run/live execution
- reject non-positive `--dwell`/`--speed` and out-of-range `--variance`
- extend external parser regression for zero/negative trap inputs

Verification:
- `bash build.sh --no-restart --force` (passes; existing warnings in canvas targeting and deprecated speech APIs)
- `bash tests/external-parser-flags.sh`
- `git diff --check`
- `./aos help --json`
- `./aos help see --json`
- `./aos help do --json`
- `./aos help show --json`

DOX:
- Read root `AGENTS.md`, `src/AGENTS.md`, and `tests/AGENTS.md`; no DOX update needed because this narrows existing parser validation and adds focused regression coverage.

Notes:
- Addresses the medium Swift input-validation trap cluster for `--speed 0`, `--variance -0.5`, and `--dwell -1` from the July 3 review packet.