### PR TITLE
Clarify native AX direct action help contract

### DIFF
--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -3521,7 +3521,7 @@
             "aos do press --pid 1234 --role AXButton --title Save --dry-run",
             "aos do press --pid 1234 --role AXButton --title Save"
           ],
-          "summary" : "Stable native AX saved-ref press validates durable identity before mutation and returns post_action.recommended_next_command for fresh aos see capture --save",
+          "summary" : "Press stable native AX saved refs or direct AX targets; saved refs validate durable identity before mutation and return post_action.recommended_next_command for fresh aos see capture --save; direct AX uses current matching with no_foreground proof still not claimed",
           "execution" : {
             "auto_starts_daemon" : false,
             "interactive" : false,
@@ -3873,7 +3873,7 @@
             "aos do focus --pid 1234 --role AXTextField --dry-run",
             "aos do focus --pid 1234 --role AXTextField"
           ],
-          "summary" : "Stable native AX saved-ref focus validates durable identity before mutation and returns post_action.recommended_next_command for fresh aos see capture --save",
+          "summary" : "Focus stable native AX saved refs or direct AX targets; saved refs validate durable identity before mutation and return post_action.recommended_next_command for fresh aos see capture --save; direct AX uses current matching with no_foreground proof still not claimed",
           "execution" : {
             "auto_starts_daemon" : false,
             "interactive" : false,

--- a/manifests/commands/source/aos/07-do-03-controls.json
+++ b/manifests/commands/source/aos/07-do-03-controls.json
@@ -151,7 +151,7 @@
             "aos do press --pid 1234 --role AXButton --title Save --dry-run",
             "aos do press --pid 1234 --role AXButton --title Save"
           ],
-          "summary": "Stable native AX saved-ref press validates durable identity before mutation and returns post_action.recommended_next_command for fresh aos see capture --save",
+          "summary": "Press stable native AX saved refs or direct AX targets; saved refs validate durable identity before mutation and return post_action.recommended_next_command for fresh aos see capture --save; direct AX uses current matching with no_foreground proof still not claimed",
           "execution": {
             "auto_starts_daemon": false,
             "interactive": false,
@@ -503,7 +503,7 @@
             "aos do focus --pid 1234 --role AXTextField --dry-run",
             "aos do focus --pid 1234 --role AXTextField"
           ],
-          "summary": "Stable native AX saved-ref focus validates durable identity before mutation and returns post_action.recommended_next_command for fresh aos see capture --save",
+          "summary": "Focus stable native AX saved refs or direct AX targets; saved refs validate durable identity before mutation and return post_action.recommended_next_command for fresh aos see capture --save; direct AX uses current matching with no_foreground proof still not claimed",
           "execution": {
             "auto_starts_daemon": false,
             "interactive": false,

--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -653,7 +653,9 @@ assert.ok(doCommand, 'manifest missing do command');
 const doFormsByID = new Map(doCommand.forms.map((form) => [form.id, form]));
 for (const action of ['press', 'focus']) {
   const form = doFormsByID.get(`do-${action}`);
-  assert.ok(form.summary.includes(`Stable native AX saved-ref ${action}`), `manifest do-${action} summary must mark saved refs as stable native AX only`);
+  assert.ok(form.summary.includes(`stable native AX saved refs or direct AX targets`), `manifest do-${action} summary must distinguish stable saved refs from direct AX targets`);
+  assert.ok(form.summary.includes('direct AX uses current matching'), `manifest do-${action} summary must disclose direct AX current matching`);
+  assert.ok(form.summary.includes('no_foreground proof still not claimed'), `manifest do-${action} summary must avoid claiming direct AX no-foreground proof`);
   const targetArg = form.args.find((arg) => arg.id === 'target');
   assert.ok(targetArg.summary.includes('Stable saved native AX ref'), `manifest do-${action} target arg must mark saved refs as stable native AX only`);
 }


### PR DESCRIPTION
## Summary

- clarify `do press` and `do focus` help summaries so they distinguish stable native AX saved refs from direct AX `--pid/--role` targets
- preserve saved-ref `post_action.recommended_next_command` guidance while stating direct AX uses current matching and still does not claim `no_foreground` proof
- update the contract drift assertion and regenerate the command manifest

## Tests

- `bash tests/command-manifest-generation.sh`
- `bash tests/help-contract.sh`
- `bash tests/agent-workspace-contract-drift.sh`
- `bash tests/agent-workspace-native-refs.sh`
- `node --test tests/schemas/aos-external-command-manifest-v0.test.mjs`
- `git diff --check`
- `./aos help --json`
- `./aos help see --json`
- `./aos help do --json`
- `./aos help show --json`
