### PR TITLE
Clarify set-value route summary

### DIFF
--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -3605,7 +3605,7 @@
             "aos do set-value canvas:settings/brightness-slider --value \"42\"",
             "aos do set-value --pid 1234 --role AXTextField --value \"hello\""
           ],
-          "summary" : "Saved-ref set-value validates before mutation and returns post_action.recommended_next_command for fresh aos see capture --save",
+          "summary" : "Set saved refs, direct canvas semantic refs, or direct AX targets; saved-ref set-value validates before mutation and returns post_action.recommended_next_command for fresh aos see capture --save",
           "execution" : {
             "auto_starts_daemon" : false,
             "interactive" : false,

--- a/manifests/commands/source/aos/07-do-03-controls.json
+++ b/manifests/commands/source/aos/07-do-03-controls.json
@@ -340,7 +340,7 @@
             "aos do set-value canvas:settings/brightness-slider --value \"42\"",
             "aos do set-value --pid 1234 --role AXTextField --value \"hello\""
           ],
-          "summary": "Saved-ref set-value validates before mutation and returns post_action.recommended_next_command for fresh aos see capture --save",
+          "summary": "Set saved refs, direct canvas semantic refs, or direct AX targets; saved-ref set-value validates before mutation and returns post_action.recommended_next_command for fresh aos see capture --save",
           "execution": {
             "auto_starts_daemon": false,
             "interactive": false,

--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -466,6 +466,11 @@ for (const action of ['press', 'focus']) {
   const targetArg = form.args.find((arg) => arg.id === 'target');
   assert.ok(targetArg.summary.includes('Stable saved native AX ref'), `manifest do-${action} target arg must mark saved refs as stable native AX only`);
 }
+const doSetValueForm = doFormsByID.get('do-set-value');
+assert.ok(
+  doSetValueForm.summary.includes('saved refs, direct canvas semantic refs, or direct AX targets'),
+  'manifest do-set-value summary must distinguish saved refs, direct canvas refs, and direct AX targets',
+);
 const savedRefSupportedMatrixActions = actionMatrixRows
   .filter((row) => Object.keys(row.supported_backends).length > 0)
   .map((row) => row.action);

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -444,6 +444,7 @@ for action in ["click", "fill", "hover", "scroll", "drag", "set-value", "press",
 assert "canvas:<canvas-id>/<ref>" in set_value["usage"], set_value["usage"]
 assert set_value["usage"].startswith("aos do set-value <ref-target|canvas:<canvas-id>/<ref>>"), set_value["usage"]
 assert "| aos do set-value --pid <pid> --role <role>" in set_value["usage"], set_value["usage"]
+assert "saved refs, direct canvas semantic refs, or direct AX targets" in set_value["summary"], set_value["summary"]
 assert "ref:<snapshot-id>:" in " ".join(set_value.get("examples", [])), set_value
 set_value_value = next(arg for arg in set_value["args"] if arg.get("id") == "value")
 assert set_value_value["required"] is False, set_value_value


### PR DESCRIPTION
## Summary
- update `do set-value` help summary to distinguish saved refs, direct canvas semantic refs, and direct AX targets
- regenerate the command manifest artifact
- add help/drift assertions to keep the mixed-route summary explicit

## Verification
- bash tests/agent-workspace-contract-drift.sh
- bash tests/help-contract.sh
- bash tests/command-manifest-generation.sh
- node --test tests/schemas/aos-external-command-manifest-v0.test.mjs
- bash tests/external-command-dispatch.sh
- node --test tests/aos-dev-gh-help-parity.test.mjs
- git diff --check
- ./aos help --json; ./aos help see --json; ./aos help do --json; ./aos help show --json

Live proof: Not run. Manifest/help text alignment only; no TCC/native UI runtime proof required.