### PR TITLE
Add structured refs readback recommendations

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -165,7 +165,8 @@ Typical consumer loop:
 2. Read compact snapshots with `aos see snapshots` when choosing prior saved
    state; snapshot entries include `capture_source`, `capture_target`,
    `target`, and saved `query` without opening heavy payloads.
-3. Read compact refs with `aos see refs`.
+3. Read compact refs with `aos see refs`; use its structured
+   `recommended_next` descriptors for the scoped dry-run action.
 4. Dry-run the saved-ref action and inspect `resolution_status`.
 5. Dispatch only if the ref validates or reacquires.
 6. Use structured `recommended_next` descriptors and

--- a/scripts/lib/agent-workspace/capture.mjs
+++ b/scripts/lib/agent-workspace/capture.mjs
@@ -36,6 +36,7 @@ import {
   browserIdentityComparable,
   queryBrowserPageIdentity,
 } from './browser-identity.mjs';
+import { commandToken, compactNextRecommendations } from './recommendations.mjs';
 
 function snapshotID(explicit) {
   if (explicit) return validateLocalID(explicit, 'snapshot id');
@@ -351,68 +352,6 @@ function knownLimitsForSnapshot(mode, target) {
   return limits;
 }
 
-function commandToken(value) {
-  const text = String(value);
-  if (/^[A-Za-z0-9_./:=,@+-]+$/.test(text)) return text;
-  return `'${text.replaceAll("'", "'\\''")}'`;
-}
-
-function commandString(argv, displayName = null) {
-  const tokens = argv.map((arg, index) => (index === 0 && displayName ? displayName : arg));
-  return tokens.map(commandToken).join(' ');
-}
-
-function refsRecommendation(workspace, snapshotIDValue) {
-  const display = process.env.AOS_INVOCATION_DISPLAY_NAME || 'aos';
-  const argv = ['aos', 'see', 'refs', '--workspace', String(workspace), '--snapshot', String(snapshotIDValue), '--json'];
-  return {
-    kind: 'inspect_saved_refs',
-    reason: 'read compact refs before choosing a saved-ref action',
-    command: commandString(argv, display),
-    argv,
-    workspace_id: String(workspace),
-    snapshot_id: String(snapshotIDValue),
-  };
-}
-
-function sampleActionRecommendation(workspace, snapshotIDValue, refs) {
-  const display = process.env.AOS_INVOCATION_DISPLAY_NAME || 'aos';
-  const refTarget = (record) => `ref:${snapshotIDValue}:${record.ref}`;
-  const byPreferredAction = (action) => refs.find((record) => record.action_target && (record.supported_actions ?? []).includes(action));
-  for (const action of ['click', 'set-value', 'fill', 'hover', 'scroll', 'press', 'focus']) {
-    const record = byPreferredAction(action);
-    if (!record) continue;
-    const baseArgv = ['aos', 'do', action, refTarget(record)];
-    const descriptor = {
-      kind: 'dry_run_saved_ref_action',
-      reason: 'validate the saved ref before real mutation',
-      action,
-      workspace_id: String(workspace),
-      snapshot_id: String(snapshotIDValue),
-      ref: record.ref,
-      backend: record.backend,
-      resolution_class: record.resolution_class,
-    };
-    if (action === 'click' || action === 'hover' || action === 'press' || action === 'focus') {
-      const argv = [...baseArgv, '--workspace', String(workspace), '--dry-run'];
-      return { ...descriptor, command: commandString(argv, display), argv };
-    }
-    if (action === 'set-value') {
-      const argv = [...baseArgv, '--workspace', String(workspace), '--value', '42', '--dry-run'];
-      return { ...descriptor, command: commandString(argv, display), argv };
-    }
-    if (action === 'fill') {
-      const argv = [...baseArgv, 'sample text', '--workspace', String(workspace), '--dry-run'];
-      return { ...descriptor, command: commandString(argv, display), argv };
-    }
-    if (action === 'scroll') {
-      const argv = [...baseArgv, '0,-200', '--workspace', String(workspace), '--dry-run'];
-      return { ...descriptor, command: commandString(argv, display), argv };
-    }
-  }
-  return null;
-}
-
 export async function savedCaptureCommand(rawArgs, parsed = parseSavedCaptureArgs(rawArgs), env = process.env) {
   const workspace = workspaceID(parsed.options.workspace, env);
   const snapID = snapshotID(parsed.options.name);
@@ -460,10 +399,7 @@ export async function savedCaptureCommand(rawArgs, parsed = parseSavedCaptureArg
       });
       const matchingRefs = refs.filter((record) => queryMatches(record, parsed.options.query));
       const compactRefs = matchingRefs.map(refSummary);
-      const nextRecommendations = [
-        refsRecommendation(workspace, snapID),
-        sampleActionRecommendation(workspace, snapID, matchingRefs),
-      ].filter(Boolean);
+      const nextRecommendations = compactNextRecommendations(workspace, snapID, matchingRefs, env);
       const paths = prepared.finalPaths;
       const snapshot = {
         schema_version: SCHEMA_VERSION,

--- a/scripts/lib/agent-workspace/commands.mjs
+++ b/scripts/lib/agent-workspace/commands.mjs
@@ -23,6 +23,7 @@ import {
   workspaceLockState,
 } from './store.mjs';
 import { queryMatches, refSummary } from './refs.mjs';
+import { compactNextRecommendations } from './recommendations.mjs';
 
 const AGENT_WORKSPACE_FLAG_KINDS = new Map([
   ['--json', 'bool'],
@@ -172,6 +173,9 @@ export function refsCommand(args, env = process.env) {
     const loaded = loadSnapshot(parsed.workspace, snap, env);
     refs.push(...(loaded.refs.refs ?? []).filter((record) => queryMatches(record, parsed.query)).map(refSummary));
   }
+  const nextRecommendations = parsed.snapshot || index.current_snapshot_id
+    ? compactNextRecommendations(parsed.workspace, parsed.snapshot ?? index.current_snapshot_id, refs, env)
+    : [];
   printJSON({
     status: 'success',
     schema_version: SCHEMA_VERSION,
@@ -180,6 +184,8 @@ export function refsCommand(args, env = process.env) {
     snapshot_id: parsed.snapshot ?? index.current_snapshot_id ?? null,
     query: parsed.query,
     refs,
+    recommended_next: nextRecommendations,
+    recommended_next_commands: nextRecommendations.map((recommendation) => recommendation.command),
   });
 }
 

--- a/scripts/lib/agent-workspace/recommendations.mjs
+++ b/scripts/lib/agent-workspace/recommendations.mjs
@@ -1,0 +1,68 @@
+export function commandToken(value) {
+  const text = String(value);
+  if (/^[A-Za-z0-9_./:=,@+-]+$/.test(text)) return text;
+  return `'${text.replaceAll("'", "'\\''")}'`;
+}
+
+export function commandString(argv, displayName = null) {
+  const tokens = argv.map((arg, index) => (index === 0 && displayName ? displayName : arg));
+  return tokens.map(commandToken).join(' ');
+}
+
+export function refsRecommendation(workspace, snapshotIDValue, env = process.env) {
+  const display = env.AOS_INVOCATION_DISPLAY_NAME || 'aos';
+  const argv = ['aos', 'see', 'refs', '--workspace', String(workspace), '--snapshot', String(snapshotIDValue), '--json'];
+  return {
+    kind: 'inspect_saved_refs',
+    reason: 'read compact refs before choosing a saved-ref action',
+    command: commandString(argv, display),
+    argv,
+    workspace_id: String(workspace),
+    snapshot_id: String(snapshotIDValue),
+  };
+}
+
+export function sampleActionRecommendation(workspace, snapshotIDValue, refs, env = process.env) {
+  const display = env.AOS_INVOCATION_DISPLAY_NAME || 'aos';
+  const refTarget = (record) => `ref:${snapshotIDValue}:${record.ref}`;
+  const byPreferredAction = (action) => refs.find((record) => record.action_target && (record.supported_actions ?? []).includes(action));
+  for (const action of ['click', 'set-value', 'fill', 'hover', 'scroll', 'press', 'focus']) {
+    const record = byPreferredAction(action);
+    if (!record) continue;
+    const baseArgv = ['aos', 'do', action, refTarget(record)];
+    const descriptor = {
+      kind: 'dry_run_saved_ref_action',
+      reason: 'validate the saved ref before real mutation',
+      action,
+      workspace_id: String(workspace),
+      snapshot_id: String(snapshotIDValue),
+      ref: record.ref,
+      backend: record.backend,
+      resolution_class: record.resolution_class,
+    };
+    if (action === 'click' || action === 'hover' || action === 'press' || action === 'focus') {
+      const argv = [...baseArgv, '--workspace', String(workspace), '--dry-run'];
+      return { ...descriptor, command: commandString(argv, display), argv };
+    }
+    if (action === 'set-value') {
+      const argv = [...baseArgv, '--workspace', String(workspace), '--value', '42', '--dry-run'];
+      return { ...descriptor, command: commandString(argv, display), argv };
+    }
+    if (action === 'fill') {
+      const argv = [...baseArgv, 'sample text', '--workspace', String(workspace), '--dry-run'];
+      return { ...descriptor, command: commandString(argv, display), argv };
+    }
+    if (action === 'scroll') {
+      const argv = [...baseArgv, '0,-200', '--workspace', String(workspace), '--dry-run'];
+      return { ...descriptor, command: commandString(argv, display), argv };
+    }
+  }
+  return null;
+}
+
+export function compactNextRecommendations(workspace, snapshotIDValue, refs, env = process.env) {
+  return [
+    refsRecommendation(workspace, snapshotIDValue, env),
+    sampleActionRecommendation(workspace, snapshotIDValue, refs, env),
+  ].filter(Boolean);
+}

--- a/shared/schemas/aos-agent-workspace-v0.md
+++ b/shared/schemas/aos-agent-workspace-v0.md
@@ -136,7 +136,7 @@ Each saved ref records:
   for an unsupported or inspection-only ref. Compact summaries from
   `aos see capture --save`, `aos see refs`, saved-ref action envelopes, and
   ambiguous-ref errors expose the same lightweight model-facing fields while
-  heavy payloads stay file-backed. Saved-capture summaries include
+  heavy payloads stay file-backed. Compact capture and refs readbacks include
   `recommended_next` descriptors with reconstructable `argv` plus legacy
   `recommended_next_commands` strings so agents can continue the
   capture/refs/dry-run loop without parsing shell text.

--- a/skills/aos-agent-workspace/SKILL.md
+++ b/skills/aos-agent-workspace/SKILL.md
@@ -56,11 +56,11 @@ refs fail closed for those actions.
   postconditions for durable evidence checks.
 - Prefer scoped refs: `ref:<snapshot-id>:<ref-id>`.
 - Use bare `ref:<ref-id>` only when one snapshot in the workspace contains that
-  ref. Use structured `recommended_next` descriptors or
-  `recommended_next_commands` to choose a scoped ref. If the command returns
-  `REF_AMBIGUOUS`, use its candidate snapshots and `recommended_next_commands`
-  to choose a scoped ref. If it returns `REF_NOT_FOUND`, run the returned refs
-  inspection command before retrying.
+  ref. `aos see refs` returns structured `recommended_next` descriptors and
+  `recommended_next_commands` for scoped dry-runs. If a saved-ref command
+  returns `REF_AMBIGUOUS`, use its candidate snapshots and
+  `recommended_next_commands` to choose a scoped ref. If it returns
+  `REF_NOT_FOUND`, run the returned refs inspection command before retrying.
 - Treat compact stdout as the model-facing payload. Full capture JSON,
   screenshots, base64, AX trees, browser elements, and semantic target arrays
   stay file-backed under the snapshot directory.

--- a/tests/agent-workspace-storage.sh
+++ b/tests/agent-workspace-storage.sh
@@ -150,6 +150,12 @@ jq -e '
   and .snapshot_id == "snap1"
   and .query == "browser:todo"
   and (.refs | length) == 3
+  and .recommended_next[0].kind == "inspect_saved_refs"
+  and .recommended_next[0].argv == ["aos","see","refs","--workspace","ws1","--snapshot","snap1","--json"]
+  and .recommended_next[1].kind == "dry_run_saved_ref_action"
+  and .recommended_next[1].ref == "r1"
+  and .recommended_next[1].argv == ["aos","do","click","ref:snap1:r1","--workspace","ws1","--dry-run"]
+  and (.recommended_next_commands | index("aos do click ref:snap1:r1 --workspace ws1 --dry-run") != null)
   and all(.refs[];
     .ref_scope == "snapshot"
     and .workspace_id == "ws1"
@@ -180,6 +186,8 @@ jq -e '
   and .snapshot_id == "snap1"
   and .query == "deterministic_contract_tests_passed"
   and (.refs | length) == 3
+  and .recommended_next[1].kind == "dry_run_saved_ref_action"
+  and .recommended_next[1].action == "click"
   and all(.refs[];
     .conformance.proof.status == "deterministic_contract_tests_passed"
     and .conformance.target_uncertainty.status == "requires_current_validation"


### PR DESCRIPTION
## Summary
- add shared recommendation helpers for compact agent-workspace readbacks
- include structured `recommended_next` descriptors and legacy command strings in `aos see refs` output
- update storage coverage plus schema/API/skill docs for refs readback next steps

## Verification
- `bash tests/agent-workspace-storage.sh`
- `bash tests/agent-workspace-contract-drift.sh`
- `bash tests/agent-workspace-saved-ref.sh`
- `node --test tests/schemas/*.test.mjs`
- `bash tests/help-contract.sh`
- `node --check scripts/lib/agent-workspace/recommendations.mjs && node --check scripts/lib/agent-workspace/capture.mjs && node --check scripts/lib/agent-workspace/commands.mjs`
- `git diff --check`
- `./aos help --json`, `./aos help see --json`, `./aos help do --json`, `./aos help show --json`
