### PR TITLE
Harden HTML expression parsing and metadata

### DIFF
--- a/packages/toolkit/workbench/html-workbench-expression.js
+++ b/packages/toolkit/workbench/html-workbench-expression.js
@@ -77,8 +77,15 @@ function normalizeLine(value, fallback = 1) {
 
 function headingBlocks(lines) {
   const headings = [];
+  let fenced = false;
   for (let index = 0; index < lines.length; index += 1) {
-    const match = /^(#{1,6})\s+(.+?)\s*$/.exec(lines[index]);
+    const line = lines[index];
+    if (/^```\s*([a-zA-Z0-9_-]+)?\s*$/.test(line)) {
+      fenced = !fenced;
+      continue;
+    }
+    if (fenced) continue;
+    const match = /^(#{1,6})\s+(.+?)\s*$/.exec(line);
     if (!match) continue;
     headings.push({
       level: match[1].length,
@@ -93,6 +100,13 @@ function headingBlocks(lines) {
     current.end_line = next ? next.start_line - 1 : lines.length;
   }
   return headings;
+}
+
+function scriptJson(value) {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
 }
 
 function codeBlocks(lines) {
@@ -456,7 +470,7 @@ export function buildMarkdownWorkCardHtmlExpression({
     bodyHtml,
     '</article>',
     '</main>',
-    `<script type="application/json" id="aos-html-workbench-expression-metadata">${escHtml(JSON.stringify(metadata))}</script>`,
+    `<script type="application/json" id="aos-html-workbench-expression-metadata">${scriptJson(metadata)}</script>`,
     '</body>',
     '</html>',
   ].join('\n');

--- a/tests/toolkit/html-workbench-expression.test.mjs
+++ b/tests/toolkit/html-workbench-expression.test.mjs
@@ -167,6 +167,47 @@ test('Markdown work-card adapter emits safe HTML, metadata, semantic targets, an
   );
 });
 
+test('Markdown adapter ignores headings inside fenced code blocks', () => {
+  const expression = buildMarkdownWorkCardHtmlExpression({
+    markdown: `# Goal
+
+\`\`\`bash
+# not a section
+echo ok
+\`\`\`
+
+## Verification
+
+- [ ] Run the proof.
+`,
+    sourcePath: 'docs/design/work-cards/fenced-heading.md',
+    generatedAt: '2026-05-10T00:00:00.000Z',
+  });
+  const sectionLabels = expression.metadata.semantic_targets
+    .filter((target) => ['section', 'verification'].includes(target.kind))
+    .map((target) => target.name);
+
+  assert.deepEqual(sectionLabels, ['Goal', 'Verification']);
+  assert.equal(
+    expression.metadata.semantic_targets.some((target) => target.name === 'not a section'),
+    false,
+  );
+  assert.match(expression.html, /# not a section/);
+});
+
+test('Markdown adapter embeds metadata as parseable script JSON', () => {
+  const expression = buildMarkdownWorkCardHtmlExpression({
+    markdown: '# Parseable Metadata\n',
+    sourcePath: 'docs/design/work-cards/parseable-</script>-metadata.md',
+    generatedAt: '2026-05-10T00:00:00.000Z',
+  });
+  const match = expression.html.match(/<script type="application\/json" id="aos-html-workbench-expression-metadata">([\s\S]*?)<\/script>/);
+
+  assert.ok(match, expression.html);
+  assert.doesNotMatch(match[1], /&quot;|&lt;|<\/script>/);
+  assert.deepEqual(JSON.parse(match[1]), expression.metadata);
+});
+
 test('Markdown adapter narrowly supports human alignment pack expressions', () => {
   const expression = buildMarkdownWorkCardHtmlExpression({
     markdown: sampleWorkCard,


### PR DESCRIPTION
## Summary
- ignore Markdown headings inside fenced code blocks when building HTML workbench expression sections
- embed expression metadata as raw parseable script JSON with script-safe escaping
- cover fenced heading and metadata parse regressions

## Verification
- `node --test tests/toolkit/html-workbench-expression.test.mjs`
- `node --test tests/schemas/aos-html-workbench-expression-v0.test.mjs`
- `node --test tests/toolkit/open-message-encoding.test.mjs`
- `git diff --check`
