### PR TITLE
Fix show update anchor conflict metadata

### DIFF
--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -1757,6 +1757,7 @@
             "conflicts" : [
               [
                 "anchor-window",
+                "anchor-channel",
                 "anchor-browser"
               ]
             ]

--- a/manifests/commands/source/aos/04-show.json
+++ b/manifests/commands/source/aos/04-show.json
@@ -389,6 +389,7 @@
             "conflicts": [
               [
                 "anchor-window",
+                "anchor-channel",
                 "anchor-browser"
               ]
             ]

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -370,6 +370,8 @@ assert enum_values(create_auto) == ["cursor_trail", "highlight_focused", "label_
 assert form_arg(os.environ["UPDATE"], "show-update", "auto-project") is None
 assert form_arg(os.environ["UPDATE"], "show-update", "anchor-channel") is not None
 assert enum_values(form_arg(os.environ["UPDATE"], "show-update", "track")) == ["union"]
+update_form = next(item for item in json.loads(os.environ["UPDATE"])["forms"] if item["id"] == "show-update")
+assert ["anchor-window", "anchor-channel", "anchor-browser"] in update_form["constraints"]["conflicts"], update_form
 docs = Path("docs/api/aos.md").read_text(encoding="utf-8")
 show_section = docs.split("## `aos show`", 1)[1].split("## `aos recipe`", 1)[0]
 for token in ["--anchor-browser browser:<session>/<ref>", "--anchor-window <id>", "--anchor-channel <id>", "--offset x,y,w,h"]:


### PR DESCRIPTION
## Summary
- Align show update registry metadata with the parser single-anchor positioning rule
- Regenerate the AOS command manifest from the source manifest
- Add a help-contract assertion for the full show update anchor conflict group

## Tests
- bash tests/help-contract.sh
- bash tests/command-manifest-generation.sh
- bash tests/external-command-dispatch.sh
- node --test tests/schemas/aos-external-command-manifest-v0.test.mjs
- node --test tests/aos-dev-gh-help-parity.test.mjs
- git diff --check
- ./aos help --json
- ./aos help see --json
- ./aos help do --json
- ./aos help show --json
