### PR TITLE
perplexity-packaged-runtime: Info.plist/.entitlements spike (TCC-persistent signing for voice-I/O)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,8 @@ Default section order:
 - `experiences/AGENTS.md` governs experience manifests and app activation
   material.
 - `manifests/AGENTS.md` governs command and capability manifests.
+- `packaging/AGENTS.md` governs repo runtime packaging metadata such as
+  `Info.plist`, entitlements, and signing experiment inputs.
 - `packages/AGENTS.md` governs reusable JavaScript/package layers. Its current
   child is `packages/toolkit/AGENTS.md`, which further indexes `contracts/`,
   `controls/`, `panel/`, and `runtime/`.

--- a/build.sh
+++ b/build.sh
@@ -13,13 +13,20 @@ LOCK_PATH="${AOS_BUILD_LOCK_PATH:-$BUILD_DIR/aos-build.lock}"
 BUILD_MODE="dev"
 FORCE_BUILD=0
 RESTART_DAEMON=1
+PACKAGE_RUNTIME=0
+CODE_SIGN_IDENTIFIER="com.agentos.repo-aos"
+CODE_SIGN_IDENTITY="${AOS_CODESIGN_IDENTITY:--}"
+PACKAGING_DIR="$REPO_ROOT/packaging"
+PACKAGED_INFO_PLIST="$PACKAGING_DIR/Info.plist"
+PACKAGED_ENTITLEMENTS="$PACKAGING_DIR/aos.entitlements"
 
 usage() {
     cat <<'EOF'
-Usage: bash build.sh [--release] [--force] [--no-restart]
+Usage: bash build.sh [--release] [--package] [--force] [--no-restart]
 
 Default mode is a faster development build (`-Onone`).
 Use `--release` for optimized artifacts such as packaged app builds.
+Use `--package` to embed packaging/Info.plist and sign with packaging/aos.entitlements.
 EOF
 }
 
@@ -27,6 +34,9 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --release)
             BUILD_MODE="release"
+            ;;
+        --package)
+            PACKAGE_RUNTIME=1
             ;;
         --force)
             FORCE_BUILD=1
@@ -46,6 +56,19 @@ while [[ $# -gt 0 ]]; do
     esac
     shift
 done
+
+BUILD_VARIANT="$BUILD_MODE"
+if [[ $PACKAGE_RUNTIME -eq 1 ]]; then
+    BUILD_VARIANT="$BUILD_MODE+package"
+    if [[ ! -f "$PACKAGED_INFO_PLIST" ]]; then
+        echo "Missing packaged runtime Info.plist: $PACKAGED_INFO_PLIST" >&2
+        exit 1
+    fi
+    if [[ ! -f "$PACKAGED_ENTITLEMENTS" ]]; then
+        echo "Missing packaged runtime entitlements: $PACKAGED_ENTITLEMENTS" >&2
+        exit 1
+    fi
+fi
 
 SOURCES=()
 while IFS= read -r file; do
@@ -82,6 +105,15 @@ if [[ "$BUILD_MODE" == "release" ]]; then
 else
     SWIFTC_FLAGS=(-parse-as-library -Onone -o "$OUTPUT_PATH" -lsqlite3)
 fi
+if [[ $PACKAGE_RUNTIME -eq 1 ]]; then
+    SWIFTC_FLAGS=(
+        "${SWIFTC_FLAGS[@]}"
+        -Xlinker -sectcreate
+        -Xlinker __TEXT
+        -Xlinker __info_plist
+        -Xlinker "$PACKAGED_INFO_PLIST"
+    )
+fi
 
 codesign_available() {
     command -v codesign >/dev/null 2>&1
@@ -91,12 +123,20 @@ signature_valid() {
     if ! codesign_available; then
         return 0
     fi
-    codesign --verify "$OUTPUT_PATH" >/dev/null 2>&1
+    if [[ $PACKAGE_RUNTIME -eq 1 ]]; then
+        codesign --verify --strict "$OUTPUT_PATH" >/dev/null 2>&1
+    else
+        codesign --verify "$OUTPUT_PATH" >/dev/null 2>&1
+    fi
 }
 
 sign_output() {
     if codesign_available; then
-        if ! CODESIGN_OUTPUT="$(codesign --force --sign - --identifier com.agentos.repo-aos "$1" 2>&1)"; then
+        CODESIGN_ARGS=(--force --sign "$CODE_SIGN_IDENTITY" --identifier "$CODE_SIGN_IDENTIFIER")
+        if [[ $PACKAGE_RUNTIME -eq 1 ]]; then
+            CODESIGN_ARGS=("${CODESIGN_ARGS[@]}" --entitlements "$PACKAGED_ENTITLEMENTS")
+        fi
+        if ! CODESIGN_OUTPUT="$(codesign "${CODESIGN_ARGS[@]}" "$1" 2>&1)"; then
             printf '%s\n' "$CODESIGN_OUTPUT" >&2
             exit 1
         fi
@@ -138,7 +178,7 @@ play_rebuild_alert() {
 
 build_fingerprint() {
     {
-        printf 'mode %s\n' "$BUILD_MODE"
+        printf 'mode %s\n' "$BUILD_VARIANT"
         for input in "${INPUTS[@]}"; do
             printf 'file %s\n' "$input"
             shasum -a 256 "$input"
@@ -161,6 +201,9 @@ if [[ ${#SHARED_IPC[@]} -gt 0 ]]; then
     INPUTS+=("${SHARED_IPC[@]}")
     SWIFT_INPUTS+=("${SHARED_IPC[@]}")
 fi
+if [[ $PACKAGE_RUNTIME -eq 1 ]]; then
+    INPUTS+=("$PACKAGED_INFO_PLIST" "$PACKAGED_ENTITLEMENTS")
+fi
 CURRENT_FINGERPRINT="$(build_fingerprint)"
 NEEDS_BUILD=1
 NEEDS_SIGN=0
@@ -168,7 +211,7 @@ BINARY_REBUILT=0
 
 if [[ $FORCE_BUILD -eq 0 && -f "$OUTPUT_PATH" && -f "$MODE_FILE" ]]; then
     LAST_MODE="$(cat "$MODE_FILE")"
-    if [[ "$LAST_MODE" == "$BUILD_MODE" ]]; then
+    if [[ "$LAST_MODE" == "$BUILD_VARIANT" ]]; then
         if [[ -f "$FINGERPRINT_FILE" && "$(cat "$FINGERPRINT_FILE")" == "$CURRENT_FINGERPRINT" ]]; then
             NEEDS_BUILD=0
         elif [[ ! -f "$FINGERPRINT_FILE" ]] && ! runtime_inputs_newer_than_output; then
@@ -184,12 +227,12 @@ fi
 
 if [[ $NEEDS_BUILD -eq 0 && $NEEDS_SIGN -eq 0 ]]; then
     printf '%s\n' "$CURRENT_FINGERPRINT" > "$FINGERPRINT_FILE"
-    echo "Up to date: ./aos ($BUILD_MODE, $(du -h "$OUTPUT_PATH" | cut -f1 | xargs))"
+    echo "Up to date: ./aos ($BUILD_VARIANT, $(du -h "$OUTPUT_PATH" | cut -f1 | xargs))"
     exit 0
 fi
 
 if [[ $NEEDS_BUILD -eq 1 ]]; then
-    echo "Compiling aos ($BUILD_MODE)..."
+    echo "Compiling aos ($BUILD_VARIANT)..."
     TMP_OUTPUT="$(mktemp "$BUILD_DIR/aos.tmp.XXXXXX")"
     cleanup_tmp_output() {
         rm -f "$TMP_OUTPUT"
@@ -211,11 +254,11 @@ if [[ $NEEDS_BUILD -eq 1 ]]; then
     BINARY_REBUILT=1
     echo "Rebuilt: ./aos"
 else
-    echo "Signing aos ($BUILD_MODE)..."
+    echo "Signing aos ($BUILD_VARIANT)..."
     sign_output "$OUTPUT_PATH"
     "$OUTPUT_PATH" help --json >/dev/null
 fi
-printf '%s\n' "$BUILD_MODE" > "$MODE_FILE"
+printf '%s\n' "$BUILD_VARIANT" > "$MODE_FILE"
 printf '%s\n' "$CURRENT_FINGERPRINT" > "$FINGERPRINT_FILE"
 
 echo "Done: ./aos ($(du -h "$OUTPUT_PATH" | cut -f1 | xargs))"

--- a/build.sh
+++ b/build.sh
@@ -143,39 +143,6 @@ sign_output() {
     fi
 }
 
-play_rebuild_alert() {
-    if [[ "${AOS_BUILD_REBUILD_ALERT:-1}" == "0" ]]; then
-        return 0
-    fi
-
-    echo "Alert: repo-mode ./aos binary rebuilt; user must manually reset/regrant needed macOS TCC permissions before TCC-backed proof."
-
-    if [[ -n "${AOS_BUILD_REBUILD_ALERT_COMMAND:-}" ]]; then
-        "$AOS_BUILD_REBUILD_ALERT_COMMAND" >/dev/null 2>&1 || true
-        return 0
-    fi
-
-    local sound="${AOS_BUILD_REBUILD_ALERT_SOUND:-/System/Library/Sounds/Sosumi.aiff}"
-    local repeat="${AOS_BUILD_REBUILD_ALERT_REPEAT:-3}"
-    local volume="${AOS_BUILD_REBUILD_ALERT_VOLUME:-2}"
-    case "$repeat" in
-        ''|*[!0-9]*) repeat=3 ;;
-    esac
-
-    if [[ -x /usr/bin/afplay && -f "$sound" ]]; then
-        local i=0
-        while [[ $i -lt $repeat ]]; do
-            /usr/bin/afplay -v "$volume" "$sound" >/dev/null 2>&1 || break
-            i=$((i + 1))
-        done
-        return 0
-    fi
-
-    if command -v osascript >/dev/null 2>&1; then
-        osascript -e "beep $repeat" >/dev/null 2>&1 || true
-    fi
-}
-
 build_fingerprint() {
     {
         printf 'mode %s\n' "$BUILD_VARIANT"
@@ -263,7 +230,7 @@ printf '%s\n' "$CURRENT_FINGERPRINT" > "$FINGERPRINT_FILE"
 
 echo "Done: ./aos ($(du -h "$OUTPUT_PATH" | cut -f1 | xargs))"
 if [[ $BINARY_REBUILT -eq 1 ]]; then
-    play_rebuild_alert
+    echo "Note: TCC handoff alert is deferred until a live readiness check reports post-rebuild stale TCC."
 fi
 
 # Restart daemon if it's running as a service

--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -2384,6 +2384,14 @@ Consumers:
   `runtime_verdict` as the shared readiness/action-plan contract:
   `ready`, `phase`, `diagnosis`, `blockers`, `blocked_capabilities`, `notes`,
   `next_actions`, `ownership`, and `cleanup`.
+- When passive CLI permission checks are granted but the live daemon view
+  reports denied Accessibility or Input Monitoring after a rebuild,
+  `runtime_verdict.tcc_staleness` names the condition as
+  `post_rebuild_tcc_stale`, includes side-by-side `cli_passive` and
+  `daemon_live` booleans, includes the current runtime binary identity
+  (`path`, `mtime`, `cdhash` when available), and carries the manual reset
+  remedy. `aos ready --json` also exposes the same object at top-level
+  `tcc_staleness` for front-door agents.
 - When `runtime.ownership_state` is `"unmanaged"`, JSON exposes
   `runtime.owner_process` and `runtime_verdict.ownership.owner_process`.
   The process command line is either present as `command_line` or explicitly

--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -50,9 +50,10 @@ instead of raw `bash build.sh` unless `./aos` is missing or the build surface is
 itself under repair. The build path avoids rebuilding the TCC-owning repo-mode
 binary unless Swift runtime input content changed, the output is missing or in
 the wrong mode, or the caller passes `--force`. When it does rebuild, it emits a
-`Rebuilt: ./aos` marker and plays the configured system rebuild alert; stop
-before TCC-backed proof until the user manually resets/regrants the needed
-macOS permissions and `./aos ready --post-permission` is green. Use
+`Rebuilt: ./aos` marker but does not play the TCC alert. If a later live
+TCC-backed readiness check reports `post_rebuild_tcc_stale`, that command plays
+the three-chime handoff alert and the agent must end the current turn until the
+user manually resets/regrants TCC and replies `finished`. Use
 `./aos dev gh` for GitHub operations from repo
 sessions; it shells out to the authenticated local `gh` CLI and does not fall
 back to connector-backed GitHub tools.
@@ -725,9 +726,11 @@ runtime inputs, not mtime-based, and build-tooling edits alone do not replace
 the TCC-owning binary. No post-build hook automates TCC handling: build does not
 reset permissions, open System Settings, show a human-needed surface, write
 completed-build markers, or inject provider input. Repo-mode binary rebuilds
-are TCC-sensitive and intentionally rare; successful rebuilds play a system
-alert sound and require a user reset/regrant checkpoint before TCC-backed proof.
-After the user confirms the reset, verify with `./aos ready --post-permission`.
+are TCC-sensitive and intentionally rare; successful rebuilds only print
+`Rebuilt: ./aos`. The three-chime alert is deferred until a live readiness check
+observes `post_rebuild_tcc_stale`, then the agent must stop the turn and wait
+for the user to manually reset/regrant TCC. After the user replies `finished`,
+verify with `./aos ready --post-permission`.
 
 `capabilities` is read-only discovery over
 `docs/dev/agent-capabilities.json`. It lists or explains typed development
@@ -2329,13 +2332,13 @@ Consumers:
   and returns structured `phase`, `diagnosis`, `blockers`, `next_actions`, and
   `action_trace` fields for agents. Plain `ready` performs one short automatic
   daemon restart/recheck when it detects a daemon ownership mismatch or inactive
-  input tap, because those states commonly appear after a human refreshes macOS
-  privacy grants. Human-required Accessibility/Input Monitoring reset handoffs
-  should use `./aos permissions reset-runtime --mode repo` before Settings: it
-  stops the managed daemon, verifies `running=false`, then either runs a real
-  targeted TCC reset for a targetable runtime identity or reports targeted reset
-  unavailable for the bare repo binary. Manual Settings removal is fallback only
-  if that command reports targeted reset is unavailable or failed.
+  input tap with no permission blocker, because those states commonly appear
+  after a human refreshes macOS privacy grants. When passive CLI grants are
+  green but the live daemon reports denied Accessibility/Input Monitoring,
+  `ready` must not restart/recheck in a loop. It reports
+  `post_rebuild_tcc_stale`, plays the handoff alert once per binary identity,
+  returns a terminal handoff, and the agent ends the turn until the user replies
+  `finished` after manually resetting/regranting TCC.
   `--post-permission` is the explicit
   agent handoff check after the human has re-granted Accessibility or
   Input Monitoring access; it is bounded and reports the remaining blocker
@@ -2391,7 +2394,9 @@ Consumers:
   `daemon_live` booleans, includes the current runtime binary identity
   (`path`, `mtime`, `cdhash` when available), and carries the manual reset
   remedy. `aos ready --json` also exposes the same object at top-level
-  `tcc_staleness` for front-door agents.
+  `tcc_staleness` plus a top-level `terminal_handoff` telling agents to stop
+  the current turn, wait for the user signal `finished`, and then run
+  `./aos ready --post-permission`.
 - When `runtime.ownership_state` is `"unmanaged"`, JSON exposes
   `runtime.owner_process` and `runtime_verdict.ownership.owner_process`.
   The process command line is either present as `command_line` or explicitly
@@ -2399,7 +2404,14 @@ Consumers:
   `command_line_unavailable_reason`.
 - `aos status --json` exposes `runtime.input_tap` (full block) plus the
   legacy flat `runtime.input_tap_status` / `runtime.input_tap_attempts`.
-- `aos status` text mode includes `tap=<status>` in the one-line summary.
+- `aos status --json` also exposes top-level `readiness`, a compact projection
+  of `runtime_verdict` with `ready`, `status`, `phase`, `diagnosis`,
+  `ready_for_testing`, `ready_source`, `blocked_capabilities`, and any
+  `tcc_staleness` / `terminal_handoff` summary. This lets agents distinguish
+  recovered TCC/runtime readiness from unrelated overall status degradations
+  such as stale resource cleanup notes.
+- `aos status` text mode includes `readiness=<status>`, `ready=<bool>`, and
+  `tap=<status>` in the one-line summary.
 - `aos doctor --json` exposes top-level `ready_for_testing` and
   `ready_source`.
 - `aos service install`, `start`, and `restart` block-and-poll for up to 5s

--- a/docs/proposals/2026-07-08-packaged-runtime-infoplist-entitlements-findings.md
+++ b/docs/proposals/2026-07-08-packaged-runtime-infoplist-entitlements-findings.md
@@ -1,0 +1,177 @@
+# Packaged-Runtime `Info.plist` / `.entitlements` Findings
+
+- **Date tested:** 2026-07-08 EDT
+- **Machine:** macOS 26.5.1 (25F80), arm64, Apple M1 Pro
+- **Branch:** `perplexity-packaged-runtime-infoplist-entitlements-spike`
+- **Related proposal:** `docs/proposals/2026-07-08-packaged-runtime-infoplist-entitlements-spike.md`
+
+## Result
+
+The option A prototype works as an additive build path:
+
+```bash
+bash build.sh --package --force --no-restart
+```
+
+That path keeps the top-level `./aos` executable shape, embeds
+`packaging/Info.plist` into `__TEXT,__info_plist`, and signs with
+`packaging/aos.entitlements`. The default `build.sh` path remains un-packaged.
+
+This is a **go** as an interim build flag for embedding privacy usage strings
+and testing repo-mode identity. It is **not enough** to declare the launchd
+daemon TCC reset/regrant problem solved.
+
+## Implemented Prototype
+
+- `packaging/Info.plist`
+  - `CFBundleIdentifier=com.agentos.repo-aos`
+  - standard `CFBundle*` keys and `LSMinimumSystemVersion=26.0`
+  - `NSMicrophoneUsageDescription`
+  - `NSSpeechRecognitionUsageDescription`
+  - `NSAppleEventsUsageDescription`
+- `packaging/aos.entitlements`
+  - empty dictionary by design for this pass
+- `build.sh --package`
+  - adds linker flags for `-sectcreate __TEXT __info_plist`
+  - signs with `--entitlements packaging/aos.entitlements`
+  - keeps `--options runtime` deferred
+  - uses `AOS_CODESIGN_IDENTITY` when set, defaulting to the current ad-hoc `-`
+  - fingerprints `dev+package` separately from `dev`
+
+## Verification
+
+Passed:
+
+```bash
+bash -n build.sh
+plutil -lint packaging/Info.plist packaging/aos.entitlements
+bash build.sh --force --no-restart
+bash build.sh --package --force --no-restart
+codesign --verify --deep --strict --verbose=4 ./aos
+codesign -d --entitlements :- ./aos
+otool -s __TEXT __info_plist ./aos | ... | plutil -p -
+bash tests/build-signing.sh
+```
+
+The packaged binary reported:
+
+```text
+Identifier=com.agentos.repo-aos
+Signature=adhoc
+TeamIdentifier=not set
+Info.plist entries=12
+```
+
+The embedded plist round-tripped with the expected bundle id and usage strings.
+The entitlements readback was an empty plist dictionary.
+
+## TCC Persistence Proof
+
+CLI-side permission booleans survived ad-hoc CDHash changes:
+
+- packaged ad-hoc + entitlements: `CDHash=5fcc455e...`
+- ad-hoc + Hardened Runtime test signature: `CDHash=a3c73932...`
+- packaged rebuild through `build.sh --package --force --no-restart`:
+  `CDHash=591d8f62...`
+
+After those changes, `./aos permissions check --json` still reported:
+
+```json
+{
+  "accessibility": true,
+  "screen_recording": true,
+  "listen_access": true,
+  "post_access": true
+}
+```
+
+That is evidence that, for the foreground CLI path on this machine, fixed
+identifier + path + embedded plist can survive ad-hoc CDHash churn. A stable
+self-signed cert was not required for this CLI-side proof.
+
+The launchd-managed daemon proof did **not** pass. After:
+
+```bash
+./aos permissions reset-runtime --mode repo
+./aos permissions setup --once
+./aos ready --post-permission --json
+./aos ready --json
+```
+
+readiness remained:
+
+```text
+status=degraded
+diagnosis=daemon_tcc_grant_stale_or_missing
+blockers=accessibility,input_tap_not_active,input_monitoring_listen,input_monitoring_post
+```
+
+`reset-runtime` also reported:
+
+```text
+Targeted tccutil reset is unavailable for the bare repo ./aos binary because it is not a LaunchServices app bundle.
+```
+
+So option A improves the executable metadata, but it does not give repo-mode
+`./aos` the LaunchServices app identity needed for targeted reset/regrant
+handling.
+
+## Option A vs. Option B
+
+Option A is the right low-disruption prototype:
+
+- keeps `./aos` as a single executable
+- embeds the required mic, speech-recognition, and Apple Events usage strings
+- proves foreground CLI permissions can survive ad-hoc CDHash churn
+- leaves normal dev builds unchanged
+
+Option A limitations:
+
+- `mdls` still reports `kMDItemCFBundleIdentifier = (null)` and
+  `kMDItemContentType = public.unix-executable`
+- targeted `tccutil` reset remains unavailable for the bare executable
+- launchd-managed daemon readiness still sees stale/missing TCC grants
+
+Option B, a real `.app` bundle, is the likely follow-on for the daemon problem:
+
+- LaunchServices should recognize the bundle identity
+- targeted reset/regrant can operate on an app bundle instead of a raw Mach-O
+- the service/LaunchAgent path and relaunch logic must be updated deliberately
+
+Recommendation: keep option A as the branch prototype and use it to unblock
+usage-string validation. Do not claim it solves daemon TCC persistence. Open the
+follow-on implementation around option B if the product goal is stable daemon
+permission recovery.
+
+## Hardened Runtime
+
+Hardened Runtime was tested manually with:
+
+```bash
+codesign --force --sign - --identifier com.agentos.repo-aos \
+  --options runtime --entitlements packaging/aos.entitlements ./aos
+```
+
+`./aos permissions check --json` still preserved the CLI permission booleans.
+Adoption is deferred because the Kokoro/local-model direction has not yet been
+tested for dylib loading, mmap behavior, subprocess execution, or any required
+`com.apple.security.cs.*` exceptions.
+
+## Entitlements
+
+The entitlement file stays empty for this pass. Current `src/**` uses
+`NSAppleScript` for `aos do tell`, so the plist includes
+`NSAppleEventsUsageDescription`. There is not yet evidence that the
+non-sandboxed repo binary needs `com.apple.security.automation.apple-events`.
+
+Do not add sandbox, Apple Events, audio-input, or code-signing exception
+entitlements until a focused proof requires them.
+
+## Deferred
+
+- Live microphone / speech-recognition prompt test: no dictation code path has
+  landed yet, so this pass only proves the usage strings are embedded.
+- Self-signed and Developer ID signing: not needed for the foreground CLI proof;
+  daemon behavior points first to bundle shape, not certificate identity.
+- Notarization and distribution policy.
+- Option B `.app` bundle implementation and service/LaunchAgent migration.

--- a/docs/proposals/2026-07-08-packaged-runtime-infoplist-entitlements-spike.md
+++ b/docs/proposals/2026-07-08-packaged-runtime-infoplist-entitlements-spike.md
@@ -1,0 +1,120 @@
+# Packaged-Runtime `Info.plist` / `.entitlements` Spike
+
+- **Status:** Spike (analysis + scoped experiment) — no runtime behavior change intended
+- **Date:** 2026-07-08
+- **Decision trail:** unblocks the second item in the blocker table after `LICENSE` (commit `43365d5`, PR #589). LICENSE ✅ → **Info.plist/.entitlements 🔴 (this spike)**.
+- **Related:** PR #589 (`perplexity-voice-io-proposals`) — local TTS (`aos say`) + dictation (`aos listen`) + voice-trigger direction, which is what *adds* the microphone / speech-recognition permission surfaces this spike must anticipate.
+
+## Summary
+
+Today `aos` ships as a **bare, ad-hoc-signed Mach-O executable**, not an app bundle. `build.sh` compiles every `src/**/*.swift` with a single `swiftc -parse-as-library -o ./aos` invocation and signs it with `codesign --force --sign - --identifier com.agentos.repo-aos` — there is **no `Info.plist`, no `.entitlements`, no bundle, and no stable code-signing identity**. As a result:
+
+- Every rebuild produces a binary with a *new* ad-hoc signature, so macOS treats it as a new app and **silently drops previously-granted TCC permissions**. `build.sh` already ships an explicit `play_rebuild_alert()` warning the user to "manually reset/regrant needed macOS TCC permissions before TCC-backed proof." This is the core pain this spike targets.
+- The runtime already depends on **three TCC-gated surfaces** (Accessibility, Screen Recording, Input Monitoring), enforced via `ensureInteractivePreflight(...)` in `src/main.swift` and surfaced by the `__permissions` broker (`accessibility`, `screen_recording`, `listen_access`, `post_access`).
+- PR #589's dictation direction (`aos listen` as mic capture) and any local-model TTS will introduce **two more surfaces** — Microphone and Speech Recognition — which require `Info.plist` usage-description strings or the process will be **hard-killed by the OS** on first API touch, not merely denied.
+
+This spike is to **prove out a packaged runtime with a stable signing identity, an `Info.plist`, and an `.entitlements` file** that (a) makes TCC grants survive rebuilds, and (b) pre-declares the usage-description strings the voice-I/O roadmap needs. It is deliberately **additive and reversible**: the goal is a working experiment branch and a go/no-go recommendation, not a merged packaging pipeline.
+
+## Non-goals
+
+- No change to the `aos` CLI contract, command manifests, or any `src/**` runtime logic.
+- Not shipping notarization / Developer ID distribution — that is explicitly a *follow-on* once the bundle shape and entitlement set are proven (see Open Questions).
+- Not implementing the Kokoro/dictation features themselves — this spike only prepares the permission substrate they will land on.
+- No CI/release-automation work; the spike may hand-run `build.sh --release`.
+
+## Current-state findings (grounded in the tree at `main` @ `43365d5`)
+
+### Build & signing
+
+- `build.sh` → `swiftc … -o "$REPO_ROOT/aos"` produces a top-level executable (git-ignored via `/aos`). Modes: `--release` (`-O`) vs default dev (`-Onone`). Links `-lsqlite3`.
+- Signing is **ad-hoc**: `codesign --force --sign - --identifier com.agentos.repo-aos`. No `--entitlements` flag, no keychain identity, no `--options runtime` (hardened runtime).
+- `signature_valid()` only checks `codesign --verify`; there is no entitlement or identity assertion.
+- `play_rebuild_alert()` fires on every rebuild specifically because TCC bindings break — direct evidence of the problem.
+
+### Permission surfaces actually used today
+
+| Surface | TCC service | Where in code | `__permissions` key |
+| --- | --- | --- | --- |
+| Accessibility | `kTCCServiceAccessibility` | `AXIsProcessTrusted()` / `AXIsProcessTrustedWithOptions()` in `src/perceive/daemon.swift`, `src/perceive/capture-pipeline.swift` | `accessibility` |
+| Screen Recording | `kTCCServiceScreenCapture` | `CGPreflightScreenCaptureAccess()` / `CGRequestScreenCaptureAccess()` + `SCShareableContent` in `src/perceive/capture-pipeline.swift` | `screen_recording` |
+| Input Monitoring (listen) | `kTCCServiceListenEvent` | `CGEvent.tapCreate(...)` listen-only tap in `src/perceive/daemon.swift`, `src/daemon/unified.swift`, `src/voice/say.swift` | `listen_access` |
+| Input posting (post) | (paired with Accessibility for synthetic events) | `CGEvent` posting in `src/act/actions.swift` | `post_access` |
+
+`ensureInteractivePreflight(...)` in `src/main.swift` already gates `aos do …`, `aos see …` on these. The preflight/broker machinery is the natural consumer of a stable identity.
+
+### Permission surfaces the voice-I/O roadmap (#589) will add
+
+| Surface | TCC service | Required `Info.plist` key | Triggered by |
+| --- | --- | --- | --- |
+| Microphone | `kTCCServiceMicrophone` | `NSMicrophoneUsageDescription` | `aos listen` dictation (mic capture — *not* today's channel reader) |
+| Speech Recognition | `kTCCServiceSpeechRecognition` | `NSSpeechRecognitionUsageDescription` | on-device / `SFSpeechRecognizer`-style transcription, if used |
+
+> Note: today's `aos listen` (`manifests/commands/source/aos/12-listen.json`) is a **message-channel reader** and touches **no** audio/mic API. Mic + speech-recognition are strictly *future* surfaces the packaging must pre-declare so the dictation feature doesn't get OS-killed on first run.
+
+### `aos say` today
+
+`src/voice/say.swift` + `src/voice/engine.swift` use `NSSpeechSynthesizer` (system TTS) — this needs **no** entitlement. A local-model TTS (Kokoro) runs as compute in-process/subprocess and also needs no *new* TCC surface, but does need audio *output*, which is unrestricted. So the TTS side of #589 is entitlement-neutral; the **dictation side is what forces the `Info.plist`**.
+
+## Proposed spike work (the experiment)
+
+1. **Introduce a minimal `Info.plist`** (checked into the repo, e.g. `packaging/Info.plist`) with at least:
+   - `CFBundleIdentifier` = `com.agentos.repo-aos` (reuse the existing ad-hoc identifier so TCC continuity is preserved).
+   - `CFBundleExecutable`, `CFBundleName`, `CFBundleShortVersionString`, `CFBundleVersion`.
+   - `LSMinimumSystemVersion` (target M1 Pro / macOS 26.5.1 baseline from #589's hardware review).
+   - Usage-description strings for the surfaces we already touch and will touch: `NSMicrophoneUsageDescription`, `NSSpeechRecognitionUsageDescription` (pre-declared even if unused this pass), and — if macOS attributes AX/Screen-Recording prompts to the plist — appropriate rationale strings.
+2. **Introduce a minimal `.entitlements`** (e.g. `packaging/aos.entitlements`). Start from the *empty/minimal* set and add only what the runtime provably needs. Candidate keys to evaluate:
+   - `com.apple.security.device.audio-input` (mic, for dictation).
+   - `com.apple.security.automation.apple-events` (only if any AppleScript/AE path is used — audit first).
+   - Decide explicitly whether to adopt the **Hardened Runtime** (`codesign --options runtime`) now or defer; hardened runtime interacts with entitlements and with loading local model binaries/dylibs (Kokoro).
+3. **Decide the packaging shape.** Two options to prototype and compare:
+   - **(A) Embed `Info.plist` in the bare executable** via `-Xlinker -sectcreate __TEXT __info_plist packaging/Info.plist` in `build.sh`. Keeps the single-file `./aos` shape — lowest disruption.
+   - **(B) Produce a real `.app` bundle** (`aos.app/Contents/{MacOS/aos, Info.plist}`) as a `--release`/packaged output. More faithful to distribution but changes the artifact shape and invocation.
+   - **Recommendation to validate:** try (A) first — it may be enough to (i) give the process a real `Info.plist` for usage strings and (ii) pin identity — while keeping `./aos` as-is for dev.
+4. **Move signing to a stable identity.** Prototype signing with `--entitlements packaging/aos.entitlements` and evaluate whether ad-hoc (`--sign -`) with a *fixed identifier + embedded plist* is enough to make TCC grants survive rebuilds, or whether a self-signed / Developer ID cert is required. This is the **central hypothesis to test**.
+5. **Wire it into `build.sh` behind a flag** (e.g. `--package` or gated on `--release`) so dev builds stay fast and unchanged.
+6. **Update the `__permissions` / preflight narrative** only if the packaged identity changes what the broker should report (likely a docs/notes change, not logic).
+
+## Spike checklist (acceptance / exit criteria)
+
+Investigation:
+- [ ] Confirm the exact TCC services each current API maps to, and whether AX / Screen-Recording prompts are attributed to `CFBundleIdentifier` vs. the raw binary path on the target macOS (26.5.x).
+- [ ] Audit `src/**` for any Apple Events / AppleScript usage to decide if `com.apple.security.automation.apple-events` is needed.
+- [ ] Determine whether the current ad-hoc identifier already gives stable TCC identity, or whether every rebuild's re-sign is what breaks grants.
+
+Experiment:
+- [ ] Add `packaging/Info.plist` with bundle id `com.agentos.repo-aos` + usage strings (`NSMicrophoneUsageDescription`, `NSSpeechRecognitionUsageDescription`).
+- [ ] Add `packaging/aos.entitlements` with the minimal proven set.
+- [ ] Prototype packaging **option (A)** (embedded `__info_plist` section) in a `build.sh` flag; capture whether `codesign -d --entitlements -` and `mdls`/`otool -s __TEXT __info_plist` show the embedded plist.
+- [ ] Prototype packaging **option (B)** (`.app` bundle) far enough to compare, or record why (A) suffices.
+- [ ] Sign with `--entitlements` (+ decide on `--options runtime`) and verify with `codesign --verify --deep --strict` and `codesign -d --entitlements :-`.
+
+Proof (the payoff test):
+- [ ] **TCC-persistence test:** grant Accessibility + Screen Recording + Input Monitoring once, rebuild via the packaged path, and confirm grants **survive** (no re-prompt, `aos permissions check` stays `ready_for_testing`). This is the go/no-go signal.
+- [ ] **Usage-string test:** trigger a mic/speech-recognition code path (or a throwaway probe) and confirm the OS shows the declared rationale string instead of hard-killing the process for a missing `Info.plist` key.
+- [ ] Confirm dev build (`build.sh` with no packaging flag) is **unchanged** in speed and output.
+- [ ] Confirm `play_rebuild_alert()` can be safely quieted once grants persist (or document why it must stay).
+
+Deliverables:
+- [ ] Recommendation: option (A) vs (B), ad-hoc-stable-identity vs self-signed vs Developer ID, hardened-runtime yes/no.
+- [ ] File-level change list for the follow-on implementation PR.
+- [ ] Explicit list of anything deferred to notarization/distribution.
+
+## Concrete file-level change list (for the follow-on impl PR)
+
+- `packaging/Info.plist` — new.
+- `packaging/aos.entitlements` — new.
+- `build.sh` — add packaging flag; thread `--entitlements` (and optionally embedded `__info_plist` / `.app` assembly) into the sign step; keep dev path untouched.
+- `.gitignore` — ignore any packaged output dir (e.g. `/aos.app`, `dist/`) if option (B) is used (`dist/` already ignored).
+- `scripts/aos-permissions.mjs` / readiness notes — docs-level update only if the identity story changes broker output.
+- `docs/` — record the go/no-go decision (mirroring the #589 → LICENSE decision-trail pattern).
+
+## Open questions / risks
+
+- Does ad-hoc signing with a **fixed identifier + embedded plist** actually persist TCC grants across rebuilds, or does macOS key TCC on the full cdhash (which changes every build)? If the latter, a **stable self-signed cert in the login keychain** may be the minimum viable identity — that's the key risk to resolve early.
+- Hardened Runtime + loading a local Kokoro model (dylib / mmap'd weights / subprocess) may require `com.apple.security.cs.*` entitlements (e.g. `disable-library-validation`) — evaluate before committing to hardened runtime.
+- `.app` bundle (option B) changes how the daemon/service (`aos service`, LaunchAgent path in `scripts/aos-service.mjs`) locates and relaunches the executable — must be checked before adopting B.
+- Notarization is out of scope but the entitlement/identity choices here should not paint us into a corner for it.
+
+## Suggested branch
+
+`perplexity-packaged-runtime-infoplist-entitlements-spike` (mirrors the `perplexity-…` proposal-branch convention used by #589).

--- a/docs/proposals/2026-07-08-runtime-tcc-staleness-telemetry-task.md
+++ b/docs/proposals/2026-07-08-runtime-tcc-staleness-telemetry-task.md
@@ -1,0 +1,48 @@
+# Follow-on task: make the post-rebuild stale-TCC condition self-documenting at run-time
+
+**For:** the local flagship session on `LM-170585.local` (repo `/Users/Michael/Code/agent-os`).
+**Branch:** `perplexity-packaged-runtime-infoplist-entitlements-spike` (PR #590).
+**This is NOT a packaging task.** Option A (bare in-repo binary + embedded `Info.plist`) is the accepted dev outcome. Do not pursue an `.app` bundle, a signing cert, or enterprise whitelisting — those are release-time concerns, deferred by design.
+
+## The condition (now correctly understood)
+
+The core `aos` binary is intentionally minimal, stable infrastructure — own TCC permissions, run the daemon, little else — so rebuilds are rare by design. But when it *is* rebuilt, TCC still has the **previous** binary registered. The result is the known trap:
+
+- **Passive checks look green.** `aos permissions check --json` reports `accessibility/screen_recording/listen_access/post_access = true` because TCC still holds the stale registration.
+- **A live privileged request fails.** The daemon's actual attempt to acquire the event tap / AX access fails against the rebuilt binary.
+
+This is exactly what the spike hit: `aos ready` went `degraded` with `diagnosis=daemon_tcc_grant_stale_or_missing`. That was **not** an Option A failure — it is this expected post-rebuild staleness. The accepted human-in-the-loop remedy is unchanged: detect → stop the turn → tell the user "please reset TCC permissions" → user resets → user confirms → continue.
+
+## Why this is a telemetry problem
+
+The divergence is *already computed* but not *communicated as this specific, understood condition*. In `scripts/lib/aos-readiness.mjs`, `readyDiagnosis(...)` derives `daemon_tcc_grant_stale_or_missing` precisely from the passive-vs-live gap:
+
+```js
+if (daemon && ((daemon.permissions.accessibility === false && permissions.accessibility)
+    || daemon.inputTap.listenAccess === false
+    || daemon.inputTap.postAccess === false)) {
+  return 'daemon_tcc_grant_stale_or_missing';
+}
+```
+
+That `daemon says false while CLI passive says true` branch **is** the passive-green / live-fail signature. The runtime should name it as such and hand back the exact remedy, so neither a human nor a remote agent has to reverse-engineer "checks are green but the live test fails."
+
+## What to fix (telemetry / run-time documentation — no behavior change to permissions themselves)
+
+1. **Name the condition explicitly in the readiness output.** When the passive CLI view says granted but the daemon's live view says denied, surface a first-class, human-readable reason — e.g. `post_rebuild_tcc_stale` (or annotate the existing `daemon_tcc_grant_stale_or_missing` diagnosis) — that literally states: "TCC has a stale registration for a previous binary; passive checks pass but live privileged access fails after a rebuild."
+2. **Emit the passive-vs-live disagreement as structured telemetry.** Include both views side by side (CLI passive booleans vs. daemon live booleans, plus the current binary CDHash/mtime if available) so the mismatch is legible in the JSON, not just inferred. Consider recording the binary identity that TCC last saw vs. the one now running.
+3. **Attach the accepted remedy inline.** The degraded response should carry the manual-reset next action (reset TCC → regrant → confirm), consistent with the existing `readyNextActions` / `post-permission` flow, so the "stop the turn and ask the user to reset" handling is driven by the telemetry rather than tribal knowledge.
+4. **Cover it with a test** in `tests/aos-readiness-composition.test.mjs`: given `daemon.inputTap.listenAccess === false` while CLI passive `listen_access === true`, assert the new named reason + remedy are present in the readiness response.
+
+Relevant files: `scripts/lib/aos-readiness.mjs` (`readyDiagnosis`, `readyPhase`, `readyNextActions`), `scripts/lib/experience-runtime-readiness.mjs` (the "not reporting ready from passive service status" note), `src/shared/input-tap-health.swift` (`input_tap_not_active` / live-tap health), `scripts/aos-ready.mjs`, and `tests/aos-readiness-composition.test.mjs`.
+
+## Out of scope
+
+- No `.app` bundle, no LaunchServices identity work, no signing cert, no notarization, no MDM/whitelisting. Release-time only.
+- Do not try to make TCC auto-persist across rebuilds. The manual reset is the accepted flow; this task only makes the run-time telemetry document that clearly.
+
+## Definition of done
+
+- `aos ready --json` (and the daemon health surface) clearly identify the post-rebuild stale-TCC condition by name, expose the passive-vs-live disagreement as structured data, and include the manual-reset remedy.
+- New test asserts the passive-green / live-fail case produces the named reason + remedy.
+- Push to the branch; note it in PR #590. Keep #590 draft.

--- a/packaging/AGENTS.md
+++ b/packaging/AGENTS.md
@@ -1,0 +1,37 @@
+@../AGENTS.md
+
+# Packaging
+
+## Purpose
+
+`packaging/` contains repo-runtime packaging metadata used by build and signing
+experiments, including the embedded runtime `Info.plist` and entitlements file.
+
+## Ownership
+
+- `Info.plist` owns bundle identity and privacy usage-description strings for
+  the repo-mode `aos` runtime.
+- `aos.entitlements` owns the entitlement set used by packaged runtime signing.
+
+## Local Contracts
+
+- Keep the default development build path opt-in free; packaged behavior must
+  stay behind an explicit build flag until promoted by a durable decision.
+- Keep `CFBundleIdentifier` aligned with the repo runtime signing identifier.
+- Keep entitlements minimal and evidence-backed. Do not add broad automation,
+  sandbox, or hardened-runtime exceptions without a proof note or owning doc.
+
+## Work Guidance
+
+- Prefer additive packaging experiments that preserve the top-level `./aos`
+  invocation unless a decision record adopts a bundle shape.
+- Record option comparisons and TCC proof results in `docs/proposals/` or a
+  narrower durable owner before treating packaging metadata as release policy.
+
+## Verification
+
+- Run `plutil -lint packaging/Info.plist packaging/aos.entitlements` after
+  metadata edits.
+- Run the focused build-signing test after `build.sh` or signing metadata edits.
+
+## Child DOX Index

--- a/packaging/Info.plist
+++ b/packaging/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>aos</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.agentos.repo-aos</string>
+	<key>CFBundleName</key>
+	<string>aos</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1.0</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>26.0</string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>AOS sends Apple Events only when you run automation actions such as aos do tell.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>AOS uses microphone input only when you run voice dictation commands.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>AOS uses speech recognition only when transcribing dictated input you explicitly request.</string>
+</dict>
+</plist>

--- a/packaging/aos.entitlements
+++ b/packaging/aos.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/scripts/aos-ready.mjs
+++ b/scripts/aos-ready.mjs
@@ -53,6 +53,7 @@ function buildReadyResponse(startup, actionTrace, mode, prefix) {
     startup,
     runtime: facts.runtime,
     runtime_verdict: verdict,
+    tcc_staleness: verdict.tcc_staleness,
     permissions: facts.permissions,
     permissions_setup: facts.setup,
     blocked_capabilities: verdict.blocked_capabilities,

--- a/scripts/aos-ready.mjs
+++ b/scripts/aos-ready.mjs
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {
   compactProcessDetail,
@@ -54,6 +57,7 @@ function buildReadyResponse(startup, actionTrace, mode, prefix) {
     runtime: facts.runtime,
     runtime_verdict: verdict,
     tcc_staleness: verdict.tcc_staleness,
+    terminal_handoff: verdict.terminal_handoff,
     permissions: facts.permissions,
     permissions_setup: facts.setup,
     blocked_capabilities: verdict.blocked_capabilities,
@@ -62,6 +66,99 @@ function buildReadyResponse(startup, actionTrace, mode, prefix) {
     action_trace: actionTrace,
     notes: verdict.notes,
   };
+}
+
+function stateDir(mode) {
+  const root = process.env.AOS_STATE_ROOT
+    ? path.resolve(process.env.AOS_STATE_ROOT)
+    : path.join(os.homedir(), '.config', 'aos');
+  return path.join(root, mode);
+}
+
+function staleTccAlertMarkerPath(mode) {
+  return path.join(stateDir(mode), 'post-rebuild-tcc-handoff-alert.json');
+}
+
+function staleTccAlertKey(staleness) {
+  const identity = staleness?.binary_identity ?? {};
+  return [
+    identity.path,
+    identity.cdhash,
+    identity.mtime_ms,
+    identity.size_bytes,
+  ].filter((part) => part !== undefined && part !== null && part !== '').join('|');
+}
+
+function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function commandExists(file) {
+  try {
+    fs.accessSync(file, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function playTccHandoffAlertSound() {
+  if (process.env.AOS_TCC_HANDOFF_ALERT_COMMAND) {
+    spawnSync('/bin/sh', ['-c', process.env.AOS_TCC_HANDOFF_ALERT_COMMAND], { stdio: 'ignore' });
+    return;
+  }
+
+  const sound = process.env.AOS_TCC_HANDOFF_ALERT_SOUND || '/System/Library/Sounds/Sosumi.aiff';
+  const repeat = parsePositiveInt(process.env.AOS_TCC_HANDOFF_ALERT_REPEAT, 3);
+  const volume = process.env.AOS_TCC_HANDOFF_ALERT_VOLUME || '2';
+  if (commandExists('/usr/bin/afplay') && fs.existsSync(sound)) {
+    for (let i = 0; i < repeat; i += 1) {
+      const result = spawnSync('/usr/bin/afplay', ['-v', volume, sound], { stdio: 'ignore' });
+      if (result.status !== 0) break;
+    }
+    return;
+  }
+
+  if (commandExists('/usr/bin/osascript')) {
+    spawnSync('/usr/bin/osascript', ['-e', `beep ${repeat}`], { stdio: 'ignore' });
+  }
+}
+
+function maybePlayTccHandoffAlert(response, mode) {
+  const handoff = response.terminal_handoff;
+  const staleness = response.tcc_staleness;
+  if (!handoff?.terminal || staleness?.id !== 'post_rebuild_tcc_stale') return undefined;
+
+  const markerPath = staleTccAlertMarkerPath(mode);
+  const key = staleTccAlertKey(staleness);
+  if (!key) return { status: 'skipped', reason: 'missing_binary_identity', marker_path: markerPath };
+  if (process.env.AOS_TCC_HANDOFF_ALERT === '0') {
+    return { status: 'skipped', reason: 'disabled', marker_path: markerPath, key };
+  }
+
+  try {
+    const existing = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
+    if (existing.key === key) {
+      return { status: 'skipped', reason: 'already_alerted_for_binary_identity', marker_path: markerPath, key };
+    }
+  } catch {
+    // Missing or invalid marker: play the alert and replace it.
+  }
+
+  playTccHandoffAlertSound();
+  try {
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+    fs.writeFileSync(markerPath, `${JSON.stringify({
+      key,
+      alerted_at: new Date().toISOString(),
+      target_path: staleness.remedy?.target_path,
+      cdhash: staleness.binary_identity?.cdhash,
+    }, null, 2)}\n`);
+  } catch {
+    return { status: 'played', marker_status: 'write_failed', marker_path: markerPath, key };
+  }
+  return { status: 'played', marker_status: 'written', marker_path: markerPath, key };
 }
 
 function serviceCommandString(mode, prefix, action) {
@@ -202,6 +299,17 @@ function runReadyCleanRepair(startup, actionTrace, mode, prefix) {
 
 function printReadyHumanHandoff(response, mode, prefix) {
   if (response.phase !== 'human_required') return;
+  if (response.terminal_handoff?.reason === 'post_rebuild_tcc_stale') {
+    process.stdout.write('\n');
+    process.stdout.write('Human action needed:\n');
+    process.stdout.write('Post-rebuild TCC reset checkpoint:\n');
+    process.stdout.write(`  Runtime mode: ${mode}\n`);
+    process.stdout.write(`  Target binary: ${response.terminal_handoff.target_path}\n`);
+    process.stdout.write('  Agent: end this turn now; do not run reset-runtime, setup, ready, service restart, or other TCC-backed probes.\n');
+    process.stdout.write(`  Human: ${response.terminal_handoff.human_action}\n`);
+    process.stdout.write(`  Session: after the user says ${response.terminal_handoff.next_user_signal}, run ${prefix} ready --post-permission\n`);
+    return;
+  }
   const permissionBlockers = response.blockers.filter((blocker) => blocker.kind === 'permission');
   if (!permissionBlockers.length) return;
 
@@ -240,10 +348,12 @@ function printText(response, mode, prefix) {
     if (blocker.settings_url) process.stdout.write(`  settings: ${blocker.settings_url}\n`);
   }
   printReadyHumanHandoff(response, mode, prefix);
+  if (response.terminal_handoff?.terminal) return;
   if (response.next_actions.length) {
     process.stdout.write('Next:\n');
     for (const action of response.next_actions) {
       if (response.phase === 'human_required' && action.type === 'open_settings') continue;
+      if (response.terminal_handoff?.terminal && !action.after_user_signal && action.type !== 'manual_tcc_reset') continue;
       if (action.command) process.stdout.write(`  ${action.command}  # ${action.label}\n`);
       else process.stdout.write(`  ${action.label}\n`);
     }
@@ -286,6 +396,9 @@ if (options.repair && !response.ready) {
     response = buildReadyResponse(decision.startup, trace, mode, prefix);
   }
 }
+
+const handoffAlert = maybePlayTccHandoffAlert(response, mode);
+if (handoffAlert) response.tcc_handoff_alert = handoffAlert;
 
 if (options.json) printJSON(response);
 else printText(response, mode, prefix);

--- a/scripts/aos-status.mjs
+++ b/scripts/aos-status.mjs
@@ -148,6 +148,26 @@ function statusNotes({ runtime, permissions, setup, clean, snapshot, verdict }) 
   return notes;
 }
 
+function readinessSummary(verdict) {
+  const summary = {
+    ready: verdict.ready,
+    status: verdict.status,
+    phase: verdict.phase,
+    diagnosis: verdict.diagnosis,
+    ready_for_testing: verdict.ready_for_testing,
+    ready_source: verdict.ready_source,
+    blocked_capabilities: verdict.blocked_capabilities,
+  };
+  if (verdict.tcc_staleness) {
+    summary.tcc_staleness = {
+      id: verdict.tcc_staleness.id,
+      diagnosis: verdict.tcc_staleness.diagnosis,
+    };
+  }
+  if (verdict.terminal_handoff) summary.terminal_handoff = verdict.terminal_handoff;
+  return summary;
+}
+
 async function buildStatusResponse() {
   const facts = brokerFacts({
     failureCode: 'STATUS_PRIMITIVE_FAILED',
@@ -168,6 +188,7 @@ async function buildStatusResponse() {
   });
   return {
     status: notes.length ? 'degraded' : 'ok',
+    readiness: readinessSummary(verdict),
     identity: identity(runtime, facts.permissionsFacts),
     runtime,
     runtime_verdict: verdict,
@@ -203,7 +224,7 @@ function printText(response) {
   const daemonState = response.runtime.socket_reachable
     ? 'reachable'
     : (response.runtime.daemon_running ? 'running' : 'down');
-  let line = `status=${response.status} mode=${response.runtime.mode} daemon=${daemonState} pid=${response.runtime.daemon_pid ?? '?'} tap=${tapValue} focused_app=${focusedApp} displays=${displays} windows=${windows} channels=${channels} stale_canvases=${staleCanvasCount}`;
+  let line = `status=${response.status} readiness=${response.readiness.status} ready=${response.readiness.ready} mode=${response.runtime.mode} daemon=${daemonState} pid=${response.runtime.daemon_pid ?? '?'} tap=${tapValue} focused_app=${focusedApp} displays=${displays} windows=${windows} channels=${channels} stale_canvases=${staleCanvasCount}`;
   if (response.git) {
     line += ` branch=${response.git.branch} ahead=${response.git.ahead_of_origin_main ?? '?'} dirty=${response.git.dirty_files}`;
   }

--- a/scripts/lib/aos-cli.mjs
+++ b/scripts/lib/aos-cli.mjs
@@ -152,3 +152,29 @@ export function binaryTimestamp(file) {
     return undefined;
   }
 }
+
+export function binaryCDHash(file) {
+  const result = run('/usr/bin/codesign', ['-dvvv', file]);
+  if (result.exitCode !== 0) return undefined;
+  const match = `${result.stdout}\n${result.stderr}`.match(/^CDHash=(\S+)/m);
+  return match?.[1];
+}
+
+export function binaryFileIdentity(file) {
+  try {
+    const stat = fs.statSync(file);
+    return {
+      path: file,
+      exists: true,
+      mtime: stat.mtime.toISOString().replace(/\.\d{3}Z$/, 'Z'),
+      mtime_ms: stat.mtimeMs,
+      size_bytes: stat.size,
+      cdhash: binaryCDHash(file),
+    };
+  } catch {
+    return {
+      path: file,
+      exists: false,
+    };
+  }
+}

--- a/scripts/lib/aos-facts.mjs
+++ b/scripts/lib/aos-facts.mjs
@@ -1,5 +1,6 @@
 import {
   aosPath,
+  binaryFileIdentity,
   binaryTimestamp,
   compactProcessDetail,
   currentMode,
@@ -161,6 +162,7 @@ export function brokerFacts({
     }
   }
   const runtime = includeRuntime ? enrichRuntimeOwnership(parse(runAOS(['__runtime', 'status-facts', '--json']), '__runtime status-facts')) : undefined;
+  const runtimeIdentity = identity(runtime ?? { mode: currentMode() }, permissionsFacts);
   return {
     permissionsFacts,
     permissions: permissionsFacts.permissions ?? {},
@@ -168,6 +170,8 @@ export function brokerFacts({
     daemonHealth,
     daemon: daemonView(daemonHealth),
     runtime,
+    identity: runtimeIdentity,
+    binary_identity: binaryFileIdentity(runtimeIdentity.executable_path),
     cleanReport: includeClean ? cleanReport() : undefined,
   };
 }

--- a/scripts/lib/aos-readiness.mjs
+++ b/scripts/lib/aos-readiness.mjs
@@ -122,15 +122,13 @@ export function postRebuildTccStalenessFor(facts, mode, prefix = invocationName(
     },
     remedy: {
       type: 'manual_tcc_reset',
-      summary: 'Stop the turn, ask the user to reset/regrant macOS TCC permissions for the rebuilt aos binary, then continue with the post-permission readiness check.',
+      summary: 'Play the stale-TCC handoff alert, end the current turn, and wait for the user to manually reset/regrant macOS TCC permissions for the rebuilt aos binary.',
       commands: [
-        `${prefix} permissions reset-runtime --mode ${mode}`,
-        `${prefix} permissions setup --once`,
         `${prefix} ready --post-permission`,
-        `${prefix} ready`,
       ],
-      human_action: 'Remove/re-add or regrant the aos entry in macOS Privacy & Security if reset-runtime reports targeted reset unavailable or the grant remains stale.',
+      human_action: 'Remove/re-add or regrant the aos entry in macOS Privacy & Security, then return to the waiting session and say: finished.',
       target_path: targetPath,
+      next_user_signal: 'finished',
     },
   };
 }
@@ -246,6 +244,21 @@ export function permissionResetSafeSequenceLines(blockers, mode, prefix = invoca
     lines.splice(4, 0, 'Screen Recording can be re-requested by permissions setup after reset.');
   }
   return lines;
+}
+
+export function staleTccTerminalHandoff(tccStaleness, prefix = invocationName()) {
+  if (!tccStaleness || tccStaleness.id !== 'post_rebuild_tcc_stale') return undefined;
+  return {
+    type: 'manual_tcc_reset',
+    reason: 'post_rebuild_tcc_stale',
+    terminal: true,
+    alert: 'three_chimes',
+    instruction: 'End the current turn. Do not run reset-runtime, setup, ready, service restart, or other TCC-backed probes until the user says finished.',
+    next_user_signal: 'finished',
+    human_action: tccStaleness.remedy.human_action,
+    target_path: tccStaleness.remedy.target_path,
+    resume_command: `${prefix} ready --post-permission`,
+  };
 }
 
 export function staleGrantGuidance(mode, service) {
@@ -412,6 +425,7 @@ export function isRepairableRuntimeBlockerID(id) {
 
 export function readyAutoRepairReason(response, { postPermission = false } = {}) {
   if (response.ready) return null;
+  if ((response.blockers ?? []).some((blocker) => blocker.kind === 'permission')) return null;
   const blockerIDs = new Set((response.blockers ?? []).map((blocker) => blocker.id));
   const hasRepairableRuntimeBlocker = (response.blockers ?? [])
     .some((blocker) => isRepairableRuntimeBlockerID(blocker.id));
@@ -475,6 +489,23 @@ export function readyNextActions(blockers, setup, mode, prefix = invocationName(
   const hasStaleDaemons = blockers.some((b) => b.id === 'stale_daemons');
   const hasPostRebuildTccStale = blockers.some((b) => b.reason === 'post_rebuild_tcc_stale');
 
+  if (hasPostRebuildTccStale) {
+    appendAction(actions, seen, {
+      type: 'manual_tcc_reset',
+      label: 'play the stale-TCC handoff alert, end the turn, and wait for the user to say finished after manual TCC reset/regrant',
+      reason: 'post_rebuild_tcc_stale',
+      terminal: true,
+      next_user_signal: 'finished',
+    });
+    appendAction(actions, seen, {
+      type: 'command',
+      label: 'after the user says finished, run the bounded post-permission readiness check',
+      command: `${prefix} ready --post-permission`,
+      after_user_signal: 'finished',
+    });
+    return actions;
+  }
+
   if (hasPermissionBlocker) {
     appendAction(actions, seen, {
       type: 'command',
@@ -491,13 +522,6 @@ export function readyNextActions(blockers, setup, mode, prefix = invocationName(
       label: 'bounded handoff check after permissions have been granted',
       command: `${prefix} ready --post-permission`,
     });
-    if (hasPostRebuildTccStale) {
-      appendAction(actions, seen, {
-        type: 'manual_tcc_reset',
-        label: 'stop the turn and ask the user to reset/regrant macOS TCC permissions for the rebuilt aos binary',
-        reason: 'post_rebuild_tcc_stale',
-      });
-    }
   }
 
   if ((hasRepairableRuntimeBlocker || hasUnmanagedDaemon) && !hasPermissionBlocker) {
@@ -549,6 +573,8 @@ export function readyNotes({ runtime, daemon, permissions, setup, cleanReport },
   if (tccStaleness) {
     notes.push(tccStaleness.reason);
     notes.push(tccStaleness.remedy.summary);
+    notes.push(`After the user says ${tccStaleness.remedy.next_user_signal}, run '${prefix} ready --post-permission'.`);
+    return notes;
   }
   if (!runtime.daemon_running) notes.push('Daemon is not running.');
   else if (!runtime.socket_reachable) notes.push('Daemon process appears to be running, but the socket is not reachable.');
@@ -593,6 +619,7 @@ export function runtimeVerdict(facts, mode, prefix = invocationName()) {
   const ready = Boolean(facts.runtime.socket_reachable && evaluation.readyForTesting && blockers.length === 0);
   const blockedCapabilities = [...new Set(blockers.flatMap((blocker) => blocker.blocks || []))].sort();
   const tccStaleness = postRebuildTccStalenessFor(facts, mode, prefix);
+  const terminalHandoff = staleTccTerminalHandoff(tccStaleness, prefix);
   return {
     ready,
     status: ready ? 'ok' : 'degraded',
@@ -603,6 +630,7 @@ export function runtimeVerdict(facts, mode, prefix = invocationName()) {
     blockers,
     blocked_capabilities: blockedCapabilities,
     tcc_staleness: tccStaleness,
+    terminal_handoff: terminalHandoff,
     notes: readyNotes(facts, mode, prefix, tccStaleness),
     next_actions: readyNextActions(blockers, facts.setup, mode, prefix),
     ownership: {

--- a/scripts/lib/aos-readiness.mjs
+++ b/scripts/lib/aos-readiness.mjs
@@ -79,6 +79,62 @@ export function disagreementFor(daemon, cli) {
   return Object.keys(disagreement).length ? disagreement : undefined;
 }
 
+export function passiveLiveViewsFor(daemon, cli) {
+  return {
+    cli_passive: {
+      accessibility: Boolean(cli.accessibility),
+      screen_recording: Boolean(cli.screen_recording),
+      listen_access: Boolean(cli.listen_access),
+      post_access: Boolean(cli.post_access),
+    },
+    daemon_live: daemon ? {
+      accessibility: daemon.permissions.accessibility,
+      listen_access: daemon.inputTap.listenAccess,
+      post_access: daemon.inputTap.postAccess,
+      input_tap_status: daemon.inputTap.status,
+      input_tap_attempts: daemon.inputTap.attempts,
+    } : undefined,
+  };
+}
+
+export function postRebuildTccStalenessFor(facts, mode, prefix = invocationName()) {
+  const disagreement = disagreementFor(facts.daemon, facts.permissions);
+  if (!disagreement) return undefined;
+  const staleFields = Object.entries(disagreement)
+    .filter(([, value]) => value.cli === true && value.daemon === false)
+    .map(([field]) => field);
+  if (!staleFields.length) return undefined;
+  const targetPath = facts.binary_identity?.path ?? expectedBinaryPath(mode);
+  return {
+    id: 'post_rebuild_tcc_stale',
+    diagnosis: 'daemon_tcc_grant_stale_or_missing',
+    reason: 'TCC has a stale registration for a previous aos binary; passive checks pass, but live privileged access fails after a rebuild.',
+    stale_fields: staleFields,
+    ...passiveLiveViewsFor(facts.daemon, facts.permissions),
+    disagreement,
+    binary_identity: {
+      path: targetPath,
+      exists: facts.binary_identity?.exists,
+      mtime: facts.binary_identity?.mtime,
+      mtime_ms: facts.binary_identity?.mtime_ms,
+      size_bytes: facts.binary_identity?.size_bytes,
+      cdhash: facts.binary_identity?.cdhash,
+    },
+    remedy: {
+      type: 'manual_tcc_reset',
+      summary: 'Stop the turn, ask the user to reset/regrant macOS TCC permissions for the rebuilt aos binary, then continue with the post-permission readiness check.',
+      commands: [
+        `${prefix} permissions reset-runtime --mode ${mode}`,
+        `${prefix} permissions setup --once`,
+        `${prefix} ready --post-permission`,
+        `${prefix} ready`,
+      ],
+      human_action: 'Remove/re-add or regrant the aos entry in macOS Privacy & Security if reset-runtime reports targeted reset unavailable or the grant remains stale.',
+      target_path: targetPath,
+    },
+  };
+}
+
 export function inputTapRecoveryGuidance(status, attempts) {
   return [
     `Input tap is not active (status=${status}, attempts=${attempts}).`,
@@ -278,6 +334,7 @@ export function readyBlockers({ runtime, daemon, permissions, setup, cleanReport
       kind: 'permission',
       id: 'accessibility',
       scope: 'daemon',
+      reason: permissions.accessibility ? 'post_rebuild_tcc_stale' : 'daemon_permission_missing',
       message: staleGrantGuidance(mode, 'Accessibility'),
       target_path: daemonPath,
       settings_url: 'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility',
@@ -313,6 +370,7 @@ export function readyBlockers({ runtime, daemon, permissions, setup, cleanReport
       kind: 'permission',
       id: 'input_monitoring_listen',
       scope: 'daemon',
+      reason: permissions.listen_access ? 'post_rebuild_tcc_stale' : 'daemon_permission_missing',
       message: staleGrantGuidance(mode, 'Input Monitoring listen access'),
       target_path: daemonPath,
       settings_url: 'x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent',
@@ -325,6 +383,7 @@ export function readyBlockers({ runtime, daemon, permissions, setup, cleanReport
       kind: 'permission',
       id: 'input_monitoring_post',
       scope: 'daemon',
+      reason: permissions.post_access ? 'post_rebuild_tcc_stale' : 'daemon_permission_missing',
       message: staleGrantGuidance(mode, 'Input Monitoring post access'),
       target_path: daemonPath,
       settings_url: 'x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent',
@@ -414,6 +473,7 @@ export function readyNextActions(blockers, setup, mode, prefix = invocationName(
   const hasRepairableRuntimeBlocker = blockers.some((b) => isRepairableRuntimeBlockerID(b.id));
   const hasUnmanagedDaemon = blockers.some((b) => b.id === 'daemon_unmanaged');
   const hasStaleDaemons = blockers.some((b) => b.id === 'stale_daemons');
+  const hasPostRebuildTccStale = blockers.some((b) => b.reason === 'post_rebuild_tcc_stale');
 
   if (hasPermissionBlocker) {
     appendAction(actions, seen, {
@@ -431,6 +491,13 @@ export function readyNextActions(blockers, setup, mode, prefix = invocationName(
       label: 'bounded handoff check after permissions have been granted',
       command: `${prefix} ready --post-permission`,
     });
+    if (hasPostRebuildTccStale) {
+      appendAction(actions, seen, {
+        type: 'manual_tcc_reset',
+        label: 'stop the turn and ask the user to reset/regrant macOS TCC permissions for the rebuilt aos binary',
+        reason: 'post_rebuild_tcc_stale',
+      });
+    }
   }
 
   if ((hasRepairableRuntimeBlocker || hasUnmanagedDaemon) && !hasPermissionBlocker) {
@@ -477,8 +544,12 @@ export function readyNextActions(blockers, setup, mode, prefix = invocationName(
   return actions;
 }
 
-export function readyNotes({ runtime, daemon, permissions, setup, cleanReport }, mode, prefix = invocationName()) {
+export function readyNotes({ runtime, daemon, permissions, setup, cleanReport }, mode, prefix = invocationName(), tccStaleness = undefined) {
   const notes = [];
+  if (tccStaleness) {
+    notes.push(tccStaleness.reason);
+    notes.push(tccStaleness.remedy.summary);
+  }
   if (!runtime.daemon_running) notes.push('Daemon is not running.');
   else if (!runtime.socket_reachable) notes.push('Daemon process appears to be running, but the socket is not reachable.');
   if (runtime.ownership_state === 'mismatch') {
@@ -521,6 +592,7 @@ export function runtimeVerdict(facts, mode, prefix = invocationName()) {
   const blockers = readyBlockers(facts, mode);
   const ready = Boolean(facts.runtime.socket_reachable && evaluation.readyForTesting && blockers.length === 0);
   const blockedCapabilities = [...new Set(blockers.flatMap((blocker) => blocker.blocks || []))].sort();
+  const tccStaleness = postRebuildTccStalenessFor(facts, mode, prefix);
   return {
     ready,
     status: ready ? 'ok' : 'degraded',
@@ -530,7 +602,8 @@ export function runtimeVerdict(facts, mode, prefix = invocationName()) {
     ready_for_testing: evaluation.readyForTesting,
     blockers,
     blocked_capabilities: blockedCapabilities,
-    notes: readyNotes(facts, mode, prefix),
+    tcc_staleness: tccStaleness,
+    notes: readyNotes(facts, mode, prefix, tccStaleness),
     next_actions: readyNextActions(blockers, facts.setup, mode, prefix),
     ownership: {
       state: facts.runtime.ownership_state,

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -19,10 +19,12 @@ tooling does not by itself rebuild the TCC-owning binary; use `--force` only
 when intentionally replacing that binary.
 
 When the repo-mode `./aos` binary is actually rebuilt, the build script emits a
-`Rebuilt: ./aos` marker and plays the configured rebuild alert sound. Treat that
-as a human-attention event for TCC-sensitive sessions: stop before TCC-backed
-proof, ask the human to manually reset/regrant the needed macOS permissions, and
-run `./aos ready --post-permission` after they confirm.
+`Rebuilt: ./aos` marker but does not play the TCC alert. Continue with non-TCC
+checks as needed. If a later live TCC-backed readiness check reports
+`post_rebuild_tcc_stale`, the command plays the three-chime handoff alert,
+prints a terminal handoff, and the agent must end the current turn. The next
+user response is the signal that they manually reset/regranted TCC; resume with
+`./aos ready --post-permission`.
 
 When you are unsure which loop applies, ask the router first:
 
@@ -73,16 +75,12 @@ Before interactive commands (`do`, `see cursor/observe/capture`, `inspect`) will
 
 Interactive commands exit early with `PERMISSIONS_SETUP_REQUIRED` until onboarding completes for the current runtime mode.
 
-If readiness or permissions setup says repo-mode Accessibility/Input Monitoring
-must be reset, use `./aos permissions reset-runtime --mode repo` first. It stops
-the managed daemon, verifies `running=false`, and either runs a real targeted
-TCC reset for a targetable runtime identity or reports targeted reset
-unavailable for the bare repo binary. Then run
-`./aos permissions setup --once` to request fresh macOS prompts. If the grant
-remains stale or macOS does not prompt, the human physically removes and re-adds
-the repo-mode `aos` runtime in System Settings, then says `finished` in the
-waiting session. The session then runs `./aos ready --post-permission` to
-verify.
+If readiness reports `post_rebuild_tcc_stale`, stop immediately after the
+three-chime handoff. Do not run reset-runtime, setup, service restart, another
+ready probe, or any other TCC-backed command in the same turn. The human
+physically removes and re-adds the repo-mode `aos` runtime in System Settings,
+then says `finished` in the waiting session. The session then runs
+`./aos ready --post-permission` to verify.
 Service-wide TCC reset affects other apps and is a break-glass capability only;
 do not use `--allow-service-reset --emergency-ack-other-apps` unless Michael
 explicitly asks for emergency recovery.

--- a/tests/README.md
+++ b/tests/README.md
@@ -125,14 +125,13 @@ The build gate is content-based for Swift runtime inputs. Touching a Swift file
 without changing its content, or editing build tooling alone, should not replace
 the TCC-owning `./aos` binary. Passing `--force`, changing Swift runtime input
 content, changing build mode, or missing output can still rebuild it. A real
-rebuild emits `Rebuilt: ./aos` and plays the configured rebuild alert sound.
+rebuild emits `Rebuilt: ./aos` without playing the TCC alert.
 
-After a real rebuild, the user must manually reset/regrant the repo-mode macOS
-TCC permissions for the rebuilt `./aos` binary before Accessibility, Screen
-Recording, Input Monitoring, input-tap, daemon readiness, capture, or native
-input proof is valid. Agents should stop at that handoff and run only non-TCC
-checks until the user confirms permissions are reset, then verify with
-`./aos ready --post-permission`.
+After a real rebuild, continue with non-TCC checks as needed. The stop point is
+the first live readiness check that reports `post_rebuild_tcc_stale`: it plays
+the three-chime handoff alert, returns a terminal handoff, and agents must end
+the turn. After the user manually resets/regrants TCC and replies `finished`,
+verify with `./aos ready --post-permission`.
 
 GDI is not allowed to perform this rebuild; return native/binary work to
 Foreman instead.

--- a/tests/aos-readiness-composition.test.mjs
+++ b/tests/aos-readiness-composition.test.mjs
@@ -73,6 +73,15 @@ function facts(overrides = {}) {
     daemon: overrides.daemon === null ? null : daemon(overrides.daemon ?? {}),
     permissions: permissions(overrides.permissions),
     setup: setup(overrides.setup),
+    binary_identity: {
+      path: '/repo/aos',
+      exists: true,
+      mtime: '2026-07-09T01:36:00Z',
+      mtime_ms: 1783557360000,
+      size_bytes: 123456,
+      cdhash: 'abc123def456',
+      ...overrides.binary_identity,
+    },
     cleanReport: {
       status: 'clean',
       stale_daemons: [],
@@ -115,6 +124,49 @@ test('daemon accessibility false overrides granted CLI accessibility as stale da
   assert.deepEqual(disagreementFor(current.daemon, current.permissions), {
     accessibility: { cli: true, daemon: false },
   });
+});
+
+test('passive-green live-fail daemon input monitoring names post-rebuild stale TCC and remedy', () => {
+  const current = facts({
+    daemon: {
+      inputTap: {
+        status: 'unavailable',
+        attempts: 1,
+        listenAccess: false,
+      },
+    },
+  });
+  const verdict = runtimeVerdict(current, 'repo', './aos');
+
+  assert.equal(verdict.ready, false);
+  assert.equal(verdict.phase, 'human_required');
+  assert.equal(verdict.diagnosis, 'daemon_tcc_grant_stale_or_missing');
+  assert.equal(verdict.tcc_staleness.id, 'post_rebuild_tcc_stale');
+  assert.equal(verdict.tcc_staleness.reason.includes('stale registration for a previous aos binary'), true);
+  assert.deepEqual(verdict.tcc_staleness.stale_fields, ['listen_access']);
+  assert.deepEqual(verdict.tcc_staleness.cli_passive, {
+    accessibility: true,
+    screen_recording: true,
+    listen_access: true,
+    post_access: true,
+  });
+  assert.equal(verdict.tcc_staleness.daemon_live.listen_access, false);
+  assert.equal(verdict.tcc_staleness.daemon_live.input_tap_status, 'unavailable');
+  assert.equal(verdict.tcc_staleness.binary_identity.cdhash, 'abc123def456');
+  assert.deepEqual(verdict.tcc_staleness.remedy.commands, [
+    './aos permissions reset-runtime --mode repo',
+    './aos permissions setup --once',
+    './aos ready --post-permission',
+    './aos ready',
+  ]);
+  assert.equal(
+    verdict.next_actions.some((action) => action.type === 'manual_tcc_reset' && action.reason === 'post_rebuild_tcc_stale'),
+    true,
+  );
+  assert.equal(
+    verdict.notes.some((note) => note.includes('passive checks pass, but live privileged access fails after a rebuild')),
+    true,
+  );
 });
 
 test('legacy daemon health without access fields falls back to CLI permission view', () => {

--- a/tests/aos-readiness-composition.test.mjs
+++ b/tests/aos-readiness-composition.test.mjs
@@ -154,15 +154,34 @@ test('passive-green live-fail daemon input monitoring names post-rebuild stale T
   assert.equal(verdict.tcc_staleness.daemon_live.input_tap_status, 'unavailable');
   assert.equal(verdict.tcc_staleness.binary_identity.cdhash, 'abc123def456');
   assert.deepEqual(verdict.tcc_staleness.remedy.commands, [
-    './aos permissions reset-runtime --mode repo',
-    './aos permissions setup --once',
     './aos ready --post-permission',
-    './aos ready',
   ]);
-  assert.equal(
-    verdict.next_actions.some((action) => action.type === 'manual_tcc_reset' && action.reason === 'post_rebuild_tcc_stale'),
-    true,
-  );
+  assert.deepEqual(verdict.terminal_handoff, {
+    type: 'manual_tcc_reset',
+    reason: 'post_rebuild_tcc_stale',
+    terminal: true,
+    alert: 'three_chimes',
+    instruction: 'End the current turn. Do not run reset-runtime, setup, ready, service restart, or other TCC-backed probes until the user says finished.',
+    next_user_signal: 'finished',
+    human_action: 'Remove/re-add or regrant the aos entry in macOS Privacy & Security, then return to the waiting session and say: finished.',
+    target_path: '/repo/aos',
+    resume_command: './aos ready --post-permission',
+  });
+  assert.deepEqual(verdict.next_actions, [
+    {
+      type: 'manual_tcc_reset',
+      label: 'play the stale-TCC handoff alert, end the turn, and wait for the user to say finished after manual TCC reset/regrant',
+      reason: 'post_rebuild_tcc_stale',
+      terminal: true,
+      next_user_signal: 'finished',
+    },
+    {
+      type: 'command',
+      label: 'after the user says finished, run the bounded post-permission readiness check',
+      command: './aos ready --post-permission',
+      after_user_signal: 'finished',
+    },
+  ]);
   assert.equal(
     verdict.notes.some((note) => note.includes('passive checks pass, but live privileged access fails after a rebuild')),
     true,
@@ -381,6 +400,13 @@ test('ready auto-repair reason stays null for ready, stale, and unmanaged states
   assert.equal(readyAutoRepairReason({ ready: true, blockers: [] }), null);
   assert.equal(readyAutoRepairReason({ ready: false, blockers: [{ id: 'stale_daemons', kind: 'runtime' }] }), null);
   assert.equal(readyAutoRepairReason({ ready: false, blockers: [{ id: 'daemon_unmanaged', kind: 'runtime' }] }), null);
+  assert.equal(readyAutoRepairReason({
+    ready: false,
+    blockers: [
+      { id: 'input_tap_not_active', kind: 'runtime' },
+      { id: 'input_monitoring_listen', kind: 'permission', reason: 'post_rebuild_tcc_stale' },
+    ],
+  }), null);
 });
 
 test('ready auto-repair reason is deterministic for ownership and input-tap blockers', () => {

--- a/tests/build-signing.sh
+++ b/tests/build-signing.sh
@@ -87,13 +87,6 @@ touch "$target.signed"
 EOF
 chmod +x "$FAKE_BIN/codesign"
 
-cat >"$FAKE_BIN/rebuild-alert" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-printf 'alert\n' >> "${AOS_BUILD_SIGNING_TEST_LOG:?}"
-EOF
-chmod +x "$FAKE_BIN/rebuild-alert"
-
 FIRST_OUT="$TMP/first.out"
 REPAIR_OUT="$TMP/repair.out"
 UP_TO_DATE_OUT="$TMP/up-to-date.out"
@@ -101,14 +94,14 @@ TOUCHED_OUT="$TMP/touched.out"
 CHANGED_OUT="$TMP/changed.out"
 PACKAGE_OUT="$TMP/package.out"
 
-PATH="$FAKE_BIN:$PATH" AOS_BUILD_SIGNING_TEST_LOG="$LOG" AOS_BUILD_REBUILD_ALERT_COMMAND="$FAKE_BIN/rebuild-alert" bash "$FAKE_REPO/build.sh" --no-restart >"$FIRST_OUT"
+PATH="$FAKE_BIN:$PATH" AOS_BUILD_SIGNING_TEST_LOG="$LOG" bash "$FAKE_REPO/build.sh" --no-restart >"$FIRST_OUT"
 if ! grep -qx 'swiftc' "$LOG" || ! grep -q '^codesign ' "$LOG"; then
     echo "FAIL: first build did not compile and sign" >&2
     cat "$LOG" >&2
     exit 1
 fi
-if ! grep -qx 'alert' "$LOG"; then
-    echo "FAIL: first build did not play the rebuild alert" >&2
+if grep -qx 'alert' "$LOG"; then
+    echo "FAIL: first build should not play the TCC handoff alert" >&2
     cat "$LOG" >&2
     exit 1
 fi
@@ -117,8 +110,8 @@ if ! grep -q '^Rebuilt: ./aos' "$FIRST_OUT"; then
     cat "$FIRST_OUT" >&2
     exit 1
 fi
-if ! grep -q 'user must manually reset/regrant needed macOS TCC permissions' "$FIRST_OUT"; then
-    echo "FAIL: first build did not report the manual TCC reset handoff" >&2
+if ! grep -q 'TCC handoff alert is deferred until a live readiness check reports post-rebuild stale TCC' "$FIRST_OUT"; then
+    echo "FAIL: first build did not report deferred TCC handoff alert behavior" >&2
     cat "$FIRST_OUT" >&2
     exit 1
 fi
@@ -135,7 +128,7 @@ fi
 
 rm -f "$FAKE_REPO/aos.signed"
 : > "$LOG"
-PATH="$FAKE_BIN:$PATH" AOS_BUILD_SIGNING_TEST_LOG="$LOG" AOS_BUILD_REBUILD_ALERT_COMMAND="$FAKE_BIN/rebuild-alert" bash "$FAKE_REPO/build.sh" --no-restart >"$REPAIR_OUT"
+PATH="$FAKE_BIN:$PATH" AOS_BUILD_SIGNING_TEST_LOG="$LOG" bash "$FAKE_REPO/build.sh" --no-restart >"$REPAIR_OUT"
 if ! grep -q '^codesign ' "$LOG" || grep -qx 'swiftc' "$LOG" || grep -qx 'alert' "$LOG"; then
     echo "FAIL: signature repair should sign without compiling" >&2
     cat "$LOG" >&2
@@ -159,7 +152,7 @@ fi
 
 touch "$FAKE_REPO/src/main.swift" "$FAKE_REPO/build.sh"
 : > "$LOG"
-PATH="$FAKE_BIN:$PATH" AOS_BUILD_SIGNING_TEST_LOG="$LOG" AOS_BUILD_REBUILD_ALERT_COMMAND="$FAKE_BIN/rebuild-alert" bash "$FAKE_REPO/build.sh" --no-restart >"$TOUCHED_OUT"
+PATH="$FAKE_BIN:$PATH" AOS_BUILD_SIGNING_TEST_LOG="$LOG" bash "$FAKE_REPO/build.sh" --no-restart >"$TOUCHED_OUT"
 if [[ -s "$LOG" ]]; then
     echo "FAIL: unchanged runtime input content should not rebuild or re-sign" >&2
     cat "$LOG" >&2
@@ -173,9 +166,9 @@ fi
 
 printf '// runtime source changed\n' >> "$FAKE_REPO/src/main.swift"
 : > "$LOG"
-PATH="$FAKE_BIN:$PATH" AOS_BUILD_SIGNING_TEST_LOG="$LOG" AOS_BUILD_REBUILD_ALERT_COMMAND="$FAKE_BIN/rebuild-alert" bash "$FAKE_REPO/build.sh" --no-restart >"$CHANGED_OUT"
-if ! grep -qx 'swiftc' "$LOG" || ! grep -q '^codesign ' "$LOG" || ! grep -qx 'alert' "$LOG"; then
-    echo "FAIL: changed runtime input content should compile, sign, and alert" >&2
+PATH="$FAKE_BIN:$PATH" AOS_BUILD_SIGNING_TEST_LOG="$LOG" bash "$FAKE_REPO/build.sh" --no-restart >"$CHANGED_OUT"
+if ! grep -qx 'swiftc' "$LOG" || ! grep -q '^codesign ' "$LOG" || grep -qx 'alert' "$LOG"; then
+    echo "FAIL: changed runtime input content should compile and sign without alerting" >&2
     cat "$LOG" >&2
     exit 1
 fi
@@ -184,15 +177,15 @@ if ! grep -q '^Rebuilt: ./aos' "$CHANGED_OUT"; then
     cat "$CHANGED_OUT" >&2
     exit 1
 fi
-if ! grep -q 'user must manually reset/regrant needed macOS TCC permissions' "$CHANGED_OUT"; then
-    echo "FAIL: changed runtime input content did not report the manual TCC reset handoff" >&2
+if ! grep -q 'TCC handoff alert is deferred until a live readiness check reports post-rebuild stale TCC' "$CHANGED_OUT"; then
+    echo "FAIL: changed runtime input content did not report deferred TCC handoff alert behavior" >&2
     cat "$CHANGED_OUT" >&2
     exit 1
 fi
 
 rm -f "$FAKE_REPO/aos.signed"
 : > "$LOG"
-PATH="$FAKE_BIN:$PATH" AOS_BUILD_SIGNING_TEST_LOG="$LOG" AOS_BUILD_REBUILD_ALERT=0 bash "$FAKE_REPO/build.sh" --no-restart >"$REPAIR_OUT"
+PATH="$FAKE_BIN:$PATH" AOS_BUILD_SIGNING_TEST_LOG="$LOG" bash "$FAKE_REPO/build.sh" --no-restart >"$REPAIR_OUT"
 if ! grep -q '^codesign ' "$LOG" || grep -qx 'swiftc' "$LOG" || grep -qx 'alert' "$LOG"; then
     echo "FAIL: post-change signature repair should sign without compiling or alerting" >&2
     cat "$LOG" >&2
@@ -200,7 +193,7 @@ if ! grep -q '^codesign ' "$LOG" || grep -qx 'swiftc' "$LOG" || grep -qx 'alert'
 fi
 
 : > "$LOG"
-PATH="$FAKE_BIN:$PATH" AOS_BUILD_SIGNING_TEST_LOG="$LOG" AOS_BUILD_REBUILD_ALERT=0 bash "$FAKE_REPO/build.sh" --no-restart >"$UP_TO_DATE_OUT"
+PATH="$FAKE_BIN:$PATH" AOS_BUILD_SIGNING_TEST_LOG="$LOG" bash "$FAKE_REPO/build.sh" --no-restart >"$UP_TO_DATE_OUT"
 if [[ -s "$LOG" ]]; then
     echo "FAIL: valid signed artifact should not rebuild or re-sign" >&2
     cat "$LOG" >&2
@@ -213,7 +206,7 @@ if ! grep -q '^Up to date: ./aos' "$UP_TO_DATE_OUT"; then
 fi
 
 : > "$LOG"
-PATH="$FAKE_BIN:$PATH" AOS_BUILD_SIGNING_TEST_LOG="$LOG" AOS_BUILD_REBUILD_ALERT=0 bash "$FAKE_REPO/build.sh" --package --no-restart >"$PACKAGE_OUT"
+PATH="$FAKE_BIN:$PATH" AOS_BUILD_SIGNING_TEST_LOG="$LOG" bash "$FAKE_REPO/build.sh" --package --no-restart >"$PACKAGE_OUT"
 if ! grep -qx 'swiftc' "$LOG" || ! grep -q '^codesign ' "$LOG"; then
     echo "FAIL: packaged build should compile and sign" >&2
     cat "$LOG" >&2

--- a/tests/build-signing.sh
+++ b/tests/build-signing.sh
@@ -13,11 +13,30 @@ LOG="$TMP/events.log"
 mkdir -p "$FAKE_REPO/src" "$FAKE_BIN"
 
 cp build.sh "$FAKE_REPO/build.sh"
+mkdir -p "$FAKE_REPO/packaging"
 printf 'print("fake")\n' > "$FAKE_REPO/src/main.swift"
+cat > "$FAKE_REPO/packaging/Info.plist" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>com.agentos.repo-aos</string>
+</dict>
+</plist>
+EOF
+cat > "$FAKE_REPO/packaging/aos.entitlements" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>
+EOF
 
 cat >"$FAKE_BIN/swiftc" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+printf 'swiftc_args %s\n' "$*" >> "${AOS_BUILD_SIGNING_TEST_LOG:?}"
 out=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -80,6 +99,7 @@ REPAIR_OUT="$TMP/repair.out"
 UP_TO_DATE_OUT="$TMP/up-to-date.out"
 TOUCHED_OUT="$TMP/touched.out"
 CHANGED_OUT="$TMP/changed.out"
+PACKAGE_OUT="$TMP/package.out"
 
 PATH="$FAKE_BIN:$PATH" AOS_BUILD_SIGNING_TEST_LOG="$LOG" AOS_BUILD_REBUILD_ALERT_COMMAND="$FAKE_BIN/rebuild-alert" bash "$FAKE_REPO/build.sh" --no-restart >"$FIRST_OUT"
 if ! grep -qx 'swiftc' "$LOG" || ! grep -q '^codesign ' "$LOG"; then
@@ -189,6 +209,29 @@ fi
 if ! grep -q '^Up to date: ./aos' "$UP_TO_DATE_OUT"; then
     echo "FAIL: valid signed artifact did not report up to date" >&2
     cat "$UP_TO_DATE_OUT" >&2
+    exit 1
+fi
+
+: > "$LOG"
+PATH="$FAKE_BIN:$PATH" AOS_BUILD_SIGNING_TEST_LOG="$LOG" AOS_BUILD_REBUILD_ALERT=0 bash "$FAKE_REPO/build.sh" --package --no-restart >"$PACKAGE_OUT"
+if ! grep -qx 'swiftc' "$LOG" || ! grep -q '^codesign ' "$LOG"; then
+    echo "FAIL: packaged build should compile and sign" >&2
+    cat "$LOG" >&2
+    exit 1
+fi
+if ! grep -q 'swiftc_args .*__TEXT .*__info_plist .*packaging/Info.plist' "$LOG"; then
+    echo "FAIL: packaged build did not embed packaging/Info.plist with linker flags" >&2
+    cat "$LOG" >&2
+    exit 1
+fi
+if ! grep -q -- '--entitlements .*/packaging/aos.entitlements' "$LOG"; then
+    echo "FAIL: packaged build did not sign with packaging/aos.entitlements" >&2
+    cat "$LOG" >&2
+    exit 1
+fi
+if ! grep -q '^Compiling aos (dev+package)' "$PACKAGE_OUT"; then
+    echo "FAIL: packaged build did not report the package build variant" >&2
+    cat "$PACKAGE_OUT" >&2
     exit 1
 fi
 

--- a/tests/input-tap-readiness.sh
+++ b/tests/input-tap-readiness.sh
@@ -17,6 +17,7 @@ mkdir -p "$(dirname "$SOCK")"
 # This isolates the test from developer-machine state and makes it portable.
 export AOS_BYPASS_PERMISSIONS_SETUP=1
 export AOS_TEST_SKIP_READY_SERVICE_START=1
+export AOS_TCC_HANDOFF_ALERT=0
 
 cleanup() {
   if [[ -n "${MOCK_PID:-}" ]] && kill -0 "$MOCK_PID" 2>/dev/null; then
@@ -82,9 +83,15 @@ assert tap.get("status") == "retrying", f"runtime.input_tap.status: {tap}"
 assert tap.get("listen_access") is False, f"listen_access: {tap}"
 assert tap.get("post_access") is False, f"post_access: {tap}"
 verdict = d.get("runtime_verdict") or {}
+readiness = d.get("readiness") or {}
 stale = verdict.get("tcc_staleness") or {}
 assert stale.get("id") == "post_rebuild_tcc_stale", d
 assert stale.get("daemon_live", {}).get("listen_access") is False, stale
+assert readiness.get("ready") is False, readiness
+assert readiness.get("status") == "degraded", readiness
+assert readiness.get("phase") == "human_required", readiness
+assert readiness.get("diagnosis") == "daemon_tcc_grant_stale_or_missing", readiness
+assert readiness.get("tcc_staleness", {}).get("id") == "post_rebuild_tcc_stale", readiness
 
 notes = d.get("notes", [])
 joined = "\n".join(notes)
@@ -96,8 +103,8 @@ echo "PASS: status --json (degraded tap)"
 # status (text) one-liner should include tap=retrying.
 OUT_TEXT="$(./aos status 2>&1 | head -1)"
 case "$OUT_TEXT" in
-  *"tap=retrying"*) echo "PASS: status text one-liner" ;;
-  *) echo "FAIL: status text one-liner missing tap=retrying: $OUT_TEXT"; exit 1 ;;
+  *"readiness=degraded"*"ready=false"*"tap=retrying"*) echo "PASS: status text one-liner" ;;
+  *) echo "FAIL: status text one-liner missing readiness/tap fields: $OUT_TEXT"; exit 1 ;;
 esac
 
 # do click should fail at the preflight gate with INPUT_TAP_NOT_ACTIVE.
@@ -153,15 +160,19 @@ assert "passive checks pass" in stale.get("reason", ""), stale
 assert stale.get("binary_identity", {}).get("path") == target, stale
 actions = d.get("next_actions", [])
 commands = [a.get("command", "") for a in actions]
-assert "./aos permissions reset-runtime --mode repo" in commands, actions
-assert "./aos permissions setup --once" in commands, actions
 assert "./aos ready --post-permission" in commands, actions
-assert any(a.get("type") == "manual_tcc_reset" and a.get("reason") == "post_rebuild_tcc_stale" for a in actions), actions
-reset_index = commands.index("./aos permissions reset-runtime --mode repo")
-setup_index = commands.index("./aos permissions setup --once")
+manual = [a for a in actions if a.get("type") == "manual_tcc_reset" and a.get("reason") == "post_rebuild_tcc_stale"]
+assert len(manual) == 1 and manual[0].get("terminal") is True, actions
 post_index = commands.index("./aos ready --post-permission")
-assert reset_index < setup_index < post_index, actions
+assert actions[post_index].get("after_user_signal") == "finished", actions
+assert not any(a.get("command") == "./aos permissions reset-runtime --mode repo" for a in actions), actions
+assert not any(a.get("command") == "./aos permissions setup --once" for a in actions), actions
 assert not any(a.get("type") == "open_settings" for a in actions), actions
+handoff = d.get("terminal_handoff") or {}
+assert handoff.get("terminal") is True, handoff
+assert handoff.get("reason") == "post_rebuild_tcc_stale", handoff
+assert handoff.get("next_user_signal") == "finished", handoff
+assert handoff.get("resume_command") == "./aos ready --post-permission", handoff
 blockers = d.get("blockers", [])
 assert any(b.get("target_path") == target for b in blockers), blockers
 PY
@@ -171,21 +182,73 @@ if [[ "$READY_RC" -eq 0 ]]; then
 fi
 echo "PASS: ready --json safe permission reset next_actions"
 
+ALERT_LOG="$STATE_ROOT/tcc-alert.log"
+ALERT_MARKER="$STATE_ROOT/repo/post-rebuild-tcc-handoff-alert.json"
+rm -f "$ALERT_LOG" "$ALERT_MARKER"
+set +e
+ALERT_READY_JSON="$(AOS_TCC_HANDOFF_ALERT=1 AOS_TCC_HANDOFF_ALERT_COMMAND="printf alert >> \"$ALERT_LOG\"" ./aos ready --json)"
+ALERT_READY_RC=$?
+set -e
+if [[ "$ALERT_READY_RC" -eq 0 ]]; then
+  echo "FAIL: stale TCC alert readiness unexpectedly exited 0"
+  exit 1
+fi
+python3 - "$ALERT_READY_JSON" "$ALERT_MARKER" <<'PY'
+import json
+import pathlib
+import sys
+
+d = json.loads(sys.argv[1])
+marker_path = pathlib.Path(sys.argv[2])
+alert = d.get("tcc_handoff_alert") or {}
+assert alert.get("status") == "played", alert
+assert alert.get("marker_status") == "written", alert
+assert marker_path.exists(), marker_path
+marker = json.loads(marker_path.read_text())
+assert marker.get("key") == alert.get("key"), (marker, alert)
+PY
+if [[ "$(cat "$ALERT_LOG")" != "alert" ]]; then
+  echo "FAIL: stale TCC handoff alert did not fire exactly once on first live failure"
+  cat "$ALERT_LOG" 2>/dev/null || true
+  exit 1
+fi
+set +e
+ALERT_REPEAT_JSON="$(AOS_TCC_HANDOFF_ALERT=1 AOS_TCC_HANDOFF_ALERT_COMMAND="printf alert >> \"$ALERT_LOG\"" ./aos ready --json)"
+ALERT_REPEAT_RC=$?
+set -e
+if [[ "$ALERT_REPEAT_RC" -eq 0 ]]; then
+  echo "FAIL: repeated stale TCC alert readiness unexpectedly exited 0"
+  exit 1
+fi
+python3 - "$ALERT_REPEAT_JSON" <<'PY'
+import json
+import sys
+
+d = json.loads(sys.argv[1])
+alert = d.get("tcc_handoff_alert") or {}
+assert alert.get("status") == "skipped", alert
+assert alert.get("reason") == "already_alerted_for_binary_identity", alert
+PY
+if [[ "$(cat "$ALERT_LOG")" != "alert" ]]; then
+  echo "FAIL: stale TCC handoff alert repeated for the same binary identity"
+  cat "$ALERT_LOG" >&2
+  exit 1
+fi
+echo "PASS: ready stale TCC handoff alert is one-shot per binary identity"
+
 set +e
 READY_TEXT="$(./aos ready 2>&1)"
 READY_TEXT_RC=$?
 set -e
-if [[ "$READY_TEXT" == *"Preferred permission reset sequence:"* ]] &&
+if [[ "$READY_TEXT" == *"Post-rebuild TCC reset checkpoint:"* ]] &&
    [[ "$READY_TEXT" == *"Runtime mode: repo"* ]] &&
    [[ "$READY_TEXT" == *"Target binary: $ROOT/aos"* ]] &&
-   [[ "$READY_TEXT" == *"1. Agent: run ./aos permissions reset-runtime --mode repo"* ]] &&
-   [[ "$READY_TEXT" == *"2. Agent: run ./aos permissions setup --once"* ]] &&
-   [[ "$READY_TEXT" == *"4. Human: return to the waiting session and say: finished"* ]] &&
-   [[ "$READY_TEXT" == *"5. Session: run ./aos ready --post-permission"* ]] &&
-   [[ "$READY_TEXT" == *"Manual Settings removal is required when reset-runtime reports targeted reset unavailable or the grant remains stale."* ]]; then
-  echo "PASS: ready text safe permission reset handoff"
+   [[ "$READY_TEXT" == *"Agent: end this turn now; do not run reset-runtime, setup, ready, service restart, or other TCC-backed probes."* ]] &&
+   [[ "$READY_TEXT" == *"Human: Remove/re-add or regrant the aos entry in macOS Privacy & Security, then return to the waiting session and say: finished."* ]] &&
+   [[ "$READY_TEXT" == *"Session: after the user says finished, run ./aos ready --post-permission"* ]]; then
+  echo "PASS: ready text terminal TCC handoff"
 else
-  echo "FAIL: ready text missing safe permission reset handoff:"
+  echo "FAIL: ready text missing terminal TCC handoff:"
   echo "$READY_TEXT"
   exit 1
 fi

--- a/tests/input-tap-readiness.sh
+++ b/tests/input-tap-readiness.sh
@@ -81,6 +81,10 @@ assert isinstance(tap, dict), f"runtime.input_tap missing: {d}"
 assert tap.get("status") == "retrying", f"runtime.input_tap.status: {tap}"
 assert tap.get("listen_access") is False, f"listen_access: {tap}"
 assert tap.get("post_access") is False, f"post_access: {tap}"
+verdict = d.get("runtime_verdict") or {}
+stale = verdict.get("tcc_staleness") or {}
+assert stale.get("id") == "post_rebuild_tcc_stale", d
+assert stale.get("daemon_live", {}).get("listen_access") is False, stale
 
 notes = d.get("notes", [])
 joined = "\n".join(notes)
@@ -141,11 +145,18 @@ target = sys.argv[1]
 assert d.get("ready") is False, d
 assert d.get("phase") == "human_required", d
 assert d.get("diagnosis") == "daemon_tcc_grant_stale_or_missing", d
+stale = d.get("tcc_staleness") or {}
+assert stale.get("id") == "post_rebuild_tcc_stale", d
+assert stale.get("cli_passive", {}).get("listen_access") is True, stale
+assert stale.get("daemon_live", {}).get("listen_access") is False, stale
+assert "passive checks pass" in stale.get("reason", ""), stale
+assert stale.get("binary_identity", {}).get("path") == target, stale
 actions = d.get("next_actions", [])
 commands = [a.get("command", "") for a in actions]
 assert "./aos permissions reset-runtime --mode repo" in commands, actions
 assert "./aos permissions setup --once" in commands, actions
 assert "./aos ready --post-permission" in commands, actions
+assert any(a.get("type") == "manual_tcc_reset" and a.get("reason") == "post_rebuild_tcc_stale" for a in actions), actions
 reset_index = commands.index("./aos permissions reset-runtime --mode repo")
 setup_index = commands.index("./aos permissions setup --once")
 post_index = commands.index("./aos ready --post-permission")

--- a/tests/ready-fast-healthy-path.sh
+++ b/tests/ready-fast-healthy-path.sh
@@ -82,10 +82,16 @@ import json, sys
 d = json.loads(sys.stdin.read())
 runtime = d.get("runtime", {})
 tap = runtime.get("input_tap", {})
+readiness = d.get("readiness", {})
 notes = d.get("notes", [])
 joined = "\n".join(notes)
 
 assert d.get("status") == "ok", d
+assert readiness.get("ready") is True, readiness
+assert readiness.get("status") == "ok", readiness
+assert readiness.get("phase") == "ready", readiness
+assert readiness.get("diagnosis") == "ready", readiness
+assert readiness.get("ready_source") == "daemon", readiness
 assert runtime.get("socket_reachable") is True, runtime
 assert runtime.get("input_tap_status") == "active", runtime
 assert tap.get("status") == "active", tap


### PR DESCRIPTION
## Summary

Analysis-only spike proposal (no runtime code changes) scoping the **second item in the blocker table after `LICENSE`**: making macOS TCC grants survive rebuilds via a stable signing identity + a real `Info.plist`, and pre-declaring the microphone / speech-recognition usage strings the `aos listen` dictation direction (PR #589) will need.

**Decision trail:** LICENSE ✅ (commit 43365d5, PR #589) → **Info.plist/.entitlements 🔴 (this spike)**.

## What's inside

`docs/proposals/2026-07-08-packaged-runtime-infoplist-entitlements-spike.md` covers:

- **Current state, grounded in the tree:** `aos` ships as a bare, ad-hoc-signed Mach-O (`build.sh` → `swiftc -o ./aos`, `codesign --force --sign - --identifier com.agentos.repo-aos`) with **no `Info.plist`, no `.entitlements`, no bundle**. `build.sh` already warns via `play_rebuild_alert()` that every rebuild forces manual TCC re-grants — the exact pain this spike targets.
- **Permission-surface map:** the three TCC surfaces used today (Accessibility via `AXIsProcessTrusted`, Screen Recording via `CGPreflightScreenCaptureAccess`/`SCShareableContent`, Input Monitoring via `CGEvent.tapCreate` — surfaced by `__permissions` as `accessibility`/`screen_recording`/`listen_access`/`post_access`), plus the two future surfaces #589 adds (Microphone → `NSMicrophoneUsageDescription`, Speech Recognition → `NSSpeechRecognitionUsageDescription`).
- **Key nuance:** today's `aos listen` is a message-channel reader (no mic API); mic + speech-recognition are strictly *future* surfaces. `aos say`/`NSSpeechSynthesizer` (and a local Kokoro TTS) are entitlement-neutral — the **dictation side is what forces the `Info.plist`**.
- **Proposed experiment:** minimal `packaging/Info.plist` + `packaging/aos.entitlements`, two packaging shapes to compare (embedded `__info_plist` section vs. a real `.app`), a move to a stable signing identity, and a `build.sh` flag that leaves the dev path untouched.
- **Spike checklist** with a concrete go/no-go proof: grant permissions once → rebuild via the packaged path → confirm grants **survive** with no re-prompt.
- File-level change list and explicit open questions (does fixed-identifier ad-hoc signing persist TCC across rebuilds, or is a self-signed cert the minimum? hardened runtime vs. loading local model dylibs? `.app` shape vs. the `aos service` LaunchAgent path?).

## Non-goals

No Swift/runtime code is changed in this PR. Notarization / Developer ID distribution is explicitly deferred. The Kokoro/dictation features themselves are out of scope — this only prepares the permission substrate.
