### PR TITLE
Document browser focus and assertion boundary

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -883,6 +883,12 @@ aos do key browser:<session> "cmd+s"
 Saved-ref `type` and `key` attempts with `--workspace` or `--snapshot` fail
 closed through the saved-ref resolver until browser keyboard semantics are
 promoted through the action matrix.
+Browser focus and text assertions are not separate public actions in this
+slice: `aos do focus` is native AX only, and saved workspaces do not expose
+`aos see assert`. Use direct browser `click`, `fill`, `type`, or `key` where
+those routes intentionally focus as part of Playwright execution, then verify
+through a fresh saved capture, Recipe JSON assertions, or Work Record
+postconditions.
 Refs with `confidence: low` are readback-only for saved-ref mutation and fail
 closed with `REF_UNSUPPORTED` and `reason: low_confidence_target` before dry-run
 validation or dispatch. Non-dry-run mutation refuses unsafe resolution classes or

--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -419,6 +419,14 @@ assert.ok(
   apiDoc.replace(/\s+/g, ' ').includes('Direct browser `type` and `key` are current-host routes'),
   'API doc must distinguish direct browser type/key from saved-ref actions',
 );
+assert.ok(
+  apiDoc.replace(/\s+/g, ' ').includes('Browser focus and text assertions are not separate public actions in this slice'),
+  'API doc must explicitly reject standalone browser focus/text assertion actions',
+);
+assert.ok(
+  apiDoc.replace(/\s+/g, ' ').includes('`aos do focus` is native AX only, and saved workspaces do not expose `aos see assert`'),
+  'API doc must route browser focus/assertion gaps to the current native/saved-workspace boundaries',
+);
 
 for (const field of ['app_pid', 'app_name', 'window_id', 'identifier', 'enabled', 'action_names', 'permission_state', 'focus_cursor_space_baseline', 'native_saved_ref_evidence', 'window_state', 'space_state', 'control_kind', 'surface_kind', 'focus_state', 'minimized', 'off_space', 'custom_control', 'canvas_surface']) {
   assert.ok(swiftAXModel.includes(field), `native AX element JSON model must expose ${field}`);


### PR DESCRIPTION
## Summary
- document that standalone browser focus and text assertions are not current public actions
- point browser focus-like flows to direct Playwright-backed browser actions and fresh saved capture verification
- add drift assertions for the API boundary

## Verification
- bash tests/agent-workspace-contract-drift.sh
- bash tests/help-contract.sh
- git diff --check

Live proof: Not run. API contract wording only; no browser runtime proof required.