### PR TITLE
Add TTS provider dispatch seam

### DIFF
--- a/src/voice/provider.swift
+++ b/src/voice/provider.swift
@@ -5,3 +5,37 @@ protocol VoiceProvider {
     var availability: ProviderAvailability { get }
     func enumerate() -> [VoiceRecord]
 }
+
+struct VoiceSpeakRequest {
+    let text: String
+    let voice: VoiceRecord
+    let rate: Float?
+    let skipAudio: Bool
+}
+
+struct VoiceSpeakResult {
+    let provider: String
+    let voiceID: String
+    let mode: String
+    let audioPerformed: Bool
+    let metadata: [String: AnyCodableJSON]
+
+    func dictionary() -> [String: Any] {
+        return [
+            "provider": provider,
+            "voice_id": voiceID,
+            "mode": mode,
+            "audio_performed": audioPerformed,
+            "metadata": metadata.mapValues { $0.asAny }
+        ]
+    }
+}
+
+struct VoiceSpeakError: Error {
+    let code: String
+    let message: String
+}
+
+protocol SpeakableVoiceProvider: VoiceProvider {
+    func speak(_ request: VoiceSpeakRequest) throws -> VoiceSpeakResult
+}

--- a/src/voice/providers/kokoro.swift
+++ b/src/voice/providers/kokoro.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+struct KokoroProvider: SpeakableVoiceProvider {
+    let name = "kokoro"
+
+    private var fakeRunnerEnabled: Bool {
+        ProcessInfo.processInfo.environment["AOS_VOICE_KOKORO_FAKE_RUNNER"] == "1"
+    }
+
+    var availability: ProviderAvailability {
+        if fakeRunnerEnabled {
+            return ProviderAvailability(reachable: true, reason: nil)
+        }
+        return ProviderAvailability(reachable: false, reason: "kokoro runner/model unavailable")
+    }
+
+    func enumerate() -> [VoiceRecord] {
+        let reachable = availability.reachable
+        return [
+            VoiceRecord(
+                id: VoiceID.make(provider: name, providerVoiceID: "kokoro-82m-default"),
+                provider: name,
+                provider_voice_id: "kokoro-82m-default",
+                name: "Kokoro 82M Default",
+                display_name: "Kokoro 82M",
+                locale: "en-US",
+                language: "en",
+                region: "US",
+                gender: "neutral",
+                kind: "synthetic",
+                quality_tier: "local-model",
+                tags: ["local", "model", "kokoro", "unbundled"],
+                capabilities: VoiceCapabilities(local: true, streaming: false, ssml: false, speak_supported: true),
+                availability: VoiceAvailability(installed: fakeRunnerEnabled, enabled: true, reachable: reachable),
+                metadata: [
+                    "model_family": .string("kokoro"),
+                    "model_size": .string("82m"),
+                    "distribution": .string("weights-not-bundled"),
+                    "runner": .string(fakeRunnerEnabled ? "fake" : "missing")
+                ]
+            )
+        ]
+    }
+
+    func speak(_ request: VoiceSpeakRequest) throws -> VoiceSpeakResult {
+        guard fakeRunnerEnabled else {
+            throw VoiceSpeakError(code: "VOICE_PROVIDER_UNAVAILABLE", message: "kokoro runner/model unavailable")
+        }
+        return VoiceSpeakResult(
+            provider: name,
+            voiceID: request.voice.id,
+            mode: "kokoro-fake-runner",
+            audioPerformed: false,
+            metadata: [
+                "skip_audio": .bool(request.skipAudio),
+                "runner": .string("fake")
+            ]
+        )
+    }
+}

--- a/src/voice/providers/mock.swift
+++ b/src/voice/providers/mock.swift
@@ -4,7 +4,7 @@ import Foundation
 /// process start. The canonical [system, elevenlabs] providers stay live
 /// alongside it, allowing tests to also exercise NOT_SPEAKABLE paths against
 /// the elevenlabs stub without restarting the daemon.
-struct MockVoiceProvider: VoiceProvider {
+struct MockVoiceProvider: SpeakableVoiceProvider {
     let name: String
     let _availability: ProviderAvailability
     private let voices: [VoiceRecord]
@@ -16,7 +16,60 @@ struct MockVoiceProvider: VoiceProvider {
     }
 
     var availability: ProviderAvailability { _availability }
-    func enumerate() -> [VoiceRecord] { voices }
+    func enumerate() -> [VoiceRecord] {
+        voices.map { voice in
+            var record = voice
+            record.availability.reachable = availability.reachable
+            return record
+        }
+    }
+
+    func speak(_ request: VoiceSpeakRequest) throws -> VoiceSpeakResult {
+        guard availability.reachable else {
+            throw VoiceSpeakError(code: "VOICE_PROVIDER_UNAVAILABLE", message: availability.reason ?? "mock provider unavailable")
+        }
+        if let logPath = ProcessInfo.processInfo.environment["AOS_VOICE_MOCK_SPEAK_LOG"],
+           !logPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            try appendSpeakLog(path: logPath, request: request)
+        }
+        return VoiceSpeakResult(
+            provider: name,
+            voiceID: request.voice.id,
+            mode: "mock",
+            audioPerformed: false,
+            metadata: [
+                "skip_audio": .bool(request.skipAudio)
+            ]
+        )
+    }
+
+    private func appendSpeakLog(path: String, request: VoiceSpeakRequest) throws {
+        var payload: [String: Any] = [
+            "provider": name,
+            "voice": request.voice.id,
+            "text": request.text,
+            "skip_audio": request.skipAudio
+        ]
+        if let rate = request.rate {
+            payload["rate"] = rate
+        }
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+        guard let line = String(data: data, encoding: .utf8) else {
+            throw VoiceSpeakError(code: "VOICE_PROVIDER_ERROR", message: "mock speak log encoding failed")
+        }
+        let url = URL(fileURLWithPath: path)
+        let parent = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        if !FileManager.default.fileExists(atPath: path) {
+            FileManager.default.createFile(atPath: path, contents: nil)
+        }
+        let handle = try FileHandle(forWritingTo: url)
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        if let lineData = "\(line)\n".data(using: .utf8) {
+            try handle.write(contentsOf: lineData)
+        }
+    }
 
     static func defaultFixture() -> [VoiceRecord] {
         let names = ["Alpha", "Bravo", "Charlie", "Delta", "Echo"]

--- a/src/voice/registry.swift
+++ b/src/voice/registry.swift
@@ -177,11 +177,27 @@ final class VoiceRegistry {
 
     static func defaultProviders() -> [VoiceProvider] {
         var providers: [VoiceProvider] = [SystemVoiceProvider(), ElevenLabsStubProvider()]
-        let env = ProcessInfo.processInfo.environment["AOS_VOICE_TEST_PROVIDERS"]
-        if env == "mock" {
+        let testProviders = providerFlags(ProcessInfo.processInfo.environment["AOS_VOICE_TEST_PROVIDERS"])
+        if testProviders.contains("mock-unreachable") {
+            providers.append(MockVoiceProvider(name: "mock", reachable: false))
+        } else if testProviders.contains("mock") {
             providers.append(MockVoiceProvider(name: "mock"))
         }
+        if testProviders.contains("kokoro") || ProcessInfo.processInfo.environment["AOS_VOICE_KOKORO_PROVIDER"] == "1" {
+            providers.append(KokoroProvider())
+        }
         return providers
+    }
+
+    private static func providerFlags(_ raw: String?) -> Set<String> {
+        guard let raw, !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return [] }
+        return Set(
+            raw.split { ch in
+                ch == "," || ch == ":" || ch == ";" || ch.isWhitespace
+            }
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            .filter { !$0.isEmpty }
+        )
     }
 
     func providersInfo() -> [ProviderInfo] {
@@ -235,6 +251,38 @@ final class VoiceRegistry {
     }
 
     func contains(_ uri: String) -> Bool { lookup(uri) != nil }
+
+    func speak(text: String, voiceID rawVoiceID: String, rate: Float?, skipAudio: Bool) throws -> VoiceSpeakResult {
+        let canonical = VoiceID.canonicalize(rawVoiceID)
+        guard let parsed = VoiceID.parse(canonical) else {
+            throw VoiceSpeakError(code: "INVALID_VOICE_ID", message: "invalid voice id: \(rawVoiceID)")
+        }
+        guard parsed.provider != "system" else {
+            throw VoiceSpeakError(code: "INVALID_VOICE_PROVIDER", message: "system voices use the NSSpeechSynthesizer path")
+        }
+        guard let record = lookup(canonical) else {
+            throw VoiceSpeakError(code: "VOICE_NOT_FOUND", message: "voice not found in registry: \(canonical)")
+        }
+        guard record.capabilities.speak_supported else {
+            throw VoiceSpeakError(code: "VOICE_NOT_SPEAKABLE", message: "voice cannot synthesize in this version: \(canonical)")
+        }
+        guard record.availability.enabled else {
+            throw VoiceSpeakError(code: "VOICE_NOT_ALLOCATABLE", message: "voice is disabled by policy: \(canonical)")
+        }
+        guard record.availability.installed && record.availability.reachable else {
+            throw VoiceSpeakError(code: "VOICE_PROVIDER_UNAVAILABLE", message: "voice provider is unavailable for \(canonical)")
+        }
+        guard let provider = providers.first(where: { $0.name == parsed.provider }) else {
+            throw VoiceSpeakError(code: "VOICE_PROVIDER_UNAVAILABLE", message: "voice provider not loaded: \(parsed.provider)")
+        }
+        guard provider.availability.reachable else {
+            throw VoiceSpeakError(code: "VOICE_PROVIDER_UNAVAILABLE", message: provider.availability.reason ?? "voice provider unavailable: \(parsed.provider)")
+        }
+        guard let speakable = provider as? SpeakableVoiceProvider else {
+            throw VoiceSpeakError(code: "VOICE_NOT_SPEAKABLE", message: "voice provider cannot synthesize in this version: \(parsed.provider)")
+        }
+        return try speakable.speak(VoiceSpeakRequest(text: text, voice: record, rate: rate, skipAudio: skipAudio))
+    }
 
     func refresh() -> [VoiceRecord] { snapshot() }
 

--- a/src/voice/say.swift
+++ b/src/voice/say.swift
@@ -110,57 +110,78 @@ func sayCommand(args: [String]) {
                   code: "MISSING_ARG")
     }
 
+    let store = VoicePolicyStore()
+    let registry = VoiceRegistry(policyLoader: { store.load() })
+
     var reportedVoiceID = voiceID ?? SpeechEngine.defaultVoiceID
+    var nonSystemVoiceID: String?
     if let rawSlot = voiceSlot {
         voiceFilter.quality_tiers = qualityTiers
-        let resolved = resolveSayVoiceSlot(rawSlot, matching: voiceFilter)
+        let resolved = resolveSayVoiceSlot(rawSlot, matching: voiceFilter, registry: registry)
         voiceID = resolved.engineVoiceID
         reportedVoiceID = resolved.reportedVoiceID
+        nonSystemVoiceID = resolved.nonSystemVoiceID
+    } else if let rawVoiceID = voiceID {
+        let resolved = resolveExplicitSayVoice(rawVoiceID, registry: registry)
+        voiceID = resolved.engineVoiceID
+        reportedVoiceID = resolved.reportedVoiceID
+        nonSystemVoiceID = resolved.nonSystemVoiceID
     }
 
-    // Initialize NSApplication (needed for NSSpeechSynthesizer and global event monitor)
-    _ = NSApplication.shared
+    let skipSpeech = ProcessInfo.processInfo.environment["AOS_SAY_TEST_SKIP_SPEECH"] == "1"
+    if let nonSystemVoiceID {
+        do {
+            _ = try registry.speak(text: text, voiceID: nonSystemVoiceID, rate: rate, skipAudio: skipSpeech)
+        } catch let error as VoiceSpeakError {
+            exitError(error.message, code: error.code)
+        } catch {
+            exitError("voice provider failed: \(error.localizedDescription)", code: "VOICE_PROVIDER_ERROR")
+        }
+    } else {
+        // Initialize NSApplication (needed for NSSpeechSynthesizer and global event monitor)
+        _ = NSApplication.shared
 
-    // Create engine with configured voice
-    let engine = SpeechEngine(voice: voiceID)
-    if let r = rate { engine.setRate(r) }
+        // Create engine with configured voice
+        let engine = SpeechEngine(voice: voiceID)
+        if let r = rate { engine.setRate(r) }
 
-    // Hotkey: cancel speech (default: ESC = keyCode 53) via CGEvent tap
-    let cancelKey = effectiveSpeechCancelKeyCode(config: config)
-    let engineRef = Unmanaged.passUnretained(engine).toOpaque()
-    let tap = cancelKey.flatMap { cancelKey in
-        CGEvent.tapCreate(
-            tap: .cgSessionEventTap,
-            place: .headInsertEventTap,
-            options: .listenOnly,
-            eventsOfInterest: CGEventMask(1 << CGEventType.keyDown.rawValue),
-            callback: { _, _, event, refcon -> Unmanaged<CGEvent>? in
-                guard let refcon = refcon else { return Unmanaged.passUnretained(event) }
-                let eng = Unmanaged<SpeechEngine>.fromOpaque(refcon).takeUnretainedValue()
-                let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
-                if let activeKey = effectiveSpeechCancelKeyCode(config: loadConfig()),
-                   keyCode == activeKey {
-                    eng.stop()
-                }
-                return Unmanaged.passUnretained(event)
-            },
-            userInfo: engineRef
-        )
+        // Hotkey: cancel speech (default: ESC = keyCode 53) via CGEvent tap
+        let cancelKey = skipSpeech ? nil : effectiveSpeechCancelKeyCode(config: config)
+        let engineRef = Unmanaged.passUnretained(engine).toOpaque()
+        let tap = cancelKey.flatMap { cancelKey in
+            CGEvent.tapCreate(
+                tap: .cgSessionEventTap,
+                place: .headInsertEventTap,
+                options: .listenOnly,
+                eventsOfInterest: CGEventMask(1 << CGEventType.keyDown.rawValue),
+                callback: { _, _, event, refcon -> Unmanaged<CGEvent>? in
+                    guard let refcon = refcon else { return Unmanaged.passUnretained(event) }
+                    let eng = Unmanaged<SpeechEngine>.fromOpaque(refcon).takeUnretainedValue()
+                    let keyCode = UInt16(event.getIntegerValueField(.keyboardEventKeycode))
+                    if let activeKey = effectiveSpeechCancelKeyCode(config: loadConfig()),
+                       keyCode == activeKey {
+                        eng.stop()
+                    }
+                    return Unmanaged.passUnretained(event)
+                },
+                userInfo: engineRef
+            )
+        }
+        var tapSource: CFRunLoopSource?
+        if let tap = tap {
+            tapSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+            CFRunLoopAddSource(CFRunLoopGetCurrent(), tapSource, .defaultMode)
+            CGEvent.tapEnable(tap: tap, enable: true)
+        }
+
+        // Speak and wait
+        if !skipSpeech {
+            engine.speakAndWait(text)
+        }
+
+        if let tap = tap { CGEvent.tapEnable(tap: tap, enable: false) }
+        if let s = tapSource { CFRunLoopRemoveSource(CFRunLoopGetCurrent(), s, .defaultMode) }
     }
-    var tapSource: CFRunLoopSource?
-    if let tap = tap {
-        tapSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
-        CFRunLoopAddSource(CFRunLoopGetCurrent(), tapSource, .defaultMode)
-        CGEvent.tapEnable(tap: tap, enable: true)
-    }
-
-    // Speak and wait
-    if ProcessInfo.processInfo.environment["AOS_SAY_TEST_SKIP_SPEECH"] != "1" {
-        engine.speakAndWait(text)
-    }
-
-    if let tap = tap { CGEvent.tapEnable(tap: tap, enable: false) }
-    if let s = tapSource { CFRunLoopRemoveSource(CFRunLoopGetCurrent(), s, .defaultMode) }
 
     // Output confirmation
     let response: [String: Any] = [
@@ -175,13 +196,34 @@ func sayCommand(args: [String]) {
     }
 }
 
-private func resolveSayVoiceSlot(_ rawSlot: String, matching filter: VoiceFilter) -> (engineVoiceID: String?, reportedVoiceID: String) {
+private func resolveExplicitSayVoice(_ rawVoiceID: String, registry: VoiceRegistry) -> (engineVoiceID: String?, reportedVoiceID: String, nonSystemVoiceID: String?) {
+    let canonical = VoiceID.canonicalize(rawVoiceID)
+    guard let parsed = VoiceID.parse(canonical) else {
+        return (rawVoiceID, rawVoiceID, nil)
+    }
+    if parsed.provider == "system" {
+        return (parsed.providerVoiceID, rawVoiceID.hasPrefix(VoiceID.prefix) ? canonical : rawVoiceID, nil)
+    }
+    guard let record = registry.lookup(canonical) else {
+        exitError("voice not found in registry: \(canonical)", code: "VOICE_NOT_FOUND")
+    }
+    guard record.capabilities.speak_supported else {
+        exitError("voice cannot synthesize in this version: \(canonical)", code: "VOICE_NOT_SPEAKABLE")
+    }
+    guard record.availability.enabled else {
+        exitError("voice is disabled by policy: \(canonical)", code: "VOICE_NOT_ALLOCATABLE")
+    }
+    guard record.availability.installed && record.availability.reachable else {
+        exitError("voice provider is unavailable for \(canonical)", code: "VOICE_PROVIDER_UNAVAILABLE")
+    }
+    return (nil, record.id, record.id)
+}
+
+private func resolveSayVoiceSlot(_ rawSlot: String, matching filter: VoiceFilter, registry: VoiceRegistry) -> (engineVoiceID: String?, reportedVoiceID: String, nonSystemVoiceID: String?) {
     guard let slot = Int(rawSlot), slot > 0 else {
         exitError("say --voice-slot must be a positive 1-based integer, got \(rawSlot)", code: "INVALID_VOICE_SLOT")
     }
 
-    let store = VoicePolicyStore()
-    let registry = VoiceRegistry(policyLoader: { store.load() })
     let voices = filter.isEmpty ? registry.allocatableSnapshot() : registry.allocatableSnapshot(matching: filter)
     if voices.isEmpty {
         exitError("say --voice-slot \(slot) found no speakable voices after filters\(sayFilterDescription(filter))", code: "VOICE_FILTER_EMPTY")
@@ -192,9 +234,9 @@ private func resolveSayVoiceSlot(_ rawSlot: String, matching filter: VoiceFilter
 
     let record = voices[slot - 1]
     if record.provider == "system" {
-        return (record.provider_voice_id, record.id)
+        return (record.provider_voice_id, record.id, nil)
     }
-    return (record.provider_voice_id, record.id)
+    return (nil, record.id, record.id)
 }
 
 private func parseSayQualityTiers(_ value: String) -> [String] {

--- a/tests/README.md
+++ b/tests/README.md
@@ -545,6 +545,7 @@ Examples:
 - `bash tests/panel-tabs-activation.sh`
 - `bash tests/voice-session-leases.sh`
 - `bash tests/say-voice-slot.sh`
+- `bash tests/say-tts-provider-seam.sh`
 - `bash tests/voice-bind.sh`
 - `bash tests/voice-final-response.sh`
 - `bash tests/voice-telemetry.sh`

--- a/tests/say-tts-provider-seam.sh
+++ b/tests/say-tts-provider-seam.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+TMPDIR_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/aos-say-tts-provider-seam.XXXXXX")"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+export AOS_STATE_ROOT="$TMPDIR_ROOT"
+export AOS_SAY_TEST_SKIP_SPEECH=1
+
+say_json() {
+  ./aos say "$@" | python3 -c '
+import json
+import sys
+payload = json.loads(sys.stdin.read())
+print(json.dumps(payload, sort_keys=True))
+'
+}
+
+export AOS_VOICE_TEST_PROVIDERS=mock
+export AOS_VOICE_MOCK_SPEAK_LOG="$TMPDIR_ROOT/mock-speak.jsonl"
+
+out="$(say_json --voice voice://mock/mock-bravo --rate 210 "mock provider dispatch")"
+python3 - "$out" "$AOS_VOICE_MOCK_SPEAK_LOG" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(sys.argv[1])
+assert payload["status"] == "success", payload
+assert payload["voice"] == "voice://mock/mock-bravo", payload
+lines = pathlib.Path(sys.argv[2]).read_text().splitlines()
+assert len(lines) == 1, lines
+entry = json.loads(lines[0])
+assert entry["provider"] == "mock", entry
+assert entry["voice"] == "voice://mock/mock-bravo", entry
+assert entry["text"] == "mock provider dispatch", entry
+assert entry["rate"] == 210, entry
+assert entry["skip_audio"] is True, entry
+PY
+
+out="$(say_json --voice-slot 1 "slot provider dispatch")"
+python3 - "$out" "$AOS_VOICE_MOCK_SPEAK_LOG" <<'PY'
+import json
+import pathlib
+import sys
+
+payload = json.loads(sys.argv[1])
+assert payload["voice"] == "voice://mock/mock-alpha", payload
+lines = pathlib.Path(sys.argv[2]).read_text().splitlines()
+assert len(lines) == 2, lines
+entry = json.loads(lines[1])
+assert entry["voice"] == "voice://mock/mock-alpha", entry
+assert entry["text"] == "slot provider dispatch", entry
+PY
+
+before_count="$(wc -l < "$AOS_VOICE_MOCK_SPEAK_LOG")"
+out="$(say_json --voice voice://system/com.apple.voice.compact.en-US.Samantha "system path unchanged")"
+after_count="$(wc -l < "$AOS_VOICE_MOCK_SPEAK_LOG")"
+python3 - "$out" "$before_count" "$after_count" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+assert payload["status"] == "success", payload
+assert payload["voice"] == "voice://system/com.apple.voice.compact.en-US.Samantha", payload
+assert sys.argv[2] == sys.argv[3], (sys.argv[2], sys.argv[3])
+PY
+
+export AOS_VOICE_TEST_PROVIDERS=mock-unreachable
+if err="$(./aos say --voice voice://mock/mock-alpha "unreachable provider" 2>&1 >/dev/null)"; then
+  echo "FAIL: expected unreachable mock provider to fail" >&2
+  exit 1
+fi
+echo "$err" | grep -Eq '"code"[[:space:]]*:[[:space:]]*"VOICE_PROVIDER_UNAVAILABLE"' || {
+  echo "FAIL: expected VOICE_PROVIDER_UNAVAILABLE for unreachable mock, got $err" >&2
+  exit 1
+}
+
+export AOS_VOICE_TEST_PROVIDERS=kokoro
+unset AOS_VOICE_KOKORO_FAKE_RUNNER
+if err="$(./aos say --voice voice://kokoro/kokoro-82m-default "kokoro unavailable" 2>&1 >/dev/null)"; then
+  echo "FAIL: expected Kokoro provider without runner/model to fail" >&2
+  exit 1
+fi
+echo "$err" | grep -Eq '"code"[[:space:]]*:[[:space:]]*"VOICE_PROVIDER_UNAVAILABLE"' || {
+  echo "FAIL: expected VOICE_PROVIDER_UNAVAILABLE for Kokoro, got $err" >&2
+  exit 1
+}
+
+export AOS_VOICE_KOKORO_FAKE_RUNNER=1
+out="$(say_json --voice voice://kokoro/kokoro-82m-default "kokoro fake runner")"
+python3 - "$out" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+assert payload["status"] == "success", payload
+assert payload["voice"] == "voice://kokoro/kokoro-82m-default", payload
+assert payload["text"] == "kokoro fake runner", payload
+PY
+
+echo "ok"


### PR DESCRIPTION
## Summary
- add a SpeakableVoiceProvider seam beside the existing voice catalog provider contract
- route non-system `aos say` voices through provider dispatch while preserving the system NSSpeechSynthesizer path
- add mocked provider dispatch plus opt-in Kokoro 82M catalog shape with no bundled weights and unavailable-by-default behavior

## Scope notes
- No real model weights are vendored.
- No microphone, STT, Sigil behavior, or voice event handling is added here.
- Default proof stays mocked/static; live TCC-backed readiness was not run after the local binary rebuild.

## Validation
- AOS_TCC_HANDOFF_ALERT=0 AOS_BUILD_REBUILD_ALERT_REPEAT=0 ./aos dev build --no-restart --json
- bash tests/say-voice-slot.sh
- bash tests/voice-bind.sh
- bash tests/say-tts-provider-seam.sh
- bash tests/voice-registry-snapshot.sh
- bash tests/voice-id-canonicalization.sh
- bash tests/voice-cursor-rotation.sh
- bash tests/voice-session-allocation.sh
- bash tests/voice-policy-reload.sh
- git diff --check
- node scripts/generate-command-manifests.mjs --check
- bash tests/command-manifest-generation.sh
- bash tests/help-contract.sh
- bash tests/external-command-dispatch.sh
- ./aos help --json > /tmp/aos-help-pr3.json
- node -e "const fs = require('node:fs'); const help = JSON.parse(fs.readFileSync('/tmp/aos-help-pr3.json', 'utf8')); if (!help || typeof help !== 'object') throw new Error('help JSON root missing'); if (help.status && help.status !== 'ok') throw new Error('unexpected help status ' + help.status); console.log('aos help JSON parsed');"

Note: `voice-session-allocation` and `voice-policy-reload` initially failed only when run concurrently with other daemon-backed adjacent tests due shared launchctl fixture contention; both passed when rerun sequentially.