### PR TITLE
Clean up DesktopWorld bridge handlers

### DIFF
--- a/docs/api/toolkit/runtime.md
+++ b/docs/api/toolkit/runtime.md
@@ -385,18 +385,22 @@ it does not own radial pointer geometry, drag-to-handoff state, or per-frame
 
 ### `wireBridge(handler)`
 
-Installs an inbound message handler for daemon-to-canvas messages.
+Installs an inbound message handler for daemon-to-canvas messages and returns
+an unsubscribe function for removing that handler.
 
 ```js
-wireBridge((msg) => {
+const unsubscribe = wireBridge((msg) => {
   if (msg.type === 'hello') console.log(msg.payload)
 })
+unsubscribe()
 ```
 
 Notes:
 
 - safe to call more than once
 - each handler is retained and invoked for every inbound message
+- call the returned unsubscribe before tearing down or restarting a reusable
+  adapter
 - inbound messages arrive through `window.headsup.receive(base64Json)`
 
 ### `emit(type, payload?)`

--- a/packages/toolkit/runtime/bridge.js
+++ b/packages/toolkit/runtime/bridge.js
@@ -7,20 +7,31 @@
 const handlers = []
 
 export function wireBridge(handler) {
-  if (typeof handler === 'function') handlers.push(handler)
-  if (window.headsup && window.headsup.receive) return  // already wired
-  window.headsup = window.headsup || {}
-  window.headsup.receive = function (b64) {
-    let msg
-    try {
-      msg = JSON.parse(atob(b64))
-    } catch (e) {
-      console.error('[runtime] bridge decode error', e)
-      return
+  let active = false
+  if (typeof handler === 'function') {
+    handlers.push(handler)
+    active = true
+  }
+  if (!window.headsup || !window.headsup.receive) {
+    window.headsup = window.headsup || {}
+    window.headsup.receive = function (b64) {
+      let msg
+      try {
+        msg = JSON.parse(atob(b64))
+      } catch (e) {
+        console.error('[runtime] bridge decode error', e)
+        return
+      }
+      for (const h of handlers) {
+        try { h(msg) } catch (e) { console.error('[runtime] handler error', e) }
+      }
     }
-    for (const h of handlers) {
-      try { h(msg) } catch (e) { console.error('[runtime] handler error', e) }
-    }
+  }
+  return () => {
+    if (!active) return
+    active = false
+    const index = handlers.indexOf(handler)
+    if (index >= 0) handlers.splice(index, 1)
   }
 }
 

--- a/packages/toolkit/runtime/desktop-world-surface.js
+++ b/packages/toolkit/runtime/desktop-world-surface.js
@@ -74,14 +74,19 @@ export class DesktopWorldSurfaceAdapter {
     this._appHandlers = {}
     this._started = false
     this._firstSettled = null
+    this._startPromise = null
     this._stopHostListener = null
+    this._stopBridgeListener = null
   }
 
   async start(appHandlers = {}) {
     this._appHandlers = appHandlers
+    if (this._startPromise) return this._startPromise
+    if (this._started) return this
     const firstSettled = new Promise((resolve) => {
       this._firstSettled = resolve
     })
+    this._startPromise = firstSettled
     if (!this._started) {
       this._started = true
       this._wireMessages()
@@ -93,9 +98,12 @@ export class DesktopWorldSurfaceAdapter {
   stop() {
     this._stopHostListener?.()
     this._stopHostListener = null
+    this._stopBridgeListener?.()
+    this._stopBridgeListener = null
     if (!this.host?.subscribe) unsubscribe(['canvas_lifecycle'])
     this._started = false
     this._firstSettled = null
+    this._startPromise = null
   }
 
   handleMessage(message) {
@@ -113,7 +121,7 @@ export class DesktopWorldSurfaceAdapter {
       return
     }
     if (this.host?.subscribe) return
-    wireBridge((message) => this.handleMessage(message))
+    this._stopBridgeListener = wireBridge((message) => this.handleMessage(message))
   }
 
   _subscribeLifecycle() {
@@ -133,6 +141,7 @@ export class DesktopWorldSurfaceAdapter {
     const priorSegment = this.segment
     const firstSettled = this._firstSettled
     this._firstSettled = null
+    this._startPromise = null
 
     this.topology = normalizeTopology(segments)
     this.segment = this._identifyOwnSegment(this.topology)

--- a/tests/toolkit/desktop-world-surface.test.mjs
+++ b/tests/toolkit/desktop-world-surface.test.mjs
@@ -19,6 +19,10 @@ const segments = [
   { display_id: 11, index: 1, dw_bounds: [100, 0, 100, 100], native_bounds: [80, 0, 100, 100] },
 ]
 
+function encodeBridgeMessage(message) {
+  return Buffer.from(JSON.stringify(message), 'utf8').toString('base64')
+}
+
 test('isPrimary reflects index === 0 and runOnPrimary gates work', async () => {
   const adapter = new StubAdapter({
     canvasId: 'avatar',
@@ -99,3 +103,59 @@ test('feedInput maps native input into DesktopWorld coordinates', () => {
   assert.equal(seen.length, 1)
 })
 
+test('stop removes global bridge handler before restart', async () => {
+  const previousWindow = globalThis.window
+  globalThis.window = { headsup: {} }
+  const calls = []
+  const adapter = new StubAdapter({ canvasId: 'avatar' })
+  const message = {
+    type: 'canvas_lifecycle',
+    event: 'canvas_topology_settled',
+    canvas_id: 'avatar',
+    segments,
+  }
+
+  try {
+    const firstStart = adapter.start({
+      onInit: () => calls.push('init:first'),
+      onTopologyChange: () => calls.push('topology:first'),
+    })
+    globalThis.window.headsup.receive(encodeBridgeMessage(message))
+    await firstStart
+
+    adapter.stop()
+    globalThis.window.headsup.receive(encodeBridgeMessage(message))
+
+    const secondStart = adapter.start({
+      onInit: () => calls.push('init:second'),
+      onTopologyChange: () => calls.push('topology:second'),
+    })
+    globalThis.window.headsup.receive(encodeBridgeMessage(message))
+    await secondStart
+
+    assert.deepEqual(calls, ['init:first', 'init:second'])
+  } finally {
+    adapter.stop()
+    globalThis.window = previousWindow
+  }
+})
+
+test('concurrent starts share the first topology settlement', async () => {
+  const callbacks = []
+  const calls = []
+  const adapter = new StubAdapter({
+    canvasId: 'avatar',
+    host: {
+      subscribe: () => ({ on: (handler) => callbacks.push(handler) }),
+    },
+  })
+
+  const firstStart = adapter.start({ onInit: () => calls.push('init:first') })
+  const secondStart = adapter.start({ onInit: () => calls.push('init:second') })
+  callbacks[0]({ type: 'canvas_lifecycle', event: 'canvas_topology_settled', canvas_id: 'avatar', segments })
+
+  await Promise.all([firstStart, secondStart])
+
+  assert.deepEqual(calls, ['init:second'])
+  assert.equal(adapter.segment.display_id, 10)
+})


### PR DESCRIPTION
## Summary
- make `wireBridge()` return an idempotent unsubscribe function
- remove DesktopWorldSurfaceAdapter global bridge handlers on stop/restart
- make overlapping `start()` calls share the same first topology settlement
- document the bridge unsubscribe contract

## Verification
- `node --test tests/toolkit/desktop-world-surface.test.mjs`
- `node --test tests/toolkit/desktop-world-surface.test.mjs tests/toolkit/desktop-world-surface-2d.test.mjs tests/toolkit/desktop-world-surface-three.test.mjs`
- `node --test tests/toolkit/toolkit-api-docs-contract.test.mjs`
- `git diff --check`
