### PR TITLE
Avoid blocking aos scheme port lookup

### DIFF
--- a/src/display/canvas.swift
+++ b/src/display/canvas.swift
@@ -15,15 +15,8 @@ class AosSchemeHandler: NSObject, WKURLSchemeHandler {
     private var stopped = Set<ObjectIdentifier>()
     private let lock = NSLock()
 
-    private func waitForPort(timeoutMs: Int = 10000, pollMs: Int = 25) -> UInt16 {
-        var port = portProvider()
-        if port > 0 { return port }
-        let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1000)
-        while port == 0 && Date() < deadline {
-            Thread.sleep(forTimeInterval: Double(pollMs) / 1000)
-            port = portProvider()
-        }
-        return port
+    private func currentContentPort() -> UInt16 {
+        return portProvider()
     }
 
     func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
@@ -34,7 +27,7 @@ class AosSchemeHandler: NSObject, WKURLSchemeHandler {
             return
         }
 
-        let port = waitForPort()
+        let port = currentContentPort()
         guard port > 0 else {
             fputs("[aos-scheme] content server unavailable for \(url.absoluteString)\n", stderr)
             let html = "<html><body style=\"font-family:system-ui;color:#fff;background:#1a1a2e;padding:2em\"><h2>aos:// content server unavailable</h2><pre>aos content status --json</pre><p>\(url.absoluteString)</p></body></html>"

--- a/tests/daemon/aos-scheme-handler-nonblocking.test.mjs
+++ b/tests/daemon/aos-scheme-handler-nonblocking.test.mjs
@@ -1,0 +1,58 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+
+const canvasPath = new URL('../../src/display/canvas.swift', import.meta.url)
+
+function classBody(source, className) {
+  const signature = `class ${className}`
+  const signatureIndex = source.indexOf(signature)
+  assert.notEqual(signatureIndex, -1, `${signature} should exist`)
+  const openBraceIndex = source.indexOf('{', signatureIndex)
+  assert.notEqual(openBraceIndex, -1, `${signature} should have a body`)
+
+  let depth = 0
+  for (let index = openBraceIndex; index < source.length; index += 1) {
+    if (source[index] === '{') {
+      depth += 1
+    } else if (source[index] === '}') {
+      depth -= 1
+      if (depth === 0) return source.slice(openBraceIndex + 1, index)
+    }
+  }
+  assert.fail(`${signature} body should close`)
+}
+
+function swiftFunctionBody(source, signature) {
+  const signatureIndex = source.indexOf(signature)
+  assert.notEqual(signatureIndex, -1, `${signature} should exist`)
+  const openBraceIndex = source.indexOf('{', signatureIndex)
+  assert.notEqual(openBraceIndex, -1, `${signature} should have a body`)
+
+  let depth = 0
+  for (let index = openBraceIndex; index < source.length; index += 1) {
+    if (source[index] === '{') {
+      depth += 1
+    } else if (source[index] === '}') {
+      depth -= 1
+      if (depth === 0) return source.slice(openBraceIndex + 1, index)
+    }
+  }
+  assert.fail(`${signature} body should close`)
+}
+
+test('AosSchemeHandler fails fast without blocking the main thread when content port is unavailable', () => {
+  const source = fs.readFileSync(canvasPath, 'utf8')
+  const handlerBody = classBody(source, 'AosSchemeHandler')
+  const startBody = swiftFunctionBody(handlerBody, 'func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask)')
+
+  assert.doesNotMatch(handlerBody, /waitForPort/)
+  assert.doesNotMatch(handlerBody, /Thread\.sleep/)
+  assert.doesNotMatch(handlerBody, /while\s+[^{}]*port/)
+  assert.match(handlerBody, /private func currentContentPort\(\) -> UInt16[\s\S]*return portProvider\(\)/)
+  assert.match(startBody, /let port = currentContentPort\(\)/)
+  assert.match(startBody, /guard port > 0 else/)
+  assert.match(startBody, /content server unavailable for/)
+  assert.match(startBody, /aos:\/\/ content server unavailable/)
+  assert.match(startBody, /urlSchemeTask\.didReceive\(response\)[\s\S]*urlSchemeTask\.didReceive\(data\)[\s\S]*urlSchemeTask\.didFinish\(\)/)
+})


### PR DESCRIPTION
## Summary

- Replace AosSchemeHandler port polling with a single nonblocking content-port snapshot.
- Preserve the existing aos:// content server unavailable fallback response when no content port is assigned.
- Add static regression coverage that prevents Thread.sleep/poll-loop reintroduction in the scheme handler.

## Verification

- node --test tests/daemon/aos-scheme-handler-nonblocking.test.mjs tests/canvas-close-callback-contract.test.mjs
- ./aos dev build --no-restart exited 137 twice with no output before rebuild; bash build.sh --no-restart passed as fallback
- ./aos help --json
- git diff --check
