### PR TITLE
Clarify listen future source boundary

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -221,13 +221,18 @@ aos tell <audience> "message"
 aos listen <channel>|--session-id <canonical-session-id>
          ▲
       daemon (arbiter)
-         ├── STT engine         (source = human)
-         ├── channel message    (source = agent)
-         ├── stdin pipe         (source = bash)
-         └── future sources     (webhook, file watch)
+        ├── channel message    (source = agent)
+        ├── direct-session msg (source = session)
+        └── future sources     (STT/dictation, stdin, webhook, file watch)
 ```
 
-The daemon routes based on config (`aos set voice.*`), presence (which sessions are online), and channel state. This is a natural extension of the daemon's existing responsibilities — it already manages voice config, canvases, and perception state.
+The current public `listen` surface reads channels and direct-session messages.
+STT/dictation, stdin ingestion, webhooks, and file-watch inputs are reserved
+future sources; they require explicit help, parser, schema, and daemon contracts
+before agents should rely on them. The daemon routes based on config
+(`aos set voice.*`), presence (which sessions are online), and channel state.
+This is a natural extension of the daemon's existing responsibilities — it
+already manages voice config, canvases, and perception state.
 
 ### Coordination Bus
 

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -248,9 +248,13 @@ for form_id in ["listen-read", "listen-follow"]:
 text = os.environ["TEXT"]
 assert text.count("requires one listen source: <channel> OR --session-id") == 2, text
 api_doc = Path("docs/api/aos.md").read_text(encoding="utf-8")
+architecture = Path("ARCHITECTURE.md").read_text(encoding="utf-8")
 assert "STT/dictation is planned as a future" in api_doc, "missing planned listen source boundary"
 assert "current public surface only reads channels" in api_doc, "missing current listen source boundary"
 assert "direct-session messages" in api_doc, "missing direct-session listen boundary"
+assert "The current public `listen` surface reads channels and direct-session messages" in architecture, "missing architecture listen boundary"
+assert "future sources     (STT/dictation, stdin, webhook, file watch)" in architecture, "architecture must keep future listen sources out of current forms"
+assert "stdin pipe         (source = bash)" not in architecture, "architecture must not advertise stdin as a current listen source"
 PY
 then
     pass "listen help exposes channel or direct-session source alternatives"


### PR DESCRIPTION
## Summary
- align `ARCHITECTURE.md` with the current public `aos listen` contract: channels and direct-session messages today
- mark STT/dictation, stdin, webhooks, and file-watch input as reserved future sources until help/parser/schema/daemon contracts exist
- extend `tests/help-contract.sh` to guard the architecture/API/help listen boundary

## Verification
- `bash tests/help-contract.sh`
- `git diff --check`
- `./aos help --json`, `./aos help see --json`, `./aos help do --json`, `./aos help show --json`

## Live proof
- Not applicable; architecture/help-contract boundary only.
