### PR TITLE
Remove slider semantic action listener on destroy

### DIFF
--- a/packages/toolkit/controls/slider.js
+++ b/packages/toolkit/controls/slider.js
@@ -265,7 +265,7 @@ export function createSlider(config = {}) {
   syncSemanticMetadata();
   bindAll();
 
-  el.addEventListener('aos:semantic-action', (event) => {
+  function handleSemanticAction(event) {
     const detail = event?.detail || {};
     const action = detail.action || detail.primitive;
     if (disabled || values.length !== 1) return;
@@ -287,7 +287,9 @@ export function createSlider(config = {}) {
     bindAll();
     emitChange();
     emitCommit();
-  });
+  }
+
+  el.addEventListener('aos:semantic-action', handleSemanticAction);
 
   return {
     el,
@@ -317,6 +319,7 @@ export function createSlider(config = {}) {
       return type === 'change' || type === 'commit' ? hub.on(type, callback) : () => {};
     },
     destroy() {
+      el.removeEventListener('aos:semantic-action', handleSemanticAction);
       adapter.destroy();
       hub.clear();
     },

--- a/tests/toolkit/controls-slider-color.test.mjs
+++ b/tests/toolkit/controls-slider-color.test.mjs
@@ -92,6 +92,35 @@ test('createSlider handles internal AOS semantic set-value events', () => {
   assert.equal(control.getAttribute('aria-valuenow'), '0.8');
 });
 
+test('destroy removes slider semantic-action listener', () => {
+  const document = createPatchedDocument();
+  const slider = createSlider({
+    document,
+    id: 'opacity',
+    value: 0.25,
+    min: 0,
+    max: 1,
+  });
+  const control = slider.el.querySelector('[data-aos-slider-control]');
+  const changes = [];
+  const commits = [];
+
+  slider.on('change', (value) => changes.push(value));
+  slider.on('commit', (value) => commits.push(value));
+  slider.destroy();
+
+  const event = new FakeEvent('aos:semantic-action', {
+    bubbles: true,
+    detail: { action: 'set-value', value: 0.8 },
+  });
+  control.dispatchEvent(event);
+
+  assert.equal(event.defaultPrevented, false);
+  assert.equal(slider.getValue(), 0.25);
+  assert.deepEqual(changes, []);
+  assert.deepEqual(commits, []);
+});
+
 test('createSlider updates value from pointer drag on the control', () => {
   const document = createPatchedDocument();
   const slider = createSlider({


### PR DESCRIPTION
## Summary
- name the slider semantic-action handler so it can be removed
- remove that listener during `destroy()` before clearing callbacks
- cover post-destroy semantic actions with a regression test

## Verification
- `node --test tests/toolkit/controls-slider-color.test.mjs`
- `git diff --check`
