### PR TITLE
Handle host SDK socket write failures

### DIFF
--- a/packages/host/src/sdk-client.ts
+++ b/packages/host/src/sdk-client.ts
@@ -109,10 +109,21 @@ export class HostClient {
 
   private call(method: string, params: Record<string, unknown>): Promise<unknown> {
     return new Promise((resolve, reject) => {
+      const socket = this.activeSocket();
+      if (!socket) {
+        reject(new Error('Host socket is not connected'));
+        return;
+      }
       const id = ulid();
       this.pending.set(id, { resolve, reject });
       const req: SocketRequest = { id, method, params };
-      this.socket!.write(JSON.stringify(req) + '\n');
+      socket.write(JSON.stringify(req) + '\n', (error) => {
+        if (!error) return;
+        const handler = this.pending.get(id);
+        if (!handler) return;
+        this.pending.delete(id);
+        handler.reject(error);
+      });
     });
   }
 
@@ -122,10 +133,25 @@ export class HostClient {
     onStream: (event: StreamEvent) => void,
   ): Promise<unknown> {
     return new Promise((resolve, reject) => {
+      const socket = this.activeSocket();
+      if (!socket) {
+        reject(new Error('Host socket is not connected'));
+        return;
+      }
       const id = ulid();
       this.pending.set(id, { resolve, reject, onStream });
       const req: SocketRequest = { id, method, params };
-      this.socket!.write(JSON.stringify(req) + '\n');
+      socket.write(JSON.stringify(req) + '\n', (error) => {
+        if (!error) return;
+        const handler = this.pending.get(id);
+        if (!handler) return;
+        this.pending.delete(id);
+        handler.reject(error);
+      });
     });
+  }
+
+  private activeSocket(): net.Socket | null {
+    return this.socket && !this.socket.destroyed ? this.socket : null;
   }
 }

--- a/packages/host/test/sdk-client.test.ts
+++ b/packages/host/test/sdk-client.test.ts
@@ -69,4 +69,33 @@ describe('HostClient', () => {
       /Host socket disconnected/,
     );
   });
+
+  it('rejects calls made before connect instead of throwing from socket access', async () => {
+    const socketPath = path.join(os.tmpdir(), `aos-host-client-unconnected-${process.pid}-${Date.now()}.sock`);
+    const client = new HostClient(socketPath);
+
+    await assert.rejects(
+      () => client.listTools(),
+      /Host socket is not connected/,
+    );
+  });
+
+  it('rejects a pending call when socket write reports an error', async () => {
+    const client = new HostClient('unused');
+    const writeError = new Error('write failed');
+    const fakeSocket = {
+      destroyed: false,
+      write(_data: string, callback: (error?: Error) => void): boolean {
+        callback(writeError);
+        return false;
+      },
+    };
+
+    (client as unknown as { socket: typeof fakeSocket }).socket = fakeSocket;
+
+    await assert.rejects(
+      () => client.listSessions(),
+      /write failed/,
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Reject HostClient calls cleanly when no active socket is connected.
- Reject pending HostClient calls when socket.write reports a callback error.
- Add regression coverage for pre-connect calls and write failures.

## Verification
- cd packages/host && npm test
- cd packages/host && npm run check
- git diff --check
- ./aos help --json
- ./aos help see --json
- ./aos help do --json
- ./aos help show --json
