### PR TITLE
Add structured refresh recommendations to blocked refs

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -208,12 +208,12 @@ must first define a multi-agent-safe contract.
 
 Current wait/diff/assertion boundary: saved workspaces do not expose
 `aos see capture --wait-for-change`, `aos see capture --until-stable`,
-`aos see refs --diff`, or `aos see assert`. Use `recommended_next_command` plus
-a fresh saved capture for re-perception, `aos show wait` only for canvas
-readiness, Recipe assertions only for command JSON checks, and Work Record
-postconditions for durable evidence checks. Future saved wait/diff/assert
-commands need manifest help, parser, schema/doc, and drift tests before public
-use.
+`aos see refs --diff`, or `aos see assert`. Use structured
+`recommended_next` descriptors and `recommended_next_command` plus a fresh saved
+capture for re-perception, `aos show wait` only for canvas readiness, Recipe
+assertions only for command JSON checks, and Work Record postconditions for
+durable evidence checks. Future saved wait/diff/assert commands need manifest
+help, parser, schema/doc, and drift tests before public use.
 
 Capture modes are explicit:
 

--- a/scripts/lib/agent-workspace/actions.mjs
+++ b/scripts/lib/agent-workspace/actions.mjs
@@ -8,7 +8,7 @@ import {
   failLowConfidenceRef,
   failUnsupportedRef,
   loadRefRecord,
-  recommendedRefreshCommand,
+  recommendedRefreshResponseFields,
   unsafeResolutionForMutation,
 } from './ref-action-resolution.mjs';
 import {
@@ -159,8 +159,7 @@ function maybeRunRefAction(action, args, env = process.env) {
     exitAgentWorkspaceError(`Ref '${unsafeRecord.ref}' is ${unsafeStatus}; refresh perception before mutating`, 'REF_REVALIDATION_REQUIRED', {
       status: unsafeStatus,
       ref: refSummary(unsafeRecord),
-      safe_next_action: recommendedRefreshCommand(workspace, unsafeRecord),
-      recommended_next_command: recommendedRefreshCommand(workspace, unsafeRecord),
+      ...recommendedRefreshResponseFields(workspace, unsafeRecord),
       requires_user_approval: false,
     });
   }

--- a/scripts/lib/agent-workspace/browser-ref-validation.mjs
+++ b/scripts/lib/agent-workspace/browser-ref-validation.mjs
@@ -17,7 +17,7 @@ import {
 } from './contracts.mjs';
 import {
   failIncompatibleDragEndpoint,
-  recommendedRefreshCommand,
+  recommendedRefreshResponseFields,
 } from './ref-action-resolution.mjs';
 
 export function parseBrowserActionTarget(value) {
@@ -117,8 +117,7 @@ function currentBrowserCapture(session, workspace, record, env) {
       status: 'known_limit',
       backend: 'browser',
       known_limit: 'current browser xray capture failed during saved-ref validation',
-      safe_next_action: recommendedRefreshCommand(workspace, record),
-      recommended_next_command: recommendedRefreshCommand(workspace, record),
+      ...recommendedRefreshResponseFields(workspace, record),
       requires_user_approval: false,
       stderr: result.stderr || null,
     });
@@ -130,8 +129,7 @@ function currentBrowserCapture(session, workspace, record, env) {
         status: 'known_limit',
         backend: 'browser',
         known_limit: 'current browser xray capture returned no element list',
-        safe_next_action: recommendedRefreshCommand(workspace, record),
-        recommended_next_command: recommendedRefreshCommand(workspace, record),
+        ...recommendedRefreshResponseFields(workspace, record),
         requires_user_approval: false,
       });
     }
@@ -142,8 +140,7 @@ function currentBrowserCapture(session, workspace, record, env) {
       status: 'known_limit',
       backend: 'browser',
       known_limit: 'current browser xray capture returned invalid JSON',
-      safe_next_action: recommendedRefreshCommand(workspace, record),
-      recommended_next_command: recommendedRefreshCommand(workspace, record),
+      ...recommendedRefreshResponseFields(workspace, record),
       requires_user_approval: false,
     });
   }
@@ -160,8 +157,7 @@ export function validateBrowserCurrentRef(record, action, workspace, env, captur
       reason: 'session_changed',
       backend: 'browser',
       ref: refSummary(record),
-      safe_next_action: recommendedRefreshCommand(workspace, record),
-      recommended_next_command: recommendedRefreshCommand(workspace, record),
+      ...recommendedRefreshResponseFields(workspace, record),
       requires_user_approval: false,
     });
   }
@@ -181,8 +177,7 @@ export function validateBrowserCurrentRef(record, action, workspace, env, captur
       backend: 'browser',
       ref: refSummary(record),
       current_identity: pageIdentity,
-      safe_next_action: recommendedRefreshCommand(workspace, record),
-      recommended_next_command: recommendedRefreshCommand(workspace, record),
+      ...recommendedRefreshResponseFields(workspace, record),
       requires_user_approval: false,
     });
   }
@@ -193,8 +188,7 @@ export function validateBrowserCurrentRef(record, action, workspace, env, captur
       reason: 'current_target_not_found',
       backend: 'browser',
       ref: refSummary(record),
-      safe_next_action: recommendedRefreshCommand(workspace, record),
-      recommended_next_command: recommendedRefreshCommand(workspace, record),
+      ...recommendedRefreshResponseFields(workspace, record),
       requires_user_approval: false,
     });
   }
@@ -205,8 +199,7 @@ export function validateBrowserCurrentRef(record, action, workspace, env, captur
       backend: 'browser',
       ref: refSummary(record),
       candidates: matches.map(compactBrowserElement),
-      safe_next_action: recommendedRefreshCommand(workspace, record),
-      recommended_next_command: recommendedRefreshCommand(workspace, record),
+      ...recommendedRefreshResponseFields(workspace, record),
       requires_user_approval: false,
     });
   }
@@ -219,8 +212,7 @@ export function validateBrowserCurrentRef(record, action, workspace, env, captur
       backend: 'browser',
       ref: refSummary(record),
       current_target: compactBrowserElement(current),
-      safe_next_action: recommendedRefreshCommand(workspace, record),
-      recommended_next_command: recommendedRefreshCommand(workspace, record),
+      ...recommendedRefreshResponseFields(workspace, record),
       requires_user_approval: false,
     });
   }
@@ -232,8 +224,7 @@ export function validateBrowserCurrentRef(record, action, workspace, env, captur
       backend: 'browser',
       ref: refSummary(record),
       current_target: compactBrowserElement(current),
-      safe_next_action: recommendedRefreshCommand(workspace, record),
-      recommended_next_command: recommendedRefreshCommand(workspace, record),
+      ...recommendedRefreshResponseFields(workspace, record),
       requires_user_approval: false,
     });
   }
@@ -247,8 +238,7 @@ export function validateBrowserCurrentRef(record, action, workspace, env, captur
       ref: refSummary(record),
       current_target: compactBrowserElement(current),
       supported_actions: currentSupportedActions,
-      safe_next_action: recommendedRefreshCommand(workspace, record),
-      recommended_next_command: recommendedRefreshCommand(workspace, record),
+      ...recommendedRefreshResponseFields(workspace, record),
       requires_user_approval: false,
     });
   }

--- a/scripts/lib/agent-workspace/ref-action-execution.mjs
+++ b/scripts/lib/agent-workspace/ref-action-execution.mjs
@@ -42,6 +42,7 @@ export function emitDryRunEnvelope({
   secondaryUnsafe,
 }) {
   const validationRequired = unsafe || secondaryUnsafe;
+  const unsafeRecord = unsafe ? record : secondary?.record;
   printJSON({
     status: 'dry_run',
     schema_version: SCHEMA_VERSION,
@@ -56,7 +57,8 @@ export function emitDryRunEnvelope({
     },
     current_validation: currentValidation,
     secondary_current_validation: secondaryCurrentValidation,
-    recommended_next_command: validationRequired ? recommendedRefreshCommand(workspace, unsafe ? record : secondary?.record) : null,
+    recommended_next: validationRequired ? recommendedRefreshDescriptor(workspace, unsafeRecord) : null,
+    recommended_next_command: validationRequired ? recommendedRefreshCommand(workspace, unsafeRecord) : null,
   });
 }
 

--- a/scripts/lib/agent-workspace/ref-action-resolution.mjs
+++ b/scripts/lib/agent-workspace/ref-action-resolution.mjs
@@ -85,6 +85,15 @@ export function recommendedRefreshDescriptor(workspace, record = null) {
   };
 }
 
+export function recommendedRefreshResponseFields(workspace, record = null) {
+  const command = recommendedRefreshCommand(workspace, record);
+  return {
+    safe_next_action: command,
+    recommended_next_command: command,
+    recommended_next: recommendedRefreshDescriptor(workspace, record),
+  };
+}
+
 function recommendedRefsCommand(workspace, snapshot = null) {
   return [
     'aos',
@@ -173,8 +182,7 @@ export function failUnsupportedRef(record, workspace) {
   exitAgentWorkspaceError(`Ref '${record.ref}' is not actionable`, 'REF_UNSUPPORTED', {
     status: 'unsupported',
     ref: refSummary(record),
-    recommended_next_command: recommendedRefreshCommand(workspace, record),
-    safe_next_action: recommendedRefreshCommand(workspace, record),
+    ...recommendedRefreshResponseFields(workspace, record),
     requires_user_approval: false,
   });
 }
@@ -184,8 +192,7 @@ export function failLowConfidenceRef(record, workspace) {
     status: 'unsupported',
     reason: 'low_confidence_target',
     ref: refSummary(record),
-    recommended_next_command: recommendedRefreshCommand(workspace, record),
-    safe_next_action: recommendedRefreshCommand(workspace, record),
+    ...recommendedRefreshResponseFields(workspace, record),
     requires_user_approval: false,
   });
 }
@@ -195,8 +202,7 @@ export function failIncompatibleAction(record, action, workspace) {
     status: 'action_incompatible',
     ref: refSummary(record),
     supported_actions: record.supported_actions ?? [],
-    recommended_next_command: recommendedRefreshCommand(workspace, record),
-    safe_next_action: recommendedRefreshCommand(workspace, record),
+    ...recommendedRefreshResponseFields(workspace, record),
     requires_user_approval: false,
   });
 }
@@ -206,8 +212,7 @@ export function failIncompatibleDragEndpoint(record, workspace, reason) {
     status: 'action_incompatible',
     reason,
     ref: refSummary(record),
-    recommended_next_command: recommendedRefreshCommand(workspace, record),
-    safe_next_action: recommendedRefreshCommand(workspace, record),
+    ...recommendedRefreshResponseFields(workspace, record),
     requires_user_approval: false,
   });
 }

--- a/shared/schemas/aos-agent-workspace-v0.md
+++ b/shared/schemas/aos-agent-workspace-v0.md
@@ -57,11 +57,12 @@ Current wait/diff/assertion boundary: saved workspaces do not expose
 `aos see capture --wait-for-change`, `aos see capture --until-stable`,
 `aos see refs --diff`, or `aos see assert`.
 
-Use `recommended_next_command` plus a fresh saved capture for re-perception,
-`aos show wait` only for canvas readiness, Recipe assertions only for command
-JSON checks, and Work Record postconditions for durable evidence checks. Future
-saved wait/diff/assert commands need manifest help, parser, schema/doc, and
-drift tests before public use.
+Use structured `recommended_next` descriptors and `recommended_next_command`
+plus a fresh saved capture for re-perception, `aos show wait` only for canvas
+readiness, Recipe assertions only for command JSON checks, and Work Record
+postconditions for durable evidence checks. Future saved wait/diff/assert
+commands need manifest help, parser, schema/doc, and drift tests before public
+use.
 
 `capture.json` intentionally preserves the primitive output shape. The workspace
 schema validates the saved workspace files around that payload, not every

--- a/skills/aos-agent-workspace/SKILL.md
+++ b/skills/aos-agent-workspace/SKILL.md
@@ -47,9 +47,10 @@ refs fail closed for those actions.
 - Current wait/diff/assertion boundary: saved workspaces do not expose
   `aos see capture --wait-for-change`, `aos see capture --until-stable`,
   `aos see refs --diff`, or `aos see assert`. Use
-  `recommended_next_command` plus a fresh saved capture for re-perception,
-  `aos show wait` only for canvas readiness, Recipe assertions only for command
-  JSON checks, and Work Record postconditions for durable evidence checks.
+  structured `recommended_next` descriptors and `recommended_next_command` plus
+  a fresh saved capture for re-perception, `aos show wait` only for canvas
+  readiness, Recipe assertions only for command JSON checks, and Work Record
+  postconditions for durable evidence checks.
 - Prefer scoped refs: `ref:<snapshot-id>:<ref-id>`.
 - Use bare `ref:<ref-id>` only when one snapshot in the workspace contains that
   ref. If the command returns `REF_AMBIGUOUS`, use its candidate snapshots and

--- a/tests/agent-workspace-browser-refs.sh
+++ b/tests/agent-workspace-browser-refs.sh
@@ -267,7 +267,13 @@ if ./aos do click "ref:snap1:$REF" --workspace ws-browser >"$TMP_DIR/do-ref-reva
 fi
 mv "$REFS_PATH.revalidation-backup" "$REFS_PATH"
 expect_error_code "REF_REVALIDATION_REQUIRED" "$REVALIDATION_ERR"
-jq -e '.status == "validation_required" and .reason == "missing_saved_page_url" and .recommended_next_command == "aos see capture browser:todo --save --workspace ws-browser --mode ax --query \u0027Click me\u0027"' "$REVALIDATION_ERR" >/dev/null \
+jq -e '
+  .status == "validation_required"
+  and .reason == "missing_saved_page_url"
+  and .recommended_next.kind == "fresh_saved_capture"
+  and .recommended_next.argv == ["aos","see","capture","browser:todo","--save","--workspace","ws-browser","--mode","ax","--query","Click me"]
+  and .recommended_next_command == "aos see capture browser:todo --save --workspace ws-browser --mode ax --query \u0027Click me\u0027"
+' "$REVALIDATION_ERR" >/dev/null \
     || fail "browser revalidation-required recommendation drifted: $(cat "$REVALIDATION_ERR")"
 
 cp "$REFS_PATH" "$REFS_PATH.drag-backup"
@@ -497,6 +503,8 @@ jq -e '
   and .backend == "browser"
   and .ref.ref == "r1"
   and .safe_next_action == "aos see capture browser:form --save --workspace ws-form --mode ax"
+  and .recommended_next.kind == "fresh_saved_capture"
+  and .recommended_next.argv == ["aos","see","capture","browser:form","--save","--workspace","ws-form","--mode","ax"]
   and .recommended_next_command == "aos see capture browser:form --save --workspace ws-form --mode ax"
   and .requires_user_approval == false
 ' "$FORM_FILL_STALE_REAL_ERR" >/dev/null \

--- a/tests/agent-workspace-canvas-refs.sh
+++ b/tests/agent-workspace-canvas-refs.sh
@@ -291,7 +291,13 @@ if AOS_PATH="$FAKE_CANVAS_AOS" node scripts/aos-do-ref.mjs focus ref:snapcanvas:
     fail "unsupported AOS canvas focus ref unexpectedly succeeded"
 fi
 expect_error_code "ACTION_INCOMPATIBLE" "$CANVAS_FOCUS_ERR"
-jq -e '.status == "action_incompatible" and .ref.backend == "aos_canvas" and .safe_next_action == "aos see capture main --save --workspace ws-canvas --mode som"' "$CANVAS_FOCUS_ERR" >/dev/null \
+jq -e '
+  .status == "action_incompatible"
+  and .ref.backend == "aos_canvas"
+  and .safe_next_action == "aos see capture main --save --workspace ws-canvas --mode som"
+  and .recommended_next.kind == "fresh_saved_capture"
+  and .recommended_next.argv == ["aos","see","capture","main","--save","--workspace","ws-canvas","--mode","som"]
+' "$CANVAS_FOCUS_ERR" >/dev/null \
     || fail "AOS canvas focus ref did not fail closed through action matrix: $(cat "$CANVAS_FOCUS_ERR")"
 
 CANVAS_PRESS_ERR="$TMP_DIR/do-canvas-press.err"

--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -31,7 +31,11 @@ import {
 } from './scripts/lib/agent-workspace/contracts.mjs';
 import { AGENT_WORKSPACE_V0_CONTRACT_COVERAGE } from './tests/lib/agent-workspace-contract-coverage.mjs';
 import { parseCaptureArgs } from './scripts/lib/agent-workspace/capture.mjs';
-import { recommendedRefreshCommand, recommendedRefreshDescriptor } from './scripts/lib/agent-workspace/ref-action-resolution.mjs';
+import {
+  recommendedRefreshCommand,
+  recommendedRefreshDescriptor,
+  recommendedRefreshResponseFields,
+} from './scripts/lib/agent-workspace/ref-action-resolution.mjs';
 import { workspaceID } from './scripts/lib/agent-workspace/core.mjs';
 
 const schema = JSON.parse(fs.readFileSync('shared/schemas/aos-agent-workspace-v0.schema.json', 'utf8'));
@@ -426,6 +430,7 @@ for (const text of [schemaDoc, apiDoc, skill]) {
   );
   assert.ok(prose.includes('saved-ref execution envelope'), 'docs/skill must describe real saved-ref execution envelope');
   assert.ok(text.includes('underlying_result'), 'docs/skill must describe nested underlying action result');
+  assert.ok(text.includes('recommended_next'), 'docs/skill must describe structured refresh recommendations');
   assert.ok(text.includes('post_action.recommended_next'), 'docs/skill must describe structured post-action refresh descriptor');
   assert.ok(text.includes('recommended_next_command'), 'docs/skill must describe post-action refresh recommendation');
   assert.ok(text.includes('conformance'), 'docs/skill must describe saved-ref conformance fields');
@@ -779,6 +784,29 @@ assert.deepEqual(
   })?.argv,
   ['aos', 'see', 'capture', 'browser:todo', '--save', '--workspace', 'default', '--mode', 'ax', '--query', 'Save button'],
   'structured refresh recommendations must preserve query argv without shell quoting',
+);
+assert.deepEqual(
+  recommendedRefreshResponseFields('default', {
+    capture_target: 'browser:todo',
+    capture_mode: 'ax',
+    query: 'Save button',
+  }),
+  {
+    safe_next_action: "aos see capture browser:todo --save --workspace default --mode ax --query 'Save button'",
+    recommended_next_command: "aos see capture browser:todo --save --workspace default --mode ax --query 'Save button'",
+    recommended_next: {
+      kind: 'fresh_saved_capture',
+      reason: 're-perceive after saved-ref mutation before asserting state',
+      command: "aos see capture browser:todo --save --workspace default --mode ax --query 'Save button'",
+      argv: ['aos', 'see', 'capture', 'browser:todo', '--save', '--workspace', 'default', '--mode', 'ax', '--query', 'Save button'],
+      workspace_id: 'default',
+      capture_mode: 'ax',
+      capture_target: 'browser:todo',
+      capture_source: null,
+      query: 'Save button',
+    },
+  },
+  'refresh response fields must keep string and structured recommendations aligned',
 );
 assert.ok(captureSaveForm.usage.includes('--region <rect>'), 'saved capture usage must advertise region source');
 assert.ok(captureSaveForm.usage.includes('--canvas <id>'), 'saved capture usage must advertise canvas source');

--- a/tests/agent-workspace-native-refs.sh
+++ b/tests/agent-workspace-native-refs.sh
@@ -282,7 +282,17 @@ if AOS_PATH="$FAKE_AOS" node scripts/aos-do-ref.mjs click ref:snapnative:r1 --wo
 fi
 mv "$NATIVE_REFS_PATH.coordinate-backup" "$NATIVE_REFS_PATH"
 expect_error_code "REF_UNSUPPORTED" "$COORDINATE_FALLBACK_ERR"
-jq -e '.status == "unsupported" and .ref.resolution_class == "coordinate_fallback" and .ref.conformance.actionability == "diagnostic_fallback_refused" and .ref.conformance.proof.status == "known_limit_refusal_tested" and .ref.conformance.target_uncertainty.status == "blocked_coordinate_fallback" and any(.ref.warnings[]; contains("diagnostic-only")) and .recommended_next_command == "aos see capture main --save --workspace ws-native --mode ax"' "$COORDINATE_FALLBACK_ERR" >/dev/null \
+jq -e '
+  .status == "unsupported"
+  and .ref.resolution_class == "coordinate_fallback"
+  and .ref.conformance.actionability == "diagnostic_fallback_refused"
+  and .ref.conformance.proof.status == "known_limit_refusal_tested"
+  and .ref.conformance.target_uncertainty.status == "blocked_coordinate_fallback"
+  and any(.ref.warnings[]; contains("diagnostic-only"))
+  and .recommended_next.kind == "fresh_saved_capture"
+  and .recommended_next.argv == ["aos","see","capture","main","--save","--workspace","ws-native","--mode","ax"]
+  and .recommended_next_command == "aos see capture main --save --workspace ws-native --mode ax"
+' "$COORDINATE_FALLBACK_ERR" >/dev/null \
     || fail "coordinate fallback diagnostic ref did not refuse with warning context: $(cat "$COORDINATE_FALLBACK_ERR")"
 
 NATIVE_FOCUS_ERR="$TMP_DIR/do-native-focus-ref.err"
@@ -290,7 +300,13 @@ if AOS_PATH="$FAKE_AOS" node scripts/aos-do-ref.mjs focus ref:snapnative:r1 --wo
     fail "native focus volatile inspection ref unexpectedly became actionable"
 fi
 expect_error_code "REF_UNSUPPORTED" "$NATIVE_FOCUS_ERR"
-jq -e '.status == "unsupported" and .ref.backend == "native_ax" and .safe_next_action == "aos see capture main --save --workspace ws-native --mode ax"' "$NATIVE_FOCUS_ERR" >/dev/null \
+jq -e '
+  .status == "unsupported"
+  and .ref.backend == "native_ax"
+  and .safe_next_action == "aos see capture main --save --workspace ws-native --mode ax"
+  and .recommended_next.kind == "fresh_saved_capture"
+  and .recommended_next.argv == ["aos","see","capture","main","--save","--workspace","ws-native","--mode","ax"]
+' "$NATIVE_FOCUS_ERR" >/dev/null \
     || fail "native focus unsupported ref payload drifted: $(cat "$NATIVE_FOCUS_ERR")"
 
 NATIVE_PRESS_ERR="$TMP_DIR/do-native-press-ref.err"


### PR DESCRIPTION
## Summary
- add shared `recommendedRefreshResponseFields()` for saved-ref blocked/error payloads
- include structured `recommended_next` descriptors alongside existing `safe_next_action` and `recommended_next_command`
- cover browser revalidation/stale, canvas incompatible, native unsupported, and contract drift cases

## Verification
- bash tests/agent-workspace-browser-refs.sh
- bash tests/agent-workspace-canvas-refs.sh
- bash tests/agent-workspace-native-refs.sh
- bash tests/agent-workspace-contract-drift.sh
- bash tests/agent-workspace-saved-ref.sh
- node --test tests/schemas/*.test.mjs
- bash tests/help-contract.sh
- git diff --check
- ./aos help --json; ./aos help see --json; ./aos help do --json; ./aos help show --json
