### PR TITLE
Guard code review burn-down status

### DIFF
--- a/docs/dev/reports/aos-code-review-2026-07-03-burn-down.md
+++ b/docs/dev/reports/aos-code-review-2026-07-03-burn-down.md
@@ -9,15 +9,15 @@ goal, not a new bug-hunt queue.
 
 | id | disposition | current evidence |
 | --- | --- | --- |
-| 1. Host tool-result message shape | fixed | `packages/host/src/provider/anthropic.ts` emits AI SDK `role: "tool"` messages with `toolName`; `packages/host/src/session-store.ts` allows `tool`; `packages/host/src/agent-loop.ts` stores tool results as `tool`. |
-| 2. `aos wiki` path traversal | fixed | `scripts/aos-wiki-mutate.mjs` and `scripts/aos-wiki-read.mjs` resolve slash and `.md` inputs through `containedPath`; `tests/wiki-integration.sh` and `tests/wiki-reindex-external.sh` cover wiki command behavior. |
-| 3. Sigil selection-mode ReferenceError | fixed | `apps/sigil/renderer/live-modules/interaction-overlay.js` binds `time` from `snapshot.time` before drawing frames. |
-| 4. Sigil glTF fallback ReferenceError | fixed | `apps/sigil/renderer/live-modules/radial-gesture-visuals.js` installs `createFallbackGlyph()` in `installFallbackGlyph`. |
+| 1. Host tool-result message shape | fixed | `packages/host/src/provider/anthropic.ts` emits AI SDK `role: "tool"` messages with `toolName`; `packages/host/src/session-store.ts` allows `tool`; `packages/host/src/agent-loop.ts` stores tool results as `tool`; `packages/host/test/provider/anthropic.test.ts` covers the provider shape. |
+| 2. `aos wiki` path traversal | fixed | `scripts/aos-wiki-mutate.mjs` and `scripts/aos-wiki-read.mjs` resolve slash and `.md` inputs through `containedPath`; `tests/wiki-read-external.sh`, `tests/wiki-mutate-external.sh`, and `tests/wiki-seed.sh` cover containment behavior. |
+| 3. Sigil selection-mode ReferenceError | fixed | `apps/sigil/renderer/live-modules/interaction-overlay.js` binds `time` from `snapshot.time` before drawing frames; `tests/code-review-burn-down-status.test.mjs` guards the source marker. |
+| 4. Sigil glTF fallback ReferenceError | fixed | `apps/sigil/renderer/live-modules/radial-gesture-visuals.js` installs `createFallbackGlyph()` in `installFallbackGlyph`; `tests/renderer/radial-gesture-visuals.test.mjs` covers fallback glyph installation. |
 | 5. Canvas removal lifecycle leak | fixed | `src/display/canvas.swift` clears `onMessage` and `onTTLExpired` in `Canvas.close()` before removing the WebKit script handler and closing the window; `tests/canvas-close-callback-contract.test.mjs` guards the teardown order. |
-| 6. Malformed click count kills `aos do` session | fixed | `src/act/actions.swift` rejects `count <= 0`; parser/range guards live in `src/act/act-cli.swift` and `tests/external-parser-flags.sh`. |
-| 7. Dead-session keystroke crashes terminal bridge | fixed | `packages/toolkit/components/agent-terminal/terminal-session-manager.mjs` checks `record.exited` and ignores child stdin errors before writing to process stdin. |
-| 8. Surface Inspector pin self-loop hang | fixed | `packages/toolkit/workbench/surface-inspector-annotations.js` nulls self-parent pins and guards ancestor walks with visited sets. |
-| 9. Decision Gate Tab handling crash | fixed | `packages/toolkit/components/decision-gate/index.js` converts the `querySelectorAll` result with `Array.from(...)` before filtering and indexing. |
+| 6. Malformed click count kills `aos do` session | fixed | `src/act/actions.swift` rejects `count <= 0`; parser/range guards live in `src/act/act-cli.swift`; `tests/click-count-contract.test.mjs` and `tests/external-parser-flags.sh` cover the invalid-count boundary. |
+| 7. Dead-session keystroke crashes terminal bridge | fixed | `packages/toolkit/components/agent-terminal/terminal-session-manager.mjs` checks `record.exited` and ignores child stdin errors before writing to process stdin; `tests/sigil-agent-terminal-server.test.mjs` covers exited/broken stdin writes. |
+| 8. Surface Inspector pin self-loop hang | fixed | `packages/toolkit/workbench/surface-inspector-annotations.js` nulls self-parent pins and guards ancestor walks with visited sets; `tests/toolkit/surface-inspector-annotations.test.mjs` covers self-parent and malformed-loop cases. |
+| 9. Decision Gate Tab handling crash | fixed | `packages/toolkit/components/decision-gate/index.js` converts the `querySelectorAll` result with `Array.from(...)` before filtering and indexing; `tests/toolkit/decision-gate.test.mjs` covers the focus trap. |
 | 10. HTML Workbench Expression sanitizer gap | fixed | `packages/toolkit/components/html-workbench-expression/index.js` removes active elements including `iframe`, strips `srcdoc` and event handlers, and rejects dangerous URL schemes; `tests/toolkit/html-workbench-expression.test.mjs` covers the sanitizer. |
 
 ## Material Medium Clusters

--- a/tests/code-review-burn-down-status.test.mjs
+++ b/tests/code-review-burn-down-status.test.mjs
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+const burnDownPath = 'docs/dev/reports/aos-code-review-2026-07-03-burn-down.md';
+const perceptionPlanPath = 'docs/design/work-cards/perception-engine-shared-state-race-plan-v0.md';
+
+async function text(relativePath) {
+  return readFile(path.join(repoRoot, relativePath), 'utf8');
+}
+
+async function assertPath(relativePath) {
+  await assert.doesNotReject(
+    stat(path.join(repoRoot, relativePath)),
+    `expected evidence path to exist: ${relativePath}`,
+  );
+}
+
+test('July 3 code review burn-down keeps critical and high findings dispositioned', async () => {
+  const report = await text(burnDownPath);
+  const requiredRows = [
+    {
+      id: '1. Host tool-result message shape',
+      paths: [
+        'packages/host/src/provider/anthropic.ts',
+        'packages/host/src/session-store.ts',
+        'packages/host/src/agent-loop.ts',
+        'packages/host/test/provider/anthropic.test.ts',
+      ],
+    },
+    {
+      id: '2. `aos wiki` path traversal',
+      paths: [
+        'scripts/aos-wiki-mutate.mjs',
+        'scripts/aos-wiki-read.mjs',
+        'tests/wiki-read-external.sh',
+        'tests/wiki-mutate-external.sh',
+        'tests/wiki-seed.sh',
+      ],
+    },
+    {
+      id: '3. Sigil selection-mode ReferenceError',
+      paths: [
+        'apps/sigil/renderer/live-modules/interaction-overlay.js',
+        'tests/code-review-burn-down-status.test.mjs',
+      ],
+    },
+    {
+      id: '4. Sigil glTF fallback ReferenceError',
+      paths: [
+        'apps/sigil/renderer/live-modules/radial-gesture-visuals.js',
+        'tests/renderer/radial-gesture-visuals.test.mjs',
+      ],
+    },
+    {
+      id: '5. Canvas removal lifecycle leak',
+      paths: ['src/display/canvas.swift', 'tests/canvas-close-callback-contract.test.mjs'],
+    },
+    {
+      id: '6. Malformed click count kills `aos do` session',
+      paths: ['src/act/actions.swift', 'src/act/act-cli.swift', 'tests/click-count-contract.test.mjs'],
+    },
+    {
+      id: '7. Dead-session keystroke crashes terminal bridge',
+      paths: [
+        'packages/toolkit/components/agent-terminal/terminal-session-manager.mjs',
+        'tests/sigil-agent-terminal-server.test.mjs',
+      ],
+    },
+    {
+      id: '8. Surface Inspector pin self-loop hang',
+      paths: [
+        'packages/toolkit/workbench/surface-inspector-annotations.js',
+        'tests/toolkit/surface-inspector-annotations.test.mjs',
+      ],
+    },
+    {
+      id: '9. Decision Gate Tab handling crash',
+      paths: ['packages/toolkit/components/decision-gate/index.js', 'tests/toolkit/decision-gate.test.mjs'],
+    },
+    {
+      id: '10. HTML Workbench Expression sanitizer gap',
+      paths: [
+        'packages/toolkit/components/html-workbench-expression/index.js',
+        'tests/toolkit/html-workbench-expression.test.mjs',
+      ],
+    },
+  ];
+
+  for (const row of requiredRows) {
+    assert.match(report, new RegExp(`\\| ${row.id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} \\| fixed \\|`));
+    for (const evidencePath of row.paths) {
+      assert.match(report, new RegExp(evidencePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+      await assertPath(evidencePath);
+    }
+  }
+
+  const interactionOverlay = await text('apps/sigil/renderer/live-modules/interaction-overlay.js');
+  assert.match(
+    interactionOverlay,
+    /const time = Number\(snapshot\.time\) \|\| 0;[\s\S]*drawFrame\([^;]+,\s*\{ time \}\);/,
+    'selection-mode frame drawing must bind time before passing it to drawFrame',
+  );
+});
+
+test('PerceptionEngine shared-state race remains plan-gated, not silently closed', async () => {
+  const report = await text(burnDownPath);
+  const plan = await text(perceptionPlanPath);
+
+  assert.match(report, /Deferred By Plan Gate/);
+  assert.match(report, /PerceptionEngine.*shared-state race/);
+  assert.match(report, new RegExp(perceptionPlanPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+
+  assert.match(plan, /Status: plan only\. Do not implement this slice without explicit approval\./);
+  assert.match(plan, /files, invariants, proof strategy, rollback risk, and stop conditions|Invariants[\s\S]*Proof Strategy[\s\S]*Rollback Boundary[\s\S]*Stop Conditions/);
+});


### PR DESCRIPTION
## Summary

- Refresh the July 3 code-review burn-down report so each critical/high row names regression evidence.
- Add a focused status test that keeps the burn-down report tied to live source/test paths and keeps the PerceptionEngine shared-state item plan-gated.

## Verification

- node --test tests/code-review-burn-down-status.test.mjs
- git diff --check

## Live Proof

- Not applicable; static review-status and report guard slice only.
