### PR TITLE
Harden action profile timing math

### DIFF
--- a/src/act/act-helpers.swift
+++ b/src/act/act-helpers.swift
@@ -112,11 +112,37 @@ func flagsForModifier(_ name: String) -> CGEventFlags? {
 
 // MARK: - Timing Math
 
+func safePositiveDouble(_ value: Double, fallback: Double) -> Double {
+    value.isFinite && value > 0 ? value : fallback
+}
+
+func safeNonNegativeDouble(_ value: Double, fallback: Double = 0) -> Double {
+    value.isFinite && value >= 0 ? value : fallback
+}
+
+func safeUnitInterval(_ value: Double, fallback: Double = 0) -> Double {
+    guard value.isFinite else { return fallback }
+    return min(1.0, max(0.0, value))
+}
+
+func safeMotionStepCount(distance: Double, pixelsPerSecond: Double, stepInterval: Double) -> Int {
+    let safeSpeed = safePositiveDouble(pixelsPerSecond, fallback: 1200.0)
+    let safeInterval = safePositiveDouble(stepInterval, fallback: 0.008)
+    let safeDistance = safeNonNegativeDouble(distance)
+    let duration = safeDistance / safeSpeed
+    let rawSteps = duration / safeInterval
+    guard rawSteps.isFinite && rawSteps > 0 else { return 1 }
+    return max(1, Int(min(rawSteps, 50_000.0)))
+}
+
 /// Sample a random delay from a DelayRange using the specified distribution.
 /// Returns microseconds (for usleep).
 func sampleDelay(_ range: DelayRange) -> UInt32 {
-    let lo = Double(range.min)
-    let hi = Double(range.max)
+    let maxDelayMs = Int(UInt32.max / 1000)
+    let lowerMs = min(max(0, range.min), maxDelayMs)
+    let upperMs = min(max(0, range.max), maxDelayMs)
+    let lo = Double(min(lowerMs, upperMs))
+    let hi = Double(max(lowerMs, upperMs))
     guard lo < hi else { return UInt32(lo) * 1000 }
 
     let value: Double

--- a/src/act/actions.swift
+++ b/src/act/actions.swift
@@ -101,12 +101,16 @@ func handleMove(_ req: ActionRequest, state: SessionState) -> ActionResponse {
     let dy = Double(target.y - from.y)
     let dist = sqrt(dx * dx + dy * dy)
 
-    // Calculate step count from distance and profile speed
-    let duration = dist / profile.mouse.pixels_per_second  // seconds
     let stepInterval = 0.008 // ~125 Hz — smooth enough for CG
-    let steps = max(1, Int(duration / stepInterval))
+    let steps = safeMotionStepCount(
+        distance: dist,
+        pixelsPerSecond: profile.mouse.pixels_per_second,
+        stepInterval: stepInterval
+    )
+    let overshoot = safeNonNegativeDouble(profile.mouse.overshoot)
+    let jitter = safeNonNegativeDouble(profile.mouse.jitter)
 
-    let points = bezierPath(from: from, to: target, steps: steps, overshoot: profile.mouse.overshoot, jitter: profile.mouse.jitter)
+    let points = bezierPath(from: from, to: target, steps: steps, overshoot: overshoot, jitter: jitter)
 
     let source = CGEventSource(stateID: .hidSystemState)
     for pt in points {
@@ -237,11 +241,15 @@ func handleDrag(_ req: ActionRequest, state: SessionState) -> ActionResponse {
     let dx = Double(target.x - origin.x)
     let dy = Double(target.y - origin.y)
     let dist = sqrt(dx * dx + dy * dy)
-    let duration = dist / profile.mouse.pixels_per_second
     let stepInterval = 0.008
-    let steps = max(1, Int(duration / stepInterval))
+    let steps = safeMotionStepCount(
+        distance: dist,
+        pixelsPerSecond: profile.mouse.pixels_per_second,
+        stepInterval: stepInterval
+    )
+    let jitter = safeNonNegativeDouble(profile.mouse.jitter)
 
-    let points = bezierPath(from: origin, to: target, steps: steps, overshoot: 0, jitter: profile.mouse.jitter)
+    let points = bezierPath(from: origin, to: target, steps: steps, overshoot: 0, jitter: jitter)
 
     for pt in points {
         if let drag = CGEvent(mouseEventSource: source, mouseType: .leftMouseDragged,
@@ -441,8 +449,10 @@ func handleType(_ req: ActionRequest, state: SessionState) -> ActionResponse {
 
     let cadence = profile.timing.typing_cadence
     // Base interval from WPM: average word is 5 chars, so chars/sec = wpm * 5 / 60
-    let charsPerSecond = Double(cadence.wpm) * 5.0 / 60.0
-    let baseIntervalMs = 1000.0 / charsPerSecond
+    let wpm = max(1, cadence.wpm)
+    let variance = safeUnitInterval(cadence.variance)
+    let charsPerSecond = Double(wpm) * 5.0 / 60.0
+    let baseIntervalMs = max(1.0, 1000.0 / charsPerSecond)
 
     let source = CGEventSource(stateID: .hidSystemState)
     let flags = currentFlags(state)
@@ -462,7 +472,6 @@ func handleType(_ req: ActionRequest, state: SessionState) -> ActionResponse {
         }
 
         // Cadence: apply variance
-        let variance = cadence.variance
         let jitteredInterval = baseIntervalMs * (1.0 + Double.random(in: -variance...variance))
         usleep(UInt32(max(1.0, jitteredInterval)) * 1000)
 

--- a/tests/action-profile-safety-contract.test.mjs
+++ b/tests/action-profile-safety-contract.test.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+function source(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+function functionBody(swiftSource, signature) {
+  const start = swiftSource.indexOf(signature);
+  assert.notEqual(start, -1, `${signature} not found`);
+  const brace = swiftSource.indexOf('{', start);
+  assert.notEqual(brace, -1, `${signature} body not found`);
+  let depth = 0;
+  for (let i = brace; i < swiftSource.length; i += 1) {
+    if (swiftSource[i] === '{') depth += 1;
+    else if (swiftSource[i] === '}') {
+      depth -= 1;
+      if (depth === 0) return swiftSource.slice(brace + 1, i);
+    }
+  }
+  throw new Error(`${signature} body did not close`);
+}
+
+test('profile-driven motion step counts sanitize speed before integer conversion', () => {
+  const helpers = source('src/act/act-helpers.swift');
+  const helperBody = functionBody(helpers, 'func safeMotionStepCount(');
+  assert.match(helperBody, /safePositiveDouble\(pixelsPerSecond,\s*fallback:\s*1200\.0\)/);
+  assert.match(helperBody, /safePositiveDouble\(stepInterval,\s*fallback:\s*0\.008\)/);
+  assert.match(helperBody, /safeNonNegativeDouble\(distance\)/);
+  assert.match(helperBody, /guard rawSteps\.isFinite && rawSteps > 0 else \{ return 1 \}/);
+  assert.match(helperBody, /Int\(min\(rawSteps,\s*50_000\.0\)\)/);
+
+  const actions = source('src/act/actions.swift');
+  const moveBody = functionBody(actions, 'func handleMove(');
+  const dragBody = functionBody(actions, 'func handleDrag(');
+
+  assert.match(moveBody, /safeMotionStepCount\(\s*distance:\s*dist,\s*pixelsPerSecond:\s*profile\.mouse\.pixels_per_second,/s);
+  assert.match(dragBody, /safeMotionStepCount\(\s*distance:\s*dist,\s*pixelsPerSecond:\s*profile\.mouse\.pixels_per_second,/s);
+  assert.doesNotMatch(moveBody, /Int\(duration \/ stepInterval\)/);
+  assert.doesNotMatch(dragBody, /Int\(duration \/ stepInterval\)/);
+});
+
+test('delay sampling clamps negative and reversed profile ranges before UInt32 conversion', () => {
+  const body = functionBody(source('src/act/act-helpers.swift'), 'func sampleDelay(');
+  const delayCap = body.indexOf('let maxDelayMs = Int(UInt32.max / 1000)');
+  const lowerClamp = body.indexOf('let lowerMs = min(max(0, range.min), maxDelayMs)');
+  const upperClamp = body.indexOf('let upperMs = min(max(0, range.max), maxDelayMs)');
+  const loNormalize = body.indexOf('let lo = Double(min(lowerMs, upperMs))');
+  const hiNormalize = body.indexOf('let hi = Double(max(lowerMs, upperMs))');
+  const uintConversion = body.indexOf('UInt32(lo) * 1000');
+  const randomRange = body.indexOf('Double.random(in: lo...hi)');
+
+  assert.ok(delayCap >= 0, 'sampleDelay should cap values before UInt32 conversion');
+  assert.ok(lowerClamp > delayCap, 'sampleDelay should clamp negative min values');
+  assert.ok(upperClamp > lowerClamp, 'sampleDelay should clamp negative max values');
+  assert.ok(loNormalize > upperClamp, 'sampleDelay should normalize the lower bound');
+  assert.ok(hiNormalize > loNormalize, 'sampleDelay should normalize the upper bound');
+  assert.ok(uintConversion > hiNormalize, 'UInt32 conversion should only see clamped values');
+  assert.ok(randomRange > hiNormalize, 'random range should only see normalized bounds');
+});
+
+test('typing cadence sanitizes WPM and variance before random jitter', () => {
+  const body = functionBody(source('src/act/actions.swift'), 'func handleType(');
+  const wpmClamp = body.indexOf('let wpm = max(1, cadence.wpm)');
+  const varianceClamp = body.indexOf('let variance = safeUnitInterval(cadence.variance)');
+  const baseInterval = body.indexOf('let baseIntervalMs = max(1.0, 1000.0 / charsPerSecond)');
+  const randomJitter = body.indexOf('Double.random(in: -variance...variance)');
+
+  assert.ok(wpmClamp >= 0, 'typing cadence should clamp non-positive WPM');
+  assert.ok(varianceClamp > wpmClamp, 'typing cadence should clamp variance');
+  assert.ok(baseInterval > varianceClamp, 'base interval should be bounded');
+  assert.ok(randomJitter > baseInterval, 'jitter range should use sanitized variance');
+});


### PR DESCRIPTION
## Summary
- sanitize action profile speed, step interval, distance, jitter, and overshoot before motion step generation
- clamp delay ranges before UInt32 conversion so malformed profiles cannot trap
- clamp typing WPM and variance before cadence jitter generation

## Tests
- node --test tests/click-count-contract.test.mjs tests/action-profile-safety-contract.test.mjs
- node --test tests/click-count-contract.test.mjs tests/action-profile-safety-contract.test.mjs tests/toolkit/decision-gate.test.mjs tests/toolkit/desktop-world-surface.test.mjs tests/toolkit/html-workbench-expression.test.mjs tests/renderer/phenomena-lifecycle.test.mjs tests/event-stream-fd-ownership-contract.test.mjs tests/run-process-drain-contract.test.mjs tests/daemon/spatial-refresh-stale-write.test.mjs tests/canvas-close-callback-contract.test.mjs tests/workbench-human-checkpoint-annotate.test.mjs
- bash tests/external-parser-flags.sh
- bash build.sh --force --no-restart
- git diff --check
- ./aos help --json; ./aos help see --json; ./aos help do --json; ./aos help show --json

## Live proof
Not run. This is a static/native math hardening slice; no Level 4 live UI or TCC-gated proof is required for the claim.