### PR TITLE
Add Sigil hold-spacebar dictation state

### DIFF
--- a/apps/sigil/renderer/live-modules/main.js
+++ b/apps/sigil/renderer/live-modules/main.js
@@ -67,6 +67,10 @@ import {
     selectionModeKeyName,
 } from './selection-mode-input.js';
 import {
+    createSigilVoiceDictationController,
+    isVoiceDictationEvent,
+} from './voice-dictation.js';
+import {
     createDefaultSelectionModeState,
     createSigilSelectionModeRuntime,
     buildSelectionModeSnapshotPayload,
@@ -233,6 +237,8 @@ const liveJs = {
     },
     activeContext: createDefaultActiveContextState(),
     contextRecording: createDefaultContextRecordingState(),
+    voiceDictation: null,
+    voiceDictationEvents: [],
     annotationReticleTargetEvidence: createAnnotationReticleTargetEvidenceCache(),
     annotationReticleBrowserDomBridge: null,
     annotationReticleEvents: [],
@@ -555,6 +561,25 @@ function recordInteraction(stage, data = {}) {
         avatarPos: liveJs.avatarPos,
     });
 }
+
+const voiceDictation = createSigilVoiceDictationController({
+    onChange(snapshot, transition) {
+        liveJs.voiceDictation = snapshot;
+        recordInteraction('voice-dictation', { transition });
+        if (!rendererSuspended) scheduleRenderFrame({ structural: false });
+    },
+    onVoiceEvent(event, transition) {
+        liveJs.voiceDictationEvents.push(event);
+        if (liveJs.voiceDictationEvents.length > 32) liveJs.voiceDictationEvents.shift();
+        liveJs.voiceDictation = voiceDictation.snapshot();
+        recordInteraction('voice-dictation:event', {
+            event: event.event,
+            data: event.data,
+            transition,
+        });
+    },
+});
+liveJs.voiceDictation = voiceDictation.snapshot();
 
 function runBootStep(stage, fn) {
     recordBoot(stage);
@@ -4123,23 +4148,25 @@ function handleInputEvent(msg) {
         rememberDaemonPointerEvent(msg);
     }
 
-        if (handleSelectionModeInput(msg)) return;
+    if (voiceDictation.handleInput(msg).handled) return;
 
-        if (liveJs.currentState === 'RADIAL' || liveJs.currentState === 'FAST_TRAVEL') {
-            if (msg.type === 'key_down' && (msg.key_code === 53 || selectionModeKeyName(msg) === 'escape')) {
-                cancelInteraction('escape');
-                return;
-            }
-            if (msg.type === 'right_mouse_down') {
-                cancelInteraction('right-click');
-                return;
-            }
+    if (handleSelectionModeInput(msg)) return;
+
+    if (liveJs.currentState === 'RADIAL' || liveJs.currentState === 'FAST_TRAVEL') {
+        if (msg.type === 'key_down' && (msg.key_code === 53 || selectionModeKeyName(msg) === 'escape')) {
+            cancelInteraction('escape');
+            return;
         }
+        if (msg.type === 'right_mouse_down') {
+            cancelInteraction('right-click');
+            return;
+        }
+    }
 
-        if (
-            avatarControls.isOpen()
-            && ['left_mouse_down', 'left_mouse_dragged', 'left_mouse_up', 'mouse_moved', 'scroll_wheel'].includes(msg.type)
-            && typeof msg.x === 'number'
+    if (
+        avatarControls.isOpen()
+        && ['left_mouse_down', 'left_mouse_dragged', 'left_mouse_up', 'mouse_moved', 'scroll_wheel'].includes(msg.type)
+        && typeof msg.x === 'number'
         && typeof msg.y === 'number'
     ) {
         const point = { x: msg.x, y: msg.y, valid: true };
@@ -4531,6 +4558,11 @@ function handleHostMessage(rawMsg) {
     }
     if (!shouldProcessGlobalDaemonEvent(msg)) return;
 
+    if (isVoiceDictationEvent(msg)) {
+        voiceDictation.handleVoiceEvent(msg);
+        return;
+    }
+
     if (msg.type === 'agent.session.telemetry' || msg.type === 'agent.session.lifecycle') {
         handleSessionTelemetryEnvelope(msg);
         return;
@@ -4830,6 +4862,10 @@ function startPrimarySurfaceServices() {
         'window_entered',
         'element_focused',
         'canvas_inspector.semantic_targets',
+        'wake_detected',
+        'dictation_opened',
+        'dictation_closed_send',
+        'dictation_closed_cancel',
     ], { snapshot: true });
     startMarkHeartbeat();
     emitRadialMenuObjectRegistry();

--- a/apps/sigil/renderer/live-modules/voice-dictation.js
+++ b/apps/sigil/renderer/live-modules/voice-dictation.js
@@ -1,0 +1,262 @@
+export const SIGIL_DICTATION_TIMEOUT_MS = 15000;
+
+export const VOICE_DICTATION_EVENT_NAMES = new Set([
+    'wake_detected',
+    'dictation_opened',
+    'dictation_closed_send',
+    'dictation_closed_cancel',
+]);
+
+const VOICE_SOURCE_VALUES = new Set(['hotkey', 'phrase']);
+const VOICE_CLOSE_REASONS = new Set(['key_release', 'phrase', 'explicit_trigger', 'timeout']);
+
+function defaultNowMs() {
+    return typeof performance !== 'undefined' && typeof performance.now === 'function'
+        ? performance.now()
+        : Date.now();
+}
+
+function defaultTimestampSeconds() {
+    return Date.now() / 1000;
+}
+
+function stringField(value) {
+    return typeof value === 'string' ? value : '';
+}
+
+function normalizeSource(source) {
+    return VOICE_SOURCE_VALUES.has(source) ? source : 'hotkey';
+}
+
+function normalizeCloseReason(reason) {
+    return VOICE_CLOSE_REASONS.has(reason) ? reason : 'explicit_trigger';
+}
+
+function keyName(msg = {}) {
+    return String(msg.key ?? msg.key_name ?? msg.code ?? '').toLowerCase();
+}
+
+export function isSpacebarDictationInput(msg = {}) {
+    if (msg.type !== 'key_down' && msg.type !== 'key_up') return false;
+    if (Number(msg.key_code) === 49) return true;
+    const key = keyName(msg);
+    return key === ' ' || key === 'space' || key === 'spacebar';
+}
+
+export function normalizeVoiceDictationEvent(msg = {}) {
+    if (msg?.service === 'voice' && VOICE_DICTATION_EVENT_NAMES.has(msg.event)) {
+        return {
+            v: msg.v ?? 1,
+            service: 'voice',
+            event: msg.event,
+            ts: Number(msg.ts) || defaultTimestampSeconds(),
+            data: (msg.data && typeof msg.data === 'object') ? msg.data : {},
+            ref: msg.ref,
+        };
+    }
+
+    if (VOICE_DICTATION_EVENT_NAMES.has(msg?.type)) {
+        const payload = (msg.payload && typeof msg.payload === 'object') ? msg.payload : msg;
+        const data = (payload.data && typeof payload.data === 'object')
+            ? payload.data
+            : {
+                ...(payload.source ? { source: payload.source } : {}),
+                ...(payload.reason ? { reason: payload.reason } : {}),
+            };
+        return {
+            v: 1,
+            service: 'voice',
+            event: msg.type,
+            ts: Number(payload.ts) || defaultTimestampSeconds(),
+            data,
+            ref: payload.ref,
+        };
+    }
+
+    return null;
+}
+
+export function isVoiceDictationEvent(msg = {}) {
+    return normalizeVoiceDictationEvent(msg) !== null;
+}
+
+export function createSigilVoiceDictationController({
+    now = defaultNowMs,
+    timestamp = defaultTimestampSeconds,
+    timeoutMs = SIGIL_DICTATION_TIMEOUT_MS,
+    onChange = () => {},
+    onVoiceEvent = () => {},
+} = {}) {
+    let state = {
+        phase: 'IDLE',
+        source: null,
+        openedAtMs: null,
+        closedAtMs: null,
+        closeReason: null,
+        transcript: '',
+        speechDetected: false,
+        lastVoiceEvent: null,
+    };
+    let spacebarHeld = false;
+
+    function snapshot() {
+        return {
+            ...state,
+            hasCapture: state.speechDetected || state.transcript.trim().length > 0,
+            timeoutMs,
+            spacebarHeld,
+        };
+    }
+
+    function publishChange(previousPhase, cause) {
+        const current = snapshot();
+        const transition = {
+            cause,
+            from: previousPhase,
+            to: current.phase,
+            source: current.source,
+            reason: current.closeReason,
+        };
+        onChange(current, transition);
+        return { handled: true, transition, snapshot: current };
+    }
+
+    function makeVoiceEvent(event, data = {}) {
+        return {
+            v: 1,
+            service: 'voice',
+            event,
+            ts: timestamp(),
+            data,
+        };
+    }
+
+    function publishVoiceEvent(event, data, transition) {
+        const envelope = makeVoiceEvent(event, data);
+        state.lastVoiceEvent = envelope;
+        onVoiceEvent(envelope, transition);
+        return envelope;
+    }
+
+    function open(source = 'hotkey', cause = 'dictation_opened', { emit = true } = {}) {
+        const previousPhase = state.phase;
+        state = {
+            phase: 'LISTENING',
+            source: normalizeSource(source),
+            openedAtMs: now(),
+            closedAtMs: null,
+            closeReason: null,
+            transcript: '',
+            speechDetected: false,
+            lastVoiceEvent: state.lastVoiceEvent,
+        };
+        const result = publishChange(previousPhase, cause);
+        if (emit) publishVoiceEvent('dictation_opened', { source: state.source }, result.transition);
+        return result;
+    }
+
+    function close(reason = 'explicit_trigger', forcedPhase = null, { emit = true } = {}) {
+        if (state.phase !== 'LISTENING') {
+            return { handled: false, reason: 'not_listening', snapshot: snapshot() };
+        }
+        const previousPhase = state.phase;
+        const closeReason = normalizeCloseReason(reason);
+        const hasCapture = state.speechDetected || state.transcript.trim().length > 0;
+        const nextPhase = forcedPhase || (hasCapture ? 'SEND' : 'CANCEL');
+        state = {
+            ...state,
+            phase: nextPhase,
+            closedAtMs: now(),
+            closeReason,
+        };
+        const result = publishChange(previousPhase, `dictation_closed_${nextPhase.toLowerCase()}`);
+        if (emit) {
+            const event = nextPhase === 'SEND' ? 'dictation_closed_send' : 'dictation_closed_cancel';
+            publishVoiceEvent(event, { reason: closeReason }, result.transition);
+        }
+        return result;
+    }
+
+    function handleInput(msg = {}) {
+        if (!isSpacebarDictationInput(msg)) return { handled: false, snapshot: snapshot() };
+
+        if (msg.type === 'key_down') {
+            if (spacebarHeld && state.phase === 'LISTENING') {
+                return { handled: true, reason: 'spacebar_repeat', snapshot: snapshot() };
+            }
+            spacebarHeld = true;
+            return open('hotkey', 'spacebar_down');
+        }
+
+        spacebarHeld = false;
+        return close('key_release');
+    }
+
+    function recordSpeech(input = {}) {
+        const previousPhase = state.phase;
+        const transcript = typeof input === 'string' ? input : stringField(input.transcript);
+        const speechDetected = typeof input === 'object' && input !== null && input.speechDetected === true;
+        state = {
+            ...state,
+            transcript,
+            speechDetected: speechDetected || transcript.trim().length > 0,
+        };
+        return publishChange(previousPhase, 'speech_update');
+    }
+
+    function handleTimeout() {
+        if (state.phase !== 'LISTENING') return { handled: false, reason: 'not_listening', snapshot: snapshot() };
+        if (now() - state.openedAtMs < timeoutMs) return { handled: false, reason: 'not_due', snapshot: snapshot() };
+        spacebarHeld = false;
+        return close('timeout');
+    }
+
+    function handleVoiceEvent(msg = {}) {
+        const event = normalizeVoiceDictationEvent(msg);
+        if (!event) return { handled: false, snapshot: snapshot() };
+        state.lastVoiceEvent = event;
+
+        if (event.event === 'wake_detected') {
+            return publishChange(state.phase, 'wake_detected');
+        }
+        if (event.event === 'dictation_opened') {
+            spacebarHeld = event.data?.source === 'hotkey';
+            return open(event.data?.source, 'voice_event.dictation_opened', { emit: false });
+        }
+        if (event.event === 'dictation_closed_send') {
+            spacebarHeld = false;
+            return close(event.data?.reason, 'SEND', { emit: false });
+        }
+        if (event.event === 'dictation_closed_cancel') {
+            spacebarHeld = false;
+            return close(event.data?.reason, 'CANCEL', { emit: false });
+        }
+
+        return { handled: false, snapshot: snapshot() };
+    }
+
+    function reset(cause = 'reset') {
+        const previousPhase = state.phase;
+        state = {
+            phase: 'IDLE',
+            source: null,
+            openedAtMs: null,
+            closedAtMs: null,
+            closeReason: null,
+            transcript: '',
+            speechDetected: false,
+            lastVoiceEvent: state.lastVoiceEvent,
+        };
+        spacebarHeld = false;
+        return publishChange(previousPhase, cause);
+    }
+
+    return {
+        handleInput,
+        handleTimeout,
+        handleVoiceEvent,
+        recordSpeech,
+        reset,
+        snapshot,
+    };
+}

--- a/tests/renderer/avatar-controls-snapshot-projection.test.mjs
+++ b/tests/renderer/avatar-controls-snapshot-projection.test.mjs
@@ -31,6 +31,7 @@ test('avatar controls snapshot projection clones bounds and reads compact surfac
   assert.deepEqual(snapshot, {
     open: true,
     bounds,
+    placementPlan: null,
     surface: 'embedded',
     panelId: null,
     stack: null,
@@ -44,6 +45,7 @@ test('avatar controls snapshot projection preserves closed null surface shape', 
   assert.deepEqual(buildAvatarControlsSnapshot({ open: false, bounds: null }, null), {
     open: false,
     bounds: null,
+    placementPlan: null,
     surface: null,
     panelId: null,
     stack: null,

--- a/tests/renderer/sigil-voice-dictation.test.mjs
+++ b/tests/renderer/sigil-voice-dictation.test.mjs
@@ -1,0 +1,166 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+import {
+  createSigilVoiceDictationController,
+  isSpacebarDictationInput,
+  normalizeVoiceDictationEvent,
+} from '../../apps/sigil/renderer/live-modules/voice-dictation.js'
+
+function createHarness(options = {}) {
+  let now = 1000
+  const voiceEvents = []
+  const changes = []
+  const controller = createSigilVoiceDictationController({
+    now: () => now,
+    timestamp: () => now / 1000,
+    timeoutMs: options.timeoutMs ?? 500,
+    onChange(snapshot, transition) {
+      changes.push({ snapshot, transition })
+    },
+    onVoiceEvent(event) {
+      voiceEvents.push(event)
+    },
+  })
+  return {
+    controller,
+    voiceEvents,
+    changes,
+    advance(ms) {
+      now += ms
+    },
+  }
+}
+
+test('Sigil dictation recognizes daemon key-code and DOM Space key shapes', () => {
+  assert.equal(isSpacebarDictationInput({ type: 'key_down', key_code: 49 }), true)
+  assert.equal(isSpacebarDictationInput({ type: 'key_up', key: ' ' }), true)
+  assert.equal(isSpacebarDictationInput({ type: 'key_down', code: 'Space' }), true)
+  assert.equal(isSpacebarDictationInput({ type: 'key_down', key: 'Enter' }), false)
+  assert.equal(isSpacebarDictationInput({ type: 'mouse_moved' }), false)
+})
+
+test('hold-spacebar opens LISTENING and emits generic dictation_opened', () => {
+  const harness = createHarness()
+  const result = harness.controller.handleInput({ type: 'key_down', key_code: 49 })
+
+  assert.equal(result.handled, true)
+  assert.equal(harness.controller.snapshot().phase, 'LISTENING')
+  assert.equal(harness.controller.snapshot().source, 'hotkey')
+  assert.equal(harness.voiceEvents.length, 1)
+  assert.deepEqual(
+    { service: harness.voiceEvents[0].service, event: harness.voiceEvents[0].event, data: harness.voiceEvents[0].data },
+    { service: 'voice', event: 'dictation_opened', data: { source: 'hotkey' } },
+  )
+
+  const repeat = harness.controller.handleInput({ type: 'key_down', key_code: 49 })
+  assert.equal(repeat.handled, true)
+  assert.equal(repeat.reason, 'spacebar_repeat')
+  assert.equal(harness.voiceEvents.length, 1)
+})
+
+test('key release sends when speech or transcript was captured', () => {
+  const harness = createHarness()
+
+  harness.controller.handleInput({ type: 'key_down', key: 'Space' })
+  harness.controller.recordSpeech({ transcript: 'open the terminal' })
+  const result = harness.controller.handleInput({ type: 'key_up', key: 'Space' })
+
+  assert.equal(result.handled, true)
+  assert.equal(harness.controller.snapshot().phase, 'SEND')
+  assert.equal(harness.controller.snapshot().closeReason, 'key_release')
+  assert.equal(harness.voiceEvents.at(-1).event, 'dictation_closed_send')
+  assert.deepEqual(harness.voiceEvents.at(-1).data, { reason: 'key_release' })
+})
+
+test('key release cancels when no speech was captured', () => {
+  const harness = createHarness()
+
+  harness.controller.handleInput({ type: 'key_down', key_code: 49 })
+  const result = harness.controller.handleInput({ type: 'key_up', key_code: 49 })
+
+  assert.equal(result.handled, true)
+  assert.equal(harness.controller.snapshot().phase, 'CANCEL')
+  assert.equal(harness.controller.snapshot().closeReason, 'key_release')
+  assert.equal(harness.voiceEvents.at(-1).event, 'dictation_closed_cancel')
+  assert.deepEqual(harness.voiceEvents.at(-1).data, { reason: 'key_release' })
+})
+
+test('timeout sends with captured speech and cancels when empty', () => {
+  const withSpeech = createHarness({ timeoutMs: 250 })
+  withSpeech.controller.handleInput({ type: 'key_down', key_code: 49 })
+  withSpeech.controller.recordSpeech({ speechDetected: true })
+  withSpeech.advance(300)
+  const send = withSpeech.controller.handleTimeout()
+
+  assert.equal(send.handled, true)
+  assert.equal(withSpeech.controller.snapshot().phase, 'SEND')
+  assert.equal(withSpeech.controller.snapshot().closeReason, 'timeout')
+  assert.equal(withSpeech.voiceEvents.at(-1).event, 'dictation_closed_send')
+  assert.deepEqual(withSpeech.voiceEvents.at(-1).data, { reason: 'timeout' })
+
+  const empty = createHarness({ timeoutMs: 250 })
+  empty.controller.handleInput({ type: 'key_down', key_code: 49 })
+  empty.advance(300)
+  const cancel = empty.controller.handleTimeout()
+
+  assert.equal(cancel.handled, true)
+  assert.equal(empty.controller.snapshot().phase, 'CANCEL')
+  assert.equal(empty.controller.snapshot().closeReason, 'timeout')
+  assert.equal(empty.voiceEvents.at(-1).event, 'dictation_closed_cancel')
+  assert.deepEqual(empty.voiceEvents.at(-1).data, { reason: 'timeout' })
+})
+
+test('Sigil consumes generic voice dictation envelopes without re-emitting them', () => {
+  const harness = createHarness()
+
+  const opened = harness.controller.handleVoiceEvent({
+    v: 1,
+    service: 'voice',
+    event: 'dictation_opened',
+    ts: 1,
+    data: { source: 'hotkey' },
+  })
+  assert.equal(opened.handled, true)
+  assert.equal(harness.controller.snapshot().phase, 'LISTENING')
+  assert.equal(harness.voiceEvents.length, 0)
+
+  harness.controller.recordSpeech('use current selection')
+  const closed = harness.controller.handleVoiceEvent({
+    v: 1,
+    service: 'voice',
+    event: 'dictation_closed_send',
+    ts: 2,
+    data: { reason: 'key_release' },
+  })
+
+  assert.equal(closed.handled, true)
+  assert.equal(harness.controller.snapshot().phase, 'SEND')
+  assert.equal(harness.controller.snapshot().closeReason, 'key_release')
+  assert.equal(harness.voiceEvents.length, 0)
+})
+
+test('Sigil accepts the existing flat canvas event bridge shape for voice events', () => {
+  const event = normalizeVoiceDictationEvent({
+    type: 'dictation_closed_cancel',
+    reason: 'timeout',
+  })
+
+  assert.deepEqual(
+    { service: event.service, event: event.event, data: event.data },
+    { service: 'voice', event: 'dictation_closed_cancel', data: { reason: 'timeout' } },
+  )
+})
+
+test('Sigil main wires dictation controller to host messages and key input', async () => {
+  const source = await readFile(new URL('../../apps/sigil/renderer/live-modules/main.js', import.meta.url), 'utf8')
+
+  assert.match(source, /createSigilVoiceDictationController/)
+  assert.match(source, /voiceDictation\.handleInput\(msg\)\.handled/)
+  assert.match(source, /isVoiceDictationEvent\(msg\)/)
+  assert.match(source, /voiceDictation\.handleVoiceEvent\(msg\)/)
+  assert.match(source, /'dictation_opened'/)
+  assert.match(source, /'dictation_closed_send'/)
+  assert.match(source, /'dictation_closed_cancel'/)
+})


### PR DESCRIPTION
## Summary

- add a Sigil-owned hold-spacebar dictation controller with `IDLE -> LISTENING -> SEND|CANCEL` state
- consume generic `voice.*` dictation envelopes and keep Space-key behavior synthetic/testable
- subscribe Sigil to the generic voice event names without adding daemon mic/STT behavior
- update stale avatar-controls snapshot expectations for the existing `placementPlan` field so renderer validation passes

## Validation

- `node --test tests/renderer/sigil-voice-dictation.test.mjs`
- `node --test tests/renderer/avatar-controls-snapshot-projection.test.mjs`
- `node --test tests/renderer/*.test.mjs`
- `./aos dev recommend --json --paths apps/sigil/renderer/live-modules/main.js apps/sigil/renderer/live-modules/voice-dictation.js tests/renderer/sigil-voice-dictation.test.mjs tests/renderer/avatar-controls-snapshot-projection.test.mjs`
- `node scripts/generate-command-manifests.mjs --check`
- `bash tests/command-manifest-generation.sh`
- `bash tests/help-contract.sh`
- `bash tests/external-command-dispatch.sh`
- `git diff --check`
- `AOS_TCC_HANDOFF_ALERT=0 AOS_BUILD_REBUILD_ALERT_REPEAT=0 ./aos dev build --no-restart --json`
- `./aos help --json` parsed via Node

Notes: `./aos dev build --no-restart --json` initially rebuilt the repo binary after the branch switch and emitted the expected TCC warning; no readiness or other TCC-backed proof was run afterward. A subsequent wrapper run briefly exited 137, recovered with `bash build.sh --force --no-restart`, and the final build-wrapper retry reported up to date.