### PR TITLE
Align coordinate fallback proof docs

### DIFF
--- a/shared/schemas/aos-agent-workspace-v0.md
+++ b/shared/schemas/aos-agent-workspace-v0.md
@@ -205,7 +205,7 @@ marks it actionable with complete known-limit facts.
 | `native_ax` stable saved refs | durable-identity plus producer-verdict `press`, `focus`, and `set-value` | `native_saved_ref_contract_tests_plus_approval_gates` | `approval_gated_live_proof_not_run` | `tests/agent-workspace-native-refs.sh` plus HITL live smoke, TCC/manual runtime flow, native repo-mode artifact rebuild, and no-foreground/focus/cursor/Space baseline verification |
 | direct AX one-shot wrappers | `--pid` / `--role` `press`, `focus`, and `set-value` | `native_primitive_response_plus_wrapper_contract` | `approval_gated_live_proof_not_run` | `tests/agent-workspace-native-refs.sh` plus the same approval gates |
 | `native_ax` volatile or known-limit refs | inspection/readback only | `known_limit_contract` | `approval_gated_live_proof_not_run` | known-limit assertions in `tests/agent-workspace-native-refs.sh` plus the same approval gates |
-| `coordinate_fallback` | diagnostic/fallback-only refs | `known_limit_contract` | `known_limit_refusal_tested` | refused-before-dispatch assertions in `tests/agent-workspace-native-refs.sh` |
+| `coordinate_fallback` | diagnostic/fallback-only refs | `known_limit_contract` | `known_limit_refusal_tested` | refused-before-dispatch assertions in browser, AOS canvas, and native saved-ref tests |
 
 Non-dry-run saved-ref mutations return a saved-ref execution envelope rather
 than raw adapter output. The envelope includes the resolved command,

--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -499,6 +499,10 @@ assert.ok(
   'API doc must name backend-wide coordinate fallback refusal evidence',
 );
 assert.ok(
+  schemaDoc.replace(/\s+/g, ' ').includes('browser, AOS canvas, and native saved-ref tests'),
+  'schema doc must name backend-wide coordinate fallback refusal evidence',
+);
+assert.ok(
   apiDoc.replace(/\s+/g, ' ').includes('`press` and `focus` examples require stable `native_ax` refs'),
   'API saved-ref examples must mark press/focus as stable native AX only',
 );


### PR DESCRIPTION
## Summary
- Align the workspace schema doc with the backend-wide coordinate fallback refusal evidence.
- Add a contract drift assertion so the schema doc and API doc both name browser, AOS canvas, and native saved-ref tests for coordinate fallback proof.

## Tests
- bash tests/agent-workspace-contract-drift.sh
- git diff --check
- ./aos help --json
- ./aos help see --json
- ./aos help do --json
- ./aos help show --json

Note: there is no dedicated tests/schemas/aos-agent-workspace-v0.test.mjs file in this repo; the drift test imports the workspace schema and schema doc for this contract.
