### PR TITLE
Clean up content wait IPC listeners

### DIFF
--- a/scripts/aos-content.mjs
+++ b/scripts/aos-content.mjs
@@ -120,27 +120,39 @@ function startDaemon() {
 function sendEnvelope(socket, service, action, data = {}) {
   return new Promise((resolve) => {
     let buffer = '';
+    let settled = false;
+    const cleanup = () => {
+      clearTimeout(timer);
+      socket.off('data', onData);
+      socket.off('error', onError);
+    };
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
     const timer = setTimeout(() => {
       socket.destroy();
-      resolve(null);
+      finish(null);
     }, 3000);
-    socket.on('data', (chunk) => {
+    const onData = (chunk) => {
       buffer += chunk.toString('utf8');
       const newline = buffer.indexOf('\n');
       if (newline < 0) return;
-      clearTimeout(timer);
       const line = buffer.slice(0, newline);
       try {
-        resolve(JSON.parse(line));
+        finish(JSON.parse(line));
       } catch {
-        resolve(null);
+        finish(null);
       }
+    };
+    const onError = () => finish(null);
+    socket.on('data', onData);
+    socket.once('error', onError);
+    socket.write(`${JSON.stringify({ v: 1, service, action, data })}\n`, (error) => {
+      if (error) finish(null);
     });
-    socket.once('error', () => {
-      clearTimeout(timer);
-      resolve(null);
-    });
-    socket.write(`${JSON.stringify({ v: 1, service, action, data })}\n`);
   });
 }
 

--- a/tests/content-wait-listener-lifecycle.test.mjs
+++ b/tests/content-wait-listener-lifecycle.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+const repoRoot = path.resolve(import.meta.dirname, '..');
+
+function runContentWait(stateRoot) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      'node',
+      ['scripts/aos-content.mjs', 'wait', '--root', 'missing-root', '--timeout', '2s', '--json'],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          AOS_STATE_ROOT: stateRoot,
+          AOS_RUNTIME_MODE: 'repo',
+          AOS_DISABLE_DAEMON_AUTOSTART: '1',
+        },
+      },
+    );
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+    child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+test('content wait does not accumulate socket listeners while polling status', async () => {
+  const stateRoot = mkdtempSync(path.join(os.tmpdir(), 'aos-content-listeners-'));
+  const socketPath = path.join(stateRoot, 'repo', 'sock');
+  mkdirSync(path.dirname(socketPath), { recursive: true });
+  const server = net.createServer((socket) => {
+    socket.on('data', (chunk) => {
+      for (const line of chunk.toString('utf8').split('\n')) {
+        if (!line.trim()) continue;
+        socket.write(`${JSON.stringify({ v: 1, data: { port: 17777, roots: {} } })}\n`);
+      }
+    });
+  });
+
+  try {
+    await new Promise((resolve) => server.listen(socketPath, resolve));
+    const result = await runContentWait(stateRoot);
+
+    assert.equal(result.code, 1);
+    assert.doesNotMatch(result.stderr, /MaxListenersExceededWarning/);
+    assert.match(result.stderr, /CONTENT_WAIT_TIMEOUT/);
+  } finally {
+    await new Promise((resolve) => server.close(() => resolve()));
+    rmSync(stateRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- remove per-poll IPC `data`/`error` listeners in `aos content wait` after each response, error, or timeout
- add a fake-daemon regression that polls long enough to catch listener accumulation warnings

## Verification
- `node --test tests/content-wait-listener-lifecycle.test.mjs`
- `bash tests/content-wait.sh`
- `git diff --check`
