### PR TITLE
Guard active authority pointers

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -23,6 +23,10 @@ source root. This file is a routing map, not a replacement for those sources.
   under `docs/api/`.
 - Schemas and cross-tool contracts: `shared/schemas/`, especially
   `shared/schemas/CONTRACT-GOVERNANCE.md`.
+- Command manifests and help metadata:
+  `manifests/commands/aos-commands.json` and
+  `manifests/commands/aos-external-commands.json`.
+- Agent workflow skill: `skills/aos-agent-workspace/SKILL.md`.
 - AOS Execution Model V0: `docs/adr/0013-aos-execution-model-v0.md`.
 - AOS TCC capability broker boundary:
   `docs/adr/0015-aos-tcc-capability-broker-boundary.md`.

--- a/tests/active-authority-pointers.test.mjs
+++ b/tests/active-authority-pointers.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { stat, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+async function text(relativePath) {
+  return readFile(path.join(repoRoot, relativePath), 'utf8');
+}
+
+async function assertPathExists(relativePath) {
+  await assert.doesNotReject(
+    stat(path.join(repoRoot, relativePath)),
+    `active authority pointer does not resolve: ${relativePath}`,
+  );
+}
+
+async function assertMentions(sourcePath, targetPath) {
+  const content = await text(sourcePath);
+  assert.match(
+    content,
+    new RegExp(targetPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+    `${sourcePath} must route to ${targetPath}`,
+  );
+}
+
+test('active authority map points to existing runtime primitive contract owners', async () => {
+  const requiredPointers = [
+    ['CONTEXT-MAP.md', 'CONTEXT.md'],
+    ['CONTEXT-MAP.md', 'ARCHITECTURE.md'],
+    ['CONTEXT-MAP.md', 'AGENTS.md'],
+    ['CONTEXT-MAP.md', 'docs/api/README.md'],
+    ['CONTEXT-MAP.md', 'docs/api/aos.md'],
+    ['CONTEXT-MAP.md', 'shared/schemas/'],
+    ['CONTEXT-MAP.md', 'shared/schemas/CONTRACT-GOVERNANCE.md'],
+    ['CONTEXT-MAP.md', 'manifests/commands/aos-commands.json'],
+    ['CONTEXT-MAP.md', 'manifests/commands/aos-external-commands.json'],
+    ['CONTEXT-MAP.md', 'skills/aos-agent-workspace/SKILL.md'],
+    ['CONTEXT-MAP.md', 'docs/design/'],
+    ['README.md', 'docs/api/aos.md'],
+    ['README.md', 'ARCHITECTURE.md'],
+    ['README.md', 'AGENTS.md'],
+    ['docs/api/README.md', 'ARCHITECTURE.md'],
+    ['docs/api/README.md', 'docs/design/'],
+    ['skills/aos-agent-workspace/SKILL.md', 'docs/api/aos.md'],
+    ['skills/aos-agent-workspace/SKILL.md', 'shared/schemas/aos-agent-workspace-v0.md'],
+    ['skills/aos-agent-workspace/SKILL.md', 'tests/agent-workspace-saved-ref.sh'],
+  ];
+
+  const targetPaths = [...new Set(requiredPointers.map(([, target]) => target))];
+
+  await Promise.all(targetPaths.map(assertPathExists));
+  await Promise.all(requiredPointers.map(([source, target]) => assertMentions(source, target)));
+});


### PR DESCRIPTION
## Summary
- add runtime primitive authority pointers for command manifests/help metadata and the saved workspace skill to CONTEXT-MAP.md
- add a focused Node contract test that requires active authority pointers to resolve and stay referenced from their owner docs

## Verification
- node --test tests/active-authority-pointers.test.mjs
- node --test tests/execution-model-terminology-contract.test.mjs
- bash tests/help-contract.sh
- git diff --check HEAD~1 HEAD
- ./aos help --json
- ./aos help see --json
- ./aos help do --json
- ./aos help show --json
