### PR TITLE
Teach fresh agent workspace loop

### DIFF
--- a/skills/aos-agent-workspace/SKILL.md
+++ b/skills/aos-agent-workspace/SKILL.md
@@ -29,6 +29,31 @@ The `press` and `focus` examples require stable `native_ax` refs with durable
 native identity facts and an actionable producer verdict; browser and AOS canvas
 refs fail closed for those actions.
 
+## Fresh-Agent Quickstart
+
+If you only have a shell and this skill, discover the command shape first, then
+run the saved observe-act-verify loop:
+
+```bash
+aos help see --json
+aos help do --json
+aos see capture browser:work --save --mode som --workspace default
+aos see snapshots --workspace default --json
+aos see refs --workspace default --query Save --json
+aos see refs --workspace default --snapshot <snapshot-id> --json
+aos do click ref:<snapshot-id>:<ref-id> --workspace default --dry-run
+aos do click ref:<snapshot-id>:<ref-id> --workspace default
+aos see capture browser:work --save --mode som --workspace default --name after-action
+```
+
+Use `aos see refs` output and action responses as the compact model-facing
+payload. Do not load screenshots, base64, full AX trees, browser element dumps,
+or canvas semantic target arrays into model context unless a compact ref,
+summary, path, or `recommended_next_command` is insufficient. When an action is
+unsupported, blocked, stale, ambiguous, or validation-required, stop and follow
+the returned `recommended_next`, `recommended_next_commands`, or
+`recommended_next_command`; do not guess a coordinate workaround.
+
 ## Contract
 
 - Use `aos see capture --save` to persist perception into the active runtime

--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -392,6 +392,24 @@ assertOrderedIncludes(
   skillQuickStartCommands,
   'AOS workspace skill quick-start must teach saved capture, compact readback, dry-run, dispatch, and fresh capture refresh in order',
 );
+const freshAgentQuickstart = skill.split('## Fresh-Agent Quickstart', 2)[1].split('## Contract', 1)[0];
+const freshAgentQuickstartProse = freshAgentQuickstart.replace(/\s+/g, ' ');
+assert.ok(
+  freshAgentQuickstart
+  && freshAgentQuickstart.indexOf('aos help see --json') < freshAgentQuickstart.indexOf('aos see capture browser:work --save --mode som --workspace default')
+  && freshAgentQuickstart.indexOf('aos help do --json') < freshAgentQuickstart.indexOf('aos see capture browser:work --save --mode som --workspace default')
+  && freshAgentQuickstart.indexOf('aos do click ref:<snapshot-id>:<ref-id> --workspace default --dry-run') < freshAgentQuickstart.indexOf('aos do click ref:<snapshot-id>:<ref-id> --workspace default\n')
+  && freshAgentQuickstart.indexOf('aos see capture browser:work --save --mode som --workspace default --name after-action') > freshAgentQuickstart.indexOf('aos do click ref:<snapshot-id>:<ref-id> --workspace default\n'),
+  'AOS workspace skill fresh-agent quickstart must lead with help, then saved capture, dry-run, dispatch, and verification capture',
+);
+for (const term of [
+  'compact model-facing payload',
+  'Do not load screenshots, base64, full AX trees, browser element dumps',
+  'recommended_next_command',
+  'do not guess a coordinate workaround',
+]) {
+  assert.ok(freshAgentQuickstartProse.includes(term), `AOS workspace skill fresh-agent quickstart missing ${term}`);
+}
 assert.ok(
   skill.includes('aos see capture --canvas surface-inspector --save --mode som --workspace default'),
   'AOS workspace skill quick-start must include a source-flag saved canvas capture',


### PR DESCRIPTION
## Summary
- add a fresh-agent quickstart to the `aos-agent-workspace` skill
- lead agents from help discovery into saved capture, compact refs, dry-run, dispatch, and verification capture
- pin the skill guidance in the agent workspace drift test so it stays compact and avoids heavy payload/context fallback

## Verification
- bash tests/agent-workspace-contract-drift.sh
- node --test tests/active-authority-pointers.test.mjs
- bash tests/help-contract.sh
- git diff --check
