### PR TITLE
Encode toolkit open messages as UTF-8

### DIFF
--- a/packages/toolkit/components/artifact-bundle-workbench/index.js
+++ b/packages/toolkit/components/artifact-bundle-workbench/index.js
@@ -13,6 +13,7 @@ import {
   rejectArtifactBundleLinkedWorkRecordOpen,
   selectArtifactBundleArtifact,
 } from './model.js';
+import { encodeOpenMessageBase64 } from '../open-message-encoding.js';
 
 function el(tag, className, textContent) {
   const node = document.createElement(tag);
@@ -367,7 +368,7 @@ function siblingWorkRecordWorkbenchUrl() {
 
 async function postWorkRecordOpenToChild(host, childId, openMessage) {
   if (!host?.evalCanvas) return false;
-  const encoded = btoa(JSON.stringify(openMessage));
+  const encoded = encodeOpenMessageBase64(openMessage);
   const expectedRecordId = text(openMessage?.record?.id);
   const script = `
 (function () {

--- a/packages/toolkit/components/open-message-encoding.js
+++ b/packages/toolkit/components/open-message-encoding.js
@@ -1,0 +1,27 @@
+function utf8BinaryString(input) {
+  if (typeof TextEncoder !== 'undefined') {
+    const bytes = new TextEncoder().encode(input);
+    let binary = '';
+    const chunkSize = 0x8000;
+    for (let index = 0; index < bytes.length; index += chunkSize) {
+      binary += String.fromCharCode(...bytes.subarray(index, index + chunkSize));
+    }
+    return binary;
+  }
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(input, 'utf8').toString('binary');
+  }
+  throw new Error('UTF-8 encoder unavailable');
+}
+
+export function encodeOpenMessageBase64(message) {
+  const json = JSON.stringify(message);
+  if (typeof btoa === 'function') {
+    return btoa(utf8BinaryString(json));
+  }
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(json, 'utf8').toString('base64');
+  }
+  throw new Error('base64 encoder unavailable');
+}
+

--- a/packages/toolkit/components/step-descriptor-workbench/index.js
+++ b/packages/toolkit/components/step-descriptor-workbench/index.js
@@ -25,6 +25,7 @@ import {
   renderWorkbenchSummaryRows,
   renderWorkbenchToolbar,
 } from '../../shell/index.js';
+import { encodeOpenMessageBase64 } from '../open-message-encoding.js';
 
 function text(value, fallback = '') {
   const normalized = String(value ?? '').replace(/\s+/g, ' ').trim();
@@ -114,7 +115,7 @@ function sleep(ms) {
 
 async function postWorkRecordOpenToChild(host, childId, openMessage) {
   if (!host?.evalCanvas) return false;
-  const encoded = btoa(JSON.stringify(openMessage));
+  const encoded = encodeOpenMessageBase64(openMessage);
   const expectedRecordId = text(openMessage?.record?.id);
   const script = `
 (function () {

--- a/packages/toolkit/components/wiki-subject-browser/index.js
+++ b/packages/toolkit/components/wiki-subject-browser/index.js
@@ -38,6 +38,7 @@ import {
   applyWikiSubjectBrowserSemanticTarget,
   wikiSubjectBrowserAosRef,
 } from './semantics.js';
+import { encodeOpenMessageBase64 } from '../open-message-encoding.js';
 
 const GRAPH_SELECTION_EVENT = `graph.${WIKI_SUBJECT_SELECTION_TYPE}`;
 const WORK_RECORD_WORKBENCH_SURFACE = 'work-record-workbench';
@@ -334,7 +335,7 @@ export default function WikiSubjectBrowser(options = {}) {
 
   async function postOpenMessageToChild(childId, openMessage, opener = {}) {
     if (!host?.evalCanvas) return false;
-    const encoded = btoa(JSON.stringify(openMessage));
+    const encoded = encodeOpenMessageBase64(openMessage);
     const { expected, expression } = openerExpectedState(openMessage, opener);
     if (!expected) return false;
     const script = `

--- a/tests/toolkit/open-message-encoding.test.mjs
+++ b/tests/toolkit/open-message-encoding.test.mjs
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { encodeOpenMessageBase64 } from '../../packages/toolkit/components/open-message-encoding.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+function decodeOpenMessageBase64(encoded) {
+  const bytes = Uint8Array.from(atob(encoded), (char) => char.charCodeAt(0));
+  return JSON.parse(new TextDecoder().decode(bytes));
+}
+
+test('open message base64 encoding preserves UTF-8 JSON payloads', () => {
+  const message = {
+    type: 'work_record.open',
+    record: {
+      id: 'record-with-unicode',
+      title: 'AOS destiny - café - 你好 - 🚀',
+    },
+  };
+
+  const encoded = encodeOpenMessageBase64(message);
+  const decoded = decodeOpenMessageBase64(encoded);
+
+  assert.deepEqual(decoded, message);
+});
+
+test('open-message child posters use UTF-8-safe encoder instead of direct btoa JSON', async () => {
+  const files = [
+    'packages/toolkit/components/wiki-subject-browser/index.js',
+    'packages/toolkit/components/artifact-bundle-workbench/index.js',
+    'packages/toolkit/components/step-descriptor-workbench/index.js',
+  ];
+
+  for (const file of files) {
+    const source = await readFile(path.join(repoRoot, file), 'utf8');
+    assert.match(source, /encodeOpenMessageBase64\(openMessage\)/, file);
+    assert.doesNotMatch(source, /btoa\(JSON\.stringify\(openMessage\)\)/, file);
+  }
+});
+


### PR DESCRIPTION
## Summary
- add a shared toolkit open-message encoder that serializes JSON as UTF-8 before base64
- replace direct btoa(JSON.stringify(openMessage)) in wiki subject browser, artifact bundle workbench, and step descriptor workbench
- add regression coverage for em dash, accented, CJK, and emoji payloads through the atob decode contract

## Tests
- node --test tests/toolkit/open-message-encoding.test.mjs
- node --test tests/toolkit/wiki-subject-browser.test.mjs tests/toolkit/artifact-bundle-subject.test.mjs tests/toolkit/step-descriptor-workbench-v0.test.mjs tests/toolkit/open-message-encoding.test.mjs
- git diff --check