### PR TITLE
Guard markdown workbench typeless messages

### DIFF
--- a/packages/toolkit/components/markdown-workbench/index.js
+++ b/packages/toolkit/components/markdown-workbench/index.js
@@ -38,6 +38,10 @@ function el(tag, className, textContent) {
   return node;
 }
 
+function messageType(message = {}) {
+  return String(message?.type || message?.payload?.type || '');
+}
+
 export default function MarkdownWorkbench(options = {}) {
   let host = null;
   let initialUrlOpenStarted = false;
@@ -826,7 +830,7 @@ export default function MarkdownWorkbench(options = {}) {
   }
 
   function onMessage(message = {}) {
-    const type = message.type || message.payload?.type;
+    const type = messageType(message);
     if (type === 'markdown_document.open') {
       openMarkdownDocument(state, message);
       splitOpen = true;

--- a/tests/toolkit/markdown-workbench-layout.test.mjs
+++ b/tests/toolkit/markdown-workbench-layout.test.mjs
@@ -176,3 +176,13 @@ test('markdown source editor leaves native undo and redo key chords alone', asyn
   assert.doesNotMatch(keydownBody, /undo/i);
   assert.doesNotMatch(keydownBody, /redo/i);
 });
+
+test('markdown workbench normalizes typeless messages before graph forwarding', async () => {
+  const js = await repoText('packages/toolkit/components/markdown-workbench/index.js');
+
+  assert.match(js, /function messageType\(message = \{\}\) \{/);
+  assert.match(js, /return String\(message\?\.type \|\| message\?\.payload\?\.type \|\| ''\)/);
+  assert.match(js, /const type = messageType\(message\)/);
+  assert.doesNotMatch(js, /const type = message\.type \|\| message\.payload\?\.type/);
+  assert.match(js, /type\.startsWith\('wiki-kb\/'\)/);
+});


### PR DESCRIPTION
## Summary
- normalize markdown workbench inbound message type to a string before dispatch
- prevent typeless messages from throwing in the wiki-kb graph forwarding fallback
- add a source-level regression in the markdown workbench layout contract test

## Tests
- node --test tests/toolkit/markdown-workbench-layout.test.mjs
- git diff --check