### PR TITLE
Preserve guided signal creation time

### DIFF
--- a/packages/toolkit/workbench/guided-user-signal-session.js
+++ b/packages/toolkit/workbench/guided-user-signal-session.js
@@ -188,7 +188,8 @@ export function assertGuidedUserSignalSessionId(id) {
 }
 
 export function createGuidedUserSignalSession(input = {}, options = {}) {
-  const now = isoNow(options.now || input.lifecycle?.created_at || input.created_at || Date.now());
+  const now = isoNow(options.now || Date.now());
+  const createdAt = isoNow(input.lifecycle?.created_at || input.created_at || now);
   const sessionId = text(input.session_id, `guided-signal-${randomUUID()}`);
   assertGuidedUserSignalSessionId(sessionId);
   const state = GUIDED_USER_SIGNAL_TERMINAL_STATES.has(input.lifecycle?.state)
@@ -206,7 +207,7 @@ export function createGuidedUserSignalSession(input = {}, options = {}) {
     linked_artifacts: normalizeLinks(input.linked_artifacts || input.links),
     lifecycle: {
       state,
-      created_at: now,
+      created_at: createdAt,
       updated_at: isoNow(input.lifecycle?.updated_at || input.updated_at || now),
       terminal_at: input.lifecycle?.terminal_at || (GUIDED_USER_SIGNAL_TERMINAL_STATES.has(state) ? now : null),
       terminal_outcome: input.lifecycle?.terminal_outcome || (GUIDED_USER_SIGNAL_TERMINAL_STATES.has(state) ? state : null),

--- a/tests/toolkit/guided-user-signal-session.test.mjs
+++ b/tests/toolkit/guided-user-signal-session.test.mjs
@@ -172,6 +172,22 @@ test('guided user signal terminal completion is idempotent', () => {
   assert.equal(second.session.lifecycle.terminal_at, CAPTURED_AT);
 });
 
+test('guided user signal completion preserves original created_at', () => {
+  const pending = createGuidedUserSignalSession(input(), { now: CREATED_AT });
+  const completed = completeGuidedUserSignalSession(pending, {
+    state: 'captured',
+    capture_result: {
+      kind: 'click',
+      captured_at: CAPTURED_AT,
+      point: { x: 50, y: 60 },
+    },
+  }, { now: CAPTURED_AT });
+
+  assert.equal(completed.session.lifecycle.created_at, CREATED_AT);
+  assert.equal(completed.session.lifecycle.updated_at, CAPTURED_AT);
+  assert.equal(completed.session.lifecycle.terminal_at, CAPTURED_AT);
+});
+
 test('guided user signal store honors isolated runtime state root', async () => {
   const stateRoot = await mkdtemp(path.join(tmpdir(), 'aos-guided-user-signal-'));
   const store = new GuidedUserSignalSessionStore({ env: { AOS_RUNTIME_MODE: 'repo', AOS_STATE_ROOT: stateRoot } });


### PR DESCRIPTION
## Summary
- preserve existing lifecycle.created_at when normalizing guided user signal sessions
- keep completion time applied to updated_at and terminal_at without rewriting original creation time
- add regression coverage for completion preserving created_at

## Tests
- node --test tests/toolkit/guided-user-signal-session.test.mjs
- git diff --check