### PR TITLE
Bound gateway SDK call lifecycle

### DIFF
--- a/packages/gateway/sdk/aos-sdk.js
+++ b/packages/gateway/sdk/aos-sdk.js
@@ -3,12 +3,29 @@
 // Zero npm dependencies. Communicates with gateway via Unix socket NDJSON.
 
 const net = require('node:net');
+const DEFAULT_CALL_TIMEOUT_MS = 10000;
 let _conn = null;
 let _reqId = 0;
 const _pending = new Map();
 
+function callTimeoutMs() {
+  const raw = globalThis.__aos_config?.sdkCallTimeoutMs ?? globalThis.__aos_config?.callTimeoutMs;
+  const timeoutMs = Number(raw);
+  return Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : DEFAULT_CALL_TIMEOUT_MS;
+}
+
+function settlePending(id, type, value) {
+  const pending = _pending.get(id);
+  if (!pending) return false;
+  _pending.delete(id);
+  clearTimeout(pending.timeout);
+  pending[type](value);
+  return true;
+}
+
 function rejectPending(error) {
   for (const pending of _pending.values()) {
+    clearTimeout(pending.timeout);
     pending.reject(error);
   }
   _pending.clear();
@@ -28,11 +45,7 @@ function getConnection() {
       buffer = buffer.slice(idx + 1);
       try {
         const resp = JSON.parse(line);
-        const pending = _pending.get(resp.id);
-        if (pending) {
-          _pending.delete(resp.id);
-          pending.resolve(resp.result);
-        }
+        settlePending(resp.id, 'resolve', resp.result);
       } catch {}
     }
   });
@@ -49,11 +62,21 @@ function getConnection() {
 function call(domain, method, params) {
   return new Promise((resolve, reject) => {
     const id = String(++_reqId);
-    _pending.set(id, { resolve, reject });
-    const conn = getConnection();
+    let conn;
+    try {
+      conn = getConnection();
+    } catch (error) {
+      reject(error);
+      return;
+    }
+    const timeoutMs = callTimeoutMs();
+    const timeout = setTimeout(() => {
+      settlePending(id, 'reject', new Error(`AOS SDK call timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    _pending.set(id, { resolve, reject, timeout });
     conn.write(JSON.stringify({ id, domain, method, params }) + '\n', (error) => {
       if (!error) return;
-      if (_pending.delete(id)) reject(error);
+      settlePending(id, 'reject', error);
     });
   });
 }

--- a/packages/gateway/src/engine/node-subprocess.ts
+++ b/packages/gateway/src/engine/node-subprocess.ts
@@ -12,6 +12,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // SDK lives at packages/gateway/sdk/aos-sdk.js
 // From src/engine/ that's ../../sdk/, from dist/engine/ that's also ../../sdk/
 const SDK_PATH = resolve(__dirname, '..', '..', 'sdk', 'aos-sdk.js');
+const SDK_TIMEOUT_GRACE_MS = 250;
+
+function sdkCallTimeoutMs(scriptTimeoutMs: number): number {
+  return Math.max(1, scriptTimeoutMs - SDK_TIMEOUT_GRACE_MS);
+}
 
 export class NodeSubprocessEngine implements ScriptEngine {
   readonly name = 'node-subprocess';
@@ -31,8 +36,12 @@ export class NodeSubprocessEngine implements ScriptEngine {
     const js = bodyMatch ? bodyMatch[1] : strippedWrapped;
     const resultFile = join(tmpdir(), `aos-result-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
 
+    const sdkConfig = {
+      ...request.context,
+      sdkCallTimeoutMs: sdkCallTimeoutMs(request.timeout),
+    };
     const wrapper = `
-globalThis.__aos_config = ${JSON.stringify(request.context)};
+globalThis.__aos_config = ${JSON.stringify(sdkConfig)};
 ${readFileSync(SDK_PATH, 'utf-8')}
 const params = ${JSON.stringify(request.params)};
 (async () => {

--- a/packages/gateway/test/engine.test.ts
+++ b/packages/gateway/test/engine.test.ts
@@ -79,6 +79,17 @@ describe('NodeSubprocessEngine', () => {
     });
     assert.equal(r.result, false);
   });
+
+  it('passes an SDK call timeout below the subprocess timeout', async () => {
+    const r = await engine.execute({
+      script: 'return globalThis.__aos_config.sdkCallTimeoutMs;',
+      params: {},
+      intent: 'automation',
+      timeout: 1000,
+      context: { gatewaySocket: TEST_SOCK, sessionId: 'test' },
+    });
+    assert.equal(r.result, 750);
+  });
 });
 
 describe('EngineRouter', () => {

--- a/tests/gateway-sdk-socket-lifecycle.test.mjs
+++ b/tests/gateway-sdk-socket-lifecycle.test.mjs
@@ -60,3 +60,46 @@ ${sdkSource}
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test('gateway SDK rejects pending calls when the socket stays open without a response', async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'aos-gateway-sdk-'));
+  const socketPath = path.join(dir, 'gateway.sock');
+  const resultPath = path.join(dir, 'result.json');
+  const scriptPath = path.join(dir, 'sdk-timeout-test.cjs');
+  const sdkSource = readFileSync(sdkPath, 'utf8');
+  const sockets = new Set();
+  const server = createServer((socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+    socket.on('data', () => {});
+  });
+
+  try {
+    await new Promise((resolve) => server.listen(socketPath, resolve));
+    writeFileSync(scriptPath, `
+globalThis.__aos_config = { gatewaySocket: ${JSON.stringify(socketPath)}, sdkCallTimeoutMs: 50 };
+${sdkSource}
+(async () => {
+  try {
+    await globalThis.aos.doctor();
+    require('node:fs').writeFileSync(${JSON.stringify(resultPath)}, JSON.stringify({ ok: true }));
+  } catch (error) {
+    require('node:fs').writeFileSync(${JSON.stringify(resultPath)}, JSON.stringify({ ok: false, error: error.message }));
+  } finally {
+    globalThis.__aos_cleanup?.();
+  }
+})();
+`);
+
+    await runNode(scriptPath);
+
+    assert.deepEqual(JSON.parse(readFileSync(resultPath, 'utf8')), {
+      ok: false,
+      error: 'AOS SDK call timed out after 50ms',
+    });
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    await new Promise((resolve) => server.close(() => resolve()));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add bounded per-call timeouts to the injected gateway SDK and clear pending timers on every settle path
- pass an SDK timeout from the Node subprocess engine that fires before the parent process timeout
- extend gateway SDK lifecycle coverage for sockets that stay open without responding

## Verification
- `node --test tests/gateway-sdk-socket-lifecycle.test.mjs`
- `npm run build` in `packages/gateway`
- `git diff --check`

## Note
- `node --test --loader ts-node/esm test/engine.test.ts` and `npm test -- --test-name-pattern "passes an SDK call timeout"` fail before test execution under Node 24 with the existing opaque `ts-node/esm` loader error (`[Object: null prototype]`).
