### PR TITLE
Expose browser fill state-id metadata

### DIFF
--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -3305,12 +3305,20 @@
               "summary" : "Snapshot id for ambiguous bare ref:<id> targets",
               "token" : "--snapshot",
               "value_type" : "string"
+            },
+            {
+              "id" : "state-id",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Perception state id for direct browser fill provenance",
+              "token" : "--state-id",
+              "value_type" : "string"
             }
           ],
           "examples" : [
             "aos do fill ref:<snapshot-id>:r2 \"buy groceries\" --workspace default --dry-run",
             "aos do fill ref:<snapshot-id>:r2 \"buy groceries\" --workspace default",
-            "aos do fill browser:todo/e21 \"buy groceries\""
+            "aos do fill browser:todo/e21 \"buy groceries\" --state-id see_abc123def456"
           ],
           "summary" : "Saved-ref fill validates before mutation and returns post_action.recommended_next_command for fresh aos see capture --save",
           "execution" : {
@@ -3329,7 +3337,7 @@
             "streaming" : false,
             "supports_json_flag" : false
           },
-          "usage" : "aos do fill <ref:<snapshot-id>:<ref>|browser:<s>/<ref>> <text> [--workspace <id>] [--snapshot <id>] [--dry-run]"
+          "usage" : "aos do fill <ref:<snapshot-id>:<ref>|browser:<s>/<ref>> <text> [--workspace <id>] [--snapshot <id>] [--state-id id] [--dry-run]"
         },
         {
           "args" : [

--- a/manifests/commands/source/aos/07-do-02-text.json
+++ b/manifests/commands/source/aos/07-do-02-text.json
@@ -222,12 +222,20 @@
               "summary": "Snapshot id for ambiguous bare ref:<id> targets",
               "token": "--snapshot",
               "value_type": "string"
+            },
+            {
+              "id": "state-id",
+              "kind": "flag",
+              "required": false,
+              "summary": "Perception state id for direct browser fill provenance",
+              "token": "--state-id",
+              "value_type": "string"
             }
           ],
           "examples": [
             "aos do fill ref:<snapshot-id>:r2 \"buy groceries\" --workspace default --dry-run",
             "aos do fill ref:<snapshot-id>:r2 \"buy groceries\" --workspace default",
-            "aos do fill browser:todo/e21 \"buy groceries\""
+            "aos do fill browser:todo/e21 \"buy groceries\" --state-id see_abc123def456"
           ],
           "summary": "Saved-ref fill validates before mutation and returns post_action.recommended_next_command for fresh aos see capture --save",
           "execution": {
@@ -246,7 +254,7 @@
             "streaming": false,
             "supports_json_flag": false
           },
-          "usage": "aos do fill <ref:<snapshot-id>:<ref>|browser:<s>/<ref>> <text> [--workspace <id>] [--snapshot <id>] [--dry-run]"
+          "usage": "aos do fill <ref:<snapshot-id>:<ref>|browser:<s>/<ref>> <text> [--workspace <id>] [--snapshot <id>] [--state-id id] [--dry-run]"
         },
         {
           "args": [

--- a/tests/browser/do-fill.test.sh
+++ b/tests/browser/do-fill.test.sh
@@ -17,6 +17,11 @@ out=$(./aos do fill "browser:todo/e21" "hello world" 2>&1)
 echo "$out" | grep -q "fake fill invoked: -s=todo fill e21 hello world" \
     || { echo "FAIL browser: $out" >&2; exit 1; }
 
+# Direct browser fill preserves state-id provenance in the action evidence
+out=$(./aos do fill "browser:todo/e21" "hello world" --state-id see_fill123 2>&1)
+echo "$out" | grep -q '"state_id":"see_fill123"' \
+    || { echo "FAIL browser state id: $out" >&2; exit 1; }
+
 # Missing text errors
 if out=$(./aos do fill "browser:todo/e21" 2>&1); then
     if echo "$out" | grep -q '"status":"success"'; then

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -465,6 +465,11 @@ key_browser = next(item for item in data["forms"] if item["id"] == "do-key-brows
 assert "browser:<session>[/<ref>]" in key_browser["usage"], key_browser["usage"]
 assert "--state-id" in {arg.get("token") for arg in key_browser["args"]}, key_browser
 assert "not a saved-ref action" in key_browser["summary"], key_browser
+fill = next(item for item in data["forms"] if item["id"] == "do-fill")
+fill_tokens = {arg.get("token") for arg in fill["args"]}
+assert "--state-id" in fill_tokens, fill
+assert "--state-id id" in fill["usage"], fill["usage"]
+assert any("browser:todo/e21" in example and "--state-id" in example for example in fill["examples"]), fill["examples"]
 set_value = next(item for item in data["forms"] if item["id"] == "do-set-value")
 set_value_tokens = {arg.get("token") for arg in set_value["args"]}
 assert {"--workspace", "--snapshot", "--value", "--dry-run"} <= set_value_tokens, set_value_tokens


### PR DESCRIPTION
## Summary
- Expose --state-id in do fill help metadata for direct browser fill provenance
- Regenerate the AOS command manifest from the source manifest
- Add regression coverage for help metadata and browser fill state_id evidence

## Tests
- bash tests/browser/do-fill.test.sh
- bash tests/help-contract.sh
- bash tests/command-manifest-generation.sh
- bash tests/external-command-dispatch.sh
- node --test tests/schemas/aos-external-command-manifest-v0.test.mjs
- node --test tests/aos-dev-gh-help-parity.test.mjs
- git diff --check
- ./aos help --json
- ./aos help see --json
- ./aos help do --json
- ./aos help show --json
