### PR TITLE
Add compact refs diff expectation gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Saved perception state is local control state under the active runtime mode.
 workspace and `aos see workspace use <id>` is not a command. After a saved-ref
 mutation, use `post_action.recommended_next_command` to run a fresh saved
 capture before reusing refs. Use `aos see refs --diff <from>..<to>` to compare
-compact ref changes between two saved snapshots without opening heavy payloads.
+compact ref changes between two saved snapshots without opening heavy payloads;
+add `--expect change|no-change` when a script needs a non-zero mismatch result.
 
 ## Track-2 consumers
 

--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -168,7 +168,9 @@ Typical consumer loop:
 3. Read compact refs with `aos see refs`; use its structured
    `recommended_next` descriptors for the scoped dry-run action.
 4. Compare saved snapshots with `aos see refs --diff <from>..<to>` when a
-   compact ref-level post-action check is enough.
+   compact ref-level post-action check is enough; add
+   `--expect change|no-change` when a recipe or shell needs a non-zero exit on
+   mismatch.
 5. Dry-run the saved-ref action and inspect `resolution_status`.
 6. Dispatch only if the ref validates or reacquires.
 7. Use structured `recommended_next` descriptors and
@@ -215,7 +217,9 @@ Current wait/assertion boundary: saved workspaces do not expose
 or `aos see assert`. Use structured `recommended_next` descriptors and
 `recommended_next_command` plus a fresh saved capture for re-perception. Use
 `aos see refs --diff <from>..<to>` only for compact saved-ref comparison between
-two existing snapshots; it is not a wait loop or full assertion engine. Use
+two existing snapshots. `--expect change|no-change` makes that compact diff a
+machine-checkable gate with `REF_DIFF_EXPECTATION_FAILED` on mismatch; it is
+still not a wait loop or full assertion engine. Use
 `aos show wait` only for canvas readiness, Recipe assertions only for command
 JSON checks, and Work Record postconditions for durable evidence checks. Future
 saved wait/assert commands need manifest help, parser, schema/doc, and drift

--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -938,6 +938,25 @@
               "value_type" : "string"
             },
             {
+              "id" : "expect",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Require the compact refs diff to show change or no-change",
+              "token" : "--expect",
+              "value_type" : {
+                "enum" : [
+                  {
+                    "summary" : "Pass only when added, removed, or changed refs are present",
+                    "value" : "change"
+                  },
+                  {
+                    "summary" : "Pass only when no added, removed, or changed refs are present",
+                    "value" : "no-change"
+                  }
+                ]
+              }
+            },
+            {
               "id" : "query",
               "kind" : "flag",
               "required" : false,
@@ -957,6 +976,7 @@
           "examples" : [
             "aos see refs --workspace default --snapshot snap-20260701-120000Z-demo --json",
             "aos see refs --workspace default --diff before..after --json",
+            "aos see refs --workspace default --diff before..after --expect change --json",
             "aos see refs --workspace default --query Save"
           ],
           "execution" : {
@@ -975,8 +995,8 @@
             "streaming" : false,
             "supports_json_flag" : true
           },
-          "summary" : "Inspect compact saved refs by workspace, snapshot, query, or snapshot diff before acting on ref targets",
-          "usage" : "aos see refs [--workspace <id>] [--snapshot <id> | --diff <from>..<to>] [--query <text>] [--json]"
+          "summary" : "Inspect compact saved refs by workspace, snapshot, query, or snapshot diff before acting on ref targets; --expect gates diff output as change or no-change",
+          "usage" : "aos see refs [--workspace <id>] [--snapshot <id> | --diff <from>..<to> [--expect change|no-change]] [--query <text>] [--json]"
         },
         {
           "args" : [

--- a/manifests/commands/source/aos/03-see-02-workspace.json
+++ b/manifests/commands/source/aos/03-see-02-workspace.json
@@ -75,6 +75,25 @@
               "value_type": "string"
             },
             {
+              "id": "expect",
+              "kind": "flag",
+              "required": false,
+              "summary": "Require the compact refs diff to show change or no-change",
+              "token": "--expect",
+              "value_type": {
+                "enum": [
+                  {
+                    "summary": "Pass only when added, removed, or changed refs are present",
+                    "value": "change"
+                  },
+                  {
+                    "summary": "Pass only when no added, removed, or changed refs are present",
+                    "value": "no-change"
+                  }
+                ]
+              }
+            },
+            {
               "id": "query",
               "kind": "flag",
               "required": false,
@@ -94,6 +113,7 @@
           "examples": [
             "aos see refs --workspace default --snapshot snap-20260701-120000Z-demo --json",
             "aos see refs --workspace default --diff before..after --json",
+            "aos see refs --workspace default --diff before..after --expect change --json",
             "aos see refs --workspace default --query Save"
           ],
           "execution": {
@@ -112,8 +132,8 @@
             "streaming": false,
             "supports_json_flag": true
           },
-          "summary": "Inspect compact saved refs by workspace, snapshot, query, or snapshot diff before acting on ref targets",
-          "usage": "aos see refs [--workspace <id>] [--snapshot <id> | --diff <from>..<to>] [--query <text>] [--json]"
+          "summary": "Inspect compact saved refs by workspace, snapshot, query, or snapshot diff before acting on ref targets; --expect gates diff output as change or no-change",
+          "usage": "aos see refs [--workspace <id>] [--snapshot <id> | --diff <from>..<to> [--expect change|no-change]] [--query <text>] [--json]"
         },
         {
           "args": [

--- a/scripts/lib/agent-workspace/commands.mjs
+++ b/scripts/lib/agent-workspace/commands.mjs
@@ -32,6 +32,7 @@ const AGENT_WORKSPACE_FLAG_KINDS = new Map([
   ['--workspace', 'value'],
   ['--snapshot', 'value'],
   ['--diff', 'value'],
+  ['--expect', 'value'],
   ['--query', 'value'],
   ['--older-than', 'value'],
 ]);
@@ -39,7 +40,7 @@ const AGENT_WORKSPACE_FLAG_KINDS = new Map([
 const AGENT_WORKSPACE_FLAGS = {
   workspaces: new Set(['--json']),
   snapshots: new Set(['--workspace', '--json']),
-  refs: new Set(['--workspace', '--snapshot', '--diff', '--query', '--json']),
+  refs: new Set(['--workspace', '--snapshot', '--diff', '--expect', '--query', '--json']),
   workspace: new Set(['--json']),
   workspacePrune: new Set(['--older-than', '--dry-run', '--i-understand-local-artifacts', '--json']),
   workspaceDelete: new Set(['--i-understand-local-artifacts', '--json']),
@@ -57,6 +58,7 @@ function parseReadArgs(args, {
   let workspace = null;
   let snapshot = null;
   let diff = null;
+  let expect = null;
   let query = null;
   let json = false;
   let dryRun = false;
@@ -81,6 +83,7 @@ function parseReadArgs(args, {
       if (arg === '--workspace') workspace = args[i + 1];
       if (arg === '--snapshot') snapshot = args[i + 1];
       if (arg === '--diff') diff = args[i + 1];
+      if (arg === '--expect') expect = args[i + 1];
       if (arg === '--query') query = args[i + 1];
       if (arg === '--older-than') olderThan = args[i + 1];
       i += 1;
@@ -105,12 +108,22 @@ function parseReadArgs(args, {
     workspace: resolvedWorkspace,
     snapshot: snapshot ? validateLocalID(snapshot, 'snapshot id') : null,
     diff,
+    expect,
     query,
     json,
     dryRun,
     acknowledge,
     olderThan,
   };
+}
+
+function parseDiffExpectation(value) {
+  if (value === null || value === undefined) return null;
+  const normalized = String(value).trim();
+  if (!['change', 'no-change'].includes(normalized)) {
+    exitAgentWorkspaceError('--expect must be change or no-change', 'INVALID_ARG');
+  }
+  return normalized;
 }
 
 function parseSnapshotDiff(value) {
@@ -187,6 +200,22 @@ function compactRefsDiff(fromRefs, toRefs) {
   };
 }
 
+function refsDiffHasChange(comparison) {
+  return (comparison.counts.added + comparison.counts.removed + comparison.counts.changed) > 0;
+}
+
+function refsDiffExpectation(expectation, comparison) {
+  if (!expectation) return null;
+  const actualChange = refsDiffHasChange(comparison);
+  const expectedChange = expectation === 'change';
+  return {
+    mode: expectation,
+    status: actualChange === expectedChange ? 'passed' : 'failed',
+    expected_change: expectedChange,
+    actual_change: actualChange,
+  };
+}
+
 function assertWorkspaceListState(value, file, label) {
   if (!value) return;
   if (typeof value !== 'object' || Array.isArray(value) || value.schema_version !== SCHEMA_VERSION) {
@@ -248,13 +277,15 @@ export function refsCommand(args, env = process.env) {
   const { index } = requireWorkspace(parsed.workspace, env);
   if (parsed.diff) {
     const diff = parseSnapshotDiff(parsed.diff);
+    const expectationMode = parseDiffExpectation(parsed.expect);
     const fromLoaded = loadSnapshot(parsed.workspace, diff.from, env);
     const toLoaded = loadSnapshot(parsed.workspace, diff.to, env);
     const fromRefs = (fromLoaded.refs.refs ?? []).filter((record) => queryMatches(record, parsed.query)).map(refSummary);
     const toRefs = (toLoaded.refs.refs ?? []).filter((record) => queryMatches(record, parsed.query)).map(refSummary);
     const comparison = compactRefsDiff(fromRefs, toRefs);
+    const expectation = refsDiffExpectation(expectationMode, comparison);
     const nextRecommendations = compactNextRecommendations(parsed.workspace, diff.to, toRefs, env);
-    printJSON({
+    const payload = {
       status: 'success',
       schema_version: SCHEMA_VERSION,
       workspace_id: parsed.workspace,
@@ -264,13 +295,32 @@ export function refsCommand(args, env = process.env) {
       diff: {
         from_snapshot_id: diff.from,
         to_snapshot_id: diff.to,
+        ...(expectation ? { expectation } : {}),
         ...comparison,
       },
       refs: toRefs,
       recommended_next: nextRecommendations,
       recommended_next_commands: nextRecommendations.map((recommendation) => recommendation.command),
-    });
+    };
+    if (expectation?.status === 'failed') {
+      exitAgentWorkspaceError(`refs diff expectation failed: expected ${expectation.mode}`, 'REF_DIFF_EXPECTATION_FAILED', {
+        status: 'expectation_failed',
+        schema_version: SCHEMA_VERSION,
+        workspace_id: parsed.workspace,
+        runtime_mode: runtimeMode(env),
+        snapshot_id: diff.to,
+        query: parsed.query,
+        diff: payload.diff,
+        refs: toRefs,
+        recommended_next: nextRecommendations,
+        recommended_next_commands: nextRecommendations.map((recommendation) => recommendation.command),
+      });
+    }
+    printJSON(payload);
     return;
+  }
+  if (parsed.expect) {
+    exitAgentWorkspaceError('--expect requires --diff', 'INVALID_ARG');
   }
   const snapshotIDs = parsed.snapshot
     ? [parsed.snapshot]

--- a/shared/schemas/aos-agent-workspace-v0.md
+++ b/shared/schemas/aos-agent-workspace-v0.md
@@ -60,7 +60,9 @@ or `aos see assert`.
 Use structured `recommended_next` descriptors and `recommended_next_command`
 plus a fresh saved capture for re-perception. Use
 `aos see refs --diff <from>..<to>` only for compact saved-ref comparison between
-two existing snapshots; it is not a wait loop or full assertion engine. Use
+two existing snapshots. `--expect change|no-change` makes that compact diff a
+machine-checkable gate with `REF_DIFF_EXPECTATION_FAILED` on mismatch; it is
+still not a wait loop or full assertion engine. Use
 `aos show wait` only for canvas readiness, Recipe assertions only for command
 JSON checks, and Work Record postconditions for durable evidence checks. Future
 saved wait/assert commands need manifest help, parser, schema/doc, and drift

--- a/skills/aos-agent-workspace/SKILL.md
+++ b/skills/aos-agent-workspace/SKILL.md
@@ -98,8 +98,10 @@ the returned `recommended_next`, `recommended_next_commands`, or
   and saved `query` fields so you do not need to open heavy capture payloads
   just to recover the saved scope.
 - Use `aos see refs --workspace <id> --diff <from>..<to> --json` for compact
-  ref-level snapshot comparison after a verification capture. Treat it as a
-  saved-ref diff, not a complete visual assertion.
+  ref-level snapshot comparison after a verification capture. Add
+  `--expect change|no-change` when a recipe or shell should fail with
+  `REF_DIFF_EXPECTATION_FAILED` on mismatch. Treat it as a saved-ref diff gate,
+  not a complete visual assertion.
 - The saved file contract is `aos.agent-workspace.v0`; see
   `shared/schemas/aos-agent-workspace-v0.md`.
 - Workspace write locks are transient local control state. If a mutation returns

--- a/tests/agent-workspace-contract-drift.sh
+++ b/tests/agent-workspace-contract-drift.sh
@@ -441,8 +441,12 @@ for (const staleCommand of [
 }
 assert.ok(
   skill.includes('aos see refs --workspace <id> --diff <from>..<to> --json')
+  && skill.includes('--expect change|no-change')
+  && apiDoc.includes('--expect change|no-change')
+  && schemaDoc.includes('--expect change|no-change')
+  && schemaDoc.includes('REF_DIFF_EXPECTATION_FAILED')
   && apiDoc.includes('aos see refs --diff <from>..<to>'),
-  'AOS workspace docs and skill must teach compact refs diff now that it is supported',
+  'AOS workspace docs and skill must teach compact refs diff and expectation gates now that they are supported',
 );
 assert.ok(
   skill.replace(/\s+/g, ' ').includes('No daemon-held current workspace exists'),
@@ -806,8 +810,10 @@ const seeRefsForm = seeCommand.forms.find((form) => form.id === 'see-refs');
 assert.ok(seeRefsForm, 'manifest missing see-refs form');
 assert.ok(
   seeRefsForm.usage.includes('--diff <from>..<to>')
-  && seeRefsForm.args.some((arg) => arg.token === '--diff'),
-  'see refs manifest must advertise supported compact snapshot diff',
+  && seeRefsForm.usage.includes('--expect change|no-change')
+  && seeRefsForm.args.some((arg) => arg.token === '--diff')
+  && seeRefsForm.args.some((arg) => arg.token === '--expect'),
+  'see refs manifest must advertise supported compact snapshot diff and expectation gate',
 );
 const captureForm = seeCommand.forms.find((form) => form.id === 'see-capture');
 const captureSaveForm = seeCommand.forms.find((form) => form.id === 'see-capture-save');

--- a/tests/agent-workspace-storage.sh
+++ b/tests/agent-workspace-storage.sh
@@ -426,6 +426,43 @@ jq -e '
   and (has("base64") | not)
 ' "$REF_DIFF" >/dev/null || fail "refs diff did not expose compact snapshot comparison: $(cat "$REF_DIFF")"
 assert_no_heavy_capture_payloads "$REF_DIFF" "refs diff readback"
+REF_DIFF_EXPECT_CHANGE="$TMP_DIR/refs-diff-expect-change.json"
+./aos see refs --workspace ws1 --diff snap1..snap2 --expect change --json >"$REF_DIFF_EXPECT_CHANGE"
+jq -e '
+  .status == "success"
+  and .diff.expectation.mode == "change"
+  and .diff.expectation.status == "passed"
+  and .diff.expectation.expected_change == true
+  and .diff.expectation.actual_change == true
+  and .diff.counts.changed == 1
+' "$REF_DIFF_EXPECT_CHANGE" >/dev/null || fail "refs diff change expectation did not pass: $(cat "$REF_DIFF_EXPECT_CHANGE")"
+REF_DIFF_EXPECT_NO_CHANGE="$TMP_DIR/refs-diff-expect-no-change.json"
+./aos see refs --workspace ws1 --diff snap2..snap2 --expect no-change --json >"$REF_DIFF_EXPECT_NO_CHANGE"
+jq -e '
+  .status == "success"
+  and .diff.expectation.mode == "no-change"
+  and .diff.expectation.status == "passed"
+  and .diff.expectation.expected_change == false
+  and .diff.expectation.actual_change == false
+  and .diff.counts.added == 0
+  and .diff.counts.removed == 0
+  and .diff.counts.changed == 0
+' "$REF_DIFF_EXPECT_NO_CHANGE" >/dev/null || fail "refs diff no-change expectation did not pass: $(cat "$REF_DIFF_EXPECT_NO_CHANGE")"
+REF_DIFF_EXPECT_FAIL_ERR="$TMP_DIR/refs-diff-expect-fail.err"
+if ./aos see refs --workspace ws1 --diff snap1..snap2 --expect no-change --json >"$TMP_DIR/refs-diff-expect-fail.out" 2>"$REF_DIFF_EXPECT_FAIL_ERR"; then
+    fail "refs diff failed expectation unexpectedly succeeded"
+fi
+expect_error_code "REF_DIFF_EXPECTATION_FAILED" "$REF_DIFF_EXPECT_FAIL_ERR"
+jq -e '
+  .status == "expectation_failed"
+  and .diff.expectation.mode == "no-change"
+  and .diff.expectation.status == "failed"
+  and .diff.expectation.expected_change == false
+  and .diff.expectation.actual_change == true
+  and .diff.counts.added == 1
+  and .diff.counts.removed == 1
+  and .diff.counts.changed == 1
+' "$REF_DIFF_EXPECT_FAIL_ERR" >/dev/null || fail "refs diff expectation failure payload drifted: $(cat "$REF_DIFF_EXPECT_FAIL_ERR")"
 REF_DIFF_QUERY="$TMP_DIR/refs-diff-query.json"
 ./aos see refs --workspace ws1 --diff snap1..snap2 --query "Added diff target" --json >"$REF_DIFF_QUERY"
 jq -e '
@@ -438,6 +475,8 @@ jq -e '
 ' "$REF_DIFF_QUERY" >/dev/null || fail "refs diff query did not filter before comparison: $(cat "$REF_DIFF_QUERY")"
 expect_command_error_code "INVALID_ARG" "refs-diff-with-snapshot" ./aos see refs --workspace ws1 --snapshot snap1 --diff snap1..snap2 --json
 expect_command_error_code "INVALID_ARG" "refs-diff-malformed" ./aos see refs --workspace ws1 --diff snap1 --json
+expect_command_error_code "INVALID_ARG" "refs-diff-invalid-expect" ./aos see refs --workspace ws1 --diff snap1..snap2 --expect maybe --json
+expect_command_error_code "INVALID_ARG" "refs-diff-expect-without-diff" ./aos see refs --workspace ws1 --snapshot snap1 --expect change --json
 mv "$SNAP2_REFS_BACKUP" "$SNAP2_REFS"
 
 mkdir -p "$WORKSPACE_PATH/.write-lock"

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -662,8 +662,8 @@ refs_form = next(item for item in refs["forms"] if item["id"] == "see-refs")
 refs_tokens = {arg.get("token") for arg in refs_form["args"]}
 assert "Inspect compact saved refs" in refs["summary"], refs["summary"]
 assert "Inspect compact saved refs" in refs_form["summary"], refs_form
-assert refs_form["usage"] == "aos see refs [--workspace <id>] [--snapshot <id> | --diff <from>..<to>] [--query <text>] [--json]", refs_form
-assert {"--workspace", "--snapshot", "--diff", "--query", "--json"} <= refs_tokens, refs_tokens
+assert refs_form["usage"] == "aos see refs [--workspace <id>] [--snapshot <id> | --diff <from>..<to> [--expect change|no-change]] [--query <text>] [--json]", refs_form
+assert {"--workspace", "--snapshot", "--diff", "--expect", "--query", "--json"} <= refs_tokens, refs_tokens
 
 snapshots = json.loads(os.environ["SNAPSHOTS"])
 snapshots_form = next(item for item in snapshots["forms"] if item["id"] == "see-snapshots")


### PR DESCRIPTION
## Summary
- add `aos see refs --diff ... --expect change|no-change` for compact machine-checkable post-action gates
- return structured `REF_DIFF_EXPECTATION_FAILED` JSON when a diff expectation mismatches
- align help, manifests, API/schema docs, README, skill text, and drift/storage tests

## Verification
- bash tests/agent-workspace-storage.sh
- bash tests/agent-workspace-contract-drift.sh
- bash tests/help-contract.sh
- bash tests/command-manifest-generation.sh
- node --test tests/schemas/aos-external-command-manifest-v0.test.mjs
- bash tests/agent-workspace-saved-ref.sh
- git diff --check
- ./aos help --json
- ./aos help see --json
- ./aos help do --json
- ./aos help show --json

## Live Proof
- Not applicable; this is a static saved-workspace command contract slice.

## DOX
- No AGENTS.md change required; existing agent-workspace, manifest, docs, shared, skill, and test ownership docs already cover this contract.
