### PR TITLE
Sigil sound/TTS hooks and backend menu

### DIFF
--- a/apps/sigil/renderer/live-modules/main.js
+++ b/apps/sigil/renderer/live-modules/main.js
@@ -71,6 +71,10 @@ import {
     isVoiceDictationEvent,
 } from './voice-dictation.js';
 import {
+    createSigilVoiceResponsePolicy,
+    sigilVoiceResponseBackendMenuItems,
+} from './voice-response-policy.js';
+import {
     createDefaultSelectionModeState,
     createSigilSelectionModeRuntime,
     buildSelectionModeSnapshotPayload,
@@ -239,6 +243,8 @@ const liveJs = {
     contextRecording: createDefaultContextRecordingState(),
     voiceDictation: null,
     voiceDictationEvents: [],
+    voiceResponse: null,
+    voiceResponseActions: [],
     annotationReticleTargetEvidence: createAnnotationReticleTargetEvidenceCache(),
     annotationReticleBrowserDomBridge: null,
     annotationReticleEvents: [],
@@ -562,6 +568,28 @@ function recordInteraction(stage, data = {}) {
     });
 }
 
+function recordVoiceResponseAction(action) {
+    liveJs.voiceResponseActions.push(action);
+    if (liveJs.voiceResponseActions.length > 32) liveJs.voiceResponseActions.shift();
+    recordInteraction('voice-response:action', {
+        kind: action.kind,
+        event: action.event,
+        backendId: action.backendId,
+        mocked: action.mocked,
+    });
+}
+
+const voiceResponsePolicy = createSigilVoiceResponsePolicy({
+    playSound: recordVoiceResponseAction,
+    speak: recordVoiceResponseAction,
+    onChange(snapshot, transition) {
+        liveJs.voiceResponse = snapshot;
+        recordInteraction('voice-response', { transition });
+        if (!rendererSuspended) scheduleRenderFrame({ structural: false });
+    },
+});
+liveJs.voiceResponse = voiceResponsePolicy.snapshot();
+
 const voiceDictation = createSigilVoiceDictationController({
     onChange(snapshot, transition) {
         liveJs.voiceDictation = snapshot;
@@ -577,6 +605,7 @@ const voiceDictation = createSigilVoiceDictationController({
             data: event.data,
             transition,
         });
+        voiceResponsePolicy.handleVoiceEvent(event);
     },
 });
 liveJs.voiceDictation = voiceDictation.snapshot();
@@ -1236,9 +1265,12 @@ function isUtilityCanvasVisible(id) {
 function publishStatusMenuItems() {
     if (!isPrimarySurfaceSegment()) return;
     const operatorAnnotationItems = operatorAnnotationStatusMenuItems(sigilOperatorAnnotationMenu);
+    const voiceResponseItems = sigilVoiceResponseBackendMenuItems(voiceResponsePolicy.snapshot());
     host.setStatusMenuItems([
         ...operatorAnnotationItems,
         ...(operatorAnnotationItems.length ? [{ type: 'separator' }] : []),
+        ...voiceResponseItems,
+        ...(voiceResponseItems.length ? [{ type: 'separator' }] : []),
         {
             id: 'sigil.status.console',
             title: 'Console Log',
@@ -1292,6 +1324,12 @@ async function handleStatusMenuAction(msg = {}) {
     if (!id) return false;
     const operatorRoute = routeOperatorAnnotationMenuAction(msg, sigilOperatorAnnotationMenu, host);
     if (operatorRoute.handled) return true;
+    const voiceResponseRoute = voiceResponsePolicy.handleMenuAction(id);
+    if (voiceResponseRoute.handled) {
+        liveJs.voiceResponse = voiceResponsePolicy.snapshot();
+        publishStatusMenuItems();
+        return true;
+    }
     if (id === 'sigil.status.console') {
         await toggleUtilityCanvas('log-console');
         return true;
@@ -4560,6 +4598,7 @@ function handleHostMessage(rawMsg) {
 
     if (isVoiceDictationEvent(msg)) {
         voiceDictation.handleVoiceEvent(msg);
+        voiceResponsePolicy.handleVoiceEvent(msg);
         return;
     }
 

--- a/apps/sigil/renderer/live-modules/voice-response-policy.js
+++ b/apps/sigil/renderer/live-modules/voice-response-policy.js
@@ -1,0 +1,235 @@
+import { normalizeVoiceDictationEvent } from './voice-dictation.js';
+
+export const SIGIL_VOICE_RESPONSE_BACKEND_MENU_PREFIX = 'sigil.voice.response.backend.';
+
+export const SIGIL_VOICE_RESPONSE_BACKEND_IDS = Object.freeze({
+    SYSTEM_SOUND: 'system-sound',
+    MOCK_TTS: 'mock-tts',
+    KOKORO: 'kokoro',
+});
+
+export const DEFAULT_SIGIL_VOICE_RESPONSE_BACKENDS = Object.freeze([
+    Object.freeze({
+        id: SIGIL_VOICE_RESPONSE_BACKEND_IDS.SYSTEM_SOUND,
+        title: 'System Sound',
+        kind: 'sound',
+        available: true,
+    }),
+    Object.freeze({
+        id: SIGIL_VOICE_RESPONSE_BACKEND_IDS.MOCK_TTS,
+        title: 'Mock TTS',
+        kind: 'tts',
+        mocked: true,
+        available: true,
+    }),
+    Object.freeze({
+        id: SIGIL_VOICE_RESPONSE_BACKEND_IDS.KOKORO,
+        title: 'Kokoro TTS',
+        kind: 'tts',
+        available: false,
+        unavailableReason: 'distribution_clearance_required',
+    }),
+]);
+
+export const SIGIL_VOICE_RESPONSE_EVENT_POLICY = Object.freeze({
+    wake_detected: Object.freeze({
+        sound: 'sigil_voice_wake',
+        text: 'Voice wake detected.',
+    }),
+    dictation_opened: Object.freeze({
+        sound: 'sigil_dictation_opened',
+        text: 'Listening.',
+    }),
+    dictation_closed_send: Object.freeze({
+        sound: 'sigil_dictation_send',
+        text: 'Sending dictation.',
+    }),
+    dictation_closed_cancel: Object.freeze({
+        sound: 'sigil_dictation_cancel',
+        text: 'Dictation cancelled.',
+    }),
+});
+
+function stringId(value) {
+    return String(value || '').trim();
+}
+
+function cloneBackend(backend) {
+    return Object.freeze({
+        id: backend.id,
+        title: backend.title,
+        kind: backend.kind,
+        mocked: backend.mocked === true,
+        available: backend.available !== false,
+        unavailableReason: backend.unavailableReason || null,
+    });
+}
+
+function normalizeBackendCatalog(backends = DEFAULT_SIGIL_VOICE_RESPONSE_BACKENDS) {
+    const seen = new Set();
+    const records = [];
+    for (const backend of backends) {
+        const id = stringId(backend?.id);
+        const title = stringId(backend?.title);
+        const kind = stringId(backend?.kind);
+        if (!id || !title || !['sound', 'tts'].includes(kind) || seen.has(id)) continue;
+        seen.add(id);
+        records.push(cloneBackend({
+            id,
+            title,
+            kind,
+            mocked: backend.mocked === true,
+            available: backend.available !== false,
+            unavailableReason: stringId(backend.unavailableReason),
+        }));
+    }
+    return Object.freeze(records);
+}
+
+function titleForBackendMenu(backend) {
+    if (backend.available) return `Voice Response: ${backend.title}`;
+    return `Voice Response: ${backend.title} (Unavailable)`;
+}
+
+function findBackend(catalog, id) {
+    const backendId = stringId(id);
+    return catalog.find((backend) => backend.id === backendId) || null;
+}
+
+function firstAvailableBackend(catalog) {
+    return catalog.find((backend) => backend.available) || null;
+}
+
+function responseKindForBackend(backend) {
+    return backend.kind === 'tts' ? 'mock_tts' : 'system_sound';
+}
+
+export function lookupSigilVoiceResponsePolicy(eventName) {
+    return SIGIL_VOICE_RESPONSE_EVENT_POLICY[stringId(eventName)] || null;
+}
+
+export function sigilVoiceResponseBackendIdFromMenuAction(actionId) {
+    const value = stringId(actionId);
+    if (!value.startsWith(SIGIL_VOICE_RESPONSE_BACKEND_MENU_PREFIX)) return null;
+    return value.slice(SIGIL_VOICE_RESPONSE_BACKEND_MENU_PREFIX.length) || null;
+}
+
+export function isSigilVoiceResponseBackendMenuAction(actionId) {
+    return sigilVoiceResponseBackendIdFromMenuAction(actionId) !== null;
+}
+
+export function sigilVoiceResponseBackendMenuItems(snapshot = {}) {
+    const selectedBackendId = stringId(snapshot.selectedBackendId);
+    const backends = normalizeBackendCatalog(snapshot.backends);
+    return backends.map((backend) => ({
+        id: `${SIGIL_VOICE_RESPONSE_BACKEND_MENU_PREFIX}${backend.id}`,
+        title: titleForBackendMenu(backend),
+        checked: backend.id === selectedBackendId,
+        enabled: backend.available,
+    }));
+}
+
+export function createSigilVoiceResponsePolicy({
+    backends = DEFAULT_SIGIL_VOICE_RESPONSE_BACKENDS,
+    defaultBackendId = SIGIL_VOICE_RESPONSE_BACKEND_IDS.SYSTEM_SOUND,
+    playSound = () => {},
+    speak = () => {},
+    onAction = () => {},
+    onChange = () => {},
+} = {}) {
+    const catalog = normalizeBackendCatalog(backends);
+    const fallbackBackend = firstAvailableBackend(catalog);
+    let selectedBackendId = (
+        findBackend(catalog, defaultBackendId)?.available
+            ? stringId(defaultBackendId)
+            : fallbackBackend?.id
+    ) || null;
+    let lastAction = null;
+
+    function selectedBackend() {
+        return findBackend(catalog, selectedBackendId) || fallbackBackend;
+    }
+
+    function snapshot() {
+        const backend = selectedBackend();
+        return Object.freeze({
+            selectedBackendId: backend?.id || null,
+            selectedBackend: backend || null,
+            backends: catalog.map(cloneBackend),
+            lastAction,
+        });
+    }
+
+    function publishChange(reason, detail = {}) {
+        onChange(snapshot(), { reason, ...detail });
+    }
+
+    function selectBackend(backendId) {
+        const backend = findBackend(catalog, backendId);
+        if (!backend) {
+            return { handled: false, selected: false, reason: 'unknown_backend', snapshot: snapshot() };
+        }
+        if (!backend.available) {
+            const result = {
+                handled: false,
+                selected: false,
+                reason: backend.unavailableReason || 'backend_unavailable',
+                backend,
+                snapshot: snapshot(),
+            };
+            publishChange(result.reason, { backendId: backend.id });
+            return result;
+        }
+        selectedBackendId = backend.id;
+        publishChange('backend_selected', { backendId: backend.id });
+        return { handled: true, selected: true, backend, snapshot: snapshot() };
+    }
+
+    function handleMenuAction(actionId) {
+        const backendId = sigilVoiceResponseBackendIdFromMenuAction(actionId);
+        if (!backendId) return { handled: false, reason: 'not_voice_response_menu_action', snapshot: snapshot() };
+        const result = selectBackend(backendId);
+        return { ...result, handled: true, menuAction: true };
+    }
+
+    function handleVoiceEvent(message = {}) {
+        const voiceEvent = normalizeVoiceDictationEvent(message);
+        if (!voiceEvent) return { handled: false, reason: 'not_voice_event', snapshot: snapshot() };
+
+        const policy = lookupSigilVoiceResponsePolicy(voiceEvent.event);
+        if (!policy) return { handled: false, reason: 'unmapped_voice_event', event: voiceEvent, snapshot: snapshot() };
+
+        const backend = selectedBackend();
+        if (!backend?.available) {
+            return { handled: false, reason: 'no_available_backend', event: voiceEvent, snapshot: snapshot() };
+        }
+
+        const action = Object.freeze({
+            kind: responseKindForBackend(backend),
+            backendId: backend.id,
+            backendTitle: backend.title,
+            event: voiceEvent.event,
+            text: policy.text,
+            sound: policy.sound,
+            mocked: backend.mocked === true || backend.id === SIGIL_VOICE_RESPONSE_BACKEND_IDS.MOCK_TTS,
+            data: voiceEvent.data,
+            ts: voiceEvent.ts,
+        });
+        if (backend.kind === 'tts') {
+            speak(action);
+        } else {
+            playSound(action);
+        }
+        lastAction = action;
+        onAction(action, voiceEvent);
+        publishChange('voice_event_response', { event: voiceEvent.event, backendId: backend.id });
+        return { handled: true, event: voiceEvent, action, snapshot: snapshot() };
+    }
+
+    return Object.freeze({
+        handleMenuAction,
+        handleVoiceEvent,
+        selectBackend,
+        snapshot,
+    });
+}

--- a/docs/design/sigil-voice-response-policy.md
+++ b/docs/design/sigil-voice-response-policy.md
@@ -1,0 +1,45 @@
+# Sigil Voice Response Policy
+
+Sigil owns the first response policy for generic `voice.*` lifecycle events. The
+daemon still owns capture, permissions, transport, and future model execution;
+Sigil only decides how its avatar should respond when it sees voice lifecycle
+events such as `voice.dictation_opened`.
+
+## Current Proof
+
+`apps/sigil/renderer/live-modules/voice-response-policy.js` maps normalized
+voice dictation events to Sigil response actions:
+
+- `dictation_opened` -> `sigil_dictation_opened` or mocked "Listening." TTS
+- `dictation_closed_send` -> `sigil_dictation_send` or mocked "Sending dictation." TTS
+- `dictation_closed_cancel` -> `sigil_dictation_cancel` or mocked "Dictation cancelled." TTS
+- `wake_detected` -> `sigil_voice_wake` or mocked "Voice wake detected." TTS
+
+The status-item menu exposes three backends:
+
+- System Sound, available by default
+- Mock TTS, available for deterministic renderer proof
+- Kokoro TTS, visible but disabled until model distribution is cleared
+
+The current Sigil hooks record response actions in renderer state. They do not
+call `aos say`, daemon voice assignment APIs, Whisper, Kokoro, or native audio
+engines. This keeps default validation static and mocked while proving policy
+lookup, backend selection, and event-to-response routing.
+
+## Future Real Assets
+
+Real Kokoro and Whisper assets can be enabled only after distribution clearance
+answers these questions:
+
+- license terms permit bundling or deterministic local download for the exact
+  model files
+- model weights have stable hashes, size expectations, and documented storage
+  paths
+- the packaged runtime has an approved launch path for the model process
+- microphone and speech permissions remain brokered by the runtime/TCC layer
+- renderer tests keep using mock audio and mock TTS by default
+
+When those gates are satisfied, Sigil should keep this policy shape and swap the
+backend callbacks behind the selected backend. The generic `voice.*` event names
+should remain the renderer contract; daemon-specific schemas and provider
+records should stay out of Sigil policy code.

--- a/tests/renderer/sigil-voice-response-policy.test.mjs
+++ b/tests/renderer/sigil-voice-response-policy.test.mjs
@@ -1,0 +1,134 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+
+import {
+  SIGIL_VOICE_RESPONSE_BACKEND_IDS,
+  createSigilVoiceResponsePolicy,
+  lookupSigilVoiceResponsePolicy,
+  sigilVoiceResponseBackendMenuItems,
+} from '../../apps/sigil/renderer/live-modules/voice-response-policy.js'
+
+function voiceEvent(event, data = {}) {
+  return {
+    v: 1,
+    service: 'voice',
+    event,
+    ts: 10,
+    data,
+  }
+}
+
+test('Sigil voice response policy maps dictation_opened to system sound by default', () => {
+  const soundActions = []
+  const ttsActions = []
+  const policy = createSigilVoiceResponsePolicy({
+    playSound(action) {
+      soundActions.push(action)
+    },
+    speak(action) {
+      ttsActions.push(action)
+    },
+  })
+
+  const result = policy.handleVoiceEvent(voiceEvent('dictation_opened', { source: 'hotkey' }))
+
+  assert.equal(result.handled, true)
+  assert.equal(soundActions.length, 1)
+  assert.equal(ttsActions.length, 0)
+  assert.equal(soundActions[0].kind, 'system_sound')
+  assert.equal(soundActions[0].event, 'dictation_opened')
+  assert.equal(soundActions[0].sound, 'sigil_dictation_opened')
+  assert.equal(soundActions[0].mocked, false)
+})
+
+test('Sigil voice response backend selection routes dictation_opened to mocked TTS', () => {
+  const soundActions = []
+  const ttsActions = []
+  const policy = createSigilVoiceResponsePolicy({
+    playSound(action) {
+      soundActions.push(action)
+    },
+    speak(action) {
+      ttsActions.push(action)
+    },
+  })
+
+  const selected = policy.handleMenuAction('sigil.voice.response.backend.mock-tts')
+  const result = policy.handleVoiceEvent(voiceEvent('dictation_opened', { source: 'phrase' }))
+
+  assert.equal(selected.handled, true)
+  assert.equal(selected.selected, true)
+  assert.equal(result.handled, true)
+  assert.equal(soundActions.length, 0)
+  assert.equal(ttsActions.length, 1)
+  assert.equal(ttsActions[0].kind, 'mock_tts')
+  assert.equal(ttsActions[0].backendId, SIGIL_VOICE_RESPONSE_BACKEND_IDS.MOCK_TTS)
+  assert.equal(ttsActions[0].text, 'Listening.')
+  assert.equal(ttsActions[0].mocked, true)
+})
+
+test('Sigil voice response menu exposes system, mock, and unavailable Kokoro backends', () => {
+  const policy = createSigilVoiceResponsePolicy()
+  const menuItems = sigilVoiceResponseBackendMenuItems(policy.snapshot())
+
+  assert.deepEqual(
+    menuItems.map((item) => ({ id: item.id, title: item.title, checked: item.checked, enabled: item.enabled })),
+    [
+      {
+        id: 'sigil.voice.response.backend.system-sound',
+        title: 'Voice Response: System Sound',
+        checked: true,
+        enabled: true,
+      },
+      {
+        id: 'sigil.voice.response.backend.mock-tts',
+        title: 'Voice Response: Mock TTS',
+        checked: false,
+        enabled: true,
+      },
+      {
+        id: 'sigil.voice.response.backend.kokoro',
+        title: 'Voice Response: Kokoro TTS (Unavailable)',
+        checked: false,
+        enabled: false,
+      },
+    ],
+  )
+
+  const unavailable = policy.handleMenuAction('sigil.voice.response.backend.kokoro')
+  assert.equal(unavailable.handled, true)
+  assert.equal(unavailable.selected, false)
+  assert.equal(unavailable.reason, 'distribution_clearance_required')
+  assert.equal(policy.snapshot().selectedBackendId, SIGIL_VOICE_RESPONSE_BACKEND_IDS.SYSTEM_SOUND)
+})
+
+test('Sigil voice response policy lookup is local and event keyed', () => {
+  assert.deepEqual(
+    lookupSigilVoiceResponsePolicy('dictation_closed_cancel'),
+    {
+      sound: 'sigil_dictation_cancel',
+      text: 'Dictation cancelled.',
+    },
+  )
+  assert.equal(lookupSigilVoiceResponsePolicy('session.started'), null)
+})
+
+test('Sigil voice response module does not import daemon schemas', async () => {
+  const source = await readFile(new URL('../../apps/sigil/renderer/live-modules/voice-response-policy.js', import.meta.url), 'utf8')
+  const imports = [...source.matchAll(/from ['"]([^'"]+)['"]/g)].map((match) => match[1])
+
+  assert.deepEqual(imports, ['./voice-dictation.js'])
+  assert.doesNotMatch(source, /shared\/schemas|src\/daemon|daemon-event|VoiceRegistry/)
+})
+
+test('Sigil main wires voice response policy to status menu and voice events', async () => {
+  const source = await readFile(new URL('../../apps/sigil/renderer/live-modules/main.js', import.meta.url), 'utf8')
+
+  assert.match(source, /createSigilVoiceResponsePolicy/)
+  assert.match(source, /sigilVoiceResponseBackendMenuItems\(voiceResponsePolicy\.snapshot\(\)\)/)
+  assert.match(source, /voiceResponsePolicy\.handleMenuAction\(id\)/)
+  assert.match(source, /voiceResponsePolicy\.handleVoiceEvent\(event\)/)
+  assert.match(source, /voiceResponsePolicy\.handleVoiceEvent\(msg\)/)
+  assert.match(source, /liveJs\.voiceResponseActions/)
+})


### PR DESCRIPTION
## Summary

- add a Sigil-owned voice response policy for generic voice lifecycle events
- expose status-menu backend selection for System Sound, Mock TTS, and disabled Kokoro TTS
- document the distribution gates before real Kokoro or Whisper assets are enabled

## Verification

- `node --test tests/renderer/sigil-voice-response-policy.test.mjs`
- `node --test tests/renderer/sigil-voice-dictation.test.mjs`
- `node --check apps/sigil/renderer/live-modules/voice-response-policy.js`
- `node --check apps/sigil/renderer/live-modules/main.js`
- `node --test tests/renderer/*.test.mjs`
- `git diff --check`
- `./aos dev recommend --json --paths apps/sigil/renderer/live-modules/main.js apps/sigil/renderer/live-modules/voice-response-policy.js tests/renderer/sigil-voice-response-policy.test.mjs docs/design/sigil-voice-response-policy.md`
- `node scripts/generate-command-manifests.mjs --check`
- `bash tests/command-manifest-generation.sh`
- `bash tests/help-contract.sh`
- `bash tests/external-command-dispatch.sh` (isolated rerun passed after one parallel-validator exit with no FAIL line)
- `AOS_TCC_HANDOFF_ALERT=0 AOS_BUILD_REBUILD_ALERT_REPEAT=0 ./aos dev build --no-restart --json`
- `./aos help --json` parsed successfully