### PR TITLE
Add structured saved capture recommendations

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -168,8 +168,9 @@ Typical consumer loop:
 3. Read compact refs with `aos see refs`.
 4. Dry-run the saved-ref action and inspect `resolution_status`.
 5. Dispatch only if the ref validates or reacquires.
-6. Use `recommended_next_command` after a real mutation when a fresh saved
-   capture is needed before reusing refs from the surface.
+6. Use structured `recommended_next` descriptors and
+   `recommended_next_command` when a fresh saved capture is needed before
+   reusing refs from the surface.
 
 Saved capture uses the same capture-source contract as ordinary capture: supply
 a positional target such as `browser:work` or a source flag such as

--- a/scripts/lib/agent-workspace/capture.mjs
+++ b/scripts/lib/agent-workspace/capture.mjs
@@ -357,24 +357,57 @@ function commandToken(value) {
   return `'${text.replaceAll("'", "'\\''")}'`;
 }
 
-function sampleActionCommand(workspace, snapshotIDValue, refs) {
+function commandString(argv, displayName = null) {
+  const tokens = argv.map((arg, index) => (index === 0 && displayName ? displayName : arg));
+  return tokens.map(commandToken).join(' ');
+}
+
+function refsRecommendation(workspace, snapshotIDValue) {
+  const display = process.env.AOS_INVOCATION_DISPLAY_NAME || 'aos';
+  const argv = ['aos', 'see', 'refs', '--workspace', String(workspace), '--snapshot', String(snapshotIDValue), '--json'];
+  return {
+    kind: 'inspect_saved_refs',
+    reason: 'read compact refs before choosing a saved-ref action',
+    command: commandString(argv, display),
+    argv,
+    workspace_id: String(workspace),
+    snapshot_id: String(snapshotIDValue),
+  };
+}
+
+function sampleActionRecommendation(workspace, snapshotIDValue, refs) {
   const display = process.env.AOS_INVOCATION_DISPLAY_NAME || 'aos';
   const refTarget = (record) => `ref:${snapshotIDValue}:${record.ref}`;
   const byPreferredAction = (action) => refs.find((record) => record.action_target && (record.supported_actions ?? []).includes(action));
   for (const action of ['click', 'set-value', 'fill', 'hover', 'scroll', 'press', 'focus']) {
     const record = byPreferredAction(action);
     if (!record) continue;
+    const baseArgv = ['aos', 'do', action, refTarget(record)];
+    const descriptor = {
+      kind: 'dry_run_saved_ref_action',
+      reason: 'validate the saved ref before real mutation',
+      action,
+      workspace_id: String(workspace),
+      snapshot_id: String(snapshotIDValue),
+      ref: record.ref,
+      backend: record.backend,
+      resolution_class: record.resolution_class,
+    };
     if (action === 'click' || action === 'hover' || action === 'press' || action === 'focus') {
-      return `${display} do ${action} ${refTarget(record)} --workspace ${workspace} --dry-run`;
+      const argv = [...baseArgv, '--workspace', String(workspace), '--dry-run'];
+      return { ...descriptor, command: commandString(argv, display), argv };
     }
     if (action === 'set-value') {
-      return `${display} do set-value ${refTarget(record)} --workspace ${workspace} --value 42 --dry-run`;
+      const argv = [...baseArgv, '--workspace', String(workspace), '--value', '42', '--dry-run'];
+      return { ...descriptor, command: commandString(argv, display), argv };
     }
     if (action === 'fill') {
-      return `${display} do fill ${refTarget(record)} ${commandToken('sample text')} --workspace ${workspace} --dry-run`;
+      const argv = [...baseArgv, 'sample text', '--workspace', String(workspace), '--dry-run'];
+      return { ...descriptor, command: commandString(argv, display), argv };
     }
     if (action === 'scroll') {
-      return `${display} do scroll ${refTarget(record)} 0,-200 --workspace ${workspace} --dry-run`;
+      const argv = [...baseArgv, '0,-200', '--workspace', String(workspace), '--dry-run'];
+      return { ...descriptor, command: commandString(argv, display), argv };
     }
   }
   return null;
@@ -427,6 +460,10 @@ export async function savedCaptureCommand(rawArgs, parsed = parseSavedCaptureArg
       });
       const matchingRefs = refs.filter((record) => queryMatches(record, parsed.options.query));
       const compactRefs = matchingRefs.map(refSummary);
+      const nextRecommendations = [
+        refsRecommendation(workspace, snapID),
+        sampleActionRecommendation(workspace, snapID, matchingRefs),
+      ].filter(Boolean);
       const paths = prepared.finalPaths;
       const snapshot = {
         schema_version: SCHEMA_VERSION,
@@ -474,10 +511,8 @@ export async function savedCaptureCommand(rawArgs, parsed = parseSavedCaptureArg
           heavy_payloads: omittedPayloads(capture),
           capture_json: paths.capture,
         },
-        recommended_next_commands: [
-          `${process.env.AOS_INVOCATION_DISPLAY_NAME || 'aos'} see refs --workspace ${workspace} --snapshot ${snapID} --json`,
-          sampleActionCommand(workspace, snapID, matchingRefs),
-        ].filter(Boolean),
+        recommended_next: nextRecommendations,
+        recommended_next_commands: nextRecommendations.map((recommendation) => recommendation.command),
         known_limits: snapshot.known_limits,
       };
 

--- a/shared/schemas/aos-agent-workspace-v0.md
+++ b/shared/schemas/aos-agent-workspace-v0.md
@@ -136,7 +136,10 @@ Each saved ref records:
   for an unsupported or inspection-only ref. Compact summaries from
   `aos see capture --save`, `aos see refs`, saved-ref action envelopes, and
   ambiguous-ref errors expose the same lightweight model-facing fields while
-  heavy payloads stay file-backed.
+  heavy payloads stay file-backed. Saved-capture summaries include
+  `recommended_next` descriptors with reconstructable `argv` plus legacy
+  `recommended_next_commands` strings so agents can continue the
+  capture/refs/dry-run loop without parsing shell text.
 
 Mutation is fail-closed. Saved-ref actions are the intersection of producer
 actions, backend durability, confidence, and existing `aos do` command behavior.

--- a/shared/schemas/aos-agent-workspace-v0.schema.json
+++ b/shared/schemas/aos-agent-workspace-v0.schema.json
@@ -56,6 +56,29 @@
       "type": "array",
       "items": { "$ref": "#/$defs/non_empty_string" }
     },
+    "recommended_next": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["kind", "reason", "command", "argv"],
+        "additionalProperties": true,
+        "properties": {
+          "kind": { "$ref": "#/$defs/non_empty_string" },
+          "reason": { "$ref": "#/$defs/non_empty_string" },
+          "command": { "$ref": "#/$defs/non_empty_string" },
+          "argv": {
+            "type": "array",
+            "items": { "$ref": "#/$defs/non_empty_string" }
+          },
+          "workspace_id": { "$ref": "#/$defs/local_id" },
+          "snapshot_id": { "$ref": "#/$defs/local_id" },
+          "ref": { "$ref": "#/$defs/non_empty_string" },
+          "backend": { "$ref": "#/$defs/backend" },
+          "resolution_class": { "$ref": "#/$defs/resolution_class" },
+          "action": { "$ref": "#/$defs/non_empty_string" }
+        }
+      }
+    },
     "artifact_ref": {
       "type": "object",
       "required": ["role", "path"],
@@ -275,6 +298,7 @@
         "artifact_refs",
         "refs",
         "omitted",
+        "recommended_next",
         "recommended_next_commands",
         "known_limits"
       ],
@@ -320,6 +344,7 @@
             "capture_json": { "$ref": "#/$defs/non_empty_string" }
           }
         },
+        "recommended_next": { "$ref": "#/$defs/recommended_next" },
         "recommended_next_commands": { "$ref": "#/$defs/string_array" },
         "known_limits": { "$ref": "#/$defs/string_array" }
       }

--- a/skills/aos-agent-workspace/SKILL.md
+++ b/skills/aos-agent-workspace/SKILL.md
@@ -33,6 +33,9 @@ refs fail closed for those actions.
 
 - Use `aos see capture --save` to persist perception into the active runtime
   mode state root: `${AOS_STATE_ROOT:-~/.config/aos}/{repo|installed}/agent-workspaces/`.
+  Read `workspace_id`, `snapshot_id`, `capture_target`, `capture_source`,
+  `query`, `paths`, `refs[]`, `known_limits`, `recommended_next`, and
+  `recommended_next_commands`.
 - A saved capture source can be a positional target such as `browser:work` or a
   source flag such as `--region <rect>`, `--canvas <id>`, or `--channel <id>`.
   These source forms are mutually exclusive. If no positional target or source
@@ -53,9 +56,11 @@ refs fail closed for those actions.
   postconditions for durable evidence checks.
 - Prefer scoped refs: `ref:<snapshot-id>:<ref-id>`.
 - Use bare `ref:<ref-id>` only when one snapshot in the workspace contains that
-  ref. If the command returns `REF_AMBIGUOUS`, use its candidate snapshots and
-  `recommended_next_commands` to choose a scoped ref. If it returns
-  `REF_NOT_FOUND`, run the returned refs inspection command before retrying.
+  ref. Use structured `recommended_next` descriptors or
+  `recommended_next_commands` to choose a scoped ref. If the command returns
+  `REF_AMBIGUOUS`, use its candidate snapshots and `recommended_next_commands`
+  to choose a scoped ref. If it returns `REF_NOT_FOUND`, run the returned refs
+  inspection command before retrying.
 - Treat compact stdout as the model-facing payload. Full capture JSON,
   screenshots, base64, AX trees, browser elements, and semantic target arrays
   stay file-backed under the snapshot directory.

--- a/tests/agent-workspace-canvas-refs.sh
+++ b/tests/agent-workspace-canvas-refs.sh
@@ -357,6 +357,9 @@ jq -e '
   and (.refs | length) == 1
   and .refs[0].ref == "r2"
   and (.refs[0].supported_actions == ["set-value"])
+  and .recommended_next[1].kind == "dry_run_saved_ref_action"
+  and .recommended_next[1].action == "set-value"
+  and .recommended_next[1].argv == ["aos","do","set-value","ref:snapcanvasq:r2","--workspace","ws-canvas-query","--value","42","--dry-run"]
   and (.recommended_next_commands[] == "aos do set-value ref:snapcanvasq:r2 --workspace ws-canvas-query --value 42 --dry-run")
 ' "$CANVAS_QUERY" >/dev/null || fail "set-value-only compact recommendation drifted: $(cat "$CANVAS_QUERY")"
 
@@ -370,6 +373,9 @@ jq -e '
   and (.refs[0].supported_actions | length) == 0
   and .refs[1].ref == "r2"
   and (.refs[1].supported_actions == ["click"])
+  and .recommended_next[1].kind == "dry_run_saved_ref_action"
+  and .recommended_next[1].ref == "r2"
+  and .recommended_next[1].argv == ["aos","do","click","ref:snapmixed:r2","--workspace","ws-mixed","--dry-run"]
   and (.recommended_next_commands[] == "aos do click ref:snapmixed:r2 --workspace ws-mixed --dry-run")
   and all(.recommended_next_commands[]; contains("ref:snapmixed:r1") | not)
 ' "$MIXED" >/dev/null || fail "unsupported-first compact recommendation drifted: $(cat "$MIXED")"

--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -55,6 +55,9 @@ assert.deepEqual(defs.conformance.properties.proof.required, ['level', 'status',
 assert.ok(defs.no_foreground_conformance.required.includes('focus_preservation'), 'no_foreground conformance must report focus preservation');
 assert.ok(defs.no_foreground_conformance.required.includes('cursor_preservation'), 'no_foreground conformance must report cursor preservation');
 assert.ok(defs.no_foreground_conformance.required.includes('space_preservation'), 'no_foreground conformance must report Space preservation');
+assert.ok(defs.recommended_next, 'schema must describe structured compact next-step descriptors');
+assert.ok(defs.summary.required.includes('recommended_next'), 'saved capture summaries must require structured next-step descriptors');
+assert.ok(defs.summary.properties.recommended_next, 'saved capture summaries must expose structured next-step descriptors');
 const workspaceIndexSnapshotRequired = defs.workspace_index.properties.snapshots.items.required;
 assert.ok(workspaceIndexSnapshotRequired.includes('capture_target'), 'workspace index snapshots must expose compact capture target readback');
 assert.ok(workspaceIndexSnapshotRequired.includes('query'), 'workspace index snapshots must expose compact saved query readback');

--- a/tests/agent-workspace-native-refs.sh
+++ b/tests/agent-workspace-native-refs.sh
@@ -376,6 +376,12 @@ jq -e '
   and .refs[0].resolution_class == "stable"
   and (.refs[0].supported_actions | index("press") != null)
   and (.refs[0].supported_actions | index("focus") != null)
+  and .recommended_next[0].kind == "inspect_saved_refs"
+  and .recommended_next[0].argv == ["aos","see","refs","--workspace","ws-native","--snapshot","snappressonly","--json"]
+  and .recommended_next[1].kind == "dry_run_saved_ref_action"
+  and .recommended_next[1].action == "press"
+  and .recommended_next[1].backend == "native_ax"
+  and .recommended_next[1].argv == ["aos","do","press","ref:snappressonly:r1","--workspace","ws-native","--dry-run"]
   and (.recommended_next_commands | index("aos see refs --workspace ws-native --snapshot snappressonly --json") != null)
   and (.recommended_next_commands | index("aos do press ref:snappressonly:r1 --workspace ws-native --dry-run") != null)
 ' "$PRESS_ONLY_NATIVE" >/dev/null || fail "native press-only saved-ref recommendation drifted: $(cat "$PRESS_ONLY_NATIVE")"

--- a/tests/agent-workspace-storage.sh
+++ b/tests/agent-workspace-storage.sh
@@ -130,6 +130,11 @@ jq -e '
   and (.omitted.heavy_payloads | index("elements") != null)
   and (.paths.capture | endswith("/capture.json"))
   and (.paths.snapshot_record | endswith("/snapshot.json"))
+  and .recommended_next[0].kind == "inspect_saved_refs"
+  and .recommended_next[0].argv == ["aos","see","refs","--workspace","ws1","--snapshot","snap1","--json"]
+  and .recommended_next[1].kind == "dry_run_saved_ref_action"
+  and .recommended_next[1].argv == ["aos","do","click","ref:snap1:r2","--workspace","ws1","--dry-run"]
+  and (.recommended_next_commands | index("aos see refs --workspace ws1 --snapshot snap1 --json") != null)
   and (has("elements") | not)
   and (has("semantic_targets") | not)
   and (has("base64") | not)


### PR DESCRIPTION
## Summary
- add structured `recommended_next` descriptors to saved capture summaries
- keep existing `recommended_next_commands` strings stable for compatibility
- schema/doc/skill/test coverage now owns the structured compact next-step contract

## Verification
- bash tests/agent-workspace-storage.sh
- bash tests/agent-workspace-canvas-refs.sh
- bash tests/agent-workspace-native-refs.sh
- bash tests/agent-workspace-contract-drift.sh
- bash tests/agent-workspace-saved-ref.sh
- node --test tests/schemas/*.test.mjs
- bash tests/help-contract.sh
- git diff --check
- ./aos help --json; ./aos help see --json; ./aos help do --json; ./aos help show --json
