### PR TITLE
Clarify saved canvas drag skill boundary

### DIFF
--- a/skills/aos-agent-workspace/SKILL.md
+++ b/skills/aos-agent-workspace/SKILL.md
@@ -124,6 +124,9 @@ matrix:
 - AOS canvas `reacquirable` refs may route `click` and `set-value` through the
   current canvas resolver. Supported canvas refs report
   `conformance.proof.status: deterministic_contract_tests_passed`.
+- Saved AOS canvas `drag` is not supported in the saved-ref action matrix.
+  Direct current-host canvas drag uses `canvas:<canvas-id>/<ref>` with `--by`
+  or `--to-value`; do not turn a saved canvas ref into a saved drag target.
 - Browser `snapshot_scoped` click, fill, hover, scroll, and drag refs use fresh
   xray plus page, frame, navigation, role, title, label, context, and
   enabled-state validation. `current_validation.current_target` includes current

--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -323,7 +323,13 @@ assert.ok(
   && skill.includes('aos do hover ref:<snapshot-id>:r5 --workspace default --dry-run')
   && skill.includes('aos do scroll ref:<snapshot-id>:r5 0,-200 --workspace default --dry-run')
   && skill.includes('aos do drag ref:<snapshot-id>:r5 ref:<snapshot-id>:r6 --workspace default --dry-run'),
-  'AOS workspace skill must show the supported browser/canvas saved-ref action families',
+  'AOS workspace skill must show the supported saved-ref action families',
+);
+assert.ok(
+  skill.includes('Saved AOS canvas `drag` is not supported in the saved-ref action matrix')
+  && skill.includes('Direct current-host canvas drag uses `canvas:<canvas-id>/<ref>` with `--by`')
+  && skill.includes('do not turn a saved canvas ref into a saved drag target'),
+  'AOS workspace skill must keep saved canvas drag distinct from direct canvas drag',
 );
 for (const staleCommand of [
   'aos see workspace use',


### PR DESCRIPTION
## Summary
- Clarify in the AOS agent workspace skill that saved AOS canvas drag is not supported by the saved-ref action matrix.
- Point agents to direct current-host canvas drag via canvas:<canvas-id>/<ref> with --by or --to-value instead.
- Add a drift assertion so the skill keeps saved canvas drag distinct from direct canvas drag.

## Verification
- bash tests/agent-workspace-contract-drift.sh
- git diff --check
- ./aos help --json
- ./aos help see --json
- ./aos help do --json
- ./aos help show --json
