### PR TITLE
Bound content port configuration

### DIFF
--- a/src/content/server.swift
+++ b/src/content/server.swift
@@ -17,7 +17,14 @@ class ContentServer {
     init(config: AosConfig.ContentConfig?, repoRoot: String?, stateDir: String? = nil) {
         self.stateDir = stateDir
         let cfg = config ?? AosConfig.ContentConfig(port: 0, roots: [:])
-        self.port = cfg.port == 0 ? .any : NWEndpoint.Port(rawValue: UInt16(cfg.port))!
+        if cfg.port == 0 {
+            self.port = .any
+        } else if let rawPort = UInt16(exactly: cfg.port), let configuredPort = NWEndpoint.Port(rawValue: rawPort) {
+            self.port = configuredPort
+        } else {
+            fputs("Warning: invalid content.port \(cfg.port); using OS-assigned port\n", stderr)
+            self.port = .any
+        }
 
         // Resolve root paths: relative paths resolve against repo root
         var resolved: [String: String] = [:]

--- a/src/shared/config.swift
+++ b/src/shared/config.swift
@@ -340,8 +340,8 @@ func setConfigValue(key: String, value: String) {
         config.feedback.sound = (value == "true" || value == "1")
     case "content.port":
         if config.content == nil { config.content = AosConfig.ContentConfig(port: 0, roots: [:]) }
-        if let n = Int(value), n >= 0 { config.content?.port = n }
-        else { exitError("content.port must be a non-negative integer", code: "INVALID_VALUE") }
+        if let n = Int(value), (0...65535).contains(n) { config.content?.port = n }
+        else { exitError("content.port must be an integer from 0 to 65535", code: "INVALID_VALUE") }
     case _ where key.hasPrefix("content.roots."):
         if config.content == nil { config.content = AosConfig.ContentConfig(port: 0, roots: [:]) }
         let rootName = String(key.dropFirst("content.roots.".count))


### PR DESCRIPTION
## Summary
- reject `content.port` values outside the UInt16 TCP port range through the config setter
- avoid content server startup traps when a hand-edited config contains an invalid port; fall back to an OS-assigned port with a warning

## Verification
- `bash tests/config-surface.sh`
- `bash tests/content-wait.sh`
- `./build.sh`
- `git diff --check`

## Note
- `bash tests/daemon-ipc-content.sh` was not applicable in this checkout because no repo daemon socket was running; it failed connecting to `/Users/Michael/.config/aos/repo/sock`.
