### PR TITLE
Document browser text and key examples

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -871,8 +871,17 @@ action arguments and flags with `MISSING_ARG`, `INVALID_ARG`, `UNKNOWN_ARG`, or
 Direct browser `type` and `key` are current-host routes when the first action
 argument is `browser:<session>/<ref>` or `browser:<session>`. They live in the
 external command manifest and route to Playwright; they are not saved-ref
-actions. Saved-ref `type` and `key` attempts with `--workspace` or `--snapshot`
-fail closed through the saved-ref resolver until browser keyboard semantics are
+actions:
+
+```bash
+aos do type browser:<session>/<ref> "hello world" --state-id <id>
+aos do key browser:<session>/<ref> "Enter" --state-id <id>
+aos do type browser:<session> "hello world"
+aos do key browser:<session> "cmd+s"
+```
+
+Saved-ref `type` and `key` attempts with `--workspace` or `--snapshot` fail
+closed through the saved-ref resolver until browser keyboard semantics are
 promoted through the action matrix.
 Refs with `confidence: low` are readback-only for saved-ref mutation and fail
 closed with `REF_UNSUPPORTED` and `reason: low_confidence_target` before dry-run

--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -413,6 +413,12 @@ assert.ok(
   apiDoc.replace(/\s+/g, ' ').includes('`press` and `focus` examples require stable `native_ax` refs'),
   'API saved-ref examples must mark press/focus as stable native AX only',
 );
+assert.ok(apiDoc.includes('aos do type browser:<session>/<ref> "hello world" --state-id <id>'), 'API doc must include direct browser type example');
+assert.ok(apiDoc.includes('aos do key browser:<session>/<ref> "Enter" --state-id <id>'), 'API doc must include direct browser key example');
+assert.ok(
+  apiDoc.replace(/\s+/g, ' ').includes('Direct browser `type` and `key` are current-host routes'),
+  'API doc must distinguish direct browser type/key from saved-ref actions',
+);
 
 for (const field of ['app_pid', 'app_name', 'window_id', 'identifier', 'enabled', 'action_names', 'permission_state', 'focus_cursor_space_baseline', 'native_saved_ref_evidence', 'window_state', 'space_state', 'control_kind', 'surface_kind', 'focus_state', 'minimized', 'off_space', 'custom_control', 'canvas_surface']) {
   assert.ok(swiftAXModel.includes(field), `native AX element JSON model must expose ${field}`);


### PR DESCRIPTION
## Summary
- add concrete API examples for direct browser `do type` and `do key` routes
- keep the examples explicitly separate from saved-ref `type` / `key` support
- add drift assertions so API docs keep accepted browser text/key examples

## Verification
- bash tests/agent-workspace-contract-drift.sh
- bash tests/help-contract.sh
- git diff --check

Live proof: Not run. API/help contract documentation only; no browser session runtime proof required.