### PR TITLE
Harden decision gate query parsing

### DIFF
--- a/packages/toolkit/components/decision-gate/deferred.html
+++ b/packages/toolkit/components/decision-gate/deferred.html
@@ -25,7 +25,8 @@
     });
 
     function decodeJson(value) {
-      return JSON.parse(atob(value));
+      const bytes = Uint8Array.from(atob(value), (char) => char.charCodeAt(0));
+      return JSON.parse(new TextDecoder().decode(bytes));
     }
 
     const root = document.getElementById('gate-root');

--- a/packages/toolkit/components/decision-gate/index.html
+++ b/packages/toolkit/components/decision-gate/index.html
@@ -26,22 +26,22 @@
 
     const params = new URLSearchParams(location.search);
     let request = null;
+    function decodeBase64Json(value) {
+      const bytes = Uint8Array.from(atob(value), (char) => char.charCodeAt(0));
+      return JSON.parse(new TextDecoder().decode(bytes));
+    }
     try {
       if (params.has('requestB64')) {
-        request = JSON.parse(atob(params.get('requestB64')));
+        request = decodeBase64Json(params.get('requestB64'));
       } else if (params.has('request')) {
         request = JSON.parse(decodeURIComponent(params.get('request')));
       }
     } catch (e) {
-      window.__gateResult = JSON.stringify({ result: null, status: 'dismissed' });
+      request = null;
     }
 
-    if (request) {
-      createDecisionGate(document.getElementById('gate-root'), { request });
-      window.setTimeout(() => emitReady(), 100);
-    } else if (window.__gateResult === undefined) {
-      window.__gateResult = JSON.stringify({ result: null, status: 'dismissed' });
-    }
+    createDecisionGate(document.getElementById('gate-root'), { request });
+    window.setTimeout(() => emitReady(), 100);
   </script>
 </body>
 </html>

--- a/packages/toolkit/components/decision-gate/index.js
+++ b/packages/toolkit/components/decision-gate/index.js
@@ -6,19 +6,24 @@ const DEFAULT_TIMEOUT_MS = 20000;
 const FALLBACK_FIELDS = [{ id: 'text', kind: 'text', placeholder: 'Your response...' }];
 
 function decodeBase64Json(value) {
-  const decode = typeof atob === 'function'
-    ? atob
-    : (input) => Buffer.from(input, 'base64').toString('utf8');
-  return JSON.parse(decode(value));
+  if (typeof atob === 'function') {
+    const bytes = Uint8Array.from(atob(value), (char) => char.charCodeAt(0));
+    return JSON.parse(new TextDecoder().decode(bytes));
+  }
+  return JSON.parse(Buffer.from(value, 'base64').toString('utf8'));
 }
 
 function requestFromLocation(win) {
   const search = win?.location?.search || '';
   if (!search) return null;
-  const params = new URLSearchParams(search);
-  if (params.has('requestB64')) return decodeBase64Json(params.get('requestB64'));
-  if (params.has('request')) return JSON.parse(decodeURIComponent(params.get('request')));
-  return null;
+  try {
+    const params = new URLSearchParams(search);
+    if (params.has('requestB64')) return decodeBase64Json(params.get('requestB64'));
+    if (params.has('request')) return JSON.parse(decodeURIComponent(params.get('request')));
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 function normalizeRequest(input) {

--- a/tests/toolkit/decision-gate.test.mjs
+++ b/tests/toolkit/decision-gate.test.mjs
@@ -1,8 +1,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 import { createDecisionGate } from '../../packages/toolkit/components/decision-gate/index.js';
 import { expandGatePresetFields } from '../../shared/gate/presets.mjs';
 import { FakeEvent, createFakeDocument } from './dom-fixture.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
 function baseRequest(overrides = {}) {
   const request = {
@@ -24,6 +29,19 @@ function mount(request) {
   document.body.appendChild(container);
   const gate = createDecisionGate(container, { request });
   return { document, container, gate };
+}
+
+function mountFromSearch(search) {
+  const document = createFakeDocument();
+  document.defaultView.location = { search };
+  const container = document.createElement('section');
+  document.body.appendChild(container);
+  const gate = createDecisionGate(container);
+  return { document, container, gate };
+}
+
+function requestB64(request) {
+  return Buffer.from(JSON.stringify(request), 'utf8').toString('base64');
 }
 
 function timerHarness() {
@@ -71,6 +89,36 @@ test('renders title', () => {
   const { container } = mount(baseRequest({ prompt: { title: 'Pick a path', body: null } }));
 
   assert.equal(container.querySelector('.aos-gate-title')?.textContent, 'Pick a path');
+});
+
+test('malformed location request falls back to default gate form', () => {
+  const { container, document } = mountFromSearch('?requestB64=%');
+
+  assert.equal(container.querySelector('.aos-gate-title')?.textContent, 'Decision required');
+  assert.equal(container.querySelector('.aos-text-input') !== null, true);
+  assert.equal(document.defaultView.__gateResult, undefined);
+});
+
+test('location requestB64 decodes UTF-8 JSON payloads', () => {
+  const request = baseRequest({
+    prompt: { title: 'Approve café - 你好 - 🚀', body: null },
+  });
+  const { container } = mountFromSearch(`?requestB64=${encodeURIComponent(requestB64(request))}`);
+
+  assert.equal(container.querySelector('.aos-gate-title')?.textContent, 'Approve café - 你好 - 🚀');
+});
+
+test('decision gate bootstraps avoid direct atob JSON parsing', async () => {
+  const files = [
+    'packages/toolkit/components/decision-gate/index.js',
+    'packages/toolkit/components/decision-gate/index.html',
+    'packages/toolkit/components/decision-gate/deferred.html',
+  ];
+
+  for (const file of files) {
+    const source = await readFile(path.join(repoRoot, file), 'utf8');
+    assert.doesNotMatch(source, /JSON\.parse\(atob\(/, file);
+  }
 });
 
 test('body omitted when null', () => {


### PR DESCRIPTION
## Summary
- make decision gate location parsing return the fallback request instead of throwing on malformed request/requestB64 params
- decode requestB64 payloads as UTF-8 JSON in the module and HTML bootstraps
- keep malformed HTML bootstrap params rendering the fallback gate form instead of resolving as dismissed

## Tests
- node --test tests/toolkit/decision-gate.test.mjs
- git diff --check