### PR TITLE
Restrict integration broker CORS

### DIFF
--- a/docs/api/integration-broker.md
+++ b/docs/api/integration-broker.md
@@ -132,6 +132,12 @@ Current interactive behavior:
 
 ## Local HTTP API
 
+The HTTP API is local-only and does not use wildcard CORS. Requests without an
+`Origin` header are accepted for local CLI/server clients. Browser requests must
+come from an AOS-owned surface origin such as `aos://toolkit` or `aos://sigil`,
+or from the same loopback host and port as the broker. Other browser origins are
+rejected before route handling.
+
 ### `GET /health`
 
 Basic readiness check.

--- a/packages/gateway/src/integrations/http-api.ts
+++ b/packages/gateway/src/integrations/http-api.ts
@@ -10,13 +10,73 @@ interface IntegrationHttpServerOptions {
   port?: number;
 }
 
-function json(res: ServerResponse, status: number, payload: unknown) {
+const AOS_SURFACE_ORIGINS = new Set([
+  'aos://sigil',
+  'aos://toolkit',
+]);
+
+function loopbackHost(value: string): boolean {
+  return value === 'localhost'
+    || value === '127.0.0.1'
+    || value === '::1'
+    || value === '[::1]';
+}
+
+function requestHost(req: IncomingMessage): URL | null {
+  const host = req.headers.host;
+  if (typeof host !== 'string' || !host.trim()) return null;
+  try {
+    return new URL(`http://${host}`);
+  } catch {
+    return null;
+  }
+}
+
+function allowedCorsOrigin(req: IncomingMessage): string | null {
+  const origin = req.headers.origin;
+  if (typeof origin !== 'string' || !origin.trim()) return null;
+  if (AOS_SURFACE_ORIGINS.has(origin)) return origin;
+  let parsed: URL;
+  try {
+    parsed = new URL(origin);
+  } catch {
+    return null;
+  }
+  const host = requestHost(req);
+  if (!host) return null;
+  if (!['http:', 'https:'].includes(parsed.protocol)) return null;
+  if (!loopbackHost(parsed.hostname) || !loopbackHost(host.hostname)) return null;
+  return parsed.port === host.port ? origin : null;
+}
+
+function rejectDisallowedOrigin(req: IncomingMessage, res: ServerResponse): boolean {
+  const origin = req.headers.origin;
+  if (typeof origin !== 'string' || !origin.trim()) return false;
+  if (allowedCorsOrigin(req)) return false;
+  res.writeHead(403, {
+    'content-type': 'application/json; charset=utf-8',
+    vary: 'origin',
+  });
+  res.end(JSON.stringify({ error: 'origin_not_allowed' }, null, 2));
+  return true;
+}
+
+function corsHeaders(req: IncomingMessage): Record<string, string> {
+  const origin = allowedCorsOrigin(req);
+  if (!origin) return { vary: 'origin' };
+  return {
+    'access-control-allow-origin': origin,
+    'access-control-allow-methods': 'GET,POST,OPTIONS',
+    'access-control-allow-headers': 'content-type',
+    vary: 'origin',
+  };
+}
+
+function json(req: IncomingMessage, res: ServerResponse, status: number, payload: unknown) {
   const body = JSON.stringify(payload, null, 2);
   res.writeHead(status, {
     'content-type': 'application/json; charset=utf-8',
-    'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,POST,OPTIONS',
-    'access-control-allow-headers': 'content-type',
+    ...corsHeaders(req),
   });
   res.end(body);
 }
@@ -35,15 +95,15 @@ export async function startIntegrationHttpServer(
 ): Promise<{ server: Server; url: string }> {
   const server = createServer(async (req, res) => {
     if (!req.url || !req.method) {
-      json(res, 400, { error: 'missing_request_url' });
+      json(req, res, 400, { error: 'missing_request_url' });
       return;
     }
 
+    if (rejectDisallowedOrigin(req, res)) return;
+
     if (req.method === 'OPTIONS') {
       res.writeHead(204, {
-        'access-control-allow-origin': '*',
-        'access-control-allow-methods': 'GET,POST,OPTIONS',
-        'access-control-allow-headers': 'content-type',
+        ...corsHeaders(req),
       });
       res.end();
       return;
@@ -54,28 +114,28 @@ export async function startIntegrationHttpServer(
 
     try {
       if (req.method === 'GET' && url.pathname === '/health') {
-        json(res, 200, { status: 'ok', broker: 'integration' });
+        json(req, res, 200, { status: 'ok', broker: 'integration' });
         return;
       }
 
       if (req.method === 'GET' && url.pathname === '/api/integrations/snapshot') {
-        json(res, 200, await options.broker.getSnapshot(limit));
+        json(req, res, 200, await options.broker.getSnapshot(limit));
         return;
       }
 
       if (req.method === 'GET' && url.pathname === '/api/integrations/providers') {
         const snapshot = await options.broker.getSnapshot(1);
-        json(res, 200, snapshot.providers);
+        json(req, res, 200, snapshot.providers);
         return;
       }
 
       if (req.method === 'GET' && url.pathname === '/api/integrations/workflows') {
-        json(res, 200, await options.broker.getWorkflowCatalog());
+        json(req, res, 200, await options.broker.getWorkflowCatalog());
         return;
       }
 
       if (req.method === 'GET' && url.pathname === '/api/integrations/jobs') {
-        json(res, 200, await options.broker.listJobs(limit));
+        json(req, res, 200, await options.broker.listJobs(limit));
         return;
       }
 
@@ -87,7 +147,7 @@ export async function startIntegrationHttpServer(
           fields: body.fields && typeof body.fields === 'object' ? body.fields as Record<string, string> : undefined,
           source: 'api',
         };
-        json(res, 200, await options.broker.launchWorkflow({
+        json(req, res, 200, await options.broker.launchWorkflow({
           provider: typeof body.provider === 'string' ? body.provider : 'slack',
           requester: typeof body.requester === 'string' ? body.requester : 'local-operator',
           workflowId: decodeURIComponent(workflowLaunchMatch[1]),
@@ -101,7 +161,7 @@ export async function startIntegrationHttpServer(
       const jobCompleteMatch = url.pathname.match(/^\/api\/integrations\/jobs\/([^/]+)\/complete$/);
       if (req.method === 'POST' && jobCompleteMatch) {
         const body = await readBody(req);
-        json(res, 200, await options.broker.completeJob(decodeURIComponent(jobCompleteMatch[1]), {
+        json(req, res, 200, await options.broker.completeJob(decodeURIComponent(jobCompleteMatch[1]), {
           summary: typeof body.summary === 'string' ? body.summary : 'Workflow completed.',
           lines: Array.isArray(body.lines) ? body.lines.filter((line: unknown): line is string => typeof line === 'string') : undefined,
           resultJson: body.resultJson,
@@ -120,7 +180,7 @@ export async function startIntegrationHttpServer(
       const jobStartMatch = url.pathname.match(/^\/api\/integrations\/jobs\/([^/]+)\/start$/);
       if (req.method === 'POST' && jobStartMatch) {
         const body = await readBody(req);
-        json(res, 200, await options.broker.startJob(decodeURIComponent(jobStartMatch[1]), {
+        json(req, res, 200, await options.broker.startJob(decodeURIComponent(jobStartMatch[1]), {
           summary: typeof body.summary === 'string' ? body.summary : undefined,
           metadata: body.metadata && typeof body.metadata === 'object' ? body.metadata as Record<string, unknown> : undefined,
           notifyRequester: body.notifyRequester === true,
@@ -131,7 +191,7 @@ export async function startIntegrationHttpServer(
       const jobFailMatch = url.pathname.match(/^\/api\/integrations\/jobs\/([^/]+)\/fail$/);
       if (req.method === 'POST' && jobFailMatch) {
         const body = await readBody(req);
-        json(res, 200, await options.broker.failJob(decodeURIComponent(jobFailMatch[1]), {
+        json(req, res, 200, await options.broker.failJob(decodeURIComponent(jobFailMatch[1]), {
           errorText: typeof body.errorText === 'string' ? body.errorText : 'Workflow failed.',
           summary: typeof body.summary === 'string' ? body.summary : undefined,
           lines: Array.isArray(body.lines) ? body.lines.filter((line: unknown): line is string => typeof line === 'string') : undefined,
@@ -150,7 +210,7 @@ export async function startIntegrationHttpServer(
           channel: typeof body.channel === 'string' ? body.channel : 'local',
           thread: typeof body.thread === 'string' ? body.thread : undefined,
         };
-        json(res, 200, await options.broker.handleMessage(message));
+        json(req, res, 200, await options.broker.handleMessage(message));
         return;
       }
     } catch (error) {
@@ -158,11 +218,11 @@ export async function startIntegrationHttpServer(
         ? (error as { statusCode: number }).statusCode
         : 500;
       const message = error instanceof Error ? error.message : String(error);
-      json(res, status, { error: message });
+      json(req, res, status, { error: message });
       return;
     }
 
-    json(res, 404, { error: 'not_found', path: url.pathname });
+    json(req, res, 404, { error: 'not_found', path: url.pathname });
   });
 
   await new Promise<void>((resolve) => {

--- a/packages/gateway/test/integration-broker.test.ts
+++ b/packages/gateway/test/integration-broker.test.ts
@@ -320,4 +320,61 @@ describe('IntegrationBroker', () => {
       });
     }
   });
+
+  it('rejects foreign browser origins without wildcard CORS', async () => {
+    const { broker } = makeBroker();
+    const http = await startIntegrationHttpServer({
+      broker,
+      host: '127.0.0.1',
+      port: 0,
+    });
+    broker.setBrokerUrl(http.url);
+
+    try {
+      const localSnapshot = await fetch(`${http.url}/api/integrations/snapshot?limit=5`);
+      assert.equal(localSnapshot.status, 200);
+      assert.equal(localSnapshot.headers.get('access-control-allow-origin'), null);
+
+      const aosOrigin = await fetch(`${http.url}/api/integrations/snapshot?limit=5`, {
+        headers: { origin: 'aos://toolkit' },
+      });
+      assert.equal(aosOrigin.status, 200);
+      assert.equal(aosOrigin.headers.get('access-control-allow-origin'), 'aos://toolkit');
+
+      const rejectedPreflight = await fetch(`${http.url}/api/integrations/workflows/queue/launch`, {
+        method: 'OPTIONS',
+        headers: {
+          origin: 'https://evil.example',
+          'access-control-request-method': 'POST',
+          'access-control-request-headers': 'content-type',
+        },
+      });
+      assert.equal(rejectedPreflight.status, 403);
+      assert.equal(rejectedPreflight.headers.get('access-control-allow-origin'), null);
+
+      const rejectedLaunch = await fetch(`${http.url}/api/integrations/workflows/queue/launch`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'text/plain',
+          origin: 'https://evil.example',
+        },
+        body: JSON.stringify({
+          provider: 'slack',
+          requester: 'cross-origin-test',
+          fields: {
+            client: 'Acme',
+          },
+        }),
+      });
+      assert.equal(rejectedLaunch.status, 403);
+      assert.equal(rejectedLaunch.headers.get('access-control-allow-origin'), null);
+
+      const snapshot = await broker.getSnapshot(10);
+      assert.equal(snapshot.jobs.some((job) => job.requester === 'cross-origin-test'), false);
+    } finally {
+      await new Promise<void>((resolveClose) => {
+        http.server.close(() => resolveClose());
+      });
+    }
+  });
 });


### PR DESCRIPTION
Summary:
- replace wildcard CORS on the integration broker HTTP API with a local/AOS-origin allowlist
- reject foreign browser origins before route handling, including simple POST attempts
- document the local-only CORS contract in the integration broker API reference

Verification:
- `npm run build` in `packages/gateway`
- compiled `dist/integrations/http-api.js` CORS smoke: no-Origin local request accepted without ACAO, `aos://toolkit` echoed, foreign preflight rejected, foreign text/plain launch rejected before broker dispatch
- `git diff --check`

Notes:
- `npm test -- --test-name-pattern "IntegrationBroker"` currently fails before test execution under Node 24 with the existing `ts-node/esm` loader path for every gateway test file; no individual assertion runs.
- Addresses the medium localhost broker wildcard CORS finding from the July 3 review packet.

DOX:
- Read root `AGENTS.md`, `packages/AGENTS.md`, and `docs/AGENTS.md`; updated `docs/api/integration-broker.md` because this changes the public HTTP API boundary.