### PR TITLE
perplexity-voice-io-proposals: local TTS (aos say), dictation (aos listen), and voice-trigger design for agent-os

### DIFF
--- a/docs/proposals/2026-07-08-kokoro-tts-backend-integration.md
+++ b/docs/proposals/2026-07-08-kokoro-tts-backend-integration.md
@@ -1,0 +1,230 @@
+# Pluggable local TTS backend for `aos say` (Kokoro-first)
+
+Author: Perplexity Computer (collaborator pass), for @michaelblum
+Date: 2026-07-08
+Status: Proposal / discussion draft — no code changes included in this PR
+Scope: `aos say` and the daemon's `announce()` / `tell human` voice route
+
+## 1. Summary
+
+`agent-os` already speaks through `NSSpeechSynthesizer` (macOS `say`) everywhere, but the voice
+*discovery* layer (`VoiceRegistry` / `VoiceProvider`) was explicitly designed as multi-backend from
+day one — it just never got a second backend that can actually produce audio. The ElevenLabs
+provider it ships today is a metadata-only stub (`speak_supported: false`), and the project's own
+design notes call a real remote/alternate synthesis path out of scope for v1
+([`docs/archive/superpowers/specs/2026-04-22-voice-registry-provider-allocation-design.md`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/docs/archive/superpowers/specs/2026-04-22-voice-registry-provider-allocation-design.md)).
+
+That means the cleanest way to add a local, higher-quality, on-device voice (Kokoro-82M first,
+Qwen3-TTS/Chatterbox later) is to **finish the seam the codebase already started**: give
+`VoiceProvider` an optional synthesis capability, add a `KokoroVoiceProvider`, and teach the two
+actual speech call sites (`aos say` and the daemon's `announce()`) to dispatch to a provider's
+synthesizer instead of always constructing an `NSSpeechSynthesizer`-backed `SpeechEngine`. The
+external CLI contract of `aos say` does not need to change at all.
+
+## 2. How `aos say` actually works today (call chain)
+
+```
+aos say "hello"
+  -> manifests/commands/source/external/18-say.json   (external command table entry)
+  -> scripts/aos-say.mjs                               (arg validation, spawns internal primitive)
+  -> ./aos __say ...                                   (src/main.swift dispatch)
+  -> sayCommand(args:)                                 (src/voice/say.swift)
+       -> loadConfig() / VoiceRegistry (resolve --voice / --voice-slot / filters)
+       -> SpeechEngine(voice: voiceID)                 (src/voice/engine.swift — NSSpeechSynthesizer)
+       -> engine.speakAndWait(text)
+       -> prints {status, text, voice, characters} JSON
+```
+
+Key files:
+- [`manifests/commands/source/external/18-say.json`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/manifests/commands/source/external/18-say.json) — declares `aos say` as an external command that shells out to `scripts/aos-say.mjs`.
+- [`scripts/aos-say.mjs`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/scripts/aos-say.mjs) — validates flags, then `spawnSync('./aos', ['__say', ...args])`.
+- [`src/main.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/main.swift#L42-L43) — the unified binary's `switch command` block maps `__say` to `sayCommand(args:)`. All the "verbs" (`__say`, `__see`, `__do`, `__serve`, `__render`, …) are internal primitives dispatched the same way; the public-facing `aos <verb>` commands are declared separately in the `manifests/commands/source/{aos,external}` JSON tables and are largely thin wrappers (Node scripts or direct primitive calls) around these primitives.
+- [`src/voice/say.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/voice/say.swift) — parses `--voice`, `--voice-slot`, `--language`, `--gender`, `--quality-tier`, `--rate`; resolves a voice via `VoiceRegistry`; then **unconditionally** builds `SpeechEngine(voice: voiceID)` and calls `speakAndWait`.
+- [`src/voice/engine.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/voice/engine.swift) — `SpeechEngine` is a thin wrapper around `NSSpeechSynthesizer`. This is the *only* thing that ever produces audio for `aos say`.
+
+So today: **`aos say` does not shell out to the macOS `say` binary** — it uses `NSSpeechSynthesizer`
+directly via `AppKit`, but that's the same underlying system TTS engine the `say` CLI uses. Either
+way, it is 100% the system voice path; there is no non-system audio production anywhere in the repo.
+
+Important operational detail: the `say` manifest entry has `"auto_starts_daemon": false`
+([`08-say.json`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/manifests/commands/source/aos/08-say.json#L86)) — `aos say` runs as a **fresh, standalone process per invocation**. It does not talk to the daemon at all. That matters for latency/warm-loading design (see §5).
+
+## 3. The second, separate speech call site: the daemon's `announce()` / `tell human`
+
+There is a **second, independent** TTS code path inside the long-running daemon
+([`src/daemon/unified.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/daemon/unified.swift#L3071-L3105)):
+
+- `initSpeechEngine()` / `stopSpeechEngine()` create/destroy a **persistent** `SpeechEngine` instance tied to `voice.enabled` config changes.
+- `announce(_ text:, voiceID:)` is the entry point used by `deliverHumanVoiceRoute` (the `tell human` → voice route) and by autonomic/status announcements. It reuses the warm `speechEngine` instance and just calls `setVoice` + `speak`.
+- This is exactly the kind of "daemon owns TTS, agent decides what to say" split the README describes: *"The daemon handles element resolution, cursor tracking, TTS, visual feedback. The agent decides WHAT and WHY."* ([`README.md`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/README.md?plain=1#L10)), and `aos say` is documented as *"Direct TTS convenience aligned with `tell human`"* ([`README.md`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/README.md?plain=1#L21)).
+
+**Implication:** a real backend swap has two distinct integration points, not one. `aos say`
+(standalone, cold-start each call) and daemon `announce()` (warm, persistent, used for `tell human`)
+both hardcode `SpeechEngine`. A complete solution should abstract both, but the warm-loading payoff
+(the thing that gets Kokoro under ~1–2s per utterance) is much easier to realize on the daemon side,
+since that process already stays alive.
+
+## 4. The existing (metadata-only) provider abstraction
+
+`agent-os` already has a provider-agnostic voice **catalog**, just not a provider-agnostic
+**synthesizer**:
+
+- [`src/voice/provider.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/voice/provider.swift) — `protocol VoiceProvider { name, availability, enumerate() -> [VoiceRecord] }`. No `speak()` method exists on the protocol at all today.
+- [`src/voice/providers/system.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/voice/providers/system.swift) — enumerates `NSSpeechSynthesizer.availableVoices`, tags them `capabilities.speak_supported: true`.
+- [`src/voice/providers/elevenlabs-stub.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/voice/providers/elevenlabs-stub.swift) — a hardcoded catalog of 5 ElevenLabs voice IDs with `capabilities.speak_supported: false`. It exists purely to exercise "not speakable" branches in the allocator; there is no synthesis code behind it.
+- [`src/voice/registry.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/voice/registry.swift) — `VoiceRegistry` aggregates `[SystemVoiceProvider(), ElevenLabsStubProvider()]` (plus a test-only `MockVoiceProvider`), applies policy (`voice/policy.json`, enable/disable, session pinning), and exposes `snapshot()`, `allocatableSnapshot()`, `snapshot(matching: VoiceFilter)`.
+- Canonical voice identity is already provider-namespaced: `VoiceID.make(provider:, providerVoiceID:)` produces URIs like `voice://system/com.apple.voice.compact.en-US.Samantha` or `voice://elevenlabs/21m00Tcm4TlvDq8ikWAM` ([`registry.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/voice/registry.swift#L1-L27)). `VoiceFilter` already has a `provider` field for filtering by backend.
+
+The project's own design spec is explicit that this was intentional and incomplete by design (not
+an oversight):
+
+> "Explicit out-of-scope items: ElevenLabs synthesis path, dynamic provider registration, hot-swap
+> when a preferred voice becomes available later, concurrent-speech mixing, per-channel/per-purpose
+> routing." — [voice-registry-provider-allocation-design.md](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/docs/archive/superpowers/specs/2026-04-22-voice-registry-provider-allocation-design.md)
+
+**This is the finding that shapes the whole recommendation:** agent-os does not need a new
+plug-in system invented from scratch. It needs someone to implement the synthesis half of a
+seam that the voice registry design already reserved — `speak_supported` and the `voice://<provider>/<id>`
+URI scheme exist specifically to let a second, real backend slot in later. Kokoro is a good first
+candidate to actually build that missing half.
+
+## 5. Hardware/backend fit for this Mac (M1 Pro, 10 cores, 16 GB RAM, ~90 GiB free, macOS 26.5.1)
+
+| Backend | Fit for this use case | Notes |
+|---|---|---|
+| **Kokoro-82M** | Best first choice | ~82M params, CPU/MPS-friendly, sub-second to ~1s synthesis for short utterances on Apple Silicon once the model is warm; small disk/RAM footprint; English-focused which matches the stated "neutral American/UK-style English" requirement; simple `pip install kokoro` path, and CoreML/Apple-optimized variants exist. |
+| **Qwen3-TTS** | Good phase-2/premium option | Heavier (larger weights, more RAM/first-load latency), richer voice control/multilingual/cloning — better suited once the pluggable seam exists and quality/latency headroom is available. |
+| **Chatterbox-TTS** | Good phase-2/expressive option | MIT-licensed, ElevenLabs-style expressiveness, 16 GB RAM is the documented minimum, so it's usable but leaves little headroom alongside the rest of the agent-os daemon + Xcode/Swift toolchain running concurrently; best treated as an optional "expressive mode," not the default. |
+
+Given the target of short interjections/replies, "1–2s with half-duplex cue sounds is fine," and
+"simplest local integration path first," **Kokoro is the right first backend**, exactly as the
+research already concluded — the rest of this document is about *where* it plugs in, not *whether*
+it's the right model.
+
+## 6. Recommended design: pluggable backend at the provider layer, not a parallel system
+
+### 6.1 Extend the provider protocol with an optional synthesis capability
+
+Add a new protocol (kept separate from `VoiceProvider` so existing metadata-only providers like
+`ElevenLabsStubProvider` don't need any change):
+
+```swift
+// src/voice/provider.swift (addition)
+protocol SpeakableVoiceProvider: VoiceProvider {
+    /// Synthesize `text` for `providerVoiceID` and return a URL to a playable audio file
+    /// (e.g. WAV/AIFF in a temp dir), or throw. Implementations own their own process/model
+    /// lifecycle; callers are responsible for playback.
+    func synthesize(text: String, providerVoiceID: String, rateWPM: Float?) throws -> URL
+}
+```
+
+`SystemVoiceProvider` does not need to conform (system playback keeps using `SpeechEngine`/
+`NSSpeechSynthesizer` directly, since that already handles playback+blocking+cancel-key
+integration). Only *new* backends that need "synthesize an audio file, then play it" conform to
+`SpeakableVoiceProvider`.
+
+### 6.2 Add `KokoroVoiceProvider`
+
+New file `src/voice/providers/kokoro.swift`:
+- `enumerate()` returns a small, hardcoded catalog of Kokoro's American/British English voices (e.g. `af_heart`, `af_bella`, `am_michael`, `am_fenrir`, `bf_emma`, `bm_george`), each `provider: "kokoro"`, `capabilities: .init(local: true, streaming: false, ssml: false, speak_supported: true)`, `quality_tier: "enhanced"` (or a new tier if you want it distinguishable from system voices in `--quality-tier` filtering).
+- `availability` reports `reachable: false` with a reason if the local Kokoro runner/service isn't installed or isn't responding (mirrors the pattern already used by `ElevenLabsStubProvider`'s env-var-gated availability), so `aos voice list` / the allocator degrade gracefully instead of crashing when Kokoro isn't installed on a given machine.
+- Conforms to `SpeakableVoiceProvider`; `synthesize(...)` shells out to a small local runner (see §6.4) and returns a temp file URL.
+
+Register it in `VoiceRegistry.defaultProviders()` ([`registry.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/voice/registry.swift#L178-L185)) — one line, additive, same pattern as the existing `AOS_VOICE_TEST_PROVIDERS=mock` gate (e.g. gate on an `AOS_TTS_KOKORO_ENABLED=1` / config flag if you want it opt-in during rollout).
+
+### 6.3 Dispatch in the two speech call sites
+
+Both `sayCommand` ([`say.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/voice/say.swift#L124-L160)) and the daemon's `announce()` ([`unified.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/daemon/unified.swift#L3096-L3105)) currently go straight to `SpeechEngine(voice:)`. The smallest viable change is to branch on the *resolved* `VoiceRecord.provider` right before that call:
+
+```swift
+let record = registry.lookup(reportedVoiceID)   // already have provider info here
+if let record, record.provider != "system",
+   let provider = registry.speakableProvider(named: record.provider) {
+    let fileURL = try provider.synthesize(text: text, providerVoiceID: record.provider_voice_id, rateWPM: rate)
+    playAudioFileAndWait(fileURL)          // simple AVAudioPlayer or `afplay` wrapper
+} else {
+    // existing NSSpeechSynthesizer path, unchanged
+    let engine = SpeechEngine(voice: voiceID)
+    ...
+}
+```
+
+This preserves:
+- The external CLI contract (`aos say "hello" [--voice ...] [--voice-slot ...] [--rate ...]`) — completely unchanged.
+- The JSON response shape (`status`, `text`, `voice`, `characters`) — unchanged.
+- All existing system-voice tests (`tests/say-voice-slot.sh`, `tests/voice-*.sh`) — unchanged, since the `system` path is untouched.
+- Backend selection reuses the mechanism the registry already has (`voice://kokoro/<id>` via `--voice`, or `--voice-slot` + `--quality-tier`/`--language` filtering once Kokoro voices are tagged) instead of inventing a second, competing selector.
+
+For a lower-friction opt-in during development, also honor an environment/config default so the
+user doesn't have to spell out a full `voice://kokoro/...` URI every time:
+- `AOS_TTS_BACKEND=kokoro` (env, matches the existing `AOS_VOICE_TEST_PROVIDERS`-style convention) or
+- `config.voice.voice = "voice://kokoro/af_heart"` in `~/.config/agent-os` (reuses the existing `VoiceConfig.voice` field — no schema change needed at all, since it's already a free-form voice-URI string).
+
+Either is a few lines; the config-field option is preferable long-term since it needs zero new
+schema and already round-trips through `aos config` today ([`src/shared/config.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/shared/config.swift#L46-L52)).
+
+### 6.4 The Kokoro runner itself (phase 1 → phase 2)
+
+Kokoro is a Python package (`pip install kokoro`), so the Swift side needs a thin process
+boundary. Two viable shapes, in order of recommended rollout:
+
+**Phase 1 — subprocess-per-call (fastest to ship, correctness-first):**
+- `scripts/kokoro_say.py`: loads `kokoro`, synthesizes `--text` with `--voice`, writes a WAV to a temp path (or to stdout), exits.
+- `KokoroVoiceProvider.synthesize` calls `Process` → `python3 scripts/kokoro_say.py ...` and returns the WAV path.
+- Simple, easy to test in isolation, but pays full model-load cost (likely >1–2s) on every single `aos say` call, since there's no daemon involved in that path today (§2). Good for validating voice quality and the plumbing; not the final latency target.
+
+**Phase 2 — warm local service (meets the 1–2s target, fits the project's own architecture):**
+- A small long-lived local process (Python, `uvicorn`/FastAPI or even a bare Unix-socket loop) that loads the Kokoro model once and serves synthesis requests over a local Unix socket, analogous to the daemon's own `voice.list` / `voice.final_response` socket actions already visible in [`tests/daemon-ipc-voice.sh`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/tests/daemon-ipc-voice.sh).
+- Two ways to own its lifecycle, both consistent with how the project already treats TTS as a daemon responsibility ("daemon handles ... TTS," README):
+  1. **Daemon-managed** (recommended): the `aos` daemon starts/stops the Kokoro service the same way it starts/stops `speechEngine` today (`initSpeechEngine()` / `stopSpeechEngine()` in `unified.swift`), keyed off a new `voice.backend` / `AOS_TTS_BACKEND` config toggle. `aos say` (standalone) then talks to that daemon-owned service over the existing socket instead of invoking Kokoro cold each time — this does mean `aos say` would need `auto_starts_daemon` semantics reconsidered for the Kokoro path specifically (system-voice `aos say` can stay daemon-independent).
+  2. **Standalone local service** (lower blast radius, if you don't want `aos say`'s "doesn't need the daemon" property to change): a small `launchd`-style or manually started Kokoro server that both `aos say` and the daemon's `announce()` hit as clients. Simpler to reason about, but you lose "one process owns the model" tidiness and duplicate the warm-up outside the daemon's existing lifecycle machinery.
+- Recommendation: start with 6.4-Phase 1 to validate voice quality/latency end-to-end this week, then move to 6.4-Phase 2 option (1) once you're happy with Kokoro's output, since it's the option that actually fits the project's stated architecture and hits the 1–2s target via warm loading.
+
+### 6.5 Masking latency with cue sounds
+
+The existing `FeedbackConfig.sound` flag and the daemon's visual/sound feedback plumbing
+([`src/shared/config.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/shared/config.swift#L79-L82)) is a natural home for the "thinking/speaking" cue sounds you proposed — no new subsystem needed, just wiring a short chime immediately before `synthesize()` is called and another right before playback starts.
+
+## 7. Smallest viable change — concrete file list
+
+1. `src/voice/provider.swift` — add `SpeakableVoiceProvider` protocol (additive, no breaking change).
+2. `src/voice/providers/kokoro.swift` — new file, `KokoroVoiceProvider` (enumerate + synthesize).
+3. `src/voice/registry.swift` — register `KokoroVoiceProvider()` in `defaultProviders()`; add a `speakableProvider(named:) -> SpeakableVoiceProvider?` lookup helper.
+4. `src/voice/say.swift` — branch on `record.provider` before constructing `SpeechEngine`; add a tiny `playAudioFileAndWait(_ url: URL)` helper (AVFoundation or `afplay` subprocess).
+5. `src/daemon/unified.swift` — same branch inside `announce(_:voiceID:)`, reusing the helper from (4).
+6. `scripts/kokoro_say.py` — phase-1 subprocess runner (or a `kokoro-service/` directory for phase 2's persistent server).
+7. `tests/say-kokoro-backend.sh` — new test mirroring `tests/say-voice-slot.sh`, using a mock/stub Kokoro provider (same pattern as `AOS_VOICE_TEST_PROVIDERS=mock`) so CI doesn't need the real Kokoro package installed.
+8. Docs: update `docs/reference/voice-control-commands.md` and `README.md`'s command table entry for `aos say` to mention backend selection once shipped.
+
+Nothing in `manifests/commands/source/{aos,external}/*say*.json` needs to change — the CLI surface
+is untouched by design.
+
+## 8. Non-goals for this first pass (mirrors how the project itself scoped ElevenLabs)
+
+- No redesign of voice across `tell`/`listen`/canvas feedback.
+- No Qwen3-TTS or Chatterbox wiring yet — just make sure `KokoroVoiceProvider`'s shape (protocol + registry slot) is generic enough that adding `QwenVoiceProvider` / `ChatterboxVoiceProvider` later is "copy the file, change the runner command."
+- No dynamic/runtime provider registration — keep providers hardcoded in `defaultProviders()`, consistent with the existing design decision to defer that.
+- No streaming synthesis in v1 (`capabilities.streaming: false` for Kokoro, matching the "wait for completion" semantics `aos say --wait` already assumes).
+
+## 9. Answers to the specific questions asked
+
+- **Where is `aos say` implemented?** [`src/voice/say.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/voice/say.swift), invoked as the `__say` internal primitive from [`src/main.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/main.swift#L42-L43), reached from the public `aos say` command via [`scripts/aos-say.mjs`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/scripts/aos-say.mjs) as declared in [`manifests/commands/source/external/18-say.json`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/manifests/commands/source/external/18-say.json).
+- **Does it shell out to macOS `say` or use another internal path?** Neither literally — it links `AppKit`/`NSSpeechSynthesizer` directly via `SpeechEngine` ([`src/voice/engine.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/voice/engine.swift)); no `Process` call to `/usr/bin/say` exists in the repo. It is functionally the same system voice engine, just invoked in-process.
+- **How are command handlers structured inside the unified `aos` binary?** A two-layer model: (1) a JSON manifest table per command (`manifests/commands/source/{aos,external}/*.json`) declares the public CLI surface, args, and whether it's a Swift-internal primitive or an external wrapper script; (2) `src/main.swift` is a flat `switch` over `__`-prefixed internal primitive names (`__say`, `__see`, `__do`, `__serve`, `__render`, etc.), each dispatching to a dedicated Swift function/file under `src/`.
+- **Is the daemon/runtime model the right place for a persistent local TTS backend?** Yes — it already owns a persistent `SpeechEngine` instance for `announce()`/`tell human` ([`src/daemon/unified.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/daemon/unified.swift#L3071-L3105)) and already exposes a `voice` service over its Unix socket ([`tests/daemon-ipc-voice.sh`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/tests/daemon-ipc-voice.sh)). Note, though, that `aos say` itself currently bypasses the daemon entirely (`auto_starts_daemon: false`), so daemon-hosted warm-loading only pays off automatically for the `tell human` path unless `aos say` is changed to route through the daemon for non-system backends specifically.
+- **Smallest viable change for pluggable backend selection without disturbing the CLI contract?** Add a `SpeakableVoiceProvider` capability to the existing (currently metadata-only) `VoiceProvider` protocol, implement it once for Kokoro, and branch on `VoiceRecord.provider` at the two existing `SpeechEngine(...)` call sites. Backend selection rides on the `voice://<provider>/<id>` URI scheme and `VoiceFilter.provider` that already exist — no new flags, no new config schema, no manifest changes required.
+
+## 10. Sources
+
+- [`README.md`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/README.md) — daemon/agent split, `aos say` command table entry.
+- [`src/main.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/main.swift) — internal primitive dispatch.
+- [`src/voice/say.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/voice/say.swift), [`src/voice/engine.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/voice/engine.swift), [`src/voice/provider.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/voice/provider.swift), [`src/voice/registry.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/voice/registry.swift), [`src/voice/providers/system.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/voice/providers/system.swift), [`src/voice/providers/elevenlabs-stub.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/voice/providers/elevenlabs-stub.swift), [`src/voice/providers/mock.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/voice/providers/mock.swift).
+- [`src/daemon/unified.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/daemon/unified.swift) — daemon `speechEngine` lifecycle and `announce()`.
+- [`src/shared/config.swift`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/src/shared/config.swift) — `VoiceConfig` schema.
+- [`manifests/commands/source/aos/08-say.json`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/manifests/commands/source/aos/08-say.json), [`manifests/commands/source/external/18-say.json`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/manifests/commands/source/external/18-say.json), [`scripts/aos-say.mjs`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/scripts/aos-say.mjs).
+- [`docs/archive/superpowers/specs/2026-04-22-voice-registry-provider-allocation-design.md`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/docs/archive/superpowers/specs/2026-04-22-voice-registry-provider-allocation-design.md) — original design intent, confirming synthesis-path abstraction was deliberately deferred.
+- [`tests/say-voice-slot.sh`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/tests/say-voice-slot.sh), [`tests/daemon-ipc-voice.sh`](https://github.com/michaelblum/agent-os/blob/58037f2bf5adbeaa993589d4dd2e2fd093ba4306/tests/daemon-ipc-voice.sh).
+- Kokoro-82M: [Hugging Face — mattmireles/kokoro-coreml](https://huggingface.co/mattmireles/kokoro-coreml); [GitHub — hexgrad/kokoro](https://github.com/hexgrad/kokoro); [dev.to — local voice AI stack on Apple Silicon](https://dev.to/xadenai/building-a-local-voice-ai-stack-whisper-ollama-kokoro-tts-on-apple-silicon-eo0).
+- Qwen3-TTS Apple Silicon port: [GitHub — kapi2800/qwen3-tts-apple-silicon](https://github.com/kapi2800/qwen3-tts-apple-silicon).
+- Chatterbox-TTS: [localaimaster.com setup guide](https://localaimaster.com/blog/chatterbox-tts-setup-guide); [Hugging Face Space — Jimmi42/chatterbox-tts-apple-silicon](https://huggingface.co/spaces/Jimmi42/chatterbox-tts-apple-silicon).
+- General local TTS landscape on macOS: [SourceForge — Mac Text-to-Speech (TTS) Models directory](https://sourceforge.net/directory/text-to-speech-tts-models/mac/).

--- a/docs/proposals/2026-07-08-macos-accessibility-features-brainstorm.md
+++ b/docs/proposals/2026-07-08-macos-accessibility-features-brainstorm.md
@@ -1,0 +1,124 @@
+# macOS Accessibility features worth a closer look for agent-os
+
+Author: Perplexity Computer (collaborator pass), for @michaelblum
+Date: 2026-07-08
+Status: Brainstorm / discussion starter — not a design doc, not scoped, no implementation implied
+
+## Why this doc exists
+
+While poking around System Settings → Accessibility, several built-in macOS features stood out as
+plausibly relevant to agent-os's daemon/agent split (element resolution, TTS, input, and feedback
+all live in the daemon; the agent decides what/why). This is intentionally a shallow pass — one
+link, one summary, one hot-take each — meant to seed a discussion about which of these (if any) are
+worth a real design spec later. Nothing here has been prototyped or verified against the codebase
+yet.
+
+## The features
+
+### 1. VoiceOver
+[support.apple.com/guide/mac-help/MH40578](https://support.apple.com/guide/mac-help/MH40578/26/mac/26.5.1)
+
+**Summary:** macOS's built-in screen reader. Settings here control turning VoiceOver on/off,
+opening VoiceOver Utility, and running the tutorial.
+
+**Hot take:** VoiceOver's whole reason for existing is walking the same Accessibility (AX) API tree
+that agent-os's daemon already uses for element resolution. That means Apple has spent two decades
+hardening exactly the kind of "what's on screen and how do I address it" problem the daemon solves
+today. Worth a look at whether VoiceOver's *rotor* concept (jump by headings/links/form
+controls/tables) or its verbosity/hint settings suggest a richer perception model than what agent-os
+currently exposes — not to replace the daemon's own AX walking, but to steal UX vocabulary and
+possibly rotor-style navigation primitives for `aos see`/perception commands.
+
+### 2. Read & Speak
+[support.apple.com/guide/mac-help/SPCH638](https://support.apple.com/guide/mac-help/SPCH638/26/mac/26.5.1)
+
+**Summary:** System-wide settings for the voice macOS uses to read text aloud — select the system
+voice, enable "speak selected text," speak announcements, typing feedback, etc.
+
+**Hot take:** This is literally the same voice catalog `SystemVoiceProvider` already enumerates via
+`NSSpeechSynthesizer.availableVoices` (see the Kokoro TTS backend proposal earlier in this PR) — so
+no new integration surface here, but it's a good reminder that "speak announcements"/"speak
+selected text" are System-level hooks a user might already have configured, and agent-os's own
+`voice.announce_actions` config should probably not fight with or double-announce alongside these
+if both are enabled on the same machine. Also: this is the settings pane that controls the
+system-wide default voice `SpeechEngine.resolvedDefaultVoiceID` falls back to when config doesn't
+pin one — worth documenting that dependency explicitly somewhere.
+
+### 3. Captions
+[support.apple.com/guide/mac-help/MH43180](https://support.apple.com/guide/mac-help/MH43180/26/mac/26.5.1)
+
+**Summary:** Controls how subtitles/closed captions are styled system-wide (size, font, background,
+edge style) for media that already ships captions.
+
+**Hot take:** Lowest-relevance item on this list since it's purely a styling layer for existing
+caption tracks, not a capture/generation feature. Only interesting if agent-os ever renders its own
+on-canvas captions of TTS output (e.g. for muted/headless sessions) and wants to inherit the user's
+existing caption style preferences instead of inventing a new style system.
+
+### 4. Live Captions
+[support.apple.com/guide/mac-help/MCHLA0B36DB8](https://support.apple.com/guide/mac-help/MCHLA0B36DB8/26/mac/26.5.1)
+
+**Summary:** System-wide, on-device real-time speech-to-text captioning of any audio playing on the
+Mac (and of the mic in FaceTime), with adjustable caption styling and language.
+
+**Hot take:** This is the most interesting one for symmetry with the Kokoro TTS work. `aos listen`
+presumably needs an ASR backend the same way `aos say` needs a TTS backend — if Live Captions'
+on-device recognizer is reachable at all programmatically (unclear — likely private API / no public
+hook today, would need real investigation), it could be a zero-install, Apple-native alternative to
+running Whisper locally for short-utterance capture, mirroring the "system vs. local model backend"
+split we just designed for voice output. Even if it's not directly callable, it's a strong signal
+that Apple already ships a fast on-device ASR model on this hardware class, which is useful context
+for `aos listen` backend decisions later.
+
+### 5. Voice Control
+[support.apple.com/guide/mac-help/SPC002](https://support.apple.com/guide/mac-help/SPC002/26/mac/26.5.1)
+
+**Summary:** Full hands-free control of the Mac by voice — built-in commands plus a custom
+vocabulary/command grammar the user can define ("when I say X, do Y").
+
+**Hot take:** Probably the single most agent-os-relevant item here. Voice Control already ships a
+mature "voice → OS action" command grammar and dictation engine as a first-class OS citizen. Two
+angles worth exploring later: (a) could custom Voice Control commands be defined to invoke `aos`
+verbs directly, giving agent-os a zero-effort voice front-end without building its own wake-word/ASR
+pipeline; and (b) is there any signal/telemetry from Voice Control being active that the daemon
+should be aware of (e.g. don't fight the user for control of dictation focus, or coordinate the
+`--voice-slot` cancel-key behavior with Voice Control's own listening state). This feels like the
+highest-leverage, lowest-effort item to spend real design time on next.
+
+### 6. Personal Voice
+[support.apple.com/guide/mac-help/MCHL4B5F02EC](https://support.apple.com/guide/mac-help/MCHL4B5F02EC/26/mac/26.5.1)
+
+**Summary:** On-device voice cloning built into macOS — records a set of phrases from the user and
+produces a synthesized voice that sounds like them, usable via Live Speech and by allowed
+third-party apps (e.g. AAC apps).
+
+**Hot take:** This lands directly on top of the pluggable-backend design from the earlier PR
+discussion. If Personal Voice is reachable through a documented API (needs verification — this is
+exactly the kind of thing that should get a real investigation pass, not just a hot take), it would
+be a *fourth* natural `VoiceProvider` candidate alongside `system`/`kokoro`/future
+`qwen`/`chatterbox`: fully on-device, zero Python dependency, zero model management, and it
+literally sounds like the user — which is a very different value proposition than
+Kokoro/Qwen/Chatterbox's "high-quality but generic" voices. Personal Voice being Apple's own
+accessibility feature for AAC use cases also suggests it's designed for exactly the "agent speaks on
+my behalf" pattern agent-os cares about.
+
+### 7. Accessibility Shortcuts panel settings
+[support.apple.com/guide/mac-help/MCHLA7804B65](https://support.apple.com/guide/mac-help/MCHLA7804B65/26/mac/26.5.1)
+
+**Summary:** Configures which accessibility features appear in the quick-toggle Accessibility
+Shortcuts panel (triggerable via keyboard shortcut/Touch Bar/Control Strip) so users can flip
+features on/off fast.
+
+**Hot take:** Least directly applicable, but it's a reminder that macOS already has a
+system-sanctioned "fast toggle panel + global hotkey" pattern for accessibility state, which is
+conceptually similar to agent-os's own `hotkeys.cancel_speech` config and status-item toggles. Not
+an integration point so much as a UX pattern worth being aware of — if agent-os grows more
+toggleable runtime features (voice backend switching, feedback modes, etc.), this panel's
+interaction model is a reasonable one to imitate rather than reinvent.
+
+## Suggested next step
+
+Pick one or two of these (Voice Control and Personal Voice look like the strongest candidates) and
+scope a real investigation into whether/how they're reachable from a native macOS app — public
+Speech framework APIs, private APIs, or "not accessible outside System Settings at all" — before
+committing to any design work.

--- a/docs/proposals/2026-07-08-sigil-voice-trigger-ideation.md
+++ b/docs/proposals/2026-07-08-sigil-voice-trigger-ideation.md
@@ -350,6 +350,82 @@ Recognition don't share that particular quirk and behave more like
 Accessibility (persistent until explicitly revoked), but this is worth
 verifying against whatever macOS version ships when this is actually built.
 
+## Prior art: local Wispr Flow-style dictation apps (license-verified)
+
+A [research comment on this PR](https://github.com/michaelblum/agent-os/pull/589#issuecomment-4919428700)
+surveyed existing open-source, local-first dictation tools (Wispr Flow /
+Superwhisper alternatives) as candidate reference implementations or fork
+bases for Concept B's transcription layer. Before folding that survey in
+here, each project's actual `LICENSE` file was checked directly against the
+GitHub license API, since licensing accuracy matters for what can be *copied*
+versus merely *read for inspiration* — and a few of the comment's license
+characterizations don't hold up under that check.
+
+**agent-os itself has no `LICENSE` file at all** (confirmed — no license is
+declared at the repo root), which means the real open question isn't yet
+"Apache vs. MIT compatibility" — it's that agent-os has no declared license
+for anyone to check compatibility against in the first place. That's a
+maintainer decision that sits upstream of any of this.
+
+**Tier 1 — permissive, verified safe to read and adapt code from directly:**
+
+- **[FreeFlow](https://github.com/zachlatta/freeflow)** (macOS-only) — `LICENSE`
+  confirmed **MIT**. Hotkey-based hold-to-talk *and* toggle modes,
+  context-aware cleanup, voice macros, custom vocabulary, no subscription,
+  reached a "feature-complete" v1.0 in May 2026. This maps almost directly
+  onto Concepts A/B's hold-vs-toggle trigger duality and is small enough to
+  read end-to-end as a state-machine reference.
+- **[OpenWhispr](https://github.com/OpenWhispr/openwhispr)** (cross-platform)
+  — `LICENSE` confirmed **MIT**. Runs Whisper/Parakeet fully on-device by
+  default, with optional cloud/Groq as an explicit opt-in — the same
+  local-first default posture already recommended in the TCC section above.
+  Its local/cloud boundary code is worth reading directly since it's the
+  closest existing analog to "on-device by default, no silent network calls."
+
+**Tier 2 — architecture/UX reference only, not code-copy sources (copyleft):**
+
+- **Whispering** (part of the [Epicenter](https://github.com/EpicenterHQ/epicenter)
+  monorepo) — the PR comment characterized this as MIT; that's only true for
+  Epicenter's separately-licensed reusable toolkit packages
+  (`packages/workspace`, `packages/ui`, `packages/sync`, etc.). The actual
+  `apps/whispering` dictation app ships under **AGPL-3.0-or-later**, per
+  Epicenter's own `LICENSE` index and `apps/whispering/LICENSE`. AGPL's
+  copyleft (including its network-use clause) means its code shouldn't be
+  forked or copied into agent-os without accepting that obligation. Its
+  transform-chain extensibility model (chaining grammar fixes, translation,
+  formatting after transcription) is still a good *concept* to study for
+  Concept C's response-hook idea — study the idea, don't copy the
+  implementation.
+- **[TypeWhisper](https://github.com/TypeWhisper/typewhisper-mac)** — the
+  comment called this generically "open source"; GitHub's license API shows
+  it's actually **GPL-3.0**, a copyleft license, not a permissive one. Same
+  caution as above.
+- **[Voicetypr](https://github.com/moinulmoin/voicetypr)** — likewise
+  **AGPL-3.0**, confirmed via its `LICENSE.md`. Reference only.
+- **[wispr-flow (shmbhvi101)](https://github.com/shmbhvi101/wispr-flow)** —
+  has **no LICENSE file at all** (all-rights-reserved by default under
+  copyright law). The original comment already scoped this as "UI/UX
+  reference" rather than a fork base, which is the only safe way to use it.
+- **Dictara** — the comment linked a Reddit announcement post rather than a
+  direct repository URL, and the announcement doesn't resolve unambiguously
+  to one verifiable GitHub repo. Treat as unverified until someone locates
+  and checks the actual source and license directly.
+
+**A technical implication worth folding back into the TCC section above:**
+FreeFlow and OpenWhispr both bundle their own local transcription model
+(Whisper/Parakeet) rather than calling Apple's Speech framework. A voice
+trigger implementation that does the same — runs a bundled local model
+in-process instead of `SFSpeechRecognizer`/`SpeechAnalyzer` — would only ever
+need the **Microphone** TCC grant, and would skip the separate **Speech
+Recognition** TCC prompt entirely, since it never calls Apple's Speech
+framework. That's a real architectural fork in the road for whoever picks
+this up: Apple's Speech framework is zero-dependency and ships with macOS,
+but a bundled local Whisper/Parakeet model (as both MIT-licensed Tier 1
+projects chose) trades a larger binary and a model-management story for one
+fewer permission prompt and full control over on-device model quality —
+worth weighing explicitly rather than defaulting to the Speech framework
+simply because it's the path of least resistance.
+
 ## Full-duplex (explicit stretch goal, likely "later or never")
 
 Flagging this honestly rather than over-scoping it: true full-duplex (agent
@@ -414,3 +490,17 @@ Checked both `skills/` and `recipes/` as candidate homes before writing this:
    Sigil's own config (the wiki-doc-based per-agent config pattern already
    used for `sigil/agents/<id>.md` seems like a strong existing precedent to
    reuse for response-bank config too).
+5. Local transcription model choice (Apple Speech framework vs. a bundled
+   local Whisper/Parakeet model, per the Prior Art section above) — this is
+   now a real decision with a concrete permission-surface tradeoff (one fewer
+   TCC prompt for the bundled-model path), not just an implementation detail.
+6. Whether agent-os adopts a project license at all, and if so which one —
+   this determines whether Tier 1 (MIT) prior-art code can actually be
+   vendored/adapted, versus only read for architectural inspiration like
+   Tier 2. Currently unresolved since agent-os has no `LICENSE` file today.
+7. Cross-platform reach vs. staying as close as possible to Wispr Flow's
+   macOS-native UX — raised directly by the PR comment surfacing this prior
+   art, and unresolved. FreeFlow (Tier 1, macOS-only) and OpenWhispr (Tier 1,
+   cross-platform) represent the two ends of that tradeoff and are both
+   license-clear to build from, so this is a product decision, not a
+   licensing constraint.

--- a/docs/proposals/2026-07-08-sigil-voice-trigger-ideation.md
+++ b/docs/proposals/2026-07-08-sigil-voice-trigger-ideation.md
@@ -1,0 +1,331 @@
+# Sigil Voice Trigger System — Deep Ideation (Track 2)
+
+**Status:** Ideation / pre-design. No code changes proposed here — this is a
+grounding document for a follow-up design pass.
+
+**Author:** Perplexity Computer, on behalf of @mikeblum603
+
+**Related:** `docs/proposals/2026-07-08-kokoro-tts-backend-integration.md`
+(pluggable local TTS backend for `aos say` — the sound-hook system below reuses
+that work for spoken responses).
+
+## Framing: this is explicitly Track 2
+
+Everything below is scoped as an **app/experience-layer concern**, not a
+change to the `aos` binary or its command surface. `apps/sigil/AGENTS.md`
+already states this precisely:
+
+> "Sigil is a **Track 2 consumer** of agent-os... It does not belong in
+> `packages/` — it's an application, not a toolkit component."
+
+And its Platform Dogfood Boundary draws the ownership lines we should respect
+when scoping any of this work:
+
+- **Sigil** owns avatar personality, product behavior, effects, agent-facing
+  content, and special visual expression.
+- **AOS daemon** owns native canvas lifecycle, display topology, input
+  streams, content serving, and generic routing primitives.
+- **Toolkit** owns reusable surface/windowing policy and interaction-region
+  helpers.
+- Rule of thumb: "If Sigil needs a reusable platform capability, extract it
+  downward before growing a private Sigil-only subsystem."
+
+Practically, that means: wake-word detection, dictation state, sound-hook
+config, and the ephemeral voice menu should be designed and prototyped as
+**Sigil product behavior**, consuming only generic AOS daemon primitives that
+already exist (event bus pub/sub, canvas lifecycle, global hotkey capture
+points). Only if a piece proves genuinely reusable across future apps (not
+just Sigil) should it be proposed for extraction into `packages/toolkit` or
+the daemon core. Nothing here should touch `manifests/commands/` or add new
+`aos` subcommands as a first move.
+
+## Current-state audit
+
+Before ideating, it's worth being precise about what already exists versus
+what's a green field. This matters because two of the four features below are
+much cheaper than they look — they're extensions of existing plumbing, not new
+subsystems.
+
+### What does not exist at all
+
+An exhaustive search of the codebase (`AVAudioEngine`, `SFSpeechRecognizer`,
+`microphone`, `wakeword`, `hotword`) turns up **zero matches**. There is
+currently no microphone capture, voice activity detection (VAD), wake-word
+spotting, or speech-to-text anywhere in agent-os. `aos listen` looks like a
+natural fit by name, but it is a **text-based** inter-agent coordination
+channel (`scripts/aos-tell-listen.mjs`, socket actions `listen.read` /
+`listen.follow` / `listen.channels`), paired with `aos tell` — it has nothing
+to do with audio. This whole feature area is a genuine green field, which is
+exactly why it belongs in Track 2 (an app can iterate on this fast; the core
+binary should not carry speculative audio-pipeline code).
+
+### What already exists and is directly reusable
+
+- **The daemon event bus already reserves a `voice` service with zero
+  events.** `shared/schemas/daemon-event.md` documents the wire protocol
+  (ndjson over a Unix socket, `{v, service, event, ts, data, ref?}` envelopes,
+  `subscribe` with optional `events` filter and `snapshot`) and lists valid
+  `service` values as `perceive`, `display`, `act`, and **`voice`** — but the
+  events table only defines perceive/display/act events today. This is a
+  ready-made namespace: `voice.wake_detected`, `voice.dictation_opened`,
+  `voice.dictation_closed_send`, `voice.dictation_closed_cancel`, etc. can be
+  added as new event names without any protocol or schema redesign.
+- **`feedback.sound` is a config flag that has never been implemented.**
+  `FeedbackConfig.sound: Bool` (default `false`) exists in
+  `src/shared/config.swift`, but there is no `NSSound` or `afplay` call
+  anywhere in the Swift codebase. It's a stub that was clearly meant for
+  exactly this kind of feedback-hook use case and has been sitting unused.
+- **Global hotkey capture has an established pattern.** `CGEvent.tapCreate`
+  is already used in three places for a "cancel speech" hotkey:
+  `src/voice/say.swift:132` (per-invocation), `src/daemon/unified.swift:3201`
+  (daemon-persistent), and `src/perceive/daemon.swift:134`. There's also
+  `src/perceive/input-safety-hotkeys.swift` and a keyCode-53 (Escape) cancel in
+  `src/perceive/capture-pipeline.swift:1344`. None of these implement a
+  *hold-duration* trigger (e.g., "spacebar held >2s"), but the tap-creation and
+  event-loop scaffolding is proven and copyable.
+- **Sigil's radial menu is already an ephemeral, fading overlay.** The exact
+  UX shape the user is describing — "an overlay appears, fades over time if
+  nothing happens" — is not hypothetical, it's shipping today.
+  `apps/sigil/renderer/radial-menu/sigil-radial-menu.json` defines the menu
+  (`avatar-controls`, `agent-terminal`, `annotation-mode`,
+  `annotation-camera`, `wiki-graph` items) with a real
+  `activationTransition` block driving fade/dissolve/zoom via `duration_ms`
+  and eased opacity interpolation
+  (`apps/sigil/renderer/live-modules/radial-activation-transition.js`:
+  `fadeOpacity()`, `dissolveOpacity()`). Today it's triggered by
+  `avatar-click` only. The fade math is currently driven by a monotonic
+  elapsed-time `progress` value, not a live signal — worth noting because
+  "brightens again on new mic input" needs a different (bidirectional, signal-
+  driven) input than what's wired in today, even though the visual fade
+  machinery itself is ready to be reused.
+
+This gives a clean way to describe the whole feature set: **new capture layer
+(green field) → existing event bus (`voice.*` namespace) → existing but
+unimplemented feedback hook (`feedback.sound`) → existing but currently
+one-directional fade UI (radial menu)**. Each arrow is a seam where new work
+plugs into something that already works, rather than a from-scratch stack.
+
+## Concept A — Wake phrase + hold-spacebar alternate trigger
+
+Two independent entry points into the same downstream state machine (below),
+so users have a hands-free and a hands-on path:
+
+- **Wake phrase ("Hey Sigil", or whatever name is configured):** requires the
+  new green-field piece — a small always-listening capture process. Given
+  there is zero existing audio infra, the honest options are (a) an on-device
+  lightweight keyword spotter (e.g., a small ONNX/CoreML wake-word model
+  running continuously at negligible CPU, similar in spirit to how
+  Siri/"Hey Siri" or open-source projects like openWakeWord work) or (b) lean
+  on Apple's `SFSpeechRecognizer` in a lower-power "on-device only" mode. (a)
+  is strongly preferred: continuous cloud/heavier STT for wake-word spotting
+  alone is wasteful and adds latency exactly where the user does not want it.
+  This process should run as a small Sigil-owned helper (not inside the AOS
+  daemon), publishing a single `voice.wake_detected` event onto the daemon bus
+  when it fires, and otherwise touching nothing else in the system. This
+  keeps the "always listening" surface area small, sandboxed to one process,
+  and easy to kill/restart independent of the daemon.
+- **Hold-spacebar (>2s):** far cheaper — a `CGEventTap` timing the key-down to
+  key-up interval, following the exact pattern already in
+  `src/perceive/input-safety-hotkeys.swift`. No ML, no always-on audio. This
+  is the trigger to ship first, since it validates the whole downstream
+  dictation state machine without needing a wake-word model at all. It also
+  gives users a reliable fallback when ambient noise makes wake-word spotting
+  unreliable.
+
+Both triggers should emit the *same* `voice.wake_detected` event (with a
+`source: "phrase" | "hotkey"` field) so the downstream state machine in
+Concept B doesn't need to know which trigger fired.
+
+## Concept B — Half-duplex dictation state machine
+
+A state machine with four states: `IDLE → LISTENING → (SEND | CANCEL) → IDLE`.
+Design goal: give the user several redundant ways to close a dictation
+session, because voice-only "stop listening" phrases are failure-prone in
+noisy environments or in the middle of a spoken sentence.
+
+**Entry into `LISTENING`:** either trigger from Concept A. On entry, publish
+`voice.dictation_opened` on the bus — this is the hook Concept C's sound
+system reacts to (e.g., playing "I'm listening, Michael!").
+
+**Exit paths, all valid simultaneously (first one to fire wins):**
+
+1. **Watchphrase stop** — user says a stop phrase ("send that" / "cancel
+   that"), disambiguated by wording, not just presence of speech.
+2. **Release spacebar** (if that's how `LISTENING` was entered) — releasing
+   immediately closes and sends. This maps hold-to-talk semantics onto the
+   same state machine as the wake-phrase path, so both triggers converge on
+   one implementation.
+3. **Third input trigger** — e.g., a distinct key chord or a UI affordance in
+   the ephemeral menu (Concept D) that's always available while `LISTENING`
+   is active, as an explicit "send" button for cases where speech alone is
+   unreliable.
+4. **Pomodoro-style timeout** — this is the most interesting of the four and
+   worth spelling out as its own sub-state:
+   - On entering `LISTENING`, start a countdown (e.g., 8–12s, tunable).
+   - Any detected speech energy (VAD, not full transcription) resets the
+     countdown, so the user isn't cut off mid-sentence.
+   - If the countdown reaches zero **while there has been any completed
+     utterance**, auto-send what's been captured so far.
+   - If the countdown reaches zero **with no speech captured at all** (dead
+     air from the moment `LISTENING` opened), auto-cancel instead — the user
+     probably triggered by accident or walked away.
+   - This "silence resolves the ambiguity" rule is the key design idea: it
+     turns an otherwise-annoying fixed timeout into something that
+     distinguishes "I said something and then paused" (send) from "nothing
+     happened" (cancel), without extra user action.
+
+Each exit path should publish either `voice.dictation_closed_send` or
+`voice.dictation_closed_cancel` with a `reason` field (`phrase` / `key_release`
+/ `explicit_trigger` / `timeout`) — useful both for the sound-hook system
+(Concept C can play a different confirmation sound per reason) and later for
+tuning which exit path users actually use in practice.
+
+## Concept C — Sound-hook / subscription config system
+
+This formalizes the currently-unimplemented `feedback.sound` stub into a real
+subscription system, and is the natural place to plug in the pluggable-TTS
+work from the companion doc.
+
+**Shape:** a small config-driven registry, keyed by the `voice.*` event names
+from Concept A/B, where each key maps to a "response" definition:
+
+```json
+{
+  "voice.dictation_opened": {
+    "kind": "tts",
+    "backend": "kokoro",
+    "pick": "random",
+    "responses": [
+      "I'm listening, Michael!",
+      "Go ahead.",
+      "Listening..."
+    ]
+  },
+  "voice.dictation_closed_send": {
+    "kind": "system_sound",
+    "sound": "Pop"
+  },
+  "voice.dictation_closed_cancel": {
+    "kind": "system_sound",
+    "sound": "Basso"
+  }
+}
+```
+
+- `kind: "system_sound"` is the cheap default — this is literally what
+  `feedback.sound` was presumably meant to gate, just never wired to
+  `NSSound`/`afplay`.
+- `kind: "tts"` is where this connects directly to
+  `2026-07-08-kokoro-tts-backend-integration.md`: once `aos say` (or the
+  underlying `SpeechEngine`) supports a pluggable `KokoroVoiceProvider` (or,
+  down the line, a macOS Personal Voice via the accessibility brainstorm doc),
+  this hook can call the same synthesis path with a specific `voice://`
+  provider URI, so "I'm listening, Michael!" can be spoken in a distinct voice
+  from whatever the agent normally uses for `aos say` responses — a clear
+  differentiator between "system acknowledging you" and "agent talking to
+  you."
+- Consumers of this config are Sigil-side (the renderer/companion process
+  subscribes to the bus and looks up the response registry), not the daemon —
+  consistent with "AOS daemon owns generic routing; Sigil owns product
+  behavior." The daemon's job is only to deliver the `voice.*` events; what
+  sound or voice line plays in response is 100% app-configurable policy.
+- Because it's keyed by event name and not hardcoded, other future
+  agents/experiences (not just Sigil) could subscribe to the same `voice.*`
+  events and define their own response banks — this is the "hooks
+  subscribable to trigger events" idea generalized past just this one app.
+
+## Concept D — Voice-triggered ephemeral menu overlay
+
+This is the smallest lift of the four, because the visual and lifecycle
+machinery already exists in `apps/sigil/renderer/radial-menu/`. Two concrete
+changes needed:
+
+1. **Add a second activation trigger.** Today `sigil-radial-menu.json`'s
+   `openAnimation.trigger` is `avatar-click` only. Add `voice.wake_detected`
+   (specifically when it resolves to something like the "Run Command" intent
+   from the wake flow) as an alternate trigger source feeding the same
+   `menu-activation-runtime.js` state machine. No new visual code needed — the
+   `activationTransition` fade/dissolve pipeline is trigger-agnostic already.
+2. **Make the fade bidirectional and signal-driven.** Currently
+   `radial-activation-transition.js`'s opacity math (`fadeOpacity`,
+   `dissolveOpacity`) is driven by a monotonic elapsed-time `progress` value —
+   fine for a one-shot open/close animation, but "fades over time if mic hears
+   nothing, brightens again if new mic input passes a threshold" needs a
+   *live* signal, not a fixed timer. The concrete change is to feed a
+   VAD-derived amplitude/confidence value (from the same capture path as
+   Concept A) into the existing opacity interpolation instead of (or in
+   addition to) the timer-derived `progress`, so the overlay visually "listens
+   back" — opacity tracks a decaying-then-refreshed signal rather than a
+   single countdown.
+
+Worked example matching the user's flow: user says wake phrase → radial menu
+overlay appears (Concept D trigger) with a "Run Command" item highlighted →
+user says "watch me" → this is itself a mini instance of the dictation state
+machine (Concept B) scoped to just resolving one menu item, which on
+`voice.dictation_closed_send` maps the transcribed phrase to a menu action →
+menu dispatches `aos see record --whatever` the same way existing radial menu
+items already dispatch `aos_command` steps (see `recipes/sigil/start.json` for
+the existing pattern of a JSON recipe step invoking an `aos_command`). No
+change to the command surface itself — the menu is just another caller of
+commands that already exist.
+
+## Full-duplex (explicit stretch goal, likely "later or never")
+
+Flagging this honestly rather than over-scoping it: true full-duplex (agent
+can be interrupted mid-speech, both sides can talk over each other) requires
+real-time echo cancellation — the mic must run continuously while
+`SpeechEngine`/`aos say` output is also playing, without the mic picking up
+the agent's own voice as new input. Before investing in custom DSP or a
+third-party AEC library, the cheap first step is to spike whether
+`AVAudioEngine`'s built-in `AVAudioEngine.inputNode` + voice-processing I/O
+unit (`setVoiceProcessingEnabled(true)`) is good enough out of the box — Apple
+ships this specifically for VoIP-style full-duplex use cases and it may cover
+this need with zero custom signal processing. If that spike doesn't hold up
+under real usage, half-duplex (Concept B) with a fast open/close cycle is a
+perfectly reasonable permanent fallback rather than a stepping stone.
+
+## Where this should actually live (Track 2 placement)
+
+Checked both `skills/` and `recipes/` as candidate homes before writing this:
+
+- `recipes/sigil/` (`start.json`, `start-agent-terminal.json`) is explicitly
+  scoped to **operational procedures** — per `recipes/AGENTS.md`, "durable
+  architecture belongs in `docs/adr/`, `docs/api/`, or `shared/schemas/`,"
+  recipes are not the place for design ideation. Once a concrete trigger
+  design is picked, a `recipes/sigil/enable-voice-triggers.json`-style recipe
+  would make sense as the *operational* activation step, but not before.
+  Instead of the vague "Track 2 recipes" label, the concrete gate here is: a
+  recipe should exist only after a design lands as real config/code — the
+  first recipe would just be turning the feature on.
+- `skills/` is entirely AOS-agent-workflow skills (`aos-desktop`,
+  `aos-focus-sessions`, `aos-recipes`, etc.) — not a fit for product design
+  ideation either; skills document how an agent operates the system, not how
+  Sigil's own features are designed.
+- **Conclusion:** this document belongs exactly where it is —
+  `docs/proposals/`, alongside the Kokoro TTS backend doc it depends on — as
+  the ideation/pre-design record. When a concrete design is chosen, it should
+  graduate to `apps/sigil/AGENTS.md` (architecture) and, if a genuinely
+  reusable capability is extracted (e.g., a generic "hold-duration hotkey"
+  primitive or a generic bus-driven sound-hook registry that other apps could
+  use), a short proposal for lifting that specific piece into
+  `packages/toolkit` — never the whole feature, per the Platform Dogfood
+  Boundary's "extract downward before growing a private subsystem" rule.
+
+## Open questions for the next design pass
+
+1. Wake-word model choice and where the always-listening helper process lives
+   (launched by Sigil? by `aos serve`? standalone LaunchAgent?) — this affects
+   permission prompts (mic access) and battery/CPU posture.
+2. Does the daemon need a new inbound path for *injecting* `voice.*` events
+   (from an external Sigil helper) or does `broadcastEvent()` already have an
+   external-facing entry point? (`src/daemon/unified.swift:562` is called
+   internally 13 times; whether an external process can post onto the bus the
+   same way needs confirming before Concept A can be built.)
+3. Exact pomodoro timeout durations and whether they should be user-tunable
+   per dictation context (a "watch me" one-word menu answer probably wants a
+   much shorter timeout than a long freeform dictation).
+4. Whether `feedback.sound` should be resurrected as a general daemon-level
+   flag at all, or whether sound-hook config should live entirely inside
+   Sigil's own config (the wiki-doc-based per-agent config pattern already
+   used for `sigil/agents/<id>.md` seems like a strong existing precedent to
+   reuse for response-bank config too).

--- a/docs/proposals/2026-07-08-sigil-voice-trigger-ideation.md
+++ b/docs/proposals/2026-07-08-sigil-voice-trigger-ideation.md
@@ -269,6 +269,87 @@ the existing pattern of a JSON recipe step invoking an `aos_command`). No
 change to the command surface itself — the menu is just another caller of
 commands that already exist.
 
+## TCC permissions this introduces
+
+agent-os today requests four permission classes through the broker's
+`__permissions prompt` primitive (`src/commands/operator.swift`, enum
+`PermissionPromptKind`): **Accessibility** (`AXIsProcessTrustedWithOptions`),
+**Screen Recording** / "Screen & System Audio Recording"
+(`CGRequestScreenCaptureAccess`), and **Input Monitoring**, which is actually
+two native triggers under one System Settings pane —
+`CGRequestListenEventAccess` (listen) and `CGRequestPostEventAccess` (post,
+used for synthetic CGEvents). None of this touches the microphone.
+
+Everything proposed in this document needs **two additional, currently
+unused TCC classes**:
+
+1. **Microphone** (`kTCCServiceMicrophone` / `NSMicrophoneUsageDescription`).
+   Required for *any* live audio capture — the always-listening wake helper in
+   Concept A, the dictation capture in Concept B, and the live VAD signal
+   driving the menu fade in Concept D all need this, even before any
+   transcription happens. This is worth stating explicitly because **"Screen
+   & System Audio Recording" does not cover this** — that permission
+   (`CGRequestScreenCaptureAccess`) governs screen video and *system audio
+   output* (what plays through speakers/apps), not the physical microphone
+   *input*. The two are commonly conflated because both are audio-adjacent,
+   but they are separate TCC services with separate prompts and separate
+   entries in System Settings → Privacy & Security.
+2. **Speech Recognition** (`kTCCServiceSpeechRecognition` /
+   `NSSpeechRecognitionUsageDescription`). A distinct *second* prompt beyond
+   Microphone, required only if Concept B's free-form dictation transcription
+   leans on Apple's Speech framework (`SFSpeechRecognizer` or the newer
+   `SpeechAnalyzer`) rather than a fully custom ASR stack — which is the
+   realistic default choice here. It is not needed for the wake-word spotter
+   alone if that stays a lightweight local keyword model operating on raw
+   audio buffers (per Concept A), since that doesn't call the Speech
+   framework at all — only the dictation-transcription step in Concept B
+   triggers this prompt. Two more things worth deciding deliberately rather
+   than by default: (a) request `requiresOnDeviceRecognition = true` to keep
+   transcription local — consistent with the local-first, low-latency
+   posture already established in the Kokoro TTS doc — since server-based
+   recognition adds a further, separate "send speech data to Apple" consent
+   nuance inside the same Speech Recognition flow; (b) on-device recognition
+   is not guaranteed available for every language/locale, so this should be
+   probed rather than assumed.
+
+Neither addition is a scope surprise: `ARCHITECTURE.md` already names
+**Microphone** as one of the four TCC classes the `./aos` broker is described
+as managing ("Screen Recording, Accessibility, Input Monitoring, and
+Microphone"), alongside voice/communication rows explicitly marked
+"STT planned." It's simply unrequested and unused today — no capture code
+exists yet (per the audit above), so there's been nothing to trigger the
+prompt.
+
+**Placement implication for the Track 2 boundary above:** `docs/adr/0015-aos-tcc-capability-broker-boundary.md`'s
+Swift Change Gate lists "a new TCC permission class" as one of the few
+*accepted* reasons to touch the broker directly — the same bucket Accessibility,
+Screen Recording, and Input Monitoring already live in. That means, unlike the
+rest of this feature set, **acquiring and probing Microphone and Speech
+Recognition authorization state is legitimately broker-owned**, not Sigil
+product behavior: the natural move is two new `PermissionPromptKind` cases
+(`microphone`, `speech-recognition`) backed by
+`AVCaptureDevice.requestAccess(for: .audio)` and
+`SFSpeechRecognizer.requestAuthorization`, following the exact shape of the
+four that exist today. Everything downstream of "permission granted" — the
+wake-word model, the dictation state machine, the sound hooks, the menu — stays
+Track 2 in Sigil, per the ownership split already established above. This is a
+clean example of the boundary doing its job: the *privileged fact/action* (is
+mic access granted; ask for it) is broker-owned; the *policy* (what to do with
+the audio once access is granted) is app-owned.
+
+**Loose ends for whoever picks this up:** no `Info.plist` or `.entitlements`
+file currently exists in the repo (confirmed by search) — before either
+permission can be requested, usage-description strings need to be added
+wherever the shipped binary's plist is generated, and — if the binary is
+sandboxed/notarized outside the Mac App Store, consistent with its existing
+global `CGEventTap` usage — the corresponding `com.apple.security.device.audio-input`
+entitlement needs auditing too. Also worth flagging operationally: Screen
+Recording permission is known to reset periodically on modern macOS (monthly,
+and after every restart on recent releases) — Microphone and Speech
+Recognition don't share that particular quirk and behave more like
+Accessibility (persistent until explicitly revoked), but this is worth
+verifying against whatever macOS version ships when this is actually built.
+
 ## Full-duplex (explicit stretch goal, likely "later or never")
 
 Flagging this honestly rather than over-scoping it: true full-duplex (agent
@@ -315,7 +396,11 @@ Checked both `skills/` and `recipes/` as candidate homes before writing this:
 
 1. Wake-word model choice and where the always-listening helper process lives
    (launched by Sigil? by `aos serve`? standalone LaunchAgent?) — this affects
-   permission prompts (mic access) and battery/CPU posture.
+   battery/CPU posture and, per the TCC section above, which process identity
+   actually needs to hold the Microphone/Speech Recognition grants (the
+   unified `./aos` broker identity, to stay consistent with the "one
+   permissioned broker binary" principle in ADR 0015, rather than a separate
+   helper binary fragmenting TCC identity).
 2. Does the daemon need a new inbound path for *injecting* `voice.*` events
    (from an external Sigil helper) or does `broadcastEvent()` already have an
    external-facing entry point? (`src/daemon/unified.swift:562` is called

--- a/docs/proposals/2026-07-08-voice-io-phased-integration-roadmap.md
+++ b/docs/proposals/2026-07-08-voice-io-phased-integration-roadmap.md
@@ -1,0 +1,223 @@
+# Voice I/O — Phased Integration Roadmap (TTS + STT + Trigger)
+
+**Author:** Perplexity Computer (collaborator pass), for @michaelblum / @mikeblum603
+**Date:** 2026-07-08
+**Status:** Proposal / roadmap — no runtime code changes in this PR
+**Pins:** All source references use commit [`1c8dc81`](https://github.com/michaelblum/agent-os/tree/1c8dc81a014e534651c95c3c763cafa539de2799).
+
+**Companion docs (this roadmap sequences and unifies them):**
+- [`2026-07-08-kokoro-tts-backend-integration.md`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/docs/proposals/2026-07-08-kokoro-tts-backend-integration.md) — the TTS-output seam (`aos say` + daemon `announce()`).
+- [`2026-07-08-sigil-voice-trigger-ideation.md`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/docs/proposals/2026-07-08-sigil-voice-trigger-ideation.md) — the trigger/dictation/sound-hook stack (Track 2, Sigil-owned).
+- [`2026-07-08-macos-accessibility-features-brainstorm.md`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/docs/proposals/2026-07-08-macos-accessibility-features-brainstorm.md) — Apple-native features (Personal Voice, Voice Control, Live Captions) to fold in opportunistically.
+
+---
+
+## 0. What this document is
+
+The three companion docs each answer "what could we build and where does it plug in." None of them answers **"in what order do we build it, and where does the road genuinely fork?"** That is this document.
+
+I was given license to make the consequential calls. I have. This roadmap is **opinionated by default** — it states a single recommended path for every decision — and only forks where a wrong pick would be expensive to unwind later. There are exactly **three such forks** (§7). Everything else is a straight line.
+
+Design invariant threaded through every phase: **the `aos` CLI/manifest contract never changes.** Backend selection, capture, dictation, and trigger UX all ride on seams that already exist (`voice://<provider>/<id>` URIs, the daemon event bus `voice` service, the broker permission enum, Sigil's radial-menu overlay). We are *finishing seams the codebase already reserved*, not inventing new command surface.
+
+---
+
+## 1. The end-state ambition (so the phasing has a target)
+
+agent-os today can only *speak*, and only in the system voice. The ambition these three docs collectively point at is a **full-duplex-capable, local-first, pluggable voice I/O layer**:
+
+- **Output:** high-quality on-device TTS (Kokoro first), selectable per-utterance, with a distinct "system acknowledging you" voice vs. "agent talking to you" voice.
+- **Input:** hands-free wake ("Hey Sigil") *and* hands-on (hold-spacebar) triggers, feeding a half-duplex dictation state machine that transcribes on-device.
+- **Feedback:** a bus-driven sound/voice hook system so any app (Sigil first) can react to `voice.*` events with cue sounds or spoken lines.
+- **Ownership discipline:** privileged facts (mic/speech permission) stay in the `./aos` broker; *policy* (what to say, when to listen, which sound to play) stays in Track 2 apps.
+
+The phasing below is ordered so that **each phase ships independent user value** and de-risks the next. You could stop after any phase and have something coherent.
+
+---
+
+## 2. Phase map at a glance
+
+| Phase | Theme | Ships value even if we stop here | Depends on | Fork? |
+|---|---|---|---|---|
+| **0** | Foundation: finish the output seam | Higher-quality `aos say` / `tell human` voice | — | — |
+| **1** | Warm TTS service | Sub-2s local TTS, `tell human` feels instant | 0 | **Fork B** (§7.2) |
+| **2** | Broker permissions for input | Mic + Speech Recognition grants exist & probe cleanly | — (parallelizable with 0/1) | — |
+| **3** | Trigger + capture (hands-on first) | Hold-spacebar dictation into any app | 2 | **Fork A** (§7.1) |
+| **4** | Wake word + dictation state machine | "Hey Sigil" hands-free dictation | 3 | — |
+| **5** | Feedback hooks + ephemeral menu | Full Sigil voice experience; cue sounds; live-listening overlay | 1, 4 | — |
+| **∞** | Full-duplex (stretch) | Barge-in / interruptible agent speech | 5 | **Fork C** is orthogonal (§7.3) |
+
+Phases 0–1 are the **TTS track**. Phases 2–4 are the **STT/trigger track**. They are independent until Phase 5 joins them, so a two-person split (one per track) is natural and the tracks only need to agree on the `voice.*` event-name vocabulary (§6).
+
+---
+
+## 3. Phase 0 — Finish the output seam (TTS, correctness-first)
+
+**Goal:** replace "system voice only" with "pluggable provider," proving it with Kokoro via a subprocess-per-call runner. Latency is explicitly *not* the goal yet — correctness and voice quality are.
+
+**Scope (exactly the smallest-viable list from the Kokoro doc §7):**
+1. Add `SpeakableVoiceProvider: VoiceProvider` to [`src/voice/provider.swift`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/src/voice/provider.swift) — additive; `SystemVoiceProvider` and `ElevenLabsStubProvider` are untouched.
+2. New `src/voice/providers/kokoro.swift` conforming to it; hardcoded en-US/en-GB catalog, `speak_supported: true`, gated availability.
+3. Register in [`VoiceRegistry.defaultProviders()`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/src/voice/registry.swift#L178-L182) (currently `[SystemVoiceProvider(), ElevenLabsStubProvider()]`), gated on an opt-in flag; add `speakableProvider(named:)`.
+4. Branch on resolved `VoiceRecord.provider` at the **two** call sites — `SpeechEngine(voice:)` in [`say.swift:125`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/src/voice/say.swift#L125) and `announce()` around [`unified.swift:3096`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/src/daemon/unified.swift#L3071-L3105) — with a shared `playAudioFileAndWait(_:)` helper.
+5. `scripts/kokoro_say.py` subprocess runner.
+6. `tests/say-kokoro-backend.sh` using a stub provider (same pattern as `AOS_VOICE_TEST_PROVIDERS=mock`), so **CI never needs the real Kokoro package**.
+
+**Opinionated calls I'm making here:**
+- **Keep the `system` path on `NSSpeechSynthesizer` forever.** Do *not* migrate system voices to the file-synthesize-then-play path. `NSSpeechSynthesizer` already owns blocking, the cancel-key `CGEventTap` ([`say.swift:132`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/src/voice/say.swift#L132)), and delegate completion. Rewriting that for zero quality gain is pure risk.
+- **Selection rides on the existing config field, not a new flag.** `config.voice.voice = "voice://kokoro/af_heart"` already round-trips through `aos config` ([`config.swift`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/src/shared/config.swift)). No manifest/CLI change. An `AOS_TTS_BACKEND=kokoro` env override is a dev-ergonomics convenience only.
+- **`playAudioFileAndWait` = `AVAudioPlayer`, not an `afplay` subprocess.** Staying in-process gives real completion callbacks (matching `--wait` semantics) and avoids a second process spawn per utterance. `afplay` is the fallback only if an AVFoundation link is undesirable in the standalone `aos say` binary.
+
+**Exit criteria:** `aos say --voice voice://kokoro/af_heart "hello"` produces Kokoro audio; every existing system-voice test still passes untouched; `aos voice list` shows Kokoro voices as unreachable (not crashing) when the runner isn't installed.
+
+**Known wart accepted on purpose:** cold model load makes this >1–2s per call. That's fine — Phase 0 exists to validate the *seam and the voice*, and Phase 1 fixes latency.
+
+---
+
+## 4. Phase 1 — Warm TTS service (hit the latency target)
+
+**Goal:** get Kokoro utterances to the ~1–2s target by loading the model once and keeping it warm. This is where **Fork B** (§7.2) lives — *who owns the warm process*.
+
+**Recommended path (Fork B → option 1, daemon-managed):** a small long-lived local Kokoro service (Python, bare Unix-socket loop or FastAPI) that the daemon starts/stops exactly the way it already manages `speechEngine` via `initSpeechEngine()` / `stopSpeechEngine()` ([`unified.swift:3071-3105`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/src/daemon/unified.swift#L3071-L3105)), keyed off the `voice.backend` toggle. This matches the README's own "daemon owns TTS" split and reuses the daemon's existing socket-service machinery.
+
+**The consequence that makes this a fork, not a detail:** `aos say` today is deliberately daemon-independent — `08-say.json` sets `auto_starts_daemon: false`, so it runs as a fresh process per call ([`manifests/commands/source/aos/08-say.json`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/manifests/commands/source/aos/08-say.json)). Warm loading only helps `aos say` if it routes to the daemon-owned service for **non-system backends specifically** — which means changing that "doesn't need the daemon" property for the Kokoro path. That is an architectural change with a real blast radius, so it's a documented fork rather than a silent decision (see §7.2 for the alternative).
+
+**Exit criteria:** warm `tell human` / `announce()` Kokoro utterances land under 2s wall-clock for short strings; `aos say` Kokoro path either meets the target (if routed to daemon) or is explicitly documented as "cold unless daemon warm" (if not).
+
+---
+
+## 5. Phase 2 — Broker permissions for input (unblocks all of STT)
+
+**Goal:** acquire and probe the two TCC classes the whole input side needs, *before* any capture code exists. Fully parallelizable with Phases 0–1.
+
+**This is legitimately broker-owned work, not Track 2.** [ADR 0015](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/docs/adr/0015-aos-tcc-capability-broker-boundary.md)'s Swift Change Gate lists "a new TCC permission class" as an *accepted* reason to touch the broker. Today `PermissionPromptKind` has exactly four cases — `accessibility`, `screenRecording`, `listenEvent`, `postEvent` ([`operator.swift:404`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/src/commands/operator.swift#L404)) — and **none touch the microphone**.
+
+**Scope:**
+1. Two new `PermissionPromptKind` cases: `microphone` (`AVCaptureDevice.requestAccess(for: .audio)`) and `speechRecognition` (`SFSpeechRecognizer.requestAuthorization`), following the exact shape of the existing four.
+2. Add `NSMicrophoneUsageDescription` + `NSSpeechRecognitionUsageDescription` to wherever the shipped binary's `Info.plist` is generated — **note the loose end from the Sigil doc: no `Info.plist`/`.entitlements` exists in the repo yet**, so this phase includes standing that up (and auditing `com.apple.security.device.audio-input` if the binary is sandboxed/notarized).
+3. `aos __permissions prompt microphone --json` / `speech-recognition --json` probe paths.
+
+**Opinionated call:** both grants are held by the **unified `./aos` broker identity**, never a separate helper binary — consistent with ADR 0015's "one permissioned broker binary" principle and answering open-question #1 in the Sigil doc. A separate helper would fragment TCC identity and re-prompt users confusingly.
+
+**Exit criteria:** `aos __permissions prompt microphone --json` triggers the real macOS prompt and reports granted/denied; same for speech-recognition; on-device availability is *probed, not assumed* (it isn't guaranteed for every locale).
+
+---
+
+## 6. Phases 3–4 — Trigger + capture + dictation (Track 2, Sigil-owned)
+
+These realize Concepts A/B from the Sigil doc. Per the Platform Dogfood Boundary, **everything downstream of "permission granted" is Sigil product behavior**; the daemon only delivers `voice.*` events.
+
+**Shared vocabulary both tracks must agree on (freeze this early):** the `voice` service is already declared in the event schema ([`shared/schemas/daemon-event.md`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/shared/schemas/daemon-event.md), line 18 lists `"voice"` as a valid `service`) but has **zero events defined** — a ready-made namespace. Freeze these names before either track writes code:
+
+```
+voice.wake_detected            { source: "phrase" | "hotkey" }
+voice.dictation_opened         { }
+voice.dictation_closed_send    { reason: "phrase"|"key_release"|"explicit_trigger"|"timeout" }
+voice.dictation_closed_cancel  { reason: ... }
+```
+
+### Phase 3 — Hands-on trigger first (hold-spacebar)
+
+**Ship the cheap, no-ML path first.** A `CGEventTap` timing key-down→key-up (the tap scaffolding is already proven in [`input-safety-hotkeys.swift`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/src/perceive/input-safety-hotkeys.swift) and the three existing cancel-speech taps). This validates the entire dictation state machine **without a wake-word model**. This is where **Fork A** (§7.1) — the STT engine choice — must be resolved, because Phase 3 is the first phase that actually transcribes.
+
+### Phase 4 — Wake word + full state machine
+
+Add the always-listening keyword spotter (`voice.wake_detected { source: "phrase" }`) as a small Sigil-owned helper, and complete the four-exit half-duplex state machine (`IDLE → LISTENING → SEND|CANCEL`), including the "silence resolves the ambiguity" pomodoro timeout — the genuinely clever idea in the Sigil doc worth preserving verbatim.
+
+**Opinionated call:** wake-word spotting uses a lightweight local keyword model (openWakeWord-style) on raw buffers, **not** continuous `SFSpeechRecognizer`. Continuous heavy STT purely for wake detection is wasteful and adds latency exactly where users won't tolerate it.
+
+---
+
+## 7. The three genuine forks
+
+Everything above is a straight recommendation. These three are where I'm explicitly *not* collapsing the decision, because the wrong pick is expensive to reverse.
+
+### 7.1 Fork A — STT engine: Apple Speech framework vs. bundled Whisper/Parakeet
+
+Resolved at **Phase 3** (first transcription).
+
+```
+                    ┌─ Path A1: Apple SpeechAnalyzer / SFSpeechRecognizer
+Phase 3 STT engine ─┤     + zero dependency, ships with macOS, small binary
+                    │     + on-device mode (requiresOnDeviceRecognition = true)
+                    │     − needs the SEPARATE Speech Recognition TCC prompt (2 prompts total)
+                    │     − quality/locale coverage is Apple's, not ours to tune
+                    │
+                    └─ Path A2: bundled local Whisper/Parakeet (FreeFlow/OpenWhispr pattern)
+                          + ONLY needs Microphone TCC (skips Speech Recognition prompt entirely)
+                          + full control over model quality; both MIT Tier-1 refs chose this
+                          − larger binary + a model-management/download story
+                          − we own the ASR quality bar
+```
+
+**My lean:** **A1 (Apple Speech) for the first shippable**, because it gets Phase 3 working with zero model-management story and the smallest binary, and `requiresOnDeviceRecognition = true` keeps it local. Revisit A2 if Apple's on-device quality/locale coverage proves inadequate — the `SpeakableVoiceProvider`-style seam means the ASR backend can be swapped without touching the state machine. This is a real fork (not a detail) because it changes the **permission surface** (one prompt vs. two) and the **binary/distribution story**, both of which are hard to walk back once shipped and documented to users.
+
+### 7.2 Fork B — Warm TTS service ownership: daemon-managed vs. standalone
+
+Resolved at **Phase 1**.
+
+```
+                       ┌─ Path B1: daemon-managed service (RECOMMENDED)
+Phase 1 warm service ──┤     + reuses initSpeechEngine/stopSpeechEngine lifecycle; "one process owns the model"
+                       │     + fits README's "daemon owns TTS" split
+                       │     − forces aos say (auto_starts_daemon:false) to route through daemon for Kokoro
+                       │
+                       └─ Path B2: standalone local service (both aos say + daemon are clients)
+                             + preserves aos say's "doesn't need the daemon" property
+                             + lower blast radius on existing behavior
+                             − duplicates warm-up outside daemon lifecycle; two owners of one model
+```
+
+**My lean:** **B1 (daemon-managed)** — it's the only option that both hits the latency target *and* matches the project's stated architecture. But it's a fork because it changes `aos say`'s daemon-independence for the Kokoro path, and if the maintainer values that independence highly, B2 is the escape hatch. Decide before writing the warm service, because the two shapes share almost no code.
+
+### 7.3 Fork C — Cross-platform vs. macOS-native UX (orthogonal, product-level)
+
+This is the open question the maintainer's own [PR comment](https://github.com/michaelblum/agent-os/pull/589#issuecomment-4919428700) ended on ("cross-platform support or staying as close as possible to Wispr Flow's UX on macOS?"), and Sigil-doc open-question #7. It's orthogonal to the phase order — it colors *how* Phases 3–5 are built, not *when*.
+
+```
+              ┌─ Path C1: macOS-native (FreeFlow, Tier-1 MIT, mac-only reference)
+Product reach ┤     + tightest integration with the TCC/AX/CGEvent stack we already depend on
+              │     + smaller surface, faster to feature-parity with Wispr Flow UX
+              │     − no Windows/Linux story
+              │
+              └─ Path C2: cross-platform-ready (OpenWhispr, Tier-1 MIT, cross-platform)
+                    + Windows/Linux reach from day one
+                    − everything in agent-os today (CGEventTap, AX API, TCC broker) is mac-specific;
+                      cross-platform would fight the entire existing foundation
+```
+
+**My lean:** **C1 (macOS-native)** for anything on this roadmap. agent-os's entire foundation — the AX API element resolution, `CGEventTap`, the TCC broker — is macOS-specific. Bolting cross-platform onto the *voice* layer while the rest of the OS stays mac-only buys reach the product can't actually use yet. Both FreeFlow (C1) and OpenWhispr (C2) are Tier-1 MIT and license-clear to learn from, so **this is purely a product-reach decision, not a licensing constraint** — which is exactly why it's the maintainer's call, not mine to hard-code.
+
+**Blocking upstream dependency for both A2 and either C path:** agent-os has **no `LICENSE` file at the repo root** (verified). Tier-1 MIT code can only be *vendored/adapted* — as opposed to merely read for inspiration — once agent-os declares its own compatible license. That decision sits upstream of any code-copying in Phase 3+.
+
+---
+
+## 8. Phase 5 — Feedback hooks + ephemeral menu (join the tracks)
+
+With warm TTS (Phase 1) and dictation events (Phase 4) both live, Concept C/D become small:
+
+- **Resurrect `feedback.sound`.** It's a config `Bool` defaulting `false` ([`config.swift`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/src/shared/config.swift), the `case "feedback.sound"` handler exists) with **no `NSSound`/`afplay` behind it** — a stub built for exactly this. Wire it to a Sigil-side, bus-driven response registry keyed by `voice.*` event names. `kind: "tts"` entries call the Phase-1 Kokoro path with a *distinct* `voice://` URI, so "I'm listening, Michael!" speaks in a different voice than the agent's normal replies.
+- **Add `voice.wake_detected` as a second radial-menu trigger.** Today `sigil-radial-menu.json`'s `openAnimation.trigger` is `avatar-click` only; the `activationTransition` fade pipeline is already trigger-agnostic ([`apps/sigil/renderer/radial-menu/`](https://github.com/michaelblum/agent-os/tree/1c8dc81a014e534651c95c3c763cafa539de2799/apps/sigil/renderer/radial-menu)). The one real change: feed a live VAD amplitude signal into the opacity interpolation so the overlay "listens back" (brightens on input, fades on silence) instead of running a one-shot timer.
+
+**Opinionated call:** sound-hook config lives in **Sigil's own config** (the `sigil/agents/<id>.md` wiki-doc pattern), not a new daemon-level schema — answering Sigil open-question #4. The daemon delivers events; policy is app-owned.
+
+---
+
+## 9. Phase ∞ — Full-duplex (honest stretch)
+
+Barge-in requires real-time echo cancellation (mic runs while TTS plays). **Don't build custom DSP first.** Spike whether `AVAudioEngine`'s voice-processing I/O unit (`setVoiceProcessingEnabled(true)`) — which Apple ships for VoIP — is good enough out of the box. If not, half-duplex (Phase 4) is a perfectly good *permanent* answer, not a failure. This is intentionally last and intentionally optional.
+
+---
+
+## 10. Sequencing summary & parallelization
+
+- **Two independent tracks** until Phase 5: TTS (0→1) and STT/trigger (2→3→4). Staff one owner each; they only need to agree on the frozen `voice.*` event names (§6).
+- **Phase 2 has no dependencies** — start it immediately, in parallel with Phase 0, so permissions/plist scaffolding isn't on the critical path.
+- **Resolve Fork B before Phase 1 code**, **Fork A before Phase 3 code**. **Fork C** can be deferred until Phase 3 but should be settled before any Tier-1 code is *copied* (and that copying is itself gated on the repo declaring a LICENSE).
+- **Every phase ships standalone value** — you can stop after any one and have a coherent, non-half-built feature.
+
+## 11. Sources
+
+- Companion proposals in this PR (linked in header).
+- Verified code anchors at [`1c8dc81`](https://github.com/michaelblum/agent-os/tree/1c8dc81a014e534651c95c3c763cafa539de2799): [`src/voice/provider.swift`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/src/voice/provider.swift), [`src/voice/registry.swift`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/src/voice/registry.swift), [`src/voice/say.swift`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/src/voice/say.swift), [`src/voice/engine.swift`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/src/voice/engine.swift), [`src/daemon/unified.swift`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/src/daemon/unified.swift), [`src/commands/operator.swift`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/src/commands/operator.swift), [`src/shared/config.swift`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/src/shared/config.swift), [`shared/schemas/daemon-event.md`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/shared/schemas/daemon-event.md), [`docs/adr/0015-aos-tcc-capability-broker-boundary.md`](https://github.com/michaelblum/agent-os/blob/1c8dc81a014e534651c95c3c763cafa539de2799/docs/adr/0015-aos-tcc-capability-broker-boundary.md).
+- Prior-art license survey: [PR #589 comment](https://github.com/michaelblum/agent-os/pull/589#issuecomment-4919428700); [FreeFlow (MIT)](https://github.com/zachlatta/freeflow), [OpenWhispr (MIT)](https://github.com/OpenWhispr/openwhispr).


### PR DESCRIPTION
## Summary

Analysis-only PR (no runtime code changes) proposing how to add a local, on-device, higher-quality TTS backend (Kokoro-82M first) behind `aos say` without changing its external CLI contract.

## What's inside

`docs/proposals/2026-07-08-kokoro-tts-backend-integration.md` covers:

- The full `aos say` call chain (manifest → `scripts/aos-say.mjs` → `__say` primitive → `src/voice/say.swift` → `SpeechEngine`/`NSSpeechSynthesizer`).
- The separate, persistent TTS path inside the daemon (`announce()` / `tell human`, `src/daemon/unified.swift`).
- Why the existing `VoiceProvider`/`VoiceRegistry` abstraction is already provider-agnostic for *discovery* (`voice://<provider>/<id>` URIs, `VoiceFilter.provider`) but not for *synthesis* — confirmed against the original voice-registry design doc, which explicitly deferred a real non-system synthesis path.
- A concrete, additive design: a new `SpeakableVoiceProvider` capability + `KokoroVoiceProvider`, dispatched at the two existing `SpeechEngine(...)` call sites based on the resolved voice's `provider`, with zero manifest/CLI-contract changes.
- A phased rollout (subprocess-per-call first for correctness, then a warm daemon-managed local Kokoro service to hit the 1–2s latency target), plus a concrete file-level change list and explicit non-goals for this first pass.
- Hardware fit review for Kokoro-82M vs. Qwen3-TTS vs. Chatterbox-TTS on an M1 Pro / 16 GB / macOS 26.5.1 machine.

## Non-goals

No Swift/runtime code is changed in this PR — it's a design/analysis document to align on the integration seam before implementation.
