### PR TITLE
Harden Python reader error contracts

### DIFF
--- a/scripts/aos-wiki-graph.py
+++ b/scripts/aos-wiki-graph.py
@@ -196,7 +196,7 @@ def graph_snapshot(include_raw):
         if include_raw:
             page_path = root / item["path"]
             if page_path.exists():
-                raw[item["path"]] = page_path.read_text(encoding="utf-8")
+                raw[item["path"]] = page_path.read_text(encoding="utf-8", errors="replace")
 
     return {
         "nodes": nodes,

--- a/scripts/aos-wiki-query.py
+++ b/scripts/aos-wiki-query.py
@@ -221,7 +221,7 @@ def search_file_content(query, excluding):
                 if rel in excluding or rel in seen:
                     continue
                 seen.add(rel)
-                content = file.read_text(encoding="utf-8")
+                content = file.read_text(encoding="utf-8", errors="replace")
                 if lower not in content.lower():
                     continue
                 frontmatter, _ = parse_frontmatter(content)

--- a/scripts/aos_agents/runner.py
+++ b/scripts/aos_agents/runner.py
@@ -236,7 +236,9 @@ def load_patch_output_spec(root: pathlib.Path, role: str) -> AgentSpec:
 def load_active_profile(root: pathlib.Path) -> ActiveProfile:
     path = root / ".docks" / "profiles" / "active-profile.json"
     try:
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise RunnerError(f"Unable to read active profile {path}: {exc}") from exc
     except json.JSONDecodeError as exc:
         raise RunnerError(f"{path} is not valid JSON: {exc}") from exc
 
@@ -255,7 +257,7 @@ def load_active_profile(root: pathlib.Path) -> ActiveProfile:
         pack_path = root / ".docks" / "profiles" / pack_name / "profile.md"
         if not pack_path.is_file():
             raise RunnerError(f"Profile pack {pack_name!r} is missing {pack_path}")
-        packs.append(ProfilePack(name=pack_name, path=pack_path, markdown=pack_path.read_text()))
+        packs.append(ProfilePack(name=pack_name, path=pack_path, markdown=pack_path.read_text(encoding="utf-8")))
 
     return ActiveProfile(
         path=path,

--- a/tests/aos-agents-runner.sh
+++ b/tests/aos-agents-runner.sh
@@ -225,6 +225,30 @@ git -C "$FIXTURE" commit -qm "fixture baseline"
 pass() { echo "PASS: $1"; }
 fail() { echo "FAIL: $1" >&2; exit 1; }
 
+ACTIVE_PROFILE_PATH="$FIXTURE/.docks/profiles/active-profile.json"
+mv "$ACTIVE_PROFILE_PATH" "$ACTIVE_PROFILE_PATH.bak"
+set +e
+ERR="$(python3 scripts/aos_agents/runner.py --repo-root "$FIXTURE" --runtime-info 2>&1 >/dev/null)"
+RC=$?
+set -e
+mv "$ACTIVE_PROFILE_PATH.bak" "$ACTIVE_PROFILE_PATH"
+if [[ "$RC" -eq 0 ]]; then
+    fail "runner accepted missing active-profile.json"
+elif ERR="$ERR" python3 - <<'PY'
+import json
+import os
+
+data = json.loads(os.environ["ERR"])
+assert data["status"] == "error", data
+assert "active-profile.json" in data["error"], data
+PY
+then
+    pass "runner reports missing active profile as structured JSON"
+else
+    echo "$ERR" >&2
+    fail "runner missing active profile error was not structured JSON"
+fi
+
 if INTEGRATION_SKIP="$(bash tests/aos-agents-runner-integration.sh)"; then
     if grep -q "SKIP: set AOS_AGENT_PROVIDER_SDK_SMOKE=1" <<<"$INTEGRATION_SKIP"; then
         pass "provider SDK integration smoke is opt-in and skips by default"

--- a/tests/wiki-graph-external.sh
+++ b/tests/wiki-graph-external.sh
@@ -41,6 +41,14 @@ node = next((item for item in graph["nodes"] if item["path"] == "aos/entities/en
 assert node and node["type"] == "entity", graph
 PY
 
+python3 - <<'PY'
+from pathlib import Path
+import os
+
+path = Path(os.environ["AOS_STATE_ROOT"]) / "repo/wiki/aos/entities/entity-frontmatter-canonical.md"
+path.write_bytes(b"---\ntype: entity\nname: Taxonomy Alignment Test Entity\n---\nraw-invalid-byte \xff\n")
+PY
+
 OUT="$(./aos wiki graph --raw --json)"
 OUT="$OUT" python3 - <<'PY'
 import json
@@ -48,6 +56,7 @@ import os
 
 graph = json.loads(os.environ["OUT"])
 assert graph["raw"]["aos/entities/gateway.md"].startswith("---"), graph["raw"].keys()
+assert "raw-invalid-byte" in graph["raw"]["aos/entities/entity-frontmatter-canonical.md"], graph["raw"]
 PY
 
 if ./aos wiki graph --bogus 2>"$ROOT/wiki-graph-bogus.err"; then

--- a/tests/wiki-query-external.sh
+++ b/tests/wiki-query-external.sh
@@ -59,6 +59,23 @@ pages = json.loads(os.environ["OUT"])
 assert any(page["path"] == "aos/concepts/ipc-protocol.md" for page in pages), pages
 PY
 
+python3 - <<'PY'
+from pathlib import Path
+import os
+
+path = Path(os.environ["AOS_STATE_ROOT"]) / "repo/wiki/aos/entities/non-utf8-search.md"
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_bytes(b"---\ntype: entity\nname: Non UTF8 Search\n---\ninvalid-byte-query \xff\n")
+PY
+OUT="$(./aos wiki search invalid-byte-query --json)"
+OUT="$OUT" python3 - <<'PY'
+import json
+import os
+
+pages = json.loads(os.environ["OUT"])
+assert any(page["path"] == "aos/entities/non-utf8-search.md" for page in pages), pages
+PY
+
 OUT="$(./aos wiki list --orphans --json)"
 OUT="$OUT" python3 - <<'PY'
 import json


### PR DESCRIPTION
## Summary
- decode wiki query and graph markdown reads with replacement instead of crashing on invalid UTF-8 bytes
- report missing active-profile.json through the runner JSON error contract
- add focused regressions for invalid wiki bytes and missing active profile handling

## Verification
- `bash tests/wiki-query-external.sh`
- `bash tests/wiki-graph-external.sh`
- `python3 -m py_compile scripts/aos_agents/runner.py`
- `bash tests/aos-agents-runner.sh`
- `git diff --check`
