### PR TITLE
Preserve repo fallback state on installed reset

### DIFF
--- a/scripts/aos-reset.mjs
+++ b/scripts/aos-reset.mjs
@@ -127,7 +127,7 @@ function reset(mode) {
   }
 
   const root = stateRoot();
-  if (fs.existsSync(root)) {
+  if (selectedModes.includes('repo') && fs.existsSync(root)) {
     for (const item of fs.readdirSync(root)) {
       if (!modes.includes(item)) removeIfExists(path.join(root, item), removedPaths);
     }

--- a/tests/external-command-dispatch.sh
+++ b/tests/external-command-dispatch.sh
@@ -599,7 +599,7 @@ fi
 RESET_ROOT="$(mktemp -d)"
 RESET_OUT="$(mktemp)"
 mkdir -p "$RESET_ROOT/installed" "$RESET_ROOT/legacy-junk"
-touch "$RESET_ROOT/installed/probe" "$RESET_ROOT/legacy-junk/probe"
+touch "$RESET_ROOT/installed/probe" "$RESET_ROOT/legacy-junk/probe" "$RESET_ROOT/experience-state.json"
 AOS_STATE_ROOT="$RESET_ROOT" AOS_RUNTIME_MODE=installed ./aos reset --mode installed --json >"$RESET_OUT" 2>/dev/null
 if RESET_ROOT="$RESET_ROOT" RESET_OUT="$RESET_OUT" python3 - <<'PY'
 import json
@@ -610,12 +610,15 @@ with open(os.environ["RESET_OUT"], encoding="utf-8") as fh:
     data = json.load(fh)
 assert data["reset_mode"] == "installed", data
 assert f"{root}/installed" in data["removed_paths"], data
-assert f"{root}/legacy-junk" in data["removed_paths"], data
+assert f"{root}/legacy-junk" not in data["removed_paths"], data
+assert f"{root}/experience-state.json" not in data["removed_paths"], data
 assert not os.path.exists(f"{root}/installed"), data
+assert os.path.exists(f"{root}/legacy-junk"), data
+assert os.path.exists(f"{root}/experience-state.json"), data
 assert os.path.exists("./aos"), "repo binary should not be removed by installed-mode reset"
 PY
 then
-    pass "reset runs through external command manifest in isolated installed mode"
+    pass "reset installed mode preserves repo fallback state"
 else
     fail "reset external dispatch drifted: $(cat "$RESET_OUT" 2>/dev/null || true)"
 fi


### PR DESCRIPTION
## Summary
- keep installed-mode reset scoped to installed runtime state
- preserve unscoped repo fallback state such as legacy `experience-state.json` during installed reset
- update the external command regression for the installed reset boundary

## Verification
- `bash tests/external-command-dispatch.sh`
- `git diff --check`
