### PR TITLE
Document show anchor API flags

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -789,6 +789,10 @@ Primary public verbs:
 - `--scope connection|global` (default: `global`)
 - `--track union`
 - `--surface desktop-world` — canonical alias for `--track union`
+- `--anchor-browser browser:<session>/<ref>`
+- `--anchor-window <id>`
+- `--anchor-channel <id>`
+- `--offset x,y,w,h`
 
 `--surface desktop-world` and legacy `--track union` create one logical
 DesktopWorld surface backed by one physical segment per active display. The
@@ -802,6 +806,13 @@ recreate the canvas so it boots with the segmented backing.
 number or numbers backing a canvas. Perception commands use this to keep
 canvas-scoped captures and `--xray` AX traversal attached to the intended AOS
 surface instead of falling back to the frontmost app.
+
+Anchor flags are placement roles, not separate target dialects.
+`--anchor-browser` consumes a browser Target-with-Ref, while `--anchor-window`
+and `--anchor-channel` consume resource ids. The display subsystem resolves the
+input into an Anchor Binding for placement. `show update` accepts the same
+anchor flags when a surface needs to be re-anchored after browser scroll,
+navigation, or layout changes.
 
 ## `aos recipe`
 

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -341,6 +341,7 @@ fi
 if CREATE="$(./aos help show create --json 2>/dev/null)" UPDATE="$(./aos help show update --json 2>/dev/null)" python3 - <<'PY'
 import json
 import os
+from pathlib import Path
 
 
 def form_arg(payload, form_id, arg_id):
@@ -358,6 +359,13 @@ assert enum_values(create_auto) == ["cursor_trail", "highlight_focused", "label_
 assert form_arg(os.environ["UPDATE"], "show-update", "auto-project") is None
 assert form_arg(os.environ["UPDATE"], "show-update", "anchor-channel") is not None
 assert enum_values(form_arg(os.environ["UPDATE"], "show-update", "track")) == ["union"]
+docs = Path("docs/api/aos.md").read_text(encoding="utf-8")
+show_section = docs.split("## `aos show`", 1)[1].split("## `aos recipe`", 1)[0]
+for token in ["--anchor-browser browser:<session>/<ref>", "--anchor-window <id>", "--anchor-channel <id>", "--offset x,y,w,h"]:
+    assert token in show_section, token
+assert "Anchor flags are placement roles, not separate target dialects" in show_section, show_section
+assert "Anchor Binding" in show_section, show_section
+assert "show update" in show_section and "re-anchored after browser scroll" in show_section, show_section
 PY
 then
     pass "show create/update registry matches canvas parser enums"


### PR DESCRIPTION
## Summary
- document `show create` anchor flags and `--offset` in the public AOS API reference
- clarify that anchor flags are placement roles that resolve to Anchor Bindings, not separate target dialects
- extend `tests/help-contract.sh` so help registry anchor support and API docs stay aligned

## Verification
- `bash tests/help-contract.sh`
- `git diff --check`
- `bash tests/command-manifest-generation.sh`
- `node --test tests/schemas/aos-external-command-manifest-v0.test.mjs`
- `bash tests/external-command-dispatch.sh`
- `node --test tests/aos-dev-gh-help-parity.test.mjs`
