### PR TITLE
Reap stale agent workspace locks

### DIFF
--- a/scripts/lib/agent-workspace/AGENTS.md
+++ b/scripts/lib/agent-workspace/AGENTS.md
@@ -36,6 +36,9 @@ backend validation, and local cleanup.
   before dispatch.
 - Workspace state is local control state, not Work Recording evidence storage.
   Preserve runtime-mode isolation and explicit cleanup acknowledgements.
+- Workspace mutation locks must fail closed for live owners, reap dead-owner
+  locks, and age out corrupt or ownerless lock directories through the
+  `AOS_AGENT_WORKSPACE_STALE_LOCK_MS` threshold.
 
 ## Work Guidance
 

--- a/scripts/lib/agent-workspace/store.mjs
+++ b/scripts/lib/agent-workspace/store.mjs
@@ -27,6 +27,7 @@ import {
 const LOCK_DIRNAME = '.write-lock';
 const STAGING_DIRNAME = '.staging';
 const COMMITTED_MARKER = 'committed.json';
+const DEFAULT_STALE_LOCK_MS = 10 * 60 * 1000;
 
 function assertPlainObject(value, file, label) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -444,9 +445,26 @@ function processIsGone(pid) {
   }
 }
 
-function reapStaleWorkspaceLock(lockDir) {
+function staleLockAgeMs(lockDir) {
+  try {
+    return Date.now() - fs.statSync(lockDir).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+function staleLockThresholdMs(env = process.env) {
+  const configured = Number(env.AOS_AGENT_WORKSPACE_STALE_LOCK_MS);
+  return Number.isFinite(configured) && configured >= 0 ? configured : DEFAULT_STALE_LOCK_MS;
+}
+
+function reapStaleWorkspaceLock(lockDir, env = process.env) {
   const pid = ownerPID(lockDir);
-  if (!pid || !processIsGone(pid)) return false;
+  if (pid) {
+    if (!processIsGone(pid)) return false;
+  } else if (staleLockAgeMs(lockDir) < staleLockThresholdMs(env)) {
+    return false;
+  }
   fs.rmSync(lockDir, { recursive: true, force: true });
   return true;
 }
@@ -465,7 +483,7 @@ export function withWorkspaceLock(workspace, callback, env = process.env, { crea
     lockHeld = true;
   } catch (error) {
     if (error?.code === 'EEXIST') {
-      if (reapStaleWorkspaceLock(lockDir)) {
+      if (reapStaleWorkspaceLock(lockDir, env)) {
         try {
           fs.mkdirSync(lockDir);
           lockHeld = true;

--- a/tests/agent-workspace-storage.sh
+++ b/tests/agent-workspace-storage.sh
@@ -365,6 +365,17 @@ jq -e '
   and any(.snapshots[]; .snapshot_id == "snap2" and .capture_target == "browser:todo" and .query == null)
 ' "$WORKSPACE_PATH/index.json" >/dev/null || fail "sequential saves did not preserve compact snapshot target/query entries: $(cat "$WORKSPACE_PATH/index.json")"
 
+mkdir -p "$WORKSPACE_PATH/.write-lock"
+printf '{' >"$WORKSPACE_PATH/.write-lock/owner.json"
+STALE_LOCK_CAPTURE="$TMP_DIR/capture-after-stale-lock.json"
+AOS_AGENT_WORKSPACE_STALE_LOCK_MS=0 ./aos see capture browser:todo --save --mode ax --workspace ws1 --name snap-stale-lock >"$STALE_LOCK_CAPTURE"
+jq -e '.status == "success" and .snapshot_id == "snap-stale-lock"' "$STALE_LOCK_CAPTURE" >/dev/null \
+    || fail "ownerless stale workspace lock was not reaped before mutation: $(cat "$STALE_LOCK_CAPTURE")"
+[[ ! -e "$WORKSPACE_PATH/.write-lock" ]] \
+    || fail "stale workspace lock remained after successful mutation"
+jq -e '(.current_snapshot_id == "snap-stale-lock") and ([.snapshots[].snapshot_id] | index("snap-stale-lock") != null)' "$WORKSPACE_PATH/index.json" >/dev/null \
+    || fail "stale-lock recovery capture did not update workspace index: $(cat "$WORKSPACE_PATH/index.json")"
+
 VISION="$TMP_DIR/capture-vision.json"
 ./aos see capture browser:todo --save --mode vision --workspace ws-vision --name snapv >"$VISION"
 ARTIFACT="$(jq -r '.artifact_refs[0].path' "$VISION")"


### PR DESCRIPTION
Summary:
- age out corrupt or ownerless agent workspace write locks using `AOS_AGENT_WORKSPACE_STALE_LOCK_MS`
- preserve fail-closed behavior for live-owner locks and immediate cleanup for dead-owner locks
- add storage regression coverage for corrupt stale lock recovery before mutation
- document the workspace lock recovery contract in the local DOX file

Verification:
- `bash tests/agent-workspace-storage.sh`
- `git diff --check`

DOX:
- Read root `AGENTS.md`, `scripts/AGENTS.md`, and `scripts/lib/agent-workspace/AGENTS.md`; updated the nearest owner because workspace lock recovery is a durable local contract.

Notes:
- Addresses the stale workspace `.write-lock` finding from the July 3 review packet.