### PR TITLE
Support gate ask choice presets

### DIFF
--- a/packages/cli/verbs/gate-ask.js
+++ b/packages/cli/verbs/gate-ask.js
@@ -9,6 +9,8 @@ function usage() {
   return `Usage:
   aos gate ask "Prompt title"
   aos gate ask --preset approve_deny --title "Run test?" --timeout 30 [--store-response]
+  aos gate ask --preset single_choice --title "Pick one" --choice fast=Fast --choice safe=Safe
+  aos gate ask --preset multi_choice --title "Pick many" --option docs --option tests
   aos gate ask --store-response --preset freetext --title "Why?"
   aos gate ask --request gate-request.json
   aos gate ask --json '{"prompt":{"title":"Continue?"},"ui":{"variant":"yes_no_with_escape"}}'
@@ -34,6 +36,7 @@ function parseArgs(argv) {
     timeoutSeconds: null,
     requestFile: null,
     json: null,
+    choices: [],
     storeResponse: false,
   };
   const positional = [];
@@ -58,6 +61,10 @@ function parseArgs(argv) {
       [parsed.title, index] = nextValue(index, arg);
     } else if (arg === '--message' || arg === '--body') {
       [parsed.message, index] = nextValue(index, arg);
+    } else if (arg === '--choice' || arg === '--option') {
+      let value;
+      [value, index] = nextValue(index, arg);
+      parsed.choices.push(parseChoice(value));
     } else if (arg === '--timeout') {
       let value;
       [value, index] = nextValue(index, arg);
@@ -75,7 +82,18 @@ function parseArgs(argv) {
   if (parsed.preset !== null && !PRESETS.has(parsed.preset)) {
     throw new Error(`--preset must be one of: ${[...PRESETS].join(', ')}`);
   }
+  if ((parsed.preset === 'single_choice' || parsed.preset === 'multi_choice') && parsed.choices.length === 0 && !parsed.requestFile && !parsed.json) {
+    throw new Error(`--preset ${parsed.preset} requires at least one --choice`);
+  }
   return parsed;
+}
+
+function parseChoice(input) {
+  const [rawValue, ...labelParts] = String(input).split('=');
+  const value = rawValue.trim();
+  const label = labelParts.join('=').trim() || value;
+  if (!value) throw new Error('--choice requires a non-empty value');
+  return { value, label };
 }
 
 async function requestFromArgs(args) {
@@ -91,6 +109,7 @@ async function requestFromArgs(args) {
   return withStoreResponse({
     schema_version: 'aos.gate.request.v1',
     prompt: { title: args.title, body: args.message ?? null },
+    choices: args.choices,
     ui: { variant: args.preset || 'yes_no_with_escape' },
     timeout_ms: Number.isFinite(args.timeoutSeconds) ? args.timeoutSeconds * 1000 : 20000,
     source: { surface: 'aos-cli' },

--- a/tests/daemon/gate-service.test.mjs
+++ b/tests/daemon/gate-service.test.mjs
@@ -102,6 +102,45 @@ test('gate ask rejects flag-shaped values for value flags', async () => {
   assert.match(stderr.text(), /--request requires a value/);
 });
 
+test('gate ask passes single choice options to the gate request', async () => {
+  const stdout = writable();
+  const stderr = writable();
+  let capturedRequest;
+  const service = {
+    async ask(request) {
+      capturedRequest = request;
+      return { decision: 'fast' };
+    },
+  };
+
+  const code = await runGateAsk([
+    '--preset', 'single_choice',
+    '--title', 'Pick mode',
+    '--choice', 'fast=Fast path',
+    '--choice', 'safe',
+  ], { stdout, stderr, service });
+
+  assert.equal(code, 0);
+  assert.equal(stderr.text(), '');
+  assert.equal(stdout.text(), '{"decision":"fast"}\n');
+  assert.equal(capturedRequest.ui.variant, 'single_choice');
+  assert.deepEqual(capturedRequest.choices, [
+    { value: 'fast', label: 'Fast path' },
+    { value: 'safe', label: 'safe' },
+  ]);
+  assert.deepEqual(capturedRequest.fields[0].options, capturedRequest.choices);
+});
+
+test('gate ask requires choices for choice presets', async () => {
+  const stdout = writable();
+  const stderr = writable();
+  const code = await runGateAsk(['--preset', 'multi_choice', '--title', 'Pick modes'], { stdout, stderr });
+
+  assert.equal(code, 1);
+  assert.equal(stdout.text(), '');
+  assert.match(stderr.text(), /--preset multi_choice requires at least one --choice/);
+});
+
 test('ask resolves with user values and cleans up pending gate', async () => {
   const harness = timeoutHarness();
   let receptor;


### PR DESCRIPTION
## Summary
- add repeatable --choice / --option flags to aos gate ask
- support value and value=Label choice syntax for single_choice and multi_choice presets
- reject choice presets without choices before daemon validation
- document choice preset usage in gate ask help

## Tests
- node --test tests/daemon/gate-service.test.mjs
- node packages/cli/verbs/gate-ask.js --help
- git diff --check