### PR TITLE
Use provenance do target in canvas tests

### DIFF
--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -230,6 +230,8 @@ const toolkitPanelWindowDoc = fs.readFileSync('docs/api/toolkit/panel-window.md'
 const manifest = fs.readFileSync('manifests/commands/aos-commands.json', 'utf8');
 const externalManifestJSON = JSON.parse(fs.readFileSync('manifests/commands/aos-external-commands.json', 'utf8'));
 const nativeDoWrapper = fs.readFileSync('scripts/aos-do-native.mjs', 'utf8');
+const canvasRefActionsTest = fs.readFileSync('tests/aos-canvas-ref-actions.sh', 'utf8');
+const runPuckHitlPlan = fs.readFileSync('tests/run-puck-hitl-plan.sh', 'utf8');
 const manifestJSON = JSON.parse(manifest);
 const swiftAXModel = fs.readFileSync('src/perceive/models.swift', 'utf8');
 const swiftAXTraversal = fs.readFileSync('src/perceive/ax.swift', 'utf8');
@@ -436,6 +438,10 @@ assert.ok(
   !toolkitPanelWindowDoc.includes('semantic_targets[].do_target'),
   'toolkit panel docs must not imply do_target is a top-level semantic target field',
 );
+assert.ok(canvasRefActionsTest.includes('.[0].provenance.do_target'), 'canvas ref action test must read provenance.do_target');
+assert.ok(!canvasRefActionsTest.includes('.[0].do_target'), 'canvas ref action test must not read top-level do_target');
+assert.ok(runPuckHitlPlan.includes('provenance.get("do_target")'), 'run puck HITL plan must read provenance.do_target');
+assert.ok(!runPuckHitlPlan.includes('target.get("do_target")'), 'run puck HITL plan must not read top-level do_target');
 
 for (const field of ['app_pid', 'app_name', 'window_id', 'identifier', 'enabled', 'action_names', 'permission_state', 'focus_cursor_space_baseline', 'native_saved_ref_evidence', 'window_state', 'space_state', 'control_kind', 'surface_kind', 'focus_state', 'minimized', 'off_space', 'custom_control', 'canvas_surface']) {
   assert.ok(swiftAXModel.includes(field), `native AX element JSON model must expose ${field}`);

--- a/tests/aos-canvas-ref-actions.sh
+++ b/tests/aos-canvas-ref-actions.sh
@@ -95,7 +95,7 @@ STATE_ID="$(printf '%s' "$CAPTURE" | jq -r '.state_id')"
 SLIDER_TARGET="$(printf '%s' "$CAPTURE" | jq -r --arg canvas "$CANVAS_ID" '
   .semantic_targets
   | map(select(
-      .canvas_id == $canvas
+      .provenance.canvas_id == $canvas
       and .ref == "action-contract:opacity"
       and .role == "slider"
       and (.actions | index("set-value"))
@@ -106,7 +106,7 @@ SLIDER_TARGET="$(printf '%s' "$CAPTURE" | jq -r --arg canvas "$CANVAS_ID" '
       and .state.thumb_count == 1
       and (.geometry.control_bounds.width | type == "number")
     ))
-  | if length == 1 then .[0].do_target else empty end
+  | if length == 1 then .[0].provenance.do_target else empty end
 ')"
 
 if [ "$SLIDER_TARGET" != "canvas:${CANVAS_ID}/action-contract:opacity" ]; then
@@ -118,12 +118,12 @@ fi
 DRAG_TARGET="$(printf '%s' "$CAPTURE" | jq -r --arg canvas "$CANVAS_ID" '
   .semantic_targets
   | map(select(
-      .canvas_id == $canvas
+      .provenance.canvas_id == $canvas
       and .ref == ($canvas + ":drag-handle")
-      and .id == "drag-handle"
+      and .target.target_id == "drag-handle"
       and (.actions | index("drag"))
     ))
-  | if length == 1 then .[0].do_target else empty end
+  | if length == 1 then .[0].provenance.do_target else empty end
 ')"
 
 if [ "$DRAG_TARGET" != "canvas:${CANVAS_ID}/${CANVAS_ID}:drag-handle" ]; then

--- a/tests/run-puck-hitl-plan.sh
+++ b/tests/run-puck-hitl-plan.sh
@@ -157,7 +157,8 @@ payload = json.loads(pathlib.Path(sys.argv[1]).read_text())
 canvas_id = sys.argv[2]
 expected = f"canvas:{canvas_id}/run-puck-v0:advance"
 for target in payload.get("semantic_targets") or []:
-    if target.get("do_target") == expected and target.get("enabled") is True:
+    provenance = target.get("provenance") or {}
+    if provenance.get("do_target") == expected and target.get("enabled") is True:
         print(expected)
         raise SystemExit(0)
 raise SystemExit(f"missing enabled run puck advance do_target {expected}")


### PR DESCRIPTION
## Summary
- update canvas action and run-puck test helpers to read `semantic_targets[].provenance.do_target`
- keep direct canvas target selection aligned with the canonical semantic target envelope
- add static drift guards against top-level `do_target` reads in those scripts

## Verification
- bash tests/agent-workspace-contract-drift.sh
- bash tests/help-contract.sh
- bash tests/external-parser-flags.sh
- git diff --check

Live proof: Not run. `tests/aos-canvas-ref-actions.sh` and `tests/run-puck-hitl-plan.sh` are live canvas/HITL flows; this slice only updates their contract paths and guards them statically.