### PR TITLE
Clarify listen STT architecture boundary

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -191,7 +191,7 @@ The verb vocabulary follows an embodied metaphor. Communication is one primitive
 | `do` | Act on the environment | CGEvents, AX actions, AppleScript |
 | `show` | Project visuals | Canvases, overlays, render |
 | `tell` | Communicate outward | Routes to TTS, channels, future sinks |
-| `listen` | Receive communication | Aggregates STT, channels, stdin, future sources |
+| `listen` | Receive communication | Channels and direct sessions today; STT, stdin, and aggregated sources planned |
 
 The agent decides WHAT to communicate and TO WHOM. The daemon decides HOW to deliver it. This follows the first principle above: agent tokens are for decisions, not plumbing.
 

--- a/tests/execution-model-terminology-contract.test.mjs
+++ b/tests/execution-model-terminology-contract.test.mjs
@@ -267,9 +267,11 @@ test('voice and communication guidance keep say, voice, tell, and listen roles d
   assert.match(architecture, /`aos say` direct TTS convenience/);
   assert.match(architecture, /`aos voice` registry\/catalog\/assignments\/providers\/final-response speech ingress/);
   assert.match(architecture, /STT audio capture is a planned `aos listen` source, not a separate public primitive/);
+  assert.match(architecture, /\| `listen` \| Receive communication \| Channels and direct sessions today; STT, stdin, and aggregated sources planned \|/);
   assert.match(aosApi, /`aos say` is a direct TTS convenience path/);
   assert.match(aosApi, /`aos tell human \.\.\.` is daemon-routed communication/);
   assert.match(readme, /\| `aos listen` \| Primitive \| Inbound communication: channel\/direct-session reads and follow today; STT and broader sources planned \|/);
+  assert.doesNotMatch(maintained, /\| `listen` \| Receive communication \| Aggregates STT/);
   assert.doesNotMatch(maintained, /`aos listen` or similar/);
   assert.doesNotMatch(maintained, /say.*sugar for tell human/i);
 });


### PR DESCRIPTION
## Summary
- clarify the `listen` row in `ARCHITECTURE.md` so channel/direct-session reads are current and STT/stdin/aggregation are planned
- add a terminology-contract assertion that prevents the old "Aggregates STT" wording from returning in active communication guidance

## Verification
- `node --test tests/execution-model-terminology-contract.test.mjs`
- `git diff --check`
