### PR TITLE
Reject concurrent host chat sends

### DIFF
--- a/packages/host/src/active-streams.ts
+++ b/packages/host/src/active-streams.ts
@@ -1,0 +1,41 @@
+const ACTIVE_CHAT_SEND_CODE = 'AOS_HOST_CHAT_SEND_ACTIVE';
+
+export class ActiveStreamRegistry {
+  private active = new Map<string, AbortController>();
+
+  begin(sessionId: string): AbortController {
+    if (this.active.has(sessionId)) {
+      throw Object.assign(
+        new Error(`chat.send already active for session: ${sessionId}`),
+        { code: ACTIVE_CHAT_SEND_CODE },
+      );
+    }
+    const controller = new AbortController();
+    this.active.set(sessionId, controller);
+    return controller;
+  }
+
+  finish(sessionId: string, controller: AbortController): void {
+    if (this.active.get(sessionId) === controller) {
+      this.active.delete(sessionId);
+    }
+  }
+
+  stop(sessionId: string): boolean {
+    const controller = this.active.get(sessionId);
+    if (!controller) return false;
+    controller.abort();
+    return true;
+  }
+
+  abortAll(): void {
+    for (const controller of this.active.values()) {
+      controller.abort();
+    }
+  }
+
+  get size(): number {
+    return this.active.size;
+  }
+}
+

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -10,6 +10,7 @@ import { registerAdapter, getAdapter } from './provider/adapter.ts';
 import { readFileTool } from './tools/read-file.ts';
 import { listFilesTool } from './tools/list-files.ts';
 import { shellExecTool } from './tools/shell-exec.ts';
+import { ActiveStreamRegistry } from './active-streams.ts';
 import type { StreamEvent } from './types.ts';
 
 function getStateDir(): string {
@@ -36,7 +37,7 @@ async function main() {
   registry.register(listFilesTool.definition, listFilesTool.executor);
   registry.register(shellExecTool.definition, shellExecTool.executor);
 
-  const activeStreams = new Map<string, AbortController>();
+  const activeStreams = new ActiveStreamRegistry();
 
   const handler = async (
     method: string,
@@ -59,23 +60,21 @@ async function main() {
           maxIterations: (params.maxIterations as number) ?? 25,
         });
 
-        const controller = new AbortController();
-        activeStreams.set(sessionId, controller);
+        const controller = activeStreams.begin(sessionId);
 
         try {
           for await (const event of loop.send(sessionId, text, controller.signal)) {
             streamCallback(event);
           }
         } finally {
-          activeStreams.delete(sessionId);
+          activeStreams.finish(sessionId, controller);
         }
         return { ok: true };
       }
 
       case 'chat.stop': {
         const { sessionId } = params as { sessionId: string };
-        const controller = activeStreams.get(sessionId);
-        if (controller) controller.abort();
+        activeStreams.stop(sessionId);
         return { ok: true };
       }
 
@@ -98,9 +97,7 @@ async function main() {
 
   const shutdown = async () => {
     console.log('Shutting down...');
-    for (const controller of activeStreams.values()) {
-      controller.abort();
-    }
+    activeStreams.abortAll();
     await server.close();
     store.close();
     process.exit(0);

--- a/packages/host/test/active-streams.test.ts
+++ b/packages/host/test/active-streams.test.ts
@@ -1,0 +1,48 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { ActiveStreamRegistry } from '../src/active-streams.ts';
+
+describe('ActiveStreamRegistry', () => {
+  it('rejects concurrent chat sends for the same session', () => {
+    const registry = new ActiveStreamRegistry();
+    const controller = registry.begin('session-a');
+
+    assert.throws(
+      () => registry.begin('session-a'),
+      (error: any) => error.code === 'AOS_HOST_CHAT_SEND_ACTIVE',
+    );
+    assert.equal(registry.size, 1);
+
+    registry.finish('session-a', controller);
+    assert.equal(registry.size, 0);
+  });
+
+  it('does not let stale cleanup delete a newer controller', () => {
+    const registry = new ActiveStreamRegistry();
+    const stale = new AbortController();
+    const current = registry.begin('session-a');
+
+    registry.finish('session-a', stale);
+    assert.equal(registry.size, 1);
+    assert.equal(registry.stop('session-a'), true);
+    assert.equal(current.signal.aborted, true);
+
+    registry.finish('session-a', current);
+    assert.equal(registry.size, 0);
+  });
+
+  it('aborts all active streams during shutdown', () => {
+    const registry = new ActiveStreamRegistry();
+    const first = registry.begin('session-a');
+    const second = registry.begin('session-b');
+
+    registry.abortAll();
+
+    assert.equal(first.signal.aborted, true);
+    assert.equal(second.signal.aborted, true);
+    registry.finish('session-a', first);
+    registry.finish('session-b', second);
+    assert.equal(registry.size, 0);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add host active stream registry for one active chat.send per session
- reject overlapping sends before they can overwrite the active abort controller or interleave session history
- guard finish cleanup so stale completion cannot clear another controller

## Tests
- npm test -- --test-name-pattern ActiveStreamRegistry (from packages/host)
- npm run check (from packages/host)
- git diff --check