### PR TITLE
Align canvas host target contract docs

### DIFF
--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -39,7 +39,7 @@ When a toolkit behavior is too heavy in WebView space, add or request a cheaper 
 
 ## Surface Interaction Decision Tree
 
-Before adding a WebView, daemon policy, app-private hit testing, or a new DesktopWorld stage layer, use the canonical decision tree in [docs/guides/aos-surface-interaction-decision-tree.md](../recipes/aos-surface-interaction-decision-tree.md). The short version is:
+Before adding a WebView, daemon policy, app-private hit testing, or a new DesktopWorld stage layer, use the canonical decision tree in [docs/guides/aos-surface-interaction-decision-tree.md](../guides/aos-surface-interaction-decision-tree.md). The short version is:
 
 1. use DOM controls when the visual and hit area already live in the same interactive canvas;
 2. use toolkit panel/windowing primitives for ordinary chrome, placement, minimize, maximize, restore, close, drag, and resize;
@@ -67,4 +67,4 @@ Before adding a WebView, daemon policy, app-private hit testing, or a new Deskto
 
 Keep this page as a map, not a component manual. Detailed contract prose belongs in the scoped files above. If a change affects a consumer-facing toolkit interface, update the scoped file in the same change and add or update a deterministic docs contract test when the routing itself matters.
 
-Do not duplicate the full [surface interaction decision tree](../recipes/aos-surface-interaction-decision-tree.md) in API docs; link to the recipe so it remains canonical. Keep active design or audit status in `docs/design/`, not in this API map.
+Do not duplicate the full [surface interaction decision tree](../guides/aos-surface-interaction-decision-tree.md) in API docs; link to the guide so it remains canonical. Keep active design or audit status in `docs/design/`, not in this API map.

--- a/docs/api/toolkit/panel-window.md
+++ b/docs/api/toolkit/panel-window.md
@@ -3,7 +3,7 @@
 Consumer-facing reference for the default opt-in AOS panel/windowing layer: panel chrome, placement, drag, resize, minimize, maximize, restore, StageAffordance, and stock panel layouts. Runtime bridge primitives live in [runtime.md](./runtime.md).
 
 For interaction mechanism selection, use the canonical
-[surface interaction decision tree](../../recipes/aos-surface-interaction-decision-tree.md)
+[surface interaction decision tree](../../guides/aos-surface-interaction-decision-tree.md)
 (`docs/guides/aos-surface-interaction-decision-tree.md`).
 
 ## StageAffordance

--- a/docs/api/toolkit/runtime.md
+++ b/docs/api/toolkit/runtime.md
@@ -121,11 +121,32 @@ pointer, scroll, and cancel events. `normalizeCanvasOriginInputMessage()` then
 adds router aliases such as `x`/`y`, camelCase identity fields, and child-local
 offsets for existing toolkit code.
 
-Use the [surface interaction decision tree](../../recipes/aos-surface-interaction-decision-tree.md)
+Use the [surface interaction decision tree](../../guides/aos-surface-interaction-decision-tree.md)
 (`docs/guides/aos-surface-interaction-decision-tree.md`) before adding a
 region: passive DesktopWorld visuals with small hit areas usually belong behind
 `createStageAffordance`, while ordinary DOM controls should stay inside the
 existing interactive canvas.
+
+## Canvas Host Target Semantics
+
+Toolkit surfaces participate in the same AOS target ladder as the public CLI.
+`aos show --id <canvas-id>` owns canvas resource lifecycle, `aos see capture
+--canvas <canvas-id>` scopes perception to the current canvas host, and
+`canvas:<canvas-id>/<ref>` is the direct current Target-with-Ref for a semantic
+element inside that host. Saved workspace refs remain the model-facing durable
+handle: agents should prefer `ref:<snapshot-id>:<ref-id>` after `aos see capture
+--save`, and use direct canvas targets for current-host actions or diagnostic
+paths where the canvas is live.
+
+Toolkit code should treat a canvas id as a resource id, not as durable object
+identity for a semantic control. Semantic targets exposed through
+`data-aos-ref`, `data-semantic-target-id`, owner metadata, and
+`provenance.do_target` provide the action vocabulary. DesktopWorld surfaces,
+segmented canvases, passthrough visuals, child hit WebViews, and interactive
+affordances should use the same split: daemon primitives own lifecycle,
+geometry, input routing, and current canvas host state; toolkit policy owns
+panel/window behavior, stage affordances, semantic target descriptors, and
+reusable interaction bindings; app code owns product behavior.
 
 Surfaces that inspect ownership rather than handle pointer input can subscribe
 to `input_region` with `{ snapshot: true }`. The daemon replays

--- a/docs/design/aos-surface-system.md
+++ b/docs/design/aos-surface-system.md
@@ -9,8 +9,8 @@ for apps such as Sigil to theme and extend.
 
 For interaction mechanism selection, use the canonical decision tree and first
 conformance audit in
-[`docs/guides/aos-surface-interaction-decision-tree.md`](../recipes/aos-surface-interaction-decision-tree.md).
-That recipe is the durable answer for whether a surface should use DOM hit
+[`docs/guides/aos-surface-interaction-decision-tree.md`](../guides/aos-surface-interaction-decision-tree.md).
+That guide is the durable answer for whether a surface should use DOM hit
 testing, toolkit panel/windowing, `createStageAffordance`, visual-only stage
 layers, a full interactive canvas, a private renderer, or a daemon primitive.
 

--- a/tests/execution-model-terminology-contract.test.mjs
+++ b/tests/execution-model-terminology-contract.test.mjs
@@ -312,6 +312,48 @@ test('show anchors stay placement roles instead of target dialects', async () =>
   assert.doesNotMatch(`${context}\n${showSection}`, /anchor:<|browser-anchor:/);
 });
 
+test('canvas host docs keep lifecycle, current targets, and saved refs distinct', async () => {
+  const aosApi = await text('docs/api/aos.md');
+  const toolkitRuntime = await text('docs/api/toolkit/runtime.md');
+  const context = await text('CONTEXT.md');
+  const manifest = JSON.parse(await text('manifests/commands/aos-commands.json'));
+  const showCommand = manifest.commands.find((command) => (
+    JSON.stringify(command.path) === JSON.stringify(['show'])
+  ));
+  const showCreateForm = showCommand?.forms?.find((form) => form.id === 'show-create');
+  const seeCommand = manifest.commands.find((command) => (
+    JSON.stringify(command.path) === JSON.stringify(['see'])
+  ));
+  const seeCaptureForm = seeCommand?.forms?.find((form) => form.id === 'see-capture');
+  const doDragCommand = manifest.commands.find((command) => (
+    JSON.stringify(command.path) === JSON.stringify(['do', 'drag'])
+  ));
+  const doCommand = manifest.commands.find((command) => (
+    JSON.stringify(command.path) === JSON.stringify(['do'])
+  ));
+  const doDragCanvasForm = doDragCommand?.forms?.find((form) => form.id === 'do-drag-canvas')
+    ?? doCommand?.forms?.find((form) => form.id === 'do-drag-canvas');
+  const doClickForm = doCommand?.forms?.find((form) => form.id === 'do-click');
+  const doSetValueForm = doCommand?.forms?.find((form) => form.id === 'do-set-value');
+  const targetLadder = aosApi.split('## Target And Handle Ladder', 2)[1].split('## Core Usage Patterns', 1)[0];
+
+  assert.ok(showCreateForm?.args?.some((arg) => arg.id === 'id' && /Canvas identifier/.test(arg.summary)));
+  assert.ok(seeCaptureForm?.args?.some((arg) => arg.token === '--canvas' && /Capture a canvas by id/.test(arg.summary)));
+  assert.match(doClickForm?.usage ?? '', /canvas:<canvas-id>\/<ref>/);
+  assert.match(doSetValueForm?.usage ?? '', /canvas:<canvas-id>\/<ref>/);
+  assert.match(doDragCanvasForm?.usage ?? '', /canvas:<canvas-id>\/<ref>/);
+  assert.match(doDragCanvasForm?.usage ?? '', /--by <dx,dy>\|--to-value <value>/);
+  assert.match(context, /Canvas Host[\s\S]*?addressed as `canvas:<canvas-id>\/<ref>`/);
+  assert.match(targetLadder, /Window, channel, browser, and\s+canvas ids remain resource ids or role-flag values/);
+  assert.match(toolkitRuntime, /`aos show --id <canvas-id>` owns canvas resource lifecycle/);
+  assert.match(toolkitRuntime, /`aos see capture\s+--canvas <canvas-id>` scopes perception to the current canvas host/);
+  assert.match(toolkitRuntime, /`canvas:<canvas-id>\/<ref>` is the direct current Target-with-Ref/);
+  assert.match(toolkitRuntime, /Saved workspace refs remain the model-facing durable\s+handle/);
+  assert.match(toolkitRuntime, /canvas id as a resource id, not as durable object\s+identity/);
+  assert.doesNotMatch(`${targetLadder}\n${toolkitRuntime}`, /canvas id is durable object identity/i);
+  assert.doesNotMatch(`${targetLadder}\n${toolkitRuntime}`, /canvas:<canvas-id> is the saved ref/i);
+});
+
 test('voice and communication guidance keep say, voice, tell, and listen roles distinct', async () => {
   const architecture = await text('ARCHITECTURE.md');
   const aosApi = await text('docs/api/aos.md');

--- a/tests/toolkit/toolkit-api-docs-contract.test.mjs
+++ b/tests/toolkit/toolkit-api-docs-contract.test.mjs
@@ -109,7 +109,24 @@ test('surface interaction decision tree remains discoverable from toolkit API do
 
   for (const doc of docs) {
     assert.match(doc, escaped(requiredPath));
+    assert.doesNotMatch(doc, /\.\.\/(?:\.\.\/)?recipes\/aos-surface-interaction-decision-tree\.md/);
   }
+});
+
+test('toolkit runtime docs keep canvas host targets separate from saved refs', async () => {
+  const runtime = await text('docs/api/toolkit/runtime.md');
+  const section = runtime.split('## Canvas Host Target Semantics', 2)[1].split('## ', 1)[0];
+
+  assert.match(section, /`aos show --id <canvas-id>` owns canvas resource lifecycle/);
+  assert.match(section, /`aos see capture\s+--canvas <canvas-id>` scopes perception to the current canvas host/);
+  assert.match(section, /`canvas:<canvas-id>\/<ref>` is the direct current Target-with-Ref/);
+  assert.match(section, /Saved workspace refs remain the model-facing durable\s+handle/);
+  assert.match(section, /`ref:<snapshot-id>:<ref-id>`/);
+  assert.match(section, /canvas id as a resource id, not as durable object\s+identity/);
+  assert.match(section, /`provenance\.do_target` provide[s]? the action vocabulary/);
+  assert.match(section, /DesktopWorld surfaces,\s+segmented canvases, passthrough visuals, child hit WebViews, and interactive\s+affordances/);
+  assert.match(section, /daemon primitives own lifecycle,\s+geometry, input routing, and current canvas host state/);
+  assert.match(section, /toolkit policy owns\s+panel\/window behavior, stage affordances, semantic target descriptors/);
 });
 
 test('generated artifact lifecycle policy is discoverable from workbench docs', async () => {


### PR DESCRIPTION
## Summary

- document the canvas host target split in toolkit runtime API docs
- fix active toolkit/surface-system links to the canonical guides path instead of the removed docs/recipes path
- add contract tests for canvas lifecycle/current-target/saved-ref separation and guide-link drift

## Tests

- `node --test tests/execution-model-terminology-contract.test.mjs`
- `node --test tests/toolkit/toolkit-api-docs-contract.test.mjs`
- `node --test tests/toolkit/surface-interaction-decision-tree-contract.test.mjs`
- `bash tests/agent-workspace-canvas-refs.sh`
- `bash tests/help-contract.sh`
- `node --test tests/schemas/aos-external-command-manifest-v0.test.mjs`
- `git diff --check`
- `./aos help --json`
- `./aos help see --json`
- `./aos help do --json`
- `./aos help show --json`
