### PR TITLE
Add structured saved-ref refresh recommendations

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -238,7 +238,8 @@ saved page/frame/navigation and element identity facts still validate. Dry-run
 reports `reacquired` when that validation is sufficient for real dispatch;
 non-dry-run then routes through the underlying `browser:<session>/<ref>` action
 target and returns a saved-ref execution envelope with `current_validation`,
-`underlying_result`, `post_action`, and `recommended_next_command`. Missing,
+`underlying_result`, `post_action`, structured `post_action.recommended_next`,
+and `recommended_next_command`. Missing,
 stale, ambiguous, disabled, changed, or identity-drifted current targets fail
 closed before dispatch:
 

--- a/scripts/lib/agent-workspace/ref-action-execution.mjs
+++ b/scripts/lib/agent-workspace/ref-action-execution.mjs
@@ -7,7 +7,7 @@ import {
   stateRoot,
 } from './core.mjs';
 import { refSummary } from './refs.mjs';
-import { recommendedRefreshCommand } from './ref-action-resolution.mjs';
+import { recommendedRefreshCommand, recommendedRefreshDescriptor } from './ref-action-resolution.mjs';
 
 function hasStateIDArg(args) {
   return args.includes('--state-id');
@@ -87,6 +87,7 @@ function actionEnvelope({
   const parsedStdout = parseJSONOutput(result.stdout);
   const parsedStderr = parseJSONOutput(result.stderr);
   const recommendation = recommendedRefreshCommand(workspace, record);
+  const recommendedNext = recommendedRefreshDescriptor(workspace, record);
   return {
     status,
     schema_version: SCHEMA_VERSION,
@@ -109,6 +110,7 @@ function actionEnvelope({
     post_action: {
       verification: status === 'success' ? 'fresh_capture_recommended' : 'underlying_action_failed',
       state: null,
+      recommended_next: recommendedNext,
       recommended_next_command: recommendation,
     },
     recommended_next_command: recommendation,

--- a/scripts/lib/agent-workspace/ref-action-resolution.mjs
+++ b/scripts/lib/agent-workspace/ref-action-resolution.mjs
@@ -25,6 +25,18 @@ function captureSourceToken(record = null) {
   return target ? captureTargetToken(target) : null;
 }
 
+function captureSourceArgv(record = null) {
+  const sourceArgv = record?.capture_source?.argv;
+  if (Array.isArray(sourceArgv) && sourceArgv.length > 0) {
+    return sourceArgv.map((arg) => String(arg));
+  }
+  const target = record?.capture_target;
+  if (!target) return null;
+  const externalMatch = String(target).match(/^external ([1-9]\d*)$/);
+  if (externalMatch) return ['external', externalMatch[1]];
+  return [String(target)];
+}
+
 export function recommendedRefreshCommand(workspace, record = null) {
   const source = captureSourceToken(record);
   const mode = record?.capture_mode;
@@ -41,6 +53,36 @@ export function recommendedRefreshCommand(workspace, record = null) {
     commandToken(mode),
     record.query ? `--query ${commandToken(record.query)}` : null,
   ].filter(Boolean).join(' ');
+}
+
+export function recommendedRefreshDescriptor(workspace, record = null) {
+  const sourceArgv = captureSourceArgv(record);
+  const mode = record?.capture_mode;
+  const command = recommendedRefreshCommand(workspace, record);
+  if (!sourceArgv || !mode || !command) return null;
+  const argv = [
+    'aos',
+    'see',
+    'capture',
+    ...sourceArgv,
+    '--save',
+    '--workspace',
+    String(workspace),
+    '--mode',
+    String(mode),
+  ];
+  if (record?.query) argv.push('--query', String(record.query));
+  return {
+    kind: 'fresh_saved_capture',
+    reason: 're-perceive after saved-ref mutation before asserting state',
+    command,
+    argv,
+    workspace_id: String(workspace),
+    capture_mode: String(mode),
+    capture_target: record?.capture_target ?? null,
+    capture_source: record?.capture_source ?? null,
+    query: record?.query ?? null,
+  };
 }
 
 function recommendedRefsCommand(workspace, snapshot = null) {

--- a/shared/schemas/aos-agent-workspace-v0.md
+++ b/shared/schemas/aos-agent-workspace-v0.md
@@ -206,7 +206,8 @@ marks it actionable with complete known-limit facts.
 Non-dry-run saved-ref mutations return a saved-ref execution envelope rather
 than raw adapter output. The envelope includes the resolved command,
 `current_validation` when a backend performs current-target validation,
-`underlying_result` for the adapter response, `post_action`, and
+`underlying_result` for the adapter response, `post_action`,
+`post_action.recommended_next` for a structured fresh-capture descriptor, and
 `recommended_next_command` when a fresh saved capture is the safe next
 verification step. After a dry-run returns a safe status such as `reacquired`,
 `resolved`, or `direct_ax_ready`, dispatch by rerunning the exact saved-ref

--- a/skills/aos-agent-workspace/SKILL.md
+++ b/skills/aos-agent-workspace/SKILL.md
@@ -136,9 +136,10 @@ matrix:
   Non-dry-run routes through the underlying `browser:<session>/<ref>` target
   only after validation passes, then returns a saved-ref execution envelope with
   `current_validation`, `underlying_result`, `post_action`, and
-  `recommended_next_command`. Drag validates both endpoints and requires the
-  same saved snapshot and browser session. Missing, stale, ambiguous, disabled,
-  unsupported, or changed current targets fail closed with
+  `post_action.recommended_next` plus `recommended_next_command`. Drag
+  validates both endpoints and requires the same saved snapshot and browser
+  session. Missing, stale, ambiguous, disabled, unsupported, or changed current
+  targets fail closed with
   `REF_NOT_FOUND`, `REF_STALE`, `REF_AMBIGUOUS`, `REF_UNSUPPORTED`, or
   `ACTION_INCOMPATIBLE`. Supported browser refs report `conformance.proof.status:
   deterministic_contract_tests_passed`.

--- a/tests/agent-workspace-browser-refs.sh
+++ b/tests/agent-workspace-browser-refs.sh
@@ -112,6 +112,10 @@ jq -e '
   and .underlying_result.execution.strategy == "playwright_click"
   and (.underlying_result.result.stdout | contains("fake click invoked: -s=todo click e2"))
   and .post_action.verification == "fresh_capture_recommended"
+  and .post_action.recommended_next.kind == "fresh_saved_capture"
+  and .post_action.recommended_next.argv == ["aos","see","capture","browser:todo","--save","--workspace","ws-browser","--mode","ax","--query","Click me"]
+  and .post_action.recommended_next.capture_target == "browser:todo"
+  and .post_action.recommended_next.query == "Click me"
   and .post_action.recommended_next_command == "aos see capture browser:todo --save --workspace ws-browser --mode ax --query \u0027Click me\u0027"
   and .recommended_next_command == "aos see capture browser:todo --save --workspace ws-browser --mode ax --query \u0027Click me\u0027"
 ' "$REAL_ACTION" >/dev/null || fail "browser saved-ref click did not dispatch after validation: $(cat "$REAL_ACTION")"

--- a/tests/agent-workspace-canvas-refs.sh
+++ b/tests/agent-workspace-canvas-refs.sh
@@ -155,6 +155,10 @@ jq -e '
   and .underlying_result.execution.state_id == "see_canvas_fixture"
   and (.underlying_result.received | index("canvas:canvas-fixture/save-button") != null)
   and .post_action.verification == "fresh_capture_recommended"
+  and .post_action.recommended_next.kind == "fresh_saved_capture"
+  and .post_action.recommended_next.argv == ["aos","see","capture","main","--save","--workspace","ws-canvas","--mode","som"]
+  and .post_action.recommended_next.capture_target == "main"
+  and .post_action.recommended_next.query == null
   and .post_action.recommended_next_command == "aos see capture main --save --workspace ws-canvas --mode som"
   and .recommended_next_command == "aos see capture main --save --workspace ws-canvas --mode som"
 ' "$CANVAS_ACTION" >/dev/null || fail "AOS canvas ref action drifted: $(cat "$CANVAS_ACTION")"

--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -31,7 +31,7 @@ import {
 } from './scripts/lib/agent-workspace/contracts.mjs';
 import { AGENT_WORKSPACE_V0_CONTRACT_COVERAGE } from './tests/lib/agent-workspace-contract-coverage.mjs';
 import { parseCaptureArgs } from './scripts/lib/agent-workspace/capture.mjs';
-import { recommendedRefreshCommand } from './scripts/lib/agent-workspace/ref-action-resolution.mjs';
+import { recommendedRefreshCommand, recommendedRefreshDescriptor } from './scripts/lib/agent-workspace/ref-action-resolution.mjs';
 import { workspaceID } from './scripts/lib/agent-workspace/core.mjs';
 
 const schema = JSON.parse(fs.readFileSync('shared/schemas/aos-agent-workspace-v0.schema.json', 'utf8'));
@@ -426,6 +426,7 @@ for (const text of [schemaDoc, apiDoc, skill]) {
   );
   assert.ok(prose.includes('saved-ref execution envelope'), 'docs/skill must describe real saved-ref execution envelope');
   assert.ok(text.includes('underlying_result'), 'docs/skill must describe nested underlying action result');
+  assert.ok(text.includes('post_action.recommended_next'), 'docs/skill must describe structured post-action refresh descriptor');
   assert.ok(text.includes('recommended_next_command'), 'docs/skill must describe post-action refresh recommendation');
   assert.ok(text.includes('conformance'), 'docs/skill must describe saved-ref conformance fields');
   assert.ok(text.includes('proof'), 'docs/skill must describe saved-ref proof fields');
@@ -742,6 +743,25 @@ assert.equal(
   'aos see capture --canvas surface-inspector --save --workspace default --mode som',
   'refresh recommendations must reconstruct source-flag captures from capture_source.argv',
 );
+assert.deepEqual(
+  recommendedRefreshDescriptor('default', {
+    capture_target: 'main',
+    capture_source: parsedCanvasSave.capture_source,
+    capture_mode: 'som',
+  }),
+  {
+    kind: 'fresh_saved_capture',
+    reason: 're-perceive after saved-ref mutation before asserting state',
+    command: 'aos see capture --canvas surface-inspector --save --workspace default --mode som',
+    argv: ['aos', 'see', 'capture', '--canvas', 'surface-inspector', '--save', '--workspace', 'default', '--mode', 'som'],
+    workspace_id: 'default',
+    capture_mode: 'som',
+    capture_target: 'main',
+    capture_source: parsedCanvasSave.capture_source,
+    query: null,
+  },
+  'structured refresh recommendations must preserve reconstructable source argv',
+);
 assert.equal(
   recommendedRefreshCommand('default', {
     capture_target: 'browser:todo',
@@ -750,6 +770,15 @@ assert.equal(
   }),
   "aos see capture browser:todo --save --workspace default --mode ax --query 'Save button'",
   'legacy records without capture_source must still fall back to capture_target',
+);
+assert.deepEqual(
+  recommendedRefreshDescriptor('default', {
+    capture_target: 'browser:todo',
+    capture_mode: 'ax',
+    query: 'Save button',
+  })?.argv,
+  ['aos', 'see', 'capture', 'browser:todo', '--save', '--workspace', 'default', '--mode', 'ax', '--query', 'Save button'],
+  'structured refresh recommendations must preserve query argv without shell quoting',
 );
 assert.ok(captureSaveForm.usage.includes('--region <rect>'), 'saved capture usage must advertise region source');
 assert.ok(captureSaveForm.usage.includes('--canvas <id>'), 'saved capture usage must advertise canvas source');

--- a/tests/agent-workspace-native-refs.sh
+++ b/tests/agent-workspace-native-refs.sh
@@ -413,6 +413,10 @@ jq -e '
   and .underlying_result.conformance.target_uncertainty.status == "direct_ax_current_matching"
   and any(.underlying_result.known_limits[]; contains("HITL proof"))
   and .post_action.verification == "fresh_capture_recommended"
+  and .post_action.recommended_next.kind == "fresh_saved_capture"
+  and .post_action.recommended_next.argv == ["aos","see","capture","main","--save","--workspace","ws-native","--mode","ax"]
+  and .post_action.recommended_next.capture_target == "main"
+  and .post_action.recommended_next.query == null
   and .post_action.recommended_next_command == "aos see capture main --save --workspace ws-native --mode ax"
   and .recommended_next_command == "aos see capture main --save --workspace ws-native --mode ax"
 ' "$DURABLE_PRESS" >/dev/null || fail "durable native AX press dispatch drifted: $(cat "$DURABLE_PRESS")"


### PR DESCRIPTION
## Summary
- add structured `post_action.recommended_next` descriptors alongside existing saved-ref `recommended_next_command` strings
- preserve reconstructable capture argv for target, source-flag, workspace, mode, and query refreshes
- guard browser, canvas, native, schema/doc/skill drift coverage

## Verification
- bash tests/agent-workspace-browser-refs.sh
- bash tests/agent-workspace-canvas-refs.sh
- bash tests/agent-workspace-native-refs.sh
- bash tests/agent-workspace-contract-drift.sh
- bash tests/agent-workspace-saved-ref.sh
- node --test tests/schemas/*.test.mjs
- bash tests/help-contract.sh
- git diff --check
- ./aos help --json; ./aos help see --json; ./aos help do --json; ./aos help show --json
