### PR TITLE
Prune Sigil phenomena resources

### DIFF
--- a/apps/sigil/renderer/phenomena.js
+++ b/apps/sigil/renderer/phenomena.js
@@ -40,10 +40,32 @@ function distributeGroupChildren(group, count) {
     }
 }
 
+function disposeMaterial(material, retainedMaterials = []) {
+    if (Array.isArray(material)) {
+        material.forEach((entry) => disposeMaterial(entry, retainedMaterials));
+        return;
+    }
+    if (!material || retainedMaterials.includes(material)) return;
+    material.dispose?.();
+}
+
+function disposeObjectResources(object, retainedMaterials = []) {
+    if (!object) return;
+    object.traverse?.((child) => {
+        child.geometry?.dispose?.();
+        disposeMaterial(child.material, retainedMaterials);
+    });
+    if (!object.traverse) {
+        object.geometry?.dispose?.();
+        disposeMaterial(object.material, retainedMaterials);
+        object.children?.forEach((child) => disposeObjectResources(child, retainedMaterials));
+    }
+}
+
 /**
  * DRY: Shared instance count syncer for phenomena groups.
  */
-function syncGroupInstanceCount(group, count, createItemFn) {
+function syncGroupInstanceCount(group, count, createItemFn, removeItemFn = null) {
     if (!group) return;
     syncInstanceCount(() => group.children.length, count, () => {
         const item = createItemFn();
@@ -51,9 +73,12 @@ function syncGroupInstanceCount(group, count, createItemFn) {
             item.userData.seed = Math.random();
             group.add(item);
         }
-    }, (item) => {
+    }, () => {
         const last = group.children[group.children.length - 1];
-        if (last) group.remove(last);
+        if (last) {
+            group.remove(last);
+            removeItemFn?.(last);
+        }
     });
     distributeGroupChildren(group, count);
 }
@@ -64,7 +89,7 @@ export function updatePulsars(count) {
         if (!state.beamMat) return null;
         const mesh = new THREE.Mesh(new THREE.BufferGeometry(), state.beamMat);
         return mesh;
-    });
+    }, (mesh) => disposeObjectResources(mesh, [state.beamMat]));
     state.pulsarGroup?.children.forEach((mesh) => configureBeamMesh(mesh, {
         minHeight: state.pulsarMinHeight,
         maxHeight: state.pulsarMaxHeight,
@@ -81,7 +106,7 @@ export function updateGammaRays(count) {
         if (!state.gammaBeamMat) return null;
         const mesh = new THREE.Mesh(new THREE.BufferGeometry(), state.gammaBeamMat);
         return mesh;
-    });
+    }, (mesh) => disposeObjectResources(mesh, [state.gammaBeamMat]));
     state.gammaRaysGroup?.children.forEach((mesh) => configureBeamMesh(mesh, {
         minHeight: state.gammaMinHeight,
         maxHeight: state.gammaMaxHeight,
@@ -115,6 +140,9 @@ export function updateAccretion(count) {
             });
         }
         return singleDiskGroup;
+    }, (diskGroup) => {
+        state.accretionRings = state.accretionRings.filter((ring) => ring.mesh?.parent !== diskGroup);
+        disposeObjectResources(diskGroup, [state.diskMat]);
     });
     const minH = Math.min(state.accretionMinHeight, state.accretionMaxHeight);
     const maxH = Math.max(state.accretionMinHeight, state.accretionMaxHeight);
@@ -153,6 +181,9 @@ export function updateNeutrinos(count) {
             });
         }
         return jetGroup;
+    }, (jetGroup) => {
+        state.neutrinoParticles = state.neutrinoParticles.filter((particle) => particle.parentJet !== jetGroup);
+        disposeObjectResources(jetGroup, [state.neutrinoMat]);
     });
 }
 

--- a/tests/renderer/phenomena-lifecycle.test.mjs
+++ b/tests/renderer/phenomena-lifecycle.test.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import THREE from '../../apps/sigil/renderer/vendor/three.min.js';
+import state from '../../apps/sigil/renderer/state.js';
+
+globalThis.THREE = THREE;
+
+const original = {
+  accretionGroup: state.accretionGroup,
+  diskMat: state.diskMat,
+  accretionRings: state.accretionRings,
+  isAccretionEnabled: state.isAccretionEnabled,
+  accretionMinHeight: state.accretionMinHeight,
+  accretionMaxHeight: state.accretionMaxHeight,
+  accretionWidth: state.accretionWidth,
+  accretionWidthVariance: state.accretionWidthVariance,
+  neutrinoGroup: state.neutrinoGroup,
+  neutrinoMat: state.neutrinoMat,
+  neutrinoParticles: state.neutrinoParticles,
+};
+
+const { updateAccretion, updateNeutrinos } = await import('../../apps/sigil/renderer/phenomena.js');
+
+function restoreState() {
+  Object.assign(state, {
+    accretionGroup: original.accretionGroup,
+    diskMat: original.diskMat,
+    accretionRings: original.accretionRings,
+    isAccretionEnabled: original.isAccretionEnabled,
+    accretionMinHeight: original.accretionMinHeight,
+    accretionMaxHeight: original.accretionMaxHeight,
+    accretionWidth: original.accretionWidth,
+    accretionWidthVariance: original.accretionWidthVariance,
+    neutrinoGroup: original.neutrinoGroup,
+    neutrinoMat: original.neutrinoMat,
+    neutrinoParticles: original.neutrinoParticles,
+  });
+}
+
+test('accretion count decrease prunes ring state and disposes removed disk resources', () => {
+  state.accretionGroup = new THREE.Group();
+  state.diskMat = new THREE.MeshBasicMaterial();
+  state.accretionRings = [];
+  state.isAccretionEnabled = true;
+  state.accretionMinHeight = 0.01;
+  state.accretionMaxHeight = 0.03;
+  state.accretionWidth = 0.7;
+  state.accretionWidthVariance = 0.18;
+
+  try {
+    updateAccretion(2);
+
+    assert.equal(state.accretionGroup.children.length, 2);
+    assert.equal(state.accretionRings.length, 20);
+
+    const removedGroup = state.accretionGroup.children[1];
+    let disposed = 0;
+    removedGroup.traverse((child) => {
+      if (child.geometry) child.geometry.dispose = () => { disposed += 1; };
+      if (child.material && child.material !== state.diskMat) {
+        child.material.dispose = () => { disposed += 1; };
+      }
+    });
+
+    updateAccretion(1);
+
+    assert.equal(state.accretionGroup.children.length, 1);
+    assert.equal(state.accretionRings.length, 10);
+    assert.equal(state.accretionRings.some((ring) => ring.mesh?.parent === removedGroup), false);
+    assert.ok(disposed >= 11, `expected removed disk resources to be disposed, got ${disposed}`);
+  } finally {
+    restoreState();
+  }
+});
+
+test('neutrino count decrease prunes particle state for removed jets', () => {
+  state.neutrinoGroup = new THREE.Group();
+  state.neutrinoMat = new THREE.SpriteMaterial();
+  state.neutrinoParticles = [];
+
+  try {
+    updateNeutrinos(2);
+
+    assert.equal(state.neutrinoGroup.children.length, 2);
+    assert.equal(state.neutrinoParticles.length, 60);
+
+    const removedGroup = state.neutrinoGroup.children[1];
+
+    updateNeutrinos(1);
+
+    assert.equal(state.neutrinoGroup.children.length, 1);
+    assert.equal(state.neutrinoParticles.length, 30);
+    assert.equal(state.neutrinoParticles.some((particle) => particle.parentJet === removedGroup), false);
+  } finally {
+    restoreState();
+  }
+});


### PR DESCRIPTION
## Summary
- dispose removed Sigil phenomena geometries/materials when effect counts shrink
- prune accretion ring and neutrino particle tracking arrays for removed parent groups
- add renderer lifecycle coverage for accretion and neutrino count decreases

## Verification
- `node --test tests/renderer/phenomena-lifecycle.test.mjs`
- `git diff --check`
