### PR TITLE
Freeze generic voice event schema

### DIFF
--- a/shared/schemas/daemon-event.md
+++ b/shared/schemas/daemon-event.md
@@ -125,6 +125,24 @@ other geometry sequence when a sequence exists.
 | `action_complete` | `{action, target, result}` | An action finished executing |
 | `context_changed` | `{pid, window_id, bounds}` | Session context changed |
 
+### voice
+
+The `voice` service is a generic daemon event namespace. It must stay
+product-neutral: the daemon publishes trigger and dictation lifecycle facts,
+while apps such as Sigil own UX policy, response sounds, TTS hooks, and menu
+behavior.
+
+| Event | Data | Trigger |
+|-------|------|---------|
+| `wake_detected` | `{source}` where `source` is `hotkey` or `phrase` | A hotkey or wake phrase trigger was detected |
+| `dictation_opened` | `{source}` where `source` is `hotkey` or `phrase` | A dictation session opened |
+| `dictation_closed_send` | `{reason}` where `reason` is `key_release`, `phrase`, `explicit_trigger`, or `timeout` | Dictation closed and captured text should be sent |
+| `dictation_closed_cancel` | `{reason}` where `reason` is `key_release`, `phrase`, `explicit_trigger`, or `timeout` | Dictation closed and captured text should be discarded |
+
+These events intentionally do not define microphone capture, transcription,
+audio playback, or Sigil behavior. Downstream shorthand such as
+`voice.wake_detected` means `{service:"voice", event:"wake_detected"}`.
+
 ## Shared Types
 
 `Bounds` from `annotation.schema.json`: `{x, y, width, height}`. Coordinate space depends on context — global CG for topology events, window-relative when scoped.

--- a/shared/schemas/daemon-event.schema.json
+++ b/shared/schemas/daemon-event.schema.json
@@ -6,6 +6,84 @@
   "type": "object",
   "required": ["v", "service", "event", "ts", "data"],
   "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "required": ["service"],
+        "properties": {
+          "service": { "const": "voice" }
+        }
+      },
+      "then": {
+        "properties": {
+          "event": {
+            "enum": [
+              "wake_detected",
+              "dictation_opened",
+              "dictation_closed_send",
+              "dictation_closed_cancel"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["service", "event"],
+        "properties": {
+          "service": { "const": "voice" },
+          "event": { "const": "wake_detected" }
+        }
+      },
+      "then": {
+        "properties": {
+          "data": { "$ref": "#/$defs/VoiceSourceData" }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["service", "event"],
+        "properties": {
+          "service": { "const": "voice" },
+          "event": { "const": "dictation_opened" }
+        }
+      },
+      "then": {
+        "properties": {
+          "data": { "$ref": "#/$defs/VoiceSourceData" }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["service", "event"],
+        "properties": {
+          "service": { "const": "voice" },
+          "event": { "const": "dictation_closed_send" }
+        }
+      },
+      "then": {
+        "properties": {
+          "data": { "$ref": "#/$defs/VoiceDictationClosedData" }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["service", "event"],
+        "properties": {
+          "service": { "const": "voice" },
+          "event": { "const": "dictation_closed_cancel" }
+        }
+      },
+      "then": {
+        "properties": {
+          "data": { "$ref": "#/$defs/VoiceDictationClosedData" }
+        }
+      }
+    }
+  ],
   "properties": {
     "v": {
       "const": 1,
@@ -38,6 +116,32 @@
     "Bounds": {
       "$ref": "annotation.schema.json#/$defs/Bounds",
       "description": "Reuse shared Bounds type (x, y, width, height)."
+    },
+    "VoiceSource": {
+      "type": "string",
+      "enum": ["hotkey", "phrase"],
+      "description": "Trigger source for generic voice events."
+    },
+    "VoiceDictationCloseReason": {
+      "type": "string",
+      "enum": ["key_release", "phrase", "explicit_trigger", "timeout"],
+      "description": "Reason a dictation session closed."
+    },
+    "VoiceSourceData": {
+      "type": "object",
+      "required": ["source"],
+      "additionalProperties": false,
+      "properties": {
+        "source": { "$ref": "#/$defs/VoiceSource" }
+      }
+    },
+    "VoiceDictationClosedData": {
+      "type": "object",
+      "required": ["reason"],
+      "additionalProperties": false,
+      "properties": {
+        "reason": { "$ref": "#/$defs/VoiceDictationCloseReason" }
+      }
     }
   }
 }

--- a/shared/schemas/daemon-ipc.md
+++ b/shared/schemas/daemon-ipc.md
@@ -194,4 +194,14 @@ Bare `{"action":"subscribe"}` (non-envelope format) is still accepted for backwa
 
 ## Event Envelope Note
 
-The event envelope (`daemon-event.schema.json` v1) uses `service` values `perceive|display|act|voice` in its enum today. The live daemon additionally emits `system`, `coordination`, and `wiki` event services. The request-side namespaces defined here (`see|do|show|tell|listen|session|voice|system`) differ from the event-side service values. Reconciling both sides is deferred to a v2 event envelope.
+The event envelope (`daemon-event.schema.json` v1) uses `service` values
+`perceive|display|act|voice` in its enum today. The `voice` service is reserved
+for generic trigger and dictation lifecycle events:
+`wake_detected`, `dictation_opened`, `dictation_closed_send`, and
+`dictation_closed_cancel`. These are pushed events, not request actions, and do
+not imply microphone capture, transcription, playback, or Sigil behavior.
+
+The live daemon additionally emits `system`, `coordination`, and `wiki` event
+services. The request-side namespaces defined here
+(`see|do|show|tell|listen|session|voice|system`) differ from the event-side
+service values. Reconciling both sides is deferred to a v2 event envelope.

--- a/shared/schemas/fixtures/daemon-event/invalid/voice-dictation-closed-send-missing-reason.json
+++ b/shared/schemas/fixtures/daemon-event/invalid/voice-dictation-closed-send-missing-reason.json
@@ -1,0 +1,7 @@
+{
+  "v": 1,
+  "service": "voice",
+  "event": "dictation_closed_send",
+  "ts": 1783570002.125,
+  "data": {}
+}

--- a/shared/schemas/fixtures/daemon-event/invalid/voice-dictation-opened-extra-field.json
+++ b/shared/schemas/fixtures/daemon-event/invalid/voice-dictation-opened-extra-field.json
@@ -1,0 +1,10 @@
+{
+  "v": 1,
+  "service": "voice",
+  "event": "dictation_opened",
+  "ts": 1783570001.125,
+  "data": {
+    "source": "phrase",
+    "transcript": "not part of this event"
+  }
+}

--- a/shared/schemas/fixtures/daemon-event/invalid/voice-unknown-event.json
+++ b/shared/schemas/fixtures/daemon-event/invalid/voice-unknown-event.json
@@ -1,0 +1,9 @@
+{
+  "v": 1,
+  "service": "voice",
+  "event": "transcript_ready",
+  "ts": 1783570004.125,
+  "data": {
+    "transcript": "hello"
+  }
+}

--- a/shared/schemas/fixtures/daemon-event/invalid/voice-wake-detected-invalid-source.json
+++ b/shared/schemas/fixtures/daemon-event/invalid/voice-wake-detected-invalid-source.json
@@ -1,0 +1,9 @@
+{
+  "v": 1,
+  "service": "voice",
+  "event": "wake_detected",
+  "ts": 1783570000.5,
+  "data": {
+    "source": "button"
+  }
+}

--- a/shared/schemas/fixtures/daemon-event/valid/perceive-cursor-moved.json
+++ b/shared/schemas/fixtures/daemon-event/valid/perceive-cursor-moved.json
@@ -1,0 +1,11 @@
+{
+  "v": 1,
+  "service": "perceive",
+  "event": "cursor_moved",
+  "ts": 1783570000.125,
+  "data": {
+    "x": 450,
+    "y": 320,
+    "display": 1
+  }
+}

--- a/shared/schemas/fixtures/daemon-event/valid/voice-dictation-closed-cancel-key-release.json
+++ b/shared/schemas/fixtures/daemon-event/valid/voice-dictation-closed-cancel-key-release.json
@@ -1,0 +1,9 @@
+{
+  "v": 1,
+  "service": "voice",
+  "event": "dictation_closed_cancel",
+  "ts": 1783570003.125,
+  "data": {
+    "reason": "key_release"
+  }
+}

--- a/shared/schemas/fixtures/daemon-event/valid/voice-dictation-closed-send-timeout.json
+++ b/shared/schemas/fixtures/daemon-event/valid/voice-dictation-closed-send-timeout.json
@@ -1,0 +1,9 @@
+{
+  "v": 1,
+  "service": "voice",
+  "event": "dictation_closed_send",
+  "ts": 1783570002.125,
+  "data": {
+    "reason": "timeout"
+  }
+}

--- a/shared/schemas/fixtures/daemon-event/valid/voice-dictation-opened-phrase.json
+++ b/shared/schemas/fixtures/daemon-event/valid/voice-dictation-opened-phrase.json
@@ -1,0 +1,9 @@
+{
+  "v": 1,
+  "service": "voice",
+  "event": "dictation_opened",
+  "ts": 1783570001.125,
+  "data": {
+    "source": "phrase"
+  }
+}

--- a/shared/schemas/fixtures/daemon-event/valid/voice-wake-detected-hotkey.json
+++ b/shared/schemas/fixtures/daemon-event/valid/voice-wake-detected-hotkey.json
@@ -1,0 +1,9 @@
+{
+  "v": 1,
+  "service": "voice",
+  "event": "wake_detected",
+  "ts": 1783570000.5,
+  "data": {
+    "source": "hotkey"
+  }
+}

--- a/tests/schemas/daemon-event.test.mjs
+++ b/tests/schemas/daemon-event.test.mjs
@@ -1,0 +1,79 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+const schemaPath = path.join(repoRoot, 'shared/schemas/daemon-event.schema.json');
+const fixtureRoot = path.join(repoRoot, 'shared/schemas/fixtures/daemon-event');
+
+async function jsonFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+    .map((entry) => path.join(dir, entry.name))
+    .sort();
+}
+
+function runJsonschema(fixturePath) {
+  return spawnSync(
+    'python3',
+    [
+      '-c',
+      `
+import json, sys
+from pathlib import Path
+from jsonschema import Draft202012Validator
+
+schema = json.loads(Path(sys.argv[1]).read_text())
+instance = json.loads(Path(sys.argv[2]).read_text())
+Draft202012Validator.check_schema(schema)
+validator = Draft202012Validator(schema)
+errors = sorted(validator.iter_errors(instance), key=lambda e: list(e.path))
+if errors:
+    for error in errors[:8]:
+        print(error.message)
+    sys.exit(1)
+`,
+      schemaPath,
+      fixturePath,
+    ],
+    { encoding: 'utf8' },
+  );
+}
+
+test('valid daemon event fixtures match the canonical schema', async () => {
+  const fixtures = await jsonFiles(path.join(fixtureRoot, 'valid'));
+  assert.ok(fixtures.length >= 1, 'expected valid fixtures');
+  for (const fixture of fixtures) {
+    const result = runJsonschema(fixture);
+    assert.equal(
+      result.status,
+      0,
+      `${path.relative(repoRoot, fixture)} should validate\n${result.stdout}${result.stderr}`,
+    );
+  }
+});
+
+test('invalid daemon event fixtures are rejected by the canonical schema', async () => {
+  const fixtures = await jsonFiles(path.join(fixtureRoot, 'invalid'));
+  assert.ok(fixtures.length >= 1, 'expected invalid fixtures');
+  for (const fixture of fixtures) {
+    const result = runJsonschema(fixture);
+    assert.notEqual(result.status, 0, `${path.relative(repoRoot, fixture)} should fail validation`);
+  }
+});
+
+test('voice event vocabulary stays frozen before behavior lands', async () => {
+  const schema = JSON.parse(await fs.readFile(schemaPath, 'utf8'));
+  const voiceServiceRule = schema.allOf.find((rule) => rule.if?.properties?.service?.const === 'voice');
+  assert.deepEqual(voiceServiceRule.then.properties.event.enum, [
+    'wake_detected',
+    'dictation_opened',
+    'dictation_closed_send',
+    'dictation_closed_cancel',
+  ]);
+});


### PR DESCRIPTION
## Summary
- freeze the generic daemon voice event vocabulary for wake and dictation lifecycle facts
- add strict voice payload validation plus valid/invalid daemon-event fixtures
- document that these pushed events do not implement microphone capture, transcription, playback, or Sigil behavior

## Validation
- node --test tests/schemas/daemon-event.test.mjs
- node --test tests/schemas/*.test.mjs
- git diff --check
- node scripts/generate-command-manifests.mjs --check
- bash tests/command-manifest-generation.sh
- bash tests/help-contract.sh
- bash tests/external-command-dispatch.sh
- AOS_TCC_HANDOFF_ALERT=0 AOS_BUILD_REBUILD_ALERT_REPEAT=0 ./aos dev build --no-restart --json
- ./aos help --json > /tmp/aos-help-pr2.json
- node -e "const fs = require('node:fs'); const help = JSON.parse(fs.readFileSync('/tmp/aos-help-pr2.json', 'utf8')); if (!help || typeof help !== 'object') throw new Error('help JSON root missing'); if (help.status && help.status !== 'ok') throw new Error('unexpected help status ' + help.status); console.log('aos help JSON parsed');"