### PR TITLE
Clarify communication state contract

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -1299,8 +1299,18 @@ For `human` delivery, `--from-session-id` lets the daemon resolve that
 session's leased voice, and `--purpose final_response` applies the configured
 final-response shaping policy before speaking.
 
-Direct routing should prefer canonical session ids. Human-readable names remain display metadata for `aos tell --who` and operator ergonomics.
-Presence is lease-based and restored from the runtime snapshot after daemon restart. Discover peers with `aos tell --who`, then keep using direct `--session-id` routing once a peer id is known; direct session messaging does not require `--who` to be non-empty at send time.
+`aos tell` is daemon-routed communication, not an app-control synonym for
+`aos do tell`. Messages flow through the daemon coordination bus into named
+channels or direct canonical-session channels. Session presence is daemon state
+mirrored into `~/.config/aos/{mode}/coordination/sessions.json`; channel
+messages remain daemon-owned bounded queues instead of model-context history.
+
+Direct routing should prefer canonical session ids. Human-readable names remain
+display metadata for `aos tell --who` and operator ergonomics. Presence is
+lease-based and restored from the runtime snapshot after daemon restart.
+Discover peers with `aos tell --who`, then keep using direct `--session-id`
+routing once a peer id is known; direct session messaging does not require
+`--who` to be non-empty at send time.
 
 Docked role sessions are ordinary registered sessions. Supervisors should
 register each role before launch with stable ids such as `<run-id>:gdi`,
@@ -1329,9 +1339,11 @@ aos listen --channels
 ```
 
 One-shot reads return a JSON envelope with a `messages` array. `--follow` emits
-one message per line as NDJSON. STT/dictation is planned as a future
-`aos listen` source, but the current public surface only reads channels and
-direct-session messages.
+one message per line as NDJSON. `--channels` lists the daemon-known channel
+names; it is discovery for existing daemon communication state, not a workspace
+or transcript index. STT/dictation is planned as a future `aos listen` source.
+Stdin ingestion is also planned as a future `aos listen` source, but the
+current public surface only reads channels and direct-session messages.
 
 ## `aos wiki`
 

--- a/tests/execution-model-terminology-contract.test.mjs
+++ b/tests/execution-model-terminology-contract.test.mjs
@@ -433,6 +433,16 @@ test('voice and communication guidance keep say, voice, tell, and listen roles d
   assert.match(architecture, /\| `listen` \| Receive communication \| Channels and direct sessions today; STT, stdin, and aggregated sources planned \|/);
   assert.match(aosApi, /`aos say` is a direct TTS convenience path/);
   assert.match(aosApi, /`aos tell human \.\.\.` is daemon-routed communication/);
+  assert.match(aosApi, /`aos tell` is daemon-routed communication, not an app-control synonym for\s+`aos do tell`/);
+  assert.match(aosApi, /Messages flow through the daemon coordination bus into named\s+channels or direct canonical-session channels/);
+  assert.match(aosApi, /Session presence is daemon state\s+mirrored into `~\/\.config\/aos\/\{mode\}\/coordination\/sessions\.json`/);
+  assert.match(aosApi, /channel\s+messages remain daemon-owned bounded queues instead of model-context history/);
+  assert.match(aosApi, /Direct routing should prefer canonical session ids/);
+  assert.match(aosApi, /This keeps `aos tell --who`, `aos voice assignments`, and docked\s+session status aligned around the same role session identity/);
+  assert.match(aosApi, /`--channels` lists the daemon-known channel\s+names/);
+  assert.match(aosApi, /not a workspace\s+or transcript index/);
+  assert.match(aosApi, /STT\/dictation is planned as a future `aos listen` source/);
+  assert.match(aosApi, /Stdin ingestion is also planned as a future `aos listen` source/);
   assert.match(readme, /\| `aos listen` \| Primitive \| Inbound communication: channel\/direct-session reads and follow today; STT and broader sources planned \|/);
   assert.match(sayCommand?.summary ?? '', /direct TTS convenience aligned with tell human/);
   assert.match(tellCommand?.summary ?? '', /send to human, channel, or session/);
@@ -455,6 +465,8 @@ test('voice and communication guidance keep say, voice, tell, and listen roles d
   assert.doesNotMatch(maintained, /\| `listen` \| Receive communication \| Aggregates STT/);
   assert.doesNotMatch(maintained, /`aos listen` or similar/);
   assert.doesNotMatch(maintained, /say.*sugar for tell human/i);
+  assert.doesNotMatch(maintained, /session names are canonical/i);
+  assert.doesNotMatch(maintained, /channels are workspace transcripts/i);
 });
 
 test('Skills and Plugins are packaging activation concepts outside the execution ladder', async () => {


### PR DESCRIPTION
## Summary
- clarify that `aos tell` routes through daemon coordination state, not app-control `do tell`
- document canonical session ids, presence snapshot storage, daemon-owned channel queues, and `listen --channels` discovery boundaries
- extend the terminology contract test so Phase 9 communication state cannot drift into workspace transcripts or name-based identity

## Verification
- node --test tests/execution-model-terminology-contract.test.mjs
- bash tests/help-contract.sh
- node --test tests/schemas/aos-external-command-manifest-v0.test.mjs
- git diff --check
