### PR TITLE
Reject browser element refs for navigate

### DIFF
--- a/scripts/aos-do-browser.mjs
+++ b/scripts/aos-do-browser.mjs
@@ -163,6 +163,7 @@ function navigateCommand(args) {
   const [targetString, url] = args;
   if (!targetString.startsWith('browser:')) error('aos do navigate is browser-only in v1.', 'BROWSER_ONLY');
   const target = parseBrowserTarget(targetString);
+  if (target.ref) error('aos do navigate targets a browser session, not an element ref (use browser:<session>).', 'INVALID_TARGET');
   ensureVersion();
   const result = runPlaywright(target.session, 'goto', [url]);
   requireSuccess(result, 'goto');

--- a/tests/browser/do-navigate.test.sh
+++ b/tests/browser/do-navigate.test.sh
@@ -20,6 +20,13 @@ stdout=$(echo "$out" | jq -r '.result.stdout')
 echo "$stdout" | grep -q "fake goto invoked: -s=todo goto https://example.com" \
     || { echo "FAIL: $out" >&2; exit 1; }
 
+# Element refs are not valid navigation targets; navigation is session-level.
+if out=$(./aos do navigate "browser:todo/e21" "https://example.com" 2>&1); then
+    echo "FAIL element ref target: expected error, got: $out" >&2; exit 1
+fi
+echo "$out" | grep -Eq '"code"[[:space:]]*:[[:space:]]*"INVALID_TARGET"' \
+    || { echo "FAIL element ref target code: $out" >&2; exit 1; }
+
 # Missing url errors
 if out=$(./aos do navigate "browser:todo" 2>&1); then
     if echo "$out" | grep -q '"status":"success"'; then


### PR DESCRIPTION
## Summary
- Reject browser element refs for session-level `aos do navigate` targets
- Keep navigate aligned with documented `browser:<session>` grammar
- Add browser adapter regression coverage for the invalid target-with-ref form

## Tests
- bash tests/browser/do-navigate.test.sh
- bash tests/browser/registry-introspection.test.sh
- bash tests/external-command-dispatch.sh
- bash tests/external-parser-flags.sh
- node --test tests/aos-dev-gh-help-parity.test.mjs
- bash tests/help-contract.sh
- git diff --check
- ./aos help --json
- ./aos help see --json
- ./aos help do --json
- ./aos help show --json
