### PR TITLE
Clarify click dwell target support

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -894,6 +894,10 @@ aos do click browser:<session>/<ref>
 aos do click canvas:<canvas-id>/<ref> --state-id <id>
 ```
 
+`--dwell` is a coordinate/native and AOS canvas click option. Direct browser
+clicks and browser saved refs reject `--dwell`; use browser click/double/right
+forms without native pointer dwell timing.
+
 Use `ref:<snapshot-id>:<ref>` for refs returned by `aos see refs` or compact
 saved capture output. `aos do <action> ref:<...> --dry-run` reports the resolved
 underlying command and, for browser refs, the fresh xray current-target

--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -2623,7 +2623,7 @@
               "id" : "dwell",
               "kind" : "flag",
               "required" : false,
-              "summary" : "Dwell time in ms",
+              "summary" : "Dwell time in ms for coordinate/native and AOS canvas click targets; browser targets reject --dwell",
               "token" : "--dwell",
               "value_type" : "int"
             },
@@ -2684,7 +2684,7 @@
             "streaming" : false,
             "supports_json_flag" : false
           },
-          "usage" : "aos do click <ref:<snapshot-id>:<ref>|x,y|canvas:<canvas-id>/<ref>|browser:<session>/<ref>> [--workspace <id>] [--snapshot <id>] [--right] [--double] [--dwell N] [--state-id id] [--dry-run]"
+          "usage" : "aos do click <ref:<snapshot-id>:<ref>|x,y|canvas:<canvas-id>/<ref>|browser:<session>/<ref>> [--workspace <id>] [--snapshot <id>] [--right] [--double] [--state-id id] [--dry-run] [--dwell N for x,y or canvas targets]"
         },
         {
           "args" : [

--- a/manifests/commands/source/aos/07-do-01-pointing.json
+++ b/manifests/commands/source/aos/07-do-01-pointing.json
@@ -36,7 +36,7 @@
               "id": "dwell",
               "kind": "flag",
               "required": false,
-              "summary": "Dwell time in ms",
+              "summary": "Dwell time in ms for coordinate/native and AOS canvas click targets; browser targets reject --dwell",
               "token": "--dwell",
               "value_type": "int"
             },
@@ -97,7 +97,7 @@
             "streaming": false,
             "supports_json_flag": false
           },
-          "usage": "aos do click <ref:<snapshot-id>:<ref>|x,y|canvas:<canvas-id>/<ref>|browser:<session>/<ref>> [--workspace <id>] [--snapshot <id>] [--right] [--double] [--dwell N] [--state-id id] [--dry-run]"
+          "usage": "aos do click <ref:<snapshot-id>:<ref>|x,y|canvas:<canvas-id>/<ref>|browser:<session>/<ref>> [--workspace <id>] [--snapshot <id>] [--right] [--double] [--state-id id] [--dry-run] [--dwell N for x,y or canvas targets]"
         },
         {
           "args": [

--- a/tests/browser/do-existing-verbs.test.sh
+++ b/tests/browser/do-existing-verbs.test.sh
@@ -38,6 +38,7 @@ assert_error_code UNKNOWN_ARG do type "browser:todo" "hello" unexpected
 assert_error_code UNKNOWN_ARG do key "browser:todo" "Enter" unexpected
 assert_error_code UNKNOWN_ARG do drag "browser:todo/e1" "browser:todo/e2" unexpected
 assert_error_code UNKNOWN_FLAG do click "browser:todo/e21" --bogus
+assert_error_code UNKNOWN_FLAG do click "browser:todo/e21" --dwell 25
 assert_error_code MISSING_ARG do click "browser:todo/e21" --state-id --double
 
 echo "PASS"

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -402,6 +402,10 @@ assert "browser:<session>/<ref>" in usage, usage
 assert "--state-id" in tokens, tokens
 assert "--workspace" in tokens, tokens
 assert "--snapshot" in tokens, tokens
+dwell = next(arg for arg in form["args"] if arg.get("id") == "dwell")
+assert "coordinate/native and AOS canvas" in dwell["summary"], dwell
+assert "browser targets reject --dwell" in dwell["summary"], dwell
+assert "--dwell N for x,y or canvas targets" in usage, usage
 PY
 then
     pass "do click help exposes ref target forms"


### PR DESCRIPTION
## Summary
- Clarify `aos do click --dwell` as coordinate/native and AOS canvas click only.
- Regenerate the AOS command manifest from source metadata.
- Add browser/help regression coverage for rejecting browser dwell targets.

## Tests
- bash tests/browser/do-existing-verbs.test.sh
- bash tests/help-contract.sh
- bash tests/command-manifest-generation.sh
- bash tests/agent-workspace-contract-drift.sh
- node --test tests/schemas/aos-external-command-manifest-v0.test.mjs
- bash tests/external-command-dispatch.sh
- node --test tests/aos-dev-gh-help-parity.test.mjs
- git diff --check
- ./aos help --json
- ./aos help see --json
- ./aos help do --json
- ./aos help show --json
