### PR TITLE
Add Bundled Whisper STT spike

### DIFF
--- a/docs/design/bundled-whisper-stt-spike.md
+++ b/docs/design/bundled-whisper-stt-spike.md
@@ -1,0 +1,72 @@
+# Bundled Whisper STT Spike
+
+Status: Spike proof, distribution-gated.
+
+Owner: `scripts/lib/aos-stt/bundled-whisper.mjs`
+
+## Purpose
+
+This spike proves the local speech-to-text provider boundary for a future
+Bundled Whisper integration without requiring live microphone input, real model
+downloads, or vendored weights in the repository.
+
+It is intentionally internal. Public `aos listen` remains the existing
+communication channel/session reader and is not repurposed as dictation input.
+Sigil dictation and daemon `voice.*` event consumption are later slices.
+
+## Proven Contract
+
+The `bundled-whisper` STT provider exposes two small operations:
+
+- `bundledWhisperStatus({ modelPath, runnerPath, fakeRunner })` reports
+  `available`, `missing_model`, or `runner_unavailable`.
+- `transcribeWithBundledWhisper({ audioPath, modelPath, runnerPath, fakeRunner })`
+  returns a structured transcript result or throws `STTProviderError` with a
+  stable `code` and diagnostic `details`.
+
+Default proof uses:
+
+- fixture audio under `tests/fixtures/stt/bundled-whisper/`
+- a fake model metadata file instead of real Whisper weights
+- `fakeRunner: true` instead of a real native runner
+
+The fake runner computes the fixture audio SHA-256 and resolves the transcript
+from fake model metadata. If the fixture is not mapped, it fails closed with
+`STT_TRANSCRIPT_NOT_FOUND`.
+
+## Explicit Unavailable States
+
+The seam treats model and runner absence as first-class states:
+
+- missing or unset `modelPath` reports `missing_model` and transcription fails
+  with `STT_MODEL_MISSING`
+- missing or unset real runner path reports `runner_unavailable` and
+  transcription fails with `STT_RUNNER_UNAVAILABLE`
+
+The model check runs before runner dispatch so callers can tell the operator
+which install step is missing without attempting runner startup.
+
+## Distribution Gates
+
+This PR does not choose, download, or vendor real Whisper assets. Real
+Bundled Whisper enablement remains gated on:
+
+- model weight license and redistribution terms
+- model size and update strategy
+- packaged runtime location and integrity checks
+- runner implementation, sandbox expectations, and crash behavior
+- microphone capture integration and Sigil dictation state ownership
+
+Until those decisions are closed, tests must continue to use fake weights,
+fixture audio, and synthetic runner behavior.
+
+## Verification
+
+Run the focused proof with:
+
+```bash
+node --test tests/bundled-whisper-stt.test.mjs
+```
+
+This verifies deterministic fixture transcription, missing-model reporting,
+runner-unavailable reporting, and fail-closed handling for unmapped audio.

--- a/scripts/lib/aos-stt/bundled-whisper.mjs
+++ b/scripts/lib/aos-stt/bundled-whisper.mjs
@@ -1,0 +1,126 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export const BUNDLED_WHISPER_PROVIDER_ID = 'bundled-whisper';
+
+export class STTProviderError extends Error {
+  constructor(code, message, details = {}) {
+    super(message);
+    this.name = 'STTProviderError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+async function fileExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readFakeModel(modelPath) {
+  let raw;
+  try {
+    raw = await fs.readFile(modelPath, 'utf8');
+  } catch {
+    throw new STTProviderError('STT_MODEL_MISSING', `Bundled Whisper model is not installed: ${modelPath}`, {
+      model_path: modelPath,
+    });
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new STTProviderError('STT_MODEL_INVALID', `Bundled Whisper model metadata is invalid: ${modelPath}`, {
+      model_path: modelPath,
+      cause: error.message,
+    });
+  }
+}
+
+export async function bundledWhisperStatus({ modelPath, runnerPath, fakeRunner = false } = {}) {
+  const modelInstalled = Boolean(modelPath) && await fileExists(modelPath);
+  const runnerAvailable = fakeRunner || (Boolean(runnerPath) && await fileExists(runnerPath));
+  let status = 'available';
+  let reason = null;
+
+  if (!modelInstalled) {
+    status = 'missing_model';
+    reason = 'model_not_installed';
+  } else if (!runnerAvailable) {
+    status = 'runner_unavailable';
+    reason = 'runner_not_available';
+  }
+
+  return {
+    provider: BUNDLED_WHISPER_PROVIDER_ID,
+    status,
+    reason,
+    model: {
+      path: modelPath ?? null,
+      installed: modelInstalled,
+      distribution: 'not-bundled',
+    },
+    runner: {
+      mode: fakeRunner ? 'fake' : 'external',
+      path: runnerPath ?? null,
+      available: runnerAvailable,
+    },
+  };
+}
+
+export async function transcribeWithBundledWhisper({ audioPath, modelPath, runnerPath, fakeRunner = false } = {}) {
+  if (!audioPath) {
+    throw new STTProviderError('STT_AUDIO_MISSING', 'audioPath is required');
+  }
+  const audio = await fs.readFile(audioPath).catch(() => {
+    throw new STTProviderError('STT_AUDIO_MISSING', `Audio fixture is missing: ${audioPath}`, {
+      audio_path: audioPath,
+    });
+  });
+  const status = await bundledWhisperStatus({ modelPath, runnerPath, fakeRunner });
+  if (status.status === 'missing_model') {
+    throw new STTProviderError('STT_MODEL_MISSING', `Bundled Whisper model is not installed: ${modelPath}`, status);
+  }
+  if (status.status === 'runner_unavailable') {
+    throw new STTProviderError('STT_RUNNER_UNAVAILABLE', 'Bundled Whisper runner is unavailable', status);
+  }
+  if (!fakeRunner) {
+    throw new STTProviderError('STT_RUNNER_UNAVAILABLE', 'Real Bundled Whisper runner is not implemented in this spike', status);
+  }
+
+  const model = await readFakeModel(modelPath);
+  const audioBasename = path.basename(audioPath);
+  const audioSha256 = crypto.createHash('sha256').update(audio).digest('hex');
+  const transcript = model.transcripts_by_sha256?.[audioSha256]
+    ?? model.transcripts_by_fixture?.[audioBasename];
+  if (typeof transcript !== 'string' || transcript.length === 0) {
+    throw new STTProviderError('STT_TRANSCRIPT_NOT_FOUND', 'Fake Bundled Whisper model has no transcript for fixture audio', {
+      audio_path: audioPath,
+      audio_sha256: audioSha256,
+      model_path: modelPath,
+    });
+  }
+
+  return {
+    provider: BUNDLED_WHISPER_PROVIDER_ID,
+    mode: 'fake-runner',
+    audio: {
+      path: audioPath,
+      bytes: audio.byteLength,
+      sha256: audioSha256,
+    },
+    model: {
+      path: modelPath,
+      id: model.model_id ?? 'fake-bundled-whisper',
+      distribution: model.distribution ?? 'fake-test-fixture',
+    },
+    transcript: {
+      text: transcript,
+      language: model.language ?? 'en',
+    },
+  };
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -169,6 +169,7 @@ Examples:
 
 - `node --test tests/renderer/*.test.mjs`
 - `node --test tests/toolkit/*.test.mjs`
+- `node --test tests/bundled-whisper-stt.test.mjs`
 - `cd packages/gateway && npm test`
 - `cd packages/host && npm test`
 

--- a/tests/bundled-whisper-stt.test.mjs
+++ b/tests/bundled-whisper-stt.test.mjs
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  bundledWhisperStatus,
+  STTProviderError,
+  transcribeWithBundledWhisper,
+} from '../scripts/lib/aos-stt/bundled-whisper.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const fixtureRoot = path.join(repoRoot, 'tests/fixtures/stt/bundled-whisper');
+const audioPath = path.join(fixtureRoot, 'hello.fixture-audio.txt');
+const modelPath = path.join(fixtureRoot, 'fake-whisper-model.json');
+
+test('fake Bundled Whisper runner returns deterministic transcript for fixture audio', async () => {
+  const result = await transcribeWithBundledWhisper({
+    audioPath,
+    modelPath,
+    fakeRunner: true,
+  });
+
+  assert.equal(result.provider, 'bundled-whisper');
+  assert.equal(result.mode, 'fake-runner');
+  assert.equal(result.model.id, 'fake-bundled-whisper-tiny');
+  assert.equal(result.model.distribution, 'fake-test-fixture');
+  assert.equal(result.transcript.text, 'hello agent os');
+  assert.equal(result.transcript.language, 'en');
+  assert.equal(result.audio.bytes > 0, true);
+  assert.match(result.audio.sha256, /^[a-f0-9]{64}$/);
+});
+
+test('missing model is explicit before runner dispatch', async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), 'aos-stt-missing-model-'));
+  const missingModel = path.join(tmp, 'missing-whisper-model.bin');
+  const status = await bundledWhisperStatus({
+    audioPath,
+    modelPath: missingModel,
+    fakeRunner: true,
+  });
+
+  assert.equal(status.status, 'missing_model');
+  assert.equal(status.reason, 'model_not_installed');
+  await assert.rejects(
+    transcribeWithBundledWhisper({ audioPath, modelPath: missingModel, fakeRunner: true }),
+    (error) => error instanceof STTProviderError
+      && error.code === 'STT_MODEL_MISSING'
+      && error.details.model?.installed === false,
+  );
+});
+
+test('real runner remains unavailable in the spike', async () => {
+  const status = await bundledWhisperStatus({
+    modelPath,
+    runnerPath: path.join(os.tmpdir(), 'aos-missing-whisper-runner'),
+  });
+
+  assert.equal(status.status, 'runner_unavailable');
+  assert.equal(status.reason, 'runner_not_available');
+  await assert.rejects(
+    transcribeWithBundledWhisper({ audioPath, modelPath }),
+    (error) => error instanceof STTProviderError
+      && error.code === 'STT_RUNNER_UNAVAILABLE'
+      && error.details.runner?.available === false,
+  );
+});
+
+test('fake runner fails closed when fixture transcript is absent', async () => {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), 'aos-stt-unknown-audio-'));
+  const unknownAudio = path.join(tmp, 'unknown.fixture-audio.txt');
+  await writeFile(unknownAudio, 'synthetic fixture audio: no transcript here');
+
+  await assert.rejects(
+    transcribeWithBundledWhisper({ audioPath: unknownAudio, modelPath, fakeRunner: true }),
+    (error) => error instanceof STTProviderError
+      && error.code === 'STT_TRANSCRIPT_NOT_FOUND'
+      && error.details.audio_path === unknownAudio,
+  );
+});

--- a/tests/fixtures/stt/bundled-whisper/fake-whisper-model.json
+++ b/tests/fixtures/stt/bundled-whisper/fake-whisper-model.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "model_id": "fake-bundled-whisper-tiny",
+  "distribution": "fake-test-fixture",
+  "language": "en",
+  "transcripts_by_fixture": {
+    "hello.fixture-audio.txt": "hello agent os"
+  }
+}

--- a/tests/fixtures/stt/bundled-whisper/hello.fixture-audio.txt
+++ b/tests/fixtures/stt/bundled-whisper/hello.fixture-audio.txt
@@ -1,0 +1,1 @@
+synthetic fixture audio: hello agent os


### PR DESCRIPTION
## Summary

- add an internal `bundled-whisper` STT provider seam with explicit status reporting
- add fake model metadata and fixture audio for deterministic transcript proof
- document what the spike proves and keep real Whisper weights/runner distribution gated

## Validation

- `node --test tests/bundled-whisper-stt.test.mjs`
- `node --check scripts/lib/aos-stt/bundled-whisper.mjs`
- `git diff --check`
- `node scripts/generate-command-manifests.mjs --check`
- `bash tests/command-manifest-generation.sh`
- `bash tests/help-contract.sh`
- `bash tests/external-command-dispatch.sh`
- `AOS_TCC_HANDOFF_ALERT=0 AOS_BUILD_REBUILD_ALERT_REPEAT=0 ./aos dev build --no-restart --json`
- `./aos help --json` parsed via Node

Notes: no live microphone input, real model download, or vendored Whisper weights are required. Public `aos listen` remains the channel/session reader.