### PR TITLE
Clarify Work Record proof boundaries

### DIFF
--- a/shared/schemas/aos-work-record-v0.md
+++ b/shared/schemas/aos-work-record-v0.md
@@ -313,6 +313,26 @@ descriptor. The builder stores the selected action target in
 `evidence[]`, and ties the post-action Postcondition to the after-perception
 evidence.
 
+### Saved Refs, Evidence, And Post-Action Proof
+
+Saved Ref is evidence provenance, not Work Record object identity. When an
+action comes from `ref:<snapshot-id>:<ref-id>`, the Work Record should preserve
+both the Saved Ref and resolved underlying target metadata in the selected
+action target, evidence metadata, or adjacent execution-map metadata. The Saved
+Ref proves which saved perception workspace supplied the action candidate; the
+resolved target metadata records what was actually dispatched through browser,
+canvas, or native bridge action code.
+
+Post-action proof is the after-perception evidence evaluated through a
+post-action Postcondition and its `claim_results[]` entry. Do not invent a raw
+JSON diff protocol to prove the result. If a ref, selector,
+Postcondition check, or artifact route drifts, repair the execution map under an
+explicit workflow/repair gate and keep the evidence immutable. Do not rewrite
+Claim text to chase selector drift, do not mutate `evidence[]`, and do not
+replay, repair, or macro-play back from a Work Record unless
+`execution_map.replay_policy` authorizes that behavior through the required
+workflow gates. The v0 verifier and harness remain report-only.
+
 This is the bridge for the Step Descriptor contract:
 a gated harness can emit the same saved evidence envelope after it runs `see`,
 resolves a target, executes `do`, and captures `see` again. The

--- a/tests/schemas/aos-work-record-v0.test.mjs
+++ b/tests/schemas/aos-work-record-v0.test.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '../..');
 const schemaPath = path.join(repoRoot, 'shared/schemas/aos-work-record-v0.schema.json');
+const contractPath = path.join(repoRoot, 'shared/schemas/aos-work-record-v0.md');
 const fixtureRoot = path.join(repoRoot, 'shared/schemas/fixtures/aos-work-record-v0');
 
 async function jsonFiles(dir) {
@@ -189,4 +190,63 @@ test('invalid Work Record v0 fixtures are rejected by the schema', async () => {
     const result = validate(fixture);
     assert.notEqual(result.status, 0, `${path.relative(repoRoot, fixture)} should fail validation`);
   }
+});
+
+test('Work Record contract keeps saved refs, evidence, proof, and replay boundaries distinct', async () => {
+  const contract = await fs.readFile(contractPath, 'utf8');
+  const normalizedContract = contract.replace(/\s+/g, ' ').toLowerCase();
+
+  for (const phrase of [
+    'Saved Refs, Evidence, And Post-Action Proof',
+    'Saved Ref is evidence provenance, not Work Record object identity.',
+    'preserve both the Saved Ref and resolved underlying target metadata',
+    'Post-action proof is the after-perception evidence',
+    'post-action Postcondition',
+    'claim_results[]',
+    'do not invent a raw JSON diff protocol',
+    'repair the execution map under an explicit workflow/repair gate',
+    'do not mutate `evidence[]`',
+    'do not replay, repair, or macro-play back from a Work Record',
+    'The v0 verifier and harness remain report-only.',
+  ]) {
+    assert.ok(
+      normalizedContract.includes(phrase.toLowerCase()),
+      `contract should include: ${phrase}`,
+    );
+  }
+
+  const record = await loadJson(
+    path.join(fixtureRoot, 'valid/aos-browser-click-status.json'),
+  );
+  const afterEvidence = record.evidence.find(
+    (evidence) => evidence.id === 'evidence:aos-browser-click-status-after-see',
+  );
+  assert.ok(afterEvidence, 'fixture must include after-perception evidence');
+  assert.equal(afterEvidence.metadata.phase, 'after');
+
+  const postcondition = record.execution_map.postconditions.find(
+    (item) => item.id === 'postcondition:aos-browser-click-status-after-status',
+  );
+  assert.ok(postcondition, 'fixture must include a post-action Postcondition');
+  assert.deepEqual(postcondition.evidence_refs, [afterEvidence.id]);
+
+  const claimResult = record.claim_results.find(
+    (result) => result.claim_id === 'claim:aos-browser-click-status-2026-05-06-post-action-state-observed',
+  );
+  assert.ok(claimResult, 'fixture must include a Claim Result for the post-action Claim');
+  assert.equal(claimResult.status, 'verified');
+  assert.deepEqual(claimResult.evidence_refs, [afterEvidence.id]);
+  assert.deepEqual(claimResult.postcondition_results, [
+    {
+      postcondition_id: postcondition.id,
+      status: 'passed',
+      evidence_refs: [afterEvidence.id],
+      reason: 'The after perception semantic target e3 has value Action recorded.',
+    },
+  ]);
+
+  assert.equal(record.execution_map.replay_policy.mode, 'report_only');
+  assert.equal(record.execution_map.replay_policy.replay_requires_workflow_gate, true);
+  assert.equal(record.execution_map.replay_policy.repair_requires_workflow_gate, true);
+  assert.match(record.execution_map.replay_policy.notes, /does not authorize autonomous replay or repair/);
 });


### PR DESCRIPTION
## Summary

- Clarify that Saved Refs are evidence provenance, not Work Record object identity.
- Define post-action proof as after-perception evidence plus post-action Postcondition and claim_results[].
- Add schema tests that lock the saved-ref/proof/replay boundary and validate the browser click fixture proof path.

## Verification

- node --test tests/schemas/aos-work-record-v0.test.mjs
- node --test tests/toolkit/work-record-verifier.test.mjs
- git diff --check
