### PR TITLE
Add README target handle ladder

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ commands, a typed MCP gateway for external consumers, and a Node.js agent host.
 
 See [docs/api/aos.md](docs/api/aos.md) for the full consumer command table.
 
+## Target Handles
+
+Normal observe-act loops should use saved refs from `aos see capture --save`:
+`ref:<snapshot-id>:<ref-id>`. Direct live refs such as
+`browser:<session>/<ref>` and `canvas:<canvas-id>/<ref>` are current-host
+addresses for diagnostics, provenance, direct execution, and placement anchors.
+Coordinate fallback remains raw `x,y` plus `--state-id <id>`; native AX direct
+actions use selector flags such as `--pid` and `--role`, not a public `ax:`
+target grammar. Semantic Targets are perception records that contain refs and
+facts, not another address system.
+
 ## Track-2 consumers
 
 | Package | Role |

--- a/tests/execution-model-terminology-contract.test.mjs
+++ b/tests/execution-model-terminology-contract.test.mjs
@@ -207,6 +207,22 @@ test('public API docs preserve the current target and handle ladder', async () =
   assert.doesNotMatch(section, /`ax:</);
 });
 
+test('README gives the simplified target handle ladder without new grammar', async () => {
+  const readme = await text('README.md');
+  const section = readme.split('## Target Handles', 2)[1].split('## Track-2 consumers', 1)[0];
+
+  assert.match(section, /saved refs from `aos see capture --save`/);
+  assert.match(section, /`ref:<snapshot-id>:<ref-id>`/);
+  assert.match(section, /`browser:<session>\/<ref>` and `canvas:<canvas-id>\/<ref>`/);
+  assert.match(section, /raw `x,y` plus `--state-id <id>`/);
+  assert.match(section, /selector flags such as `--pid` and `--role`/);
+  assert.match(section, /not a public `ax:`\s+target grammar/);
+  assert.match(section, /Semantic Targets are perception records/);
+  assert.match(section, /not another address system/);
+  assert.doesNotMatch(section, /`screen:/);
+  assert.doesNotMatch(section, /`ax:<`/);
+});
+
 test('grand unification plan qualifies screen and AX target-model vocabulary', async () => {
   const plan = await text('docs/design/aos-grand-unification-plan.md');
 


### PR DESCRIPTION
## Summary
- Add a concise Target Handles section to the root README.
- State that saved refs are the normal observe-act handle, direct browser/canvas refs are current-host addresses, coordinates use raw x,y plus --state-id, and native AX uses selector flags rather than a public ax: grammar.
- Add terminology drift coverage so README stays aligned with the API target ladder.

## Verification
- node --test tests/execution-model-terminology-contract.test.mjs
- bash tests/help-contract.sh
- git diff --check
- ./aos help --json
- ./aos help see --json
- ./aos help do --json
- ./aos help show --json
