### PR TITLE
Guard late gate dismiss failures

### DIFF
--- a/packages/daemon/gate/index.js
+++ b/packages/daemon/gate/index.js
@@ -103,6 +103,17 @@ export function createGateService({
     logger?.({ event, ...payload });
   }
 
+  async function dismissReceptor(entry, handle = entry.handle) {
+    try {
+      await entry.receptor.dismiss(handle);
+    } catch (error) {
+      log('gate.dismiss_failed', {
+        gate_id: entry.request.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   async function settle(id, resolution, value, rejectError = null) {
     const entry = pending.get(id);
     if (!entry) return;
@@ -110,11 +121,7 @@ export function createGateService({
     clearTimeoutFn(entry.timer);
     const resolvedAt = new Date();
     const elapsedMs = Date.now() - entry.startedAt;
-    try {
-      await entry.receptor.dismiss(entry.handle);
-    } catch (error) {
-      log('gate.dismiss_failed', { gate_id: id, error: error instanceof Error ? error.message : String(error) });
-    }
+    await dismissReceptor(entry);
     log('gate.resolved', { gate_id: id, resolution, elapsed_ms: elapsedMs });
     if (recordStore) {
       try {
@@ -198,7 +205,8 @@ export function createGateService({
       selectedReceptor.receive(request)
         .then((handle) => {
           if (!pending.has(request.id)) {
-            selectedReceptor.dismiss(handle);
+            const lateEntry = { ...entry, handle };
+            dismissReceptor(lateEntry);
             return;
           }
           entry.handle = handle;

--- a/tests/daemon/gate-service.test.mjs
+++ b/tests/daemon/gate-service.test.mjs
@@ -171,6 +171,51 @@ test('settle logs dismiss failures without rejecting the settlement task', async
   assert.equal(events.some((event) => event.event === 'gate.resolved'), true);
 });
 
+test('ask logs late dismiss failures after timeout without unhandled rejection', async () => {
+  const harness = timeoutHarness();
+  const events = [];
+  let releaseReceive;
+  const service = createGateService({
+    receptor: {
+      supports() {
+        return true;
+      },
+      async receive(gateRequest) {
+        await new Promise((resolve) => {
+          releaseReceive = resolve;
+        });
+        return { id: gateRequest.id };
+      },
+      async dismiss() {
+        throw new Error('late canvas already removed');
+      },
+    },
+    logger(event) {
+      events.push(event);
+    },
+    ...harness,
+  });
+
+  const unhandled = [];
+  const onUnhandled = (reason) => unhandled.push(reason);
+  process.on('unhandledRejection', onUnhandled);
+  try {
+    const promise = service.ask(request('gate-late-dismiss', { timeout_ms: 9000 }));
+    await new Promise((resolve) => setImmediate(resolve));
+    harness.timers[0].callback();
+
+    assert.deepEqual(await promise, { result: null, status: 'timeout' });
+    releaseReceive();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.equal(service.pending.size, 0);
+    assert.equal(events.some((event) => event.event === 'gate.dismiss_failed'), true);
+    assert.deepEqual(unhandled, []);
+  } finally {
+    process.off('unhandledRejection', onUnhandled);
+  }
+});
+
 test('ask resolves no-answer envelope on human dismissal', async () => {
   const harness = timeoutHarness();
   let receptor;


### PR DESCRIPTION
## Summary
- route gate receptor dismiss calls through a guarded helper that logs dismiss failures
- guard the late receive-after-timeout cleanup path so a rejected dismiss cannot become an unhandled rejection
- add focused daemon gate coverage for timeout followed by a late failing dismiss

## Tests
- node --test tests/daemon/gate-service.test.mjs
- git diff --check