### PR TITLE
Expose browser text and key help forms

### DIFF
--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -3140,6 +3140,54 @@
         {
           "args" : [
             {
+              "id" : "target",
+              "kind" : "positional",
+              "required" : true,
+              "summary" : "Browser target (browser:<session> or browser:<session>/<ref>)",
+              "value_type" : "string"
+            },
+            {
+              "id" : "text",
+              "kind" : "positional",
+              "required" : true,
+              "summary" : "Text to type into the browser target",
+              "value_type" : "string"
+            },
+            {
+              "id" : "state-id",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Perception state id this action was chosen from",
+              "token" : "--state-id",
+              "value_type" : "string"
+            }
+          ],
+          "examples" : [
+            "aos do type browser:todo/e21 \"hello world\"",
+            "aos do type browser:todo \"hello world\" --state-id see_abc123def456"
+          ],
+          "execution" : {
+            "auto_starts_daemon" : false,
+            "interactive" : false,
+            "mutates_state" : true,
+            "read_only" : false,
+            "requires_permissions" : true,
+            "streaming" : false,
+            "supports_dry_run" : false
+          },
+          "id" : "do-type-browser",
+          "output" : {
+            "default_mode" : "json",
+            "error_mode" : "json_stderr",
+            "streaming" : false,
+            "supports_json_flag" : false
+          },
+          "summary" : "Direct browser text input through Playwright; not a saved-ref action",
+          "usage" : "aos do type <browser:<session>[/<ref>]> <text> [--state-id id]"
+        },
+        {
+          "args" : [
+            {
               "id" : "combo",
               "kind" : "positional",
               "required" : true,
@@ -3168,6 +3216,54 @@
             "supports_json_flag" : false
           },
           "usage" : "aos do key <combo>"
+        },
+        {
+          "args" : [
+            {
+              "id" : "target",
+              "kind" : "positional",
+              "required" : true,
+              "summary" : "Browser target (browser:<session> or browser:<session>/<ref>)",
+              "value_type" : "string"
+            },
+            {
+              "id" : "combo",
+              "kind" : "positional",
+              "required" : true,
+              "summary" : "Key combination to press in the browser target",
+              "value_type" : "string"
+            },
+            {
+              "id" : "state-id",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Perception state id this action was chosen from",
+              "token" : "--state-id",
+              "value_type" : "string"
+            }
+          ],
+          "examples" : [
+            "aos do key browser:todo/e21 \"Enter\"",
+            "aos do key browser:todo \"cmd+s\" --state-id see_abc123def456"
+          ],
+          "execution" : {
+            "auto_starts_daemon" : false,
+            "interactive" : false,
+            "mutates_state" : true,
+            "read_only" : false,
+            "requires_permissions" : true,
+            "streaming" : false,
+            "supports_dry_run" : false
+          },
+          "id" : "do-key-browser",
+          "output" : {
+            "default_mode" : "json",
+            "error_mode" : "json_stderr",
+            "streaming" : false,
+            "supports_json_flag" : false
+          },
+          "summary" : "Direct browser key press through Playwright; not a saved-ref action",
+          "usage" : "aos do key <browser:<session>[/<ref>]> <combo> [--state-id id]"
         },
         {
           "args" : [

--- a/manifests/commands/source/aos/07-do-02-text.json
+++ b/manifests/commands/source/aos/07-do-02-text.json
@@ -58,6 +58,54 @@
         {
           "args": [
             {
+              "id": "target",
+              "kind": "positional",
+              "required": true,
+              "summary": "Browser target (browser:<session> or browser:<session>/<ref>)",
+              "value_type": "string"
+            },
+            {
+              "id": "text",
+              "kind": "positional",
+              "required": true,
+              "summary": "Text to type into the browser target",
+              "value_type": "string"
+            },
+            {
+              "id": "state-id",
+              "kind": "flag",
+              "required": false,
+              "summary": "Perception state id this action was chosen from",
+              "token": "--state-id",
+              "value_type": "string"
+            }
+          ],
+          "examples": [
+            "aos do type browser:todo/e21 \"hello world\"",
+            "aos do type browser:todo \"hello world\" --state-id see_abc123def456"
+          ],
+          "execution": {
+            "auto_starts_daemon": false,
+            "interactive": false,
+            "mutates_state": true,
+            "read_only": false,
+            "requires_permissions": true,
+            "streaming": false,
+            "supports_dry_run": false
+          },
+          "id": "do-type-browser",
+          "output": {
+            "default_mode": "json",
+            "error_mode": "json_stderr",
+            "streaming": false,
+            "supports_json_flag": false
+          },
+          "summary": "Direct browser text input through Playwright; not a saved-ref action",
+          "usage": "aos do type <browser:<session>[/<ref>]> <text> [--state-id id]"
+        },
+        {
+          "args": [
+            {
               "id": "combo",
               "kind": "positional",
               "required": true,
@@ -86,6 +134,54 @@
             "supports_json_flag": false
           },
           "usage": "aos do key <combo>"
+        },
+        {
+          "args": [
+            {
+              "id": "target",
+              "kind": "positional",
+              "required": true,
+              "summary": "Browser target (browser:<session> or browser:<session>/<ref>)",
+              "value_type": "string"
+            },
+            {
+              "id": "combo",
+              "kind": "positional",
+              "required": true,
+              "summary": "Key combination to press in the browser target",
+              "value_type": "string"
+            },
+            {
+              "id": "state-id",
+              "kind": "flag",
+              "required": false,
+              "summary": "Perception state id this action was chosen from",
+              "token": "--state-id",
+              "value_type": "string"
+            }
+          ],
+          "examples": [
+            "aos do key browser:todo/e21 \"Enter\"",
+            "aos do key browser:todo \"cmd+s\" --state-id see_abc123def456"
+          ],
+          "execution": {
+            "auto_starts_daemon": false,
+            "interactive": false,
+            "mutates_state": true,
+            "read_only": false,
+            "requires_permissions": true,
+            "streaming": false,
+            "supports_dry_run": false
+          },
+          "id": "do-key-browser",
+          "output": {
+            "default_mode": "json",
+            "error_mode": "json_stderr",
+            "streaming": false,
+            "supports_json_flag": false
+          },
+          "summary": "Direct browser key press through Playwright; not a saved-ref action",
+          "usage": "aos do key <browser:<session>[/<ref>]> <combo> [--state-id id]"
         },
         {
           "args": [

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -431,6 +431,14 @@ assert "aos see capture --save" in click["summary"], click
 click_examples = click.get("examples", [])
 assert "aos do click ref:<snapshot-id>:r1 --workspace default --dry-run" in click_examples, click_examples
 assert "aos do click ref:<snapshot-id>:r1 --workspace default" in click_examples, click_examples
+type_browser = next(item for item in data["forms"] if item["id"] == "do-type-browser")
+assert "browser:<session>[/<ref>]" in type_browser["usage"], type_browser["usage"]
+assert "--state-id" in {arg.get("token") for arg in type_browser["args"]}, type_browser
+assert "not a saved-ref action" in type_browser["summary"], type_browser
+key_browser = next(item for item in data["forms"] if item["id"] == "do-key-browser")
+assert "browser:<session>[/<ref>]" in key_browser["usage"], key_browser["usage"]
+assert "--state-id" in {arg.get("token") for arg in key_browser["args"]}, key_browser
+assert "not a saved-ref action" in key_browser["summary"], key_browser
 set_value = next(item for item in data["forms"] if item["id"] == "do-set-value")
 set_value_tokens = {arg.get("token") for arg in set_value["args"]}
 assert {"--workspace", "--snapshot", "--value", "--dry-run"} <= set_value_tokens, set_value_tokens


### PR DESCRIPTION
## Summary
- add explicit `do type` and `do key` browser forms to public command help
- mark those forms as direct Playwright browser routes, not saved-ref actions
- add help-contract assertions for browser text/key usage and `--state-id` support

## Verification
- bash tests/help-contract.sh
- bash tests/command-manifest-generation.sh
- node --test tests/schemas/aos-external-command-manifest-v0.test.mjs
- bash tests/agent-workspace-contract-drift.sh
- bash tests/external-command-dispatch.sh
- node --test tests/aos-dev-gh-help-parity.test.mjs
- git diff --check
- ./aos help --json; ./aos help see --json; ./aos help do --json; ./aos help show --json

Live proof: Not run. Manifest/help alignment for existing browser routes only; no browser session or UI runtime proof required.