### PR TITLE
Bound host file tools

### DIFF
--- a/packages/host/src/tools/list-files.ts
+++ b/packages/host/src/tools/list-files.ts
@@ -2,6 +2,9 @@
 import fs from 'node:fs/promises';
 import type { ToolDefinition, ToolExecutor, RegisteredTool } from '../types.ts';
 
+export const MAX_LIST_FILES_ENTRIES = 1000;
+const LIST_FILES_TIMEOUT_MS = 30_000;
+
 const definition: ToolDefinition = {
   name: 'list_files',
   description: 'List files and directories at the given path.',
@@ -13,13 +16,33 @@ const definition: ToolDefinition = {
     required: ['path'],
   },
   permissions: { default: 'allow' },
+  timeout: LIST_FILES_TIMEOUT_MS,
   metadata: { type: 'simple', source: 'builtin' },
 };
 
-const executor: ToolExecutor = async (input, _context) => {
+function boundedSignal(signal: AbortSignal): AbortSignal {
+  return AbortSignal.any([signal, AbortSignal.timeout(LIST_FILES_TIMEOUT_MS)]);
+}
+
+const executor: ToolExecutor = async (input, context) => {
   const { path: dirPath } = input as { path: string };
   try {
+    const signal = boundedSignal(context.signal);
+    if (signal.aborted) {
+      return { content: 'List aborted', isError: true };
+    }
+
     const entries = await fs.readdir(dirPath, { withFileTypes: true });
+    if (signal.aborted) {
+      return { content: 'List aborted', isError: true };
+    }
+    if (entries.length > MAX_LIST_FILES_ENTRIES) {
+      return {
+        content: `Directory exceeds list_files limit of ${MAX_LIST_FILES_ENTRIES} entries`,
+        isError: true,
+      };
+    }
+
     const result = entries.map(entry => ({
       name: entry.name,
       type: entry.isDirectory() ? 'directory' : 'file',

--- a/packages/host/src/tools/read-file.ts
+++ b/packages/host/src/tools/read-file.ts
@@ -2,6 +2,9 @@
 import fs from 'node:fs/promises';
 import type { ToolDefinition, ToolExecutor, RegisteredTool } from '../types.ts';
 
+export const MAX_READ_FILE_BYTES = 1024 * 1024;
+const READ_FILE_TIMEOUT_MS = 30_000;
+
 const definition: ToolDefinition = {
   name: 'read_file',
   description: 'Read the contents of a file at the given path.',
@@ -13,15 +16,39 @@ const definition: ToolDefinition = {
     required: ['path'],
   },
   permissions: { default: 'allow' },
+  timeout: READ_FILE_TIMEOUT_MS,
   metadata: { type: 'simple', source: 'builtin' },
 };
 
-const executor: ToolExecutor = async (input, _context) => {
+function boundedSignal(signal: AbortSignal): AbortSignal {
+  return AbortSignal.any([signal, AbortSignal.timeout(READ_FILE_TIMEOUT_MS)]);
+}
+
+const executor: ToolExecutor = async (input, context) => {
   const { path: filePath } = input as { path: string };
   try {
-    const content = await fs.readFile(filePath, 'utf-8');
+    const signal = boundedSignal(context.signal);
+    if (signal.aborted) {
+      return { content: 'Read aborted', isError: true };
+    }
+
+    const stat = await fs.stat(filePath);
+    if (!stat.isFile()) {
+      return { content: 'Path is not a regular file', isError: true };
+    }
+    if (stat.size > MAX_READ_FILE_BYTES) {
+      return {
+        content: `File exceeds read_file limit of ${MAX_READ_FILE_BYTES} bytes`,
+        isError: true,
+      };
+    }
+
+    const content = await fs.readFile(filePath, { encoding: 'utf-8', signal });
     return { content };
   } catch (err: any) {
+    if (err?.name === 'AbortError') {
+      return { content: 'Read aborted', isError: true };
+    }
     return { content: err.message, isError: true };
   }
 };

--- a/packages/host/test/tools/list-files.test.ts
+++ b/packages/host/test/tools/list-files.test.ts
@@ -1,7 +1,7 @@
 // packages/host/test/tools/list-files.test.ts
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { listFilesTool } from '../../src/tools/list-files.ts';
+import { MAX_LIST_FILES_ENTRIES, listFilesTool } from '../../src/tools/list-files.ts';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -25,6 +25,7 @@ describe('list_files tool', () => {
   it('has correct definition', () => {
     assert.equal(listFilesTool.definition.name, 'list_files');
     assert.equal(listFilesTool.definition.permissions?.default, 'allow');
+    assert.equal(listFilesTool.definition.timeout, 30_000);
   });
 
   it('lists directory contents', async () => {
@@ -47,5 +48,31 @@ describe('list_files tool', () => {
   it('returns error for missing directory', async () => {
     const result = await listFilesTool.executor({ path: '/nonexistent/dir' }, ctx);
     assert.equal(result.isError, true);
+  });
+
+  it('rejects directories above the entry cap', async () => {
+    const largeDir = path.join(tmpDir, 'large');
+    fs.mkdirSync(largeDir);
+    for (let index = 0; index <= MAX_LIST_FILES_ENTRIES; index++) {
+      fs.writeFileSync(path.join(largeDir, `${index}.txt`), '');
+    }
+
+    const result = await listFilesTool.executor({ path: largeDir }, ctx);
+
+    assert.equal(result.isError, true);
+    assert.match(result.content as string, /exceeds list_files limit/);
+  });
+
+  it('honors an already-aborted tool signal', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await listFilesTool.executor({ path: tmpDir }, {
+      ...ctx,
+      signal: controller.signal,
+    });
+
+    assert.equal(result.isError, true);
+    assert.equal(result.content, 'List aborted');
   });
 });

--- a/packages/host/test/tools/read-file.test.ts
+++ b/packages/host/test/tools/read-file.test.ts
@@ -1,7 +1,7 @@
 // packages/host/test/tools/read-file.test.ts
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileTool } from '../../src/tools/read-file.ts';
+import { MAX_READ_FILE_BYTES, readFileTool } from '../../src/tools/read-file.ts';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -20,6 +20,7 @@ describe('read_file tool', () => {
   it('has correct definition', () => {
     assert.equal(readFileTool.definition.name, 'read_file');
     assert.equal(readFileTool.definition.permissions?.default, 'allow');
+    assert.equal(readFileTool.definition.timeout, 30_000);
   });
 
   it('reads a file', async () => {
@@ -33,5 +34,36 @@ describe('read_file tool', () => {
     const result = await readFileTool.executor({ path: '/nonexistent/file.txt' }, ctx);
     assert.equal(result.isError, true);
     assert.ok((result.content as string).includes('ENOENT'));
+  });
+
+  it('rejects non-regular files', async () => {
+    const result = await readFileTool.executor({ path: tmpDir }, ctx);
+    assert.equal(result.isError, true);
+    assert.match(result.content as string, /not a regular file/);
+  });
+
+  it('rejects files above the size cap before reading content', async () => {
+    const filePath = path.join(tmpDir, 'large.txt');
+    fs.writeFileSync(filePath, Buffer.alloc(MAX_READ_FILE_BYTES + 1));
+
+    const result = await readFileTool.executor({ path: filePath }, ctx);
+
+    assert.equal(result.isError, true);
+    assert.match(result.content as string, /exceeds read_file limit/);
+  });
+
+  it('honors an already-aborted tool signal', async () => {
+    const filePath = path.join(tmpDir, 'test.txt');
+    fs.writeFileSync(filePath, 'hello world');
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await readFileTool.executor({ path: filePath }, {
+      ...ctx,
+      signal: controller.signal,
+    });
+
+    assert.equal(result.isError, true);
+    assert.equal(result.content, 'Read aborted');
   });
 });


### PR DESCRIPTION
## Summary
- make read_file use the tool context signal plus a 30s local bound
- reject non-regular files and files above a 1 MiB read cap before reading content
- make list_files use the tool context signal plus a 30s local bound and reject directories above 1000 entries
- add focused tool coverage for bounds and pre-aborted signals

## Tests
- npm test -- --test-name-pattern "read_file tool|list_files tool" (from packages/host)
- npm run check (from packages/host)
- git diff --check