### PR TITLE
Guard spatial refresh stale writes

### DIFF
--- a/src/perceive/spatial.swift
+++ b/src/perceive/spatial.swift
@@ -76,7 +76,11 @@ class SpatialModel {
 
             if windowMoved {
                 channelsLock.lock()
-                channels[id]?.lastBounds = newBounds
+                if var current = channels[id] {
+                    current.lastBounds = newBounds
+                    current.revision += 1
+                    channels[id] = current
+                }
                 channelsLock.unlock()
                 refreshChannel(id: id)
                 onWindowMoved?(state.windowID, newBounds)
@@ -130,12 +134,14 @@ class SpatialModel {
 
     func updateChannel(id: String, subtree: ChannelSubtree?, depth: Int?) -> SpatialResponse {
         channelsLock.lock()
-        guard channels[id] != nil else {
+        guard var state = channels[id] else {
             channelsLock.unlock()
             return .fail("Channel '\(id)' not found", code: "CHANNEL_NOT_FOUND")
         }
-        if let s = subtree { channels[id]!.subtree = s }
-        if let d = depth { channels[id]!.depth = d }
+        if let s = subtree { state.subtree = s }
+        if let d = depth { state.depth = d }
+        state.revision += 1
+        channels[id] = state
         channelsLock.unlock()
         refreshChannel(id: id)
         return .ok
@@ -305,6 +311,7 @@ class SpatialModel {
             state.depth = state.depth + 2
         }
 
+        state.revision += 1
         channels[id] = state
         channelsLock.unlock()
         refreshChannel(id: id)
@@ -342,6 +349,7 @@ class SpatialModel {
             state.subtree = nil
         }
 
+        state.revision += 1
         channels[id] = state
         channelsLock.unlock()
         refreshChannel(id: id)
@@ -359,16 +367,16 @@ class SpatialModel {
 
     func refreshChannel(id: String) {
         channelsLock.lock()
-        guard var state = channels[id] else {
+        guard let state = channels[id] else {
             channelsLock.unlock()
             return
         }
+        let refreshRevision = state.revision
         channelsLock.unlock()
 
         // Get current window bounds
         guard let winInfo = windowInfoForID(state.windowID) else { return }
         let bounds = winInfo.bounds
-        state.lastBounds = bounds
 
         // Traverse AX tree for channel elements
         let elements = traverseForChannel(
@@ -379,28 +387,32 @@ class SpatialModel {
             scaleFactor: state.scaleFactor
         )
 
-        state.lastElementCount = elements.count
-        state.lastUpdated = iso8601Now()
-
         channelsLock.lock()
-        channels[id] = state
+        guard var current = channels[id], current.revision == refreshRevision else {
+            channelsLock.unlock()
+            return
+        }
+        current.lastBounds = bounds
+        current.lastElementCount = elements.count
+        current.lastUpdated = iso8601Now()
+        channels[id] = current
         channelsLock.unlock()
 
         // Build channel file using ChannelData from display/channel.swift
         let file = ChannelData(
             channel_id: id,
             created_by: "aos",
-            created_at: state.createdAt,
-            updated_at: state.lastUpdated,
+            created_at: current.createdAt,
+            updated_at: current.lastUpdated,
             target: ChannelTarget(
-                pid: state.pid,
-                app: state.app,
-                bundle_id: state.bundleID,
-                window_id: state.windowID,
-                display: state.display,
-                scale_factor: state.scaleFactor
+                pid: current.pid,
+                app: current.app,
+                bundle_id: current.bundleID,
+                window_id: current.windowID,
+                display: current.display,
+                scale_factor: current.scaleFactor
             ),
-            focus: ChannelFocus(subtree: state.subtree, depth: state.depth),
+            focus: ChannelFocus(subtree: current.subtree, depth: current.depth),
             window_bounds: bounds,
             elements: elements
         )
@@ -690,6 +702,7 @@ struct ChannelState {
     var lastBounds: ChannelBounds
     var lastElementCount: Int = 0
     var lastUpdated: String = ""
+    var revision: UInt64 = 0
     let createdAt: String
 }
 

--- a/tests/daemon/spatial-refresh-stale-write.test.mjs
+++ b/tests/daemon/spatial-refresh-stale-write.test.mjs
@@ -1,0 +1,51 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+
+const spatialPath = new URL('../../src/perceive/spatial.swift', import.meta.url)
+
+function swiftFunctionBody(source, signature) {
+  const signatureIndex = source.indexOf(signature)
+  assert.notEqual(signatureIndex, -1, `${signature} should exist`)
+  const openBraceIndex = source.indexOf('{', signatureIndex)
+  assert.notEqual(openBraceIndex, -1, `${signature} should have a body`)
+
+  let depth = 0
+  for (let index = openBraceIndex; index < source.length; index += 1) {
+    if (source[index] === '{') {
+      depth += 1
+    } else if (source[index] === '}') {
+      depth -= 1
+      if (depth === 0) return source.slice(openBraceIndex + 1, index)
+    }
+  }
+  assert.fail(`${signature} body should close`)
+}
+
+test('spatial channel refresh drops stale AX traversal results', () => {
+  const source = fs.readFileSync(spatialPath, 'utf8')
+  const pollBody = swiftFunctionBody(source, 'private func poll()')
+  const updateBody = swiftFunctionBody(source, 'func updateChannel(id: String, subtree: ChannelSubtree?, depth: Int?)')
+  const deepenBody = swiftFunctionBody(source, 'func deepenChannel(id: String, subtree: ChannelSubtree?, depth: Int?)')
+  const collapseBody = swiftFunctionBody(source, 'func collapseChannel(id: String, depth: Int?)')
+  const refreshBody = swiftFunctionBody(source, 'func refreshChannel(id: String)')
+
+  assert.match(source, /struct ChannelState[\s\S]*var revision: UInt64 = 0/)
+  assert.match(pollBody, /current\.revision \+= 1/)
+  assert.match(updateBody, /state\.revision \+= 1/)
+  assert.match(deepenBody, /state\.revision \+= 1/)
+  assert.match(collapseBody, /state\.revision \+= 1/)
+
+  const snapshotIndex = refreshBody.indexOf('let refreshRevision = state.revision')
+  const traversalIndex = refreshBody.indexOf('let elements = traverseForChannel(')
+  const staleGuardIndex = refreshBody.indexOf('current.revision == refreshRevision')
+  const publishIndex = refreshBody.indexOf('channels[id] = current')
+  const fileIndex = refreshBody.indexOf('let file = ChannelData(')
+
+  assert.ok(snapshotIndex !== -1, 'refresh should capture the channel revision before AX traversal')
+  assert.ok(traversalIndex > snapshotIndex, 'refresh should traverse after taking the revision snapshot')
+  assert.ok(staleGuardIndex > traversalIndex, 'refresh should re-check revision after AX traversal')
+  assert.ok(publishIndex > staleGuardIndex, 'refresh should publish memory state only after stale guard')
+  assert.ok(fileIndex > publishIndex, 'refresh should write the channel file only after guarded memory publish')
+  assert.doesNotMatch(refreshBody, /channels\[id\] = state/)
+})


### PR DESCRIPTION
## Summary

- Add an internal revision token to spatial channel state.
- Drop slow refresh results when channel state changed during AX traversal, preventing stale in-memory and channel-file writes.
- Preserve the existing channel JSON contract and file format.

## Verification

- node --test tests/daemon/spatial-refresh-stale-write.test.mjs tests/daemon/perception-ax-telemetry.test.mjs
- ./aos dev build --no-restart
- git diff --check
