### PR TITLE
Align README runtime command taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ commands, a typed MCP gateway for external consumers, and a Node.js agent host.
 | `aos recipe` | Higher-order | Source-backed executable procedures built from primitive commands; `aos ops` is the compatibility alias |
 | `aos ready` | Runtime/ops | Front-door readiness gate for agents before runtime work |
 | `aos serve` / `aos service` | Runtime/ops | Unified daemon lifecycle: one socket, one CGEventTap, shared state |
+| `aos status` / `aos doctor` | Runtime/ops | Runtime, permission, and readiness diagnostics |
+| `aos permissions` | Runtime/ops | Permission preflight, onboarding, and reset guidance |
+| `aos clean` / `aos reset` | Runtime/ops | Explicit stale-resource cleanup and state reset workflows |
 
 See [docs/api/aos.md](docs/api/aos.md) for the full consumer command table.
 

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -113,7 +113,11 @@ from pathlib import Path
 root = json.loads(os.environ["ROOT_JSON"])
 root_top_level = {command["path"][0] for command in root["commands"]}
 readme = Path("README.md").read_text(encoding="utf-8")
-required = {"see", "do", "show", "tell", "listen", "say", "recipe", "ready", "serve", "service"}
+required = {
+    "see", "do", "show", "tell", "listen",
+    "say", "recipe",
+    "ready", "serve", "service", "status", "doctor", "permissions", "clean", "reset",
+}
 assert required <= root_top_level, sorted(required - root_top_level)
 for command in required:
     assert f"`aos {command}`" in readme, command
@@ -123,6 +127,9 @@ assert re.search(r"\| `aos say` \| Convenience \|.*tell human", readme), readme
 assert re.search(r"\| `aos recipe` \| Higher-order \|.*`aos ops`", readme), readme
 assert re.search(r"\| `aos ready` \| Runtime/ops \|", readme), readme
 assert re.search(r"\| `aos serve` / `aos service` \| Runtime/ops \|", readme), readme
+assert re.search(r"\| `aos status` / `aos doctor` \| Runtime/ops \|.*diagnostics", readme), readme
+assert re.search(r"\| `aos permissions` \| Runtime/ops \|.*Permission", readme), readme
+assert re.search(r"\| `aos clean` / `aos reset` \| Runtime/ops \|.*cleanup", readme), readme
 PY
 then
     pass "README public command model covers primitive, convenience, recipe, and runtime tiers"


### PR DESCRIPTION
## Summary
- add the full runtime/ops command cluster to the README public command model
- extend `tests/help-contract.sh` so README runtime/ops taxonomy stays aligned with root help discovery

## Verification
- `bash tests/help-contract.sh`
- `git diff --check`
- `./aos help --json`, `./aos help see --json`, `./aos help do --json`, `./aos help show --json`

## Live proof
- Not applicable; README/help-contract taxonomy only.
