### PR TITLE
Document listen STT boundary

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -1256,7 +1256,10 @@ aos listen --session-id 019d97cc-2f15-7951-b0bd-3a271d7fb97c --follow
 aos listen --channels
 ```
 
-One-shot reads return a JSON envelope with a `messages` array. `--follow` emits one message per line as NDJSON.
+One-shot reads return a JSON envelope with a `messages` array. `--follow` emits
+one message per line as NDJSON. STT/dictation is planned as a future
+`aos listen` source, but the current public surface only reads channels and
+direct-session messages.
 
 ## `aos wiki`
 

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -222,6 +222,7 @@ fi
 if OUT="$(./aos help listen --json 2>/dev/null)" TEXT="$(./aos help listen 2>/dev/null)" python3 - <<'PY'
 import json
 import os
+from pathlib import Path
 
 data = json.loads(os.environ["OUT"])
 assert "channels or direct sessions" in data["summary"], data["summary"]
@@ -239,6 +240,10 @@ for form_id in ["listen-read", "listen-follow"]:
     assert any("--session-id" in item for item in form.get("examples", [])), form
 text = os.environ["TEXT"]
 assert text.count("requires one listen source: <channel> OR --session-id") == 2, text
+api_doc = Path("docs/api/aos.md").read_text(encoding="utf-8")
+assert "STT/dictation is planned as a future" in api_doc, "missing planned listen source boundary"
+assert "current public surface only reads channels" in api_doc, "missing current listen source boundary"
+assert "direct-session messages" in api_doc, "missing direct-session listen boundary"
 PY
 then
     pass "listen help exposes channel or direct-session source alternatives"


### PR DESCRIPTION
## Summary
- Document that STT/dictation remains a future `aos listen` source.
- Clarify that the current public `listen` surface only reads channels and direct-session messages.
- Add a help-contract guard so the API boundary stays documented.

## Verification
- `bash tests/help-contract.sh`
- `bash tests/command-manifest-generation.sh`
- `node --test tests/schemas/aos-external-command-manifest-v0.test.mjs`
- `bash tests/external-command-dispatch.sh`
- `node --test tests/aos-dev-gh-help-parity.test.mjs`
- `git diff --check`
- `./aos help --json`
- `./aos help see --json`
- `./aos help do --json`
- `./aos help show --json`
- `./aos help listen --json`

Live UI/native/TCC proof not run; this is a docs/help-contract clarification only.
