### PR TITLE
Clarify native saved-ref action scope

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -222,6 +222,11 @@ target and returns a saved-ref execution envelope with `current_validation`,
 stale, ambiguous, disabled, changed, or identity-drifted current targets fail
 closed before dispatch:
 
+The examples below mix backend-specific saved-ref forms. The `press` and
+`focus` examples require stable `native_ax` refs with durable native identity
+facts and an actionable producer verdict; browser and AOS canvas refs fail
+closed for those actions.
+
 ```bash
 aos do click ref:<snapshot-id>:r1 --workspace default --dry-run
 aos do set-value ref:<snapshot-id>:r2 --workspace default --value "42" --dry-run

--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -3416,7 +3416,7 @@
             "aos do press --pid 1234 --role AXButton --title Save --dry-run",
             "aos do press --pid 1234 --role AXButton --title Save"
           ],
-          "summary" : "Saved-ref press validates before mutation and returns post_action.recommended_next_command for fresh aos see capture --save",
+          "summary" : "Stable native AX saved-ref press validates durable identity before mutation and returns post_action.recommended_next_command for fresh aos see capture --save",
           "execution" : {
             "auto_starts_daemon" : false,
             "interactive" : false,
@@ -3768,7 +3768,7 @@
             "aos do focus --pid 1234 --role AXTextField --dry-run",
             "aos do focus --pid 1234 --role AXTextField"
           ],
-          "summary" : "Saved-ref focus validates before mutation and returns post_action.recommended_next_command for fresh aos see capture --save",
+          "summary" : "Stable native AX saved-ref focus validates durable identity before mutation and returns post_action.recommended_next_command for fresh aos see capture --save",
           "execution" : {
             "auto_starts_daemon" : false,
             "interactive" : false,

--- a/manifests/commands/source/aos/07-do-03-controls.json
+++ b/manifests/commands/source/aos/07-do-03-controls.json
@@ -151,7 +151,7 @@
             "aos do press --pid 1234 --role AXButton --title Save --dry-run",
             "aos do press --pid 1234 --role AXButton --title Save"
           ],
-          "summary": "Saved-ref press validates before mutation and returns post_action.recommended_next_command for fresh aos see capture --save",
+          "summary": "Stable native AX saved-ref press validates durable identity before mutation and returns post_action.recommended_next_command for fresh aos see capture --save",
           "execution": {
             "auto_starts_daemon": false,
             "interactive": false,
@@ -503,7 +503,7 @@
             "aos do focus --pid 1234 --role AXTextField --dry-run",
             "aos do focus --pid 1234 --role AXTextField"
           ],
-          "summary": "Saved-ref focus validates before mutation and returns post_action.recommended_next_command for fresh aos see capture --save",
+          "summary": "Stable native AX saved-ref focus validates durable identity before mutation and returns post_action.recommended_next_command for fresh aos see capture --save",
           "execution": {
             "auto_starts_daemon": false,
             "interactive": false,

--- a/shared/schemas/aos-agent-workspace-v0.md
+++ b/shared/schemas/aos-agent-workspace-v0.md
@@ -283,6 +283,10 @@ mutation must warn or refuse before dispatching any coordinate-backed action.
 
 ## Saved-Ref Action Grammar Matrix
 
+The `press` and `focus` examples require stable `native_ax` refs with durable
+native identity facts and an actionable producer verdict; browser and AOS canvas
+refs fail closed for those actions.
+
 | action | command form | backend(s) | resolution classes | required args | dry-run | mutation risk | validation / reacquisition | statuses | post-action evidence | known limits |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `click` | `aos do click ref:<snapshot-id>:<ref> --workspace <id>` | `aos_canvas`; browser | `reacquirable` for canvas, `snapshot_scoped` for browser | ref target; optional `--right`, `--double`; `aos_canvas` also accepts `--dwell` | yes | medium; pointer activation | load saved ref, require unambiguous scope, require supported action, resolve current canvas target; browser refs require page/frame/navigation identity and exactly one enabled matching current xray element before dispatch | `dry_run`, `success`, `REF_NOT_FOUND`, `REF_STALE`, `REF_REVALIDATION_REQUIRED`, `REF_UNSUPPORTED`, `ACTION_INCOMPATIBLE`, `REF_AMBIGUOUS`, `REF_REVALIDATION_FAILED`, `UNKNOWN_ARG`, `UNKNOWN_FLAG` | real dispatch returns a saved-ref execution envelope with adapter output nested under `underlying_result` and a fresh-capture `recommended_next_command` | browser validation fails closed on page, frame, navigation, role, title, label, context, enabled-state, or uniqueness drift; native AX refs are not click-actionable and make no saved-action no-foreground guarantee |

--- a/skills/aos-agent-workspace/SKILL.md
+++ b/skills/aos-agent-workspace/SKILL.md
@@ -25,6 +25,10 @@ aos do press ref:<snapshot-id>:r7 --workspace default --dry-run
 aos do focus ref:<snapshot-id>:r7 --workspace default --dry-run
 ```
 
+The `press` and `focus` examples require stable `native_ax` refs with durable
+native identity facts and an actionable producer verdict; browser and AOS canvas
+refs fail closed for those actions.
+
 ## Contract
 
 - Use `aos see capture --save` to persist perception into the active runtime

--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -386,6 +386,7 @@ for (const text of [schemaDoc, apiDoc, skill]) {
   assert.ok(text.includes('stable'), 'docs/skill must describe stable native AX saved refs');
   assert.ok(text.includes('aos do press ref:<snapshot-id>'), 'docs/skill must include stable native press saved-ref example');
   assert.ok(text.includes('aos do focus ref:<snapshot-id>'), 'docs/skill must include stable native focus saved-ref example');
+  assert.ok(prose.includes('`press` and `focus` examples require stable `native_ax` refs'), 'docs/skill must mark press/focus examples as stable native AX only');
   assert.ok(text.includes('direct_ax_ready'), 'docs/skill must describe native direct AX saved-ref dry-run status');
   assert.ok(text.includes('requires_direct_ax_current_matching'), 'docs/skill must describe native saved-ref current matching status');
   assert.ok(text.includes('app_hint'), 'docs/skill must describe native app hint evidence');
@@ -407,6 +408,10 @@ for (const text of [schemaDoc, apiDoc, skill]) {
 assert.ok(
   apiDoc.replace(/\s+/g, ' ').includes('browser, AOS canvas, and native saved-ref tests'),
   'API doc must name backend-wide coordinate fallback refusal evidence',
+);
+assert.ok(
+  apiDoc.replace(/\s+/g, ' ').includes('`press` and `focus` examples require stable `native_ax` refs'),
+  'API saved-ref examples must mark press/focus as stable native AX only',
 );
 
 for (const field of ['app_pid', 'app_name', 'window_id', 'identifier', 'enabled', 'action_names', 'permission_state', 'focus_cursor_space_baseline', 'native_saved_ref_evidence', 'window_state', 'space_state', 'control_kind', 'surface_kind', 'focus_state', 'minimized', 'off_space', 'custom_control', 'canvas_surface']) {
@@ -455,6 +460,12 @@ assert.ok(!manifest.includes('remains dry-run advisory'), 'manifest save summary
 const doCommand = manifestJSON.commands.find((command) => JSON.stringify(command.path) === JSON.stringify(['do']));
 assert.ok(doCommand, 'manifest missing do command');
 const doFormsByID = new Map(doCommand.forms.map((form) => [form.id, form]));
+for (const action of ['press', 'focus']) {
+  const form = doFormsByID.get(`do-${action}`);
+  assert.ok(form.summary.includes(`Stable native AX saved-ref ${action}`), `manifest do-${action} summary must mark saved refs as stable native AX only`);
+  const targetArg = form.args.find((arg) => arg.id === 'target');
+  assert.ok(targetArg.summary.includes('Stable saved native AX ref'), `manifest do-${action} target arg must mark saved refs as stable native AX only`);
+}
 const savedRefSupportedMatrixActions = actionMatrixRows
   .filter((row) => Object.keys(row.supported_backends).length > 0)
   .map((row) => row.action);


### PR DESCRIPTION
## Summary
- mark saved-ref `press` and `focus` examples as stable native AX only in API, schema, and agent workspace skill docs
- update `do press` / `do focus` manifest summaries to name the stable native AX scope
- add contract-drift assertions so generic saved-ref wording does not return

## Verification
- bash tests/agent-workspace-contract-drift.sh
- bash tests/command-manifest-generation.sh
- bash tests/help-contract.sh
- node --test tests/schemas/aos-external-command-manifest-v0.test.mjs
- bash tests/external-command-dispatch.sh
- node --test tests/schemas/*.test.mjs
- git diff --check
- ./aos help --json; ./aos help see --json; ./aos help do --json; ./aos help show --json

Live proof: Not run. Static product-contract wording and manifest/help alignment only; no TCC/native UI runtime proof required.