### PR TITLE
Align coordinate fallback skill proof

### DIFF
--- a/skills/aos-agent-workspace/SKILL.md
+++ b/skills/aos-agent-workspace/SKILL.md
@@ -110,7 +110,8 @@ Backend proof quick read:
   `native_primitive_response_plus_wrapper_contract`
   / `approval_gated_live_proof_not_run`.
 - `coordinate_fallback` uses `known_limit_contract` /
-  `known_limit_refusal_tested`, refused before dispatch.
+  `known_limit_refusal_tested`, with browser, AOS canvas, and native saved-ref
+  tests refusing dispatch before mutation.
 
 ## Acting On Refs
 

--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -503,6 +503,10 @@ assert.ok(
   'schema doc must name backend-wide coordinate fallback refusal evidence',
 );
 assert.ok(
+  skill.replace(/\s+/g, ' ').includes('browser, AOS canvas, and native saved-ref tests'),
+  'skill must name backend-wide coordinate fallback refusal evidence',
+);
+assert.ok(
   apiDoc.replace(/\s+/g, ' ').includes('`press` and `focus` examples require stable `native_ax` refs'),
   'API saved-ref examples must mark press/focus as stable native AX only',
 );


### PR DESCRIPTION
## Summary
- Align the AOS agent workspace skill with the backend-wide coordinate fallback refusal proof.
- Extend the contract drift guard so API docs, schema docs, and skill text all name browser, AOS canvas, and native saved-ref tests for coordinate fallback dispatch refusal.

## Tests
- bash tests/agent-workspace-contract-drift.sh
- git diff --check
- ./aos help --json
- ./aos help see --json
- ./aos help do --json
- ./aos help show --json
