### PR TITLE
Keep long native action receipts live

### DIFF
--- a/docs/dev/test-proof-registry.d/runtime-readiness.json
+++ b/docs/dev/test-proof-registry.d/runtime-readiness.json
@@ -193,8 +193,8 @@
       "owner": "runtime-readiness",
       "harness_level": "model_unit",
       "proof_kind": "native_action_event_source_contract",
-      "contract": "Mouse, drag, key, typing, and modifier actions hold one exact terminal receipt expectation, ignore nonterminal observations, retain uncertain modifier transitions for session cleanup, and expose public streaming session stdin without fixed timing delays.",
-      "worth": "The executable Swift model covers terminal sequencing, timeout teardown, expectation replacement, and provisional or uncertain modifier state; static wiring and the public wrapper prove integration ownership.",
+      "contract": "Mouse, drag, key, typing, and modifier actions hold one exact terminal receipt expectation, ignore nonterminal observations, retain uncertain modifier transitions for session cleanup, keep acknowledged drag-down release transaction-owned until confirmed up, and expose public streaming session stdin without fixed timing delays.",
+      "worth": "The executable Swift model covers terminal sequencing, timeout teardown, expectation replacement, provisional or uncertain modifier state, and drag release obligation success/failure; static wiring and the public wrapper prove integration ownership.",
       "command": "node --test tests/click-count-contract.test.mjs tests/aos-do-session-streaming.test.mjs && bash tests/native-action-input-delivery.sh",
       "replaces": [],
       "guard": "executable transaction model plus static ownership and public-wrapper streaming; the guarded concurrent lane separately proves live click delivery",
@@ -217,6 +217,23 @@
       "replaces": [],
       "guard": "uses an isolated AOS_STATE_ROOT and requires a current raw native build",
       "status": "active"
+    },
+    {
+      "id": "native-action-long-receipt-live",
+      "path_patterns": [
+        "tests/native-action-terminal-receipt-live.sh",
+        "tests/lib/input-event-observer.mjs"
+      ],
+      "fixture_patterns": [],
+      "owner": "runtime-readiness",
+      "harness_level": "real_input",
+      "proof_kind": "native_action_long_receipt_contract",
+      "contract": "A successful public ten-second coordinate drag requires action-owned down and terminal-up acknowledgments, emits its receipt-tagged stream, and leaves the managed daemon input tap active and permission-capable.",
+      "worth": "This executes the long multi-event action that previously starved the action receipt run loop and verifies the managed daemon tap does not degrade or require service restoration afterward.",
+      "command": "AOS_REAL_INPUT_OK=1 bash tests/native-action-terminal-receipt-live.sh",
+      "replaces": [],
+      "guard": "requires explicit AOS_REAL_INPUT_OK=1, native input permissions, a current raw build, and the live repo daemon; incidental user input is permitted",
+      "status": "manual_only"
     },
     {
       "id": "canvas-lifecycle-concurrent-input-proof",

--- a/src/act/AGENTS.md
+++ b/src/act/AGENTS.md
@@ -24,6 +24,8 @@ and focused native owners for exact app, menu, and window lifecycle controls.
   session-mode action execution and reusable act-module mechanics.
 - `input-delivery-state.swift` owns the single terminal receipt expectation and
   modifier uncertainty state shared by one-shot and persistent actions.
+- `input-receipt-tap.swift` owns the continuously serviced receipt event tap
+  and its dedicated run-loop thread.
 - `SessionState` owns the CoreGraphics posting source and terminal-event receipt
   boundary used by one-shot and persistent action sessions.
 
@@ -40,6 +42,12 @@ and focused native owners for exact app, menu, and window lifecycle controls.
   Continuous pointer motion may be coalesced and must not claim such a receipt.
 - Keep an unconfirmed modifier transition in session cleanup ownership; a
   receipt timeout means delivery is unknown and must not discard release state.
+- Keep receipt-tap run-loop servicing independent of action duration; long
+  drag, scroll, or typing transactions must not defer tap callbacks until the
+  terminal wait.
+- After drag down is acknowledged, keep a best-effort mouse-up obligation
+  active across every failure path and fulfill it only after terminal up is
+  acknowledged.
 
 ## Work Guidance
 

--- a/src/act/actions.swift
+++ b/src/act/actions.swift
@@ -63,6 +63,22 @@ private func inputDeliveryError(_ action: String, state: SessionState) -> Action
     )
 }
 
+private func postBestEffortPointerRelease(
+    owner: AOSCGEventPostingOwner,
+    point: CGPoint,
+    flags: CGEventFlags,
+    receipt: AOSInputPostReceipt
+) {
+    guard let release = CGEvent(
+        mouseEventSource: owner.source,
+        mouseType: .leftMouseUp,
+        mouseCursorPosition: point,
+        mouseButton: .left
+    ) else { return }
+    release.flags = flags
+    owner.post(release, receipt: receipt)
+}
+
 /// Build CGEventFlags from all currently held modifiers in session state.
 private func currentFlags(_ state: SessionState) -> CGEventFlags {
     var flags = CGEventFlags()
@@ -338,7 +354,22 @@ func handleDrag(_ req: ActionRequest, state: SessionState) -> ActionResponse {
         return errorResponse("drag", state: state, message: "Failed to create mouseDown event", code: "CGEVENT_FAILED")
     }
     down.flags = flags
-    owner.post(down, receipt: receipt)
+    if !owner.post(down, receipt: receipt, awaitReceipt: true) {
+        postBestEffortPointerRelease(owner: owner, point: origin, flags: flags, receipt: receipt)
+        return inputDeliveryError("drag", state: state)
+    }
+
+    var releaseObligation = AOSPointerReleaseObligation(point: origin)
+    defer {
+        if releaseObligation.isPending {
+            postBestEffortPointerRelease(
+                owner: owner,
+                point: releaseObligation.point,
+                flags: flags,
+                receipt: receipt
+            )
+        }
+    }
 
     // Bezier path from origin to target
     let dx = Double(target.x - origin.x)
@@ -359,6 +390,7 @@ func handleDrag(_ req: ActionRequest, state: SessionState) -> ActionResponse {
                               mouseCursorPosition: pt, mouseButton: .left) {
             drag.flags = flags
             owner.post(drag, receipt: receipt)
+            releaseObligation.advance(to: pt)
         }
         usleep(UInt32(stepInterval * 1_000_000))
     }
@@ -369,9 +401,11 @@ func handleDrag(_ req: ActionRequest, state: SessionState) -> ActionResponse {
         return errorResponse("drag", state: state, message: "Failed to create mouseUp event", code: "CGEVENT_FAILED")
     }
     up.flags = flags
+    releaseObligation.advance(to: target)
     if !owner.post(up, receipt: receipt, awaitReceipt: true) {
         return inputDeliveryError("drag", state: state)
     }
+    releaseObligation.fulfill()
 
     state.updateCursor(target)
     return okResponse("drag", state: state, start: start, backend: "cgevent", strategy: "cgevent_drag", stateID: req.state_id, terminalReceiptID: receipt.id)

--- a/src/act/event-posting.swift
+++ b/src/act/event-posting.swift
@@ -9,15 +9,18 @@ struct AOSInputPostReceipt: Hashable {
 final class AOSCGEventPostingOwner {
     let source = CGEventSource(stateID: .hidSystemState)
 
-    private let tracker = AOSInputTerminalReceiptTracker()
+    private let tracker: AOSInputTerminalReceiptTracker
+    private let receiptTapOwner: AOSInputReceiptTapOwner
     private var nextReceiptCounter: UInt32 = 0
-    private var receiptTap: CFMachPort?
-    private var receiptRunLoopSource: CFRunLoopSource?
-    private var receiptRunLoop: CFRunLoop?
+
+    init() {
+        let tracker = AOSInputTerminalReceiptTracker()
+        self.tracker = tracker
+        receiptTapOwner = AOSInputReceiptTapOwner(tracker: tracker)
+    }
 
     func makeReceipt() -> AOSInputPostReceipt? {
-        teardownReceiptTap()
-        guard ensureReceiptTap() else { return nil }
+        guard receiptTapOwner.start() else { return nil }
         nextReceiptCounter &+= 1
         if nextReceiptCounter == 0 { nextReceiptCounter = 1 }
         let marker = aosInputReceiptMarker(
@@ -36,7 +39,7 @@ final class AOSCGEventPostingOwner {
         timeout: TimeInterval = 1.0
     ) -> Bool {
         if awaitReceipt {
-            guard let receipt, receiptTap != nil else { return false }
+            guard let receipt, receiptTapOwner.isActive else { return false }
             tracker.begin(marker: receipt.marker, eventType: event.type.rawValue)
         }
         if let receipt {
@@ -44,93 +47,16 @@ final class AOSCGEventPostingOwner {
         }
         event.post(tap: .cghidEventTap)
         guard awaitReceipt, let receipt else { return true }
-        defer { teardownReceiptTap() }
-
-        let deadline = Date().addingTimeInterval(timeout)
-        repeat {
-            if tracker.consume(marker: receipt.marker, eventType: event.type.rawValue) { return true }
-            CFRunLoopRunInMode(.defaultMode, 0.005, true)
-        } while Date() < deadline
-        return tracker.consume(marker: receipt.marker, eventType: event.type.rawValue)
+        defer { tracker.clearAll() }
+        return tracker.waitAndConsume(
+            marker: receipt.marker,
+            eventType: event.type.rawValue,
+            timeout: timeout
+        )
     }
 
     deinit {
-        teardownReceiptTap()
-    }
-
-    private func teardownReceiptTap() {
         tracker.clearAll()
-        if let receiptTap {
-            CGEvent.tapEnable(tap: receiptTap, enable: false)
-            CFMachPortInvalidate(receiptTap)
-        }
-        if let receiptRunLoop, let receiptRunLoopSource {
-            CFRunLoopRemoveSource(receiptRunLoop, receiptRunLoopSource, .commonModes)
-        }
-        receiptTap = nil
-        receiptRunLoopSource = nil
-        receiptRunLoop = nil
-    }
-
-    private func ensureReceiptTap() -> Bool {
-        if let receiptTap {
-            if !CGEvent.tapIsEnabled(tap: receiptTap) {
-                CGEvent.tapEnable(tap: receiptTap, enable: true)
-            }
-            return CGEvent.tapIsEnabled(tap: receiptTap)
-        }
-        let eventTypes: [CGEventType] = [
-            .mouseMoved,
-            .leftMouseDown,
-            .leftMouseUp,
-            .leftMouseDragged,
-            .rightMouseDown,
-            .rightMouseUp,
-            .rightMouseDragged,
-            .otherMouseDown,
-            .otherMouseUp,
-            .otherMouseDragged,
-            .scrollWheel,
-            .keyDown,
-            .keyUp,
-        ]
-        let eventMask = eventTypes.reduce(CGEventMask(0)) { mask, type in
-            mask | CGEventMask(1 << type.rawValue)
-        }
-        let refcon = Unmanaged.passUnretained(self).toOpaque()
-        guard let tap = CGEvent.tapCreate(
-            tap: .cgSessionEventTap,
-            place: .headInsertEventTap,
-            options: .listenOnly,
-            eventsOfInterest: eventMask,
-            callback: { _, type, event, refcon -> Unmanaged<CGEvent>? in
-                guard let refcon else { return Unmanaged.passUnretained(event) }
-                let owner = Unmanaged<AOSCGEventPostingOwner>
-                    .fromOpaque(refcon)
-                    .takeUnretainedValue()
-                if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-                    if let tap = owner.receiptTap {
-                        CGEvent.tapEnable(tap: tap, enable: true)
-                    }
-                    return Unmanaged.passUnretained(event)
-                }
-                let marker = event.getIntegerValueField(.eventSourceUserData)
-                if aosInputReceiptID(marker: marker) != nil {
-                    owner.tracker.observe(marker: marker, eventType: type.rawValue)
-                }
-                return Unmanaged.passUnretained(event)
-            },
-            userInfo: refcon
-        ) else {
-            return false
-        }
-        let runLoop = CFRunLoopGetCurrent()
-        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
-        CFRunLoopAddSource(runLoop, source, .commonModes)
-        CGEvent.tapEnable(tap: tap, enable: true)
-        receiptTap = tap
-        receiptRunLoopSource = source
-        receiptRunLoop = runLoop
-        return true
+        receiptTapOwner.stop()
     }
 }

--- a/src/act/input-delivery-state.swift
+++ b/src/act/input-delivery-state.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 
 final class AOSInputTerminalReceiptTracker {
@@ -6,28 +7,29 @@ final class AOSInputTerminalReceiptTracker {
         let eventType: UInt32
     }
 
-    private let lock = NSLock()
+    private let condition = NSCondition()
     private var pending: Expectation?
     private var observed = false
 
     func begin(marker: Int64, eventType: UInt32) {
-        lock.lock()
+        condition.lock()
         pending = Expectation(marker: marker, eventType: eventType)
         observed = false
-        lock.unlock()
+        condition.unlock()
     }
 
     func observe(marker: Int64, eventType: UInt32) {
-        lock.lock()
+        condition.lock()
         if pending == Expectation(marker: marker, eventType: eventType) {
             observed = true
+            condition.broadcast()
         }
-        lock.unlock()
+        condition.unlock()
     }
 
     func consume(marker: Int64, eventType: UInt32) -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
+        condition.lock()
+        defer { condition.unlock() }
         guard pending == Expectation(marker: marker, eventType: eventType), observed else {
             return false
         }
@@ -36,11 +38,27 @@ final class AOSInputTerminalReceiptTracker {
         return true
     }
 
-    func clearAll() {
-        lock.lock()
+    func waitAndConsume(marker: Int64, eventType: UInt32, timeout: TimeInterval) -> Bool {
+        let expectation = Expectation(marker: marker, eventType: eventType)
+        let deadline = Date().addingTimeInterval(timeout)
+        condition.lock()
+        defer { condition.unlock() }
+        guard pending == expectation else { return false }
+        while pending == expectation && !observed {
+            if !condition.wait(until: deadline) { break }
+        }
+        guard pending == expectation, observed else { return false }
         pending = nil
         observed = false
-        lock.unlock()
+        return true
+    }
+
+    func clearAll() {
+        condition.lock()
+        pending = nil
+        observed = false
+        condition.broadcast()
+        condition.unlock()
     }
 }
 
@@ -50,4 +68,17 @@ struct AOSModifierDeliveryTransition {
 
     var provisionalState: Set<String> { after }
     var uncertainState: Set<String> { before.union(after) }
+}
+
+struct AOSPointerReleaseObligation {
+    private(set) var point: CGPoint
+    private(set) var isPending = true
+
+    mutating func advance(to point: CGPoint) {
+        self.point = point
+    }
+
+    mutating func fulfill() {
+        isPending = false
+    }
 }

--- a/src/act/input-receipt-tap.swift
+++ b/src/act/input-receipt-tap.swift
@@ -1,0 +1,168 @@
+import CoreGraphics
+import Foundation
+
+final class AOSInputReceiptTapOwner {
+    private let tracker: AOSInputTerminalReceiptTracker
+    private let state = NSCondition()
+    private var worker: Thread?
+    private var runLoop: CFRunLoop?
+    private var tap: CFMachPort?
+    private var source: CFRunLoopSource?
+    private var startupResult: Bool?
+    private var stopping = false
+
+    init(tracker: AOSInputTerminalReceiptTracker) {
+        self.tracker = tracker
+    }
+
+    func start() -> Bool {
+        state.lock()
+        if worker == nil {
+            startupResult = nil
+            stopping = false
+            let nextWorker = Thread { [weak self] in
+                self?.run()
+            }
+            nextWorker.name = "aos-input-receipt-tap"
+            worker = nextWorker
+            nextWorker.start()
+        }
+        while startupResult == nil {
+            state.wait()
+        }
+        let started = startupResult == true
+        state.unlock()
+        return started
+    }
+
+    var isActive: Bool {
+        state.lock()
+        defer { state.unlock() }
+        return startupResult == true && tap != nil && !stopping
+    }
+
+    func stop() {
+        state.lock()
+        guard let worker else {
+            state.unlock()
+            return
+        }
+        stopping = true
+        let ownedRunLoop = runLoop
+        state.unlock()
+
+        if let ownedRunLoop {
+            CFRunLoopStop(ownedRunLoop)
+            CFRunLoopWakeUp(ownedRunLoop)
+        }
+
+        if Thread.current != worker {
+            state.lock()
+            while self.worker != nil {
+                state.wait()
+            }
+            state.unlock()
+        }
+    }
+
+    private func run() {
+        autoreleasepool {
+            let eventTypes: [CGEventType] = [
+                .mouseMoved,
+                .leftMouseDown,
+                .leftMouseUp,
+                .leftMouseDragged,
+                .rightMouseDown,
+                .rightMouseUp,
+                .rightMouseDragged,
+                .otherMouseDown,
+                .otherMouseUp,
+                .otherMouseDragged,
+                .scrollWheel,
+                .keyDown,
+                .keyUp,
+            ]
+            let eventMask = eventTypes.reduce(CGEventMask(0)) { mask, type in
+                mask | CGEventMask(1 << type.rawValue)
+            }
+            let refcon = Unmanaged.passUnretained(self).toOpaque()
+            guard let tap = CGEvent.tapCreate(
+                tap: .cgSessionEventTap,
+                place: .headInsertEventTap,
+                options: .listenOnly,
+                eventsOfInterest: eventMask,
+                callback: { _, type, event, refcon -> Unmanaged<CGEvent>? in
+                    guard let refcon else { return Unmanaged.passUnretained(event) }
+                    let owner = Unmanaged<AOSInputReceiptTapOwner>
+                        .fromOpaque(refcon)
+                        .takeUnretainedValue()
+                    if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+                        owner.reenable()
+                        return Unmanaged.passUnretained(event)
+                    }
+                    let marker = event.getIntegerValueField(.eventSourceUserData)
+                    if aosInputReceiptID(marker: marker) != nil {
+                        owner.tracker.observe(marker: marker, eventType: type.rawValue)
+                    }
+                    return Unmanaged.passUnretained(event)
+                },
+                userInfo: refcon
+            ) else {
+                finishStartup(false)
+                return
+            }
+
+            let runLoop = CFRunLoopGetCurrent()
+            let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+            CFRunLoopAddSource(runLoop, source, .commonModes)
+            CGEvent.tapEnable(tap: tap, enable: true)
+
+            state.lock()
+            self.tap = tap
+            self.source = source
+            self.runLoop = runLoop
+            startupResult = CGEvent.tapIsEnabled(tap: tap)
+            let shouldRun = startupResult == true && !stopping
+            state.broadcast()
+            state.unlock()
+
+            if shouldRun {
+                CFRunLoopRun()
+            }
+
+            CGEvent.tapEnable(tap: tap, enable: false)
+            CFMachPortInvalidate(tap)
+            CFRunLoopRemoveSource(runLoop, source, .commonModes)
+            finishWorker()
+        }
+    }
+
+    private func reenable() {
+        state.lock()
+        let tap = self.tap
+        let canEnable = !stopping
+        state.unlock()
+        if canEnable, let tap {
+            CGEvent.tapEnable(tap: tap, enable: true)
+        }
+    }
+
+    private func finishStartup(_ result: Bool) {
+        state.lock()
+        startupResult = result
+        worker = nil
+        state.broadcast()
+        state.unlock()
+    }
+
+    private func finishWorker() {
+        state.lock()
+        tap = nil
+        source = nil
+        runLoop = nil
+        worker = nil
+        startupResult = false
+        state.broadcast()
+        state.unlock()
+    }
+}

--- a/tests/click-count-contract.test.mjs
+++ b/tests/click-count-contract.test.mjs
@@ -47,27 +47,36 @@ test('CGEvent actions await terminal receipts without fixed completion sleeps', 
   const actions = source('src/act/actions.swift');
   const posting = source('src/act/event-posting.swift');
   const deliveryState = source('src/act/input-delivery-state.swift');
+  const receiptTap = source('src/act/input-receipt-tap.swift');
   const session = source('src/act/session.swift');
 
   assert.match(models, /let eventPostingOwner:\s*AOSCGEventPostingOwner/);
   assert.match(models, /var terminal_event_receipt:\s*String\?/);
   assert.doesNotMatch(actions, /CGEventSource\(stateID:\s*\.hidSystemState\)/);
-  assert.match(posting, /guard ensureReceiptTap\(\) else \{ return nil \}/);
-  assert.match(posting, /defer \{ teardownReceiptTap\(\) \}/);
-  assert.match(posting, /CGEvent\.tapIsEnabled\(tap:\s*receiptTap\)/);
-  assert.match(posting, /type == \.tapDisabledByTimeout \|\| type == \.tapDisabledByUserInput/);
-  assert.match(posting, /CGEvent\.tapEnable\(tap:\s*tap,\s*enable:\s*true\)/);
+  assert.match(posting, /guard receiptTapOwner\.start\(\) else \{ return nil \}/);
+  assert.match(posting, /guard let receipt,\s*receiptTapOwner\.isActive else \{ return false \}/);
+  assert.match(posting, /defer \{ tracker\.clearAll\(\) \}/);
+  assert.match(receiptTap, /nextWorker\.name\s*=\s*"aos-input-receipt-tap"/);
+  assert.match(receiptTap, /CFRunLoopAddSource\(runLoop,\s*source,\s*\.commonModes\)/);
+  assert.match(receiptTap, /CFRunLoopRun\(\)/);
+  assert.match(receiptTap, /type == \.tapDisabledByTimeout \|\| type == \.tapDisabledByUserInput/);
+  assert.match(receiptTap, /CGEvent\.tapEnable\(tap:\s*tap,\s*enable:\s*true\)/);
   assert.match(posting, /tracker\.begin\(marker:\s*receipt\.marker,\s*eventType:\s*event\.type\.rawValue\)/);
   assert.match(actions, /func handleMove[\s\S]*?owner\.post\(event\)[\s\S]*?func handleClick/);
   assert.match(actions, /owner\.post\(up,\s*receipt:\s*receipt,\s*awaitReceipt:\s*true\)/);
+  assert.match(actions, /func handleDrag[\s\S]*?owner\.post\(down,\s*receipt:\s*receipt,\s*awaitReceipt:\s*true\)/);
+  assert.match(actions, /func handleDrag[\s\S]*?postBestEffortPointerRelease\(owner:\s*owner,\s*point:\s*origin,\s*flags:\s*flags,\s*receipt:\s*receipt\)/);
   assert.match(actions, /CGEVENT_DELIVERY_UNCONFIRMED/);
   assert.match(posting, /event\.setIntegerValueField\(\.eventSourceUserData,\s*value:\s*receipt\.marker\)/);
-  assert.match(posting, /tracker\.consume\(marker:\s*receipt\.marker,\s*eventType:\s*event\.type\.rawValue\)/);
-  assert.match(posting, /tracker\.observe\(marker:\s*marker,\s*eventType:\s*type\.rawValue\)/);
+  assert.match(posting, /tracker\.waitAndConsume\([\s\S]*?marker:\s*receipt\.marker,[\s\S]*?eventType:\s*event\.type\.rawValue,[\s\S]*?timeout:\s*timeout/);
+  assert.match(receiptTap, /tracker\.observe\(marker:\s*marker,\s*eventType:\s*type\.rawValue\)/);
   assert.match(posting, /tracker\.clearAll\(\)/);
   assert.match(deliveryState, /private var pending:\s*Expectation\?/);
   assert.match(deliveryState, /var uncertainState:\s*Set<String>\s*\{\s*before\.union\(after\)\s*\}/);
   assert.doesNotMatch(posting, /private var observed:\s*Set/);
+  assert.doesNotMatch(posting, /CFRunLoopRunInMode/);
+  assert.doesNotMatch(posting, /Thread\.sleep/);
+  assert.match(posting, /receiptTapOwner\.stop\(\)/);
   assert.match(session, /keyboardEventSource:\s*state\.eventPostingOwner\.source/);
   assert.doesNotMatch(actions, /usleep\(50_000\)/);
 });
@@ -82,4 +91,24 @@ test('modifier receipt timeouts remain owned by session cleanup', () => {
   assert.doesNotMatch(keyDown, /state\.modifiers\.remove\(modifier\)/);
   assert.match(keyUp, /AOSModifierDeliveryTransition\(before:\s*before,\s*after:\s*after\)/);
   assert.match(keyUp, /state\.modifiers\s*=\s*transition\.uncertainState/);
+});
+
+test('drag owns mouse release until terminal up is acknowledged', () => {
+  const actions = source('src/act/actions.swift');
+  const body = functionBody(actions, 'func handleDrag(');
+  const release = functionBody(actions, 'private func postBestEffortPointerRelease(');
+  const downAcknowledged = body.indexOf('owner.post(down, receipt: receipt, awaitReceipt: true)');
+  const obligation = body.indexOf('var releaseObligation = AOSPointerReleaseObligation(point: origin)');
+  const deferredRelease = body.indexOf('if releaseObligation.isPending');
+  const terminalAcknowledged = body.lastIndexOf('owner.post(up, receipt: receipt, awaitReceipt: true)');
+  const fulfilled = body.indexOf('releaseObligation.fulfill()');
+
+  assert.ok(downAcknowledged >= 0, 'drag should acknowledge down before taking release ownership');
+  assert.ok(obligation > downAcknowledged, 'release obligation should begin only after acknowledged down');
+  assert.ok(deferredRelease > obligation, 'drag should install a deferred best-effort release');
+  assert.match(body, /postBestEffortPointerRelease\([\s\S]*?point:\s*releaseObligation\.point/);
+  assert.match(release, /mouseType:\s*\.leftMouseUp/);
+  assert.match(release, /owner\.post\(release,\s*receipt:\s*receipt\)/);
+  assert.ok(terminalAcknowledged > deferredRelease, 'terminal up should run under the release obligation');
+  assert.ok(fulfilled > terminalAcknowledged, 'only acknowledged terminal up should fulfill release ownership');
 });

--- a/tests/lib/native-action-input-delivery.swift
+++ b/tests/lib/native-action-input-delivery.swift
@@ -32,7 +32,10 @@ private func proveTerminalSequence(
     try require(!tracker.consume(marker: marker, eventType: terminalType), "\(name): nonterminal event satisfied receipt")
 
     tracker.observe(marker: marker, eventType: terminalType)
-    try require(tracker.consume(marker: marker, eventType: terminalType), "\(name): terminal event was not consumed")
+    try require(
+        tracker.waitAndConsume(marker: marker, eventType: terminalType, timeout: 0),
+        "\(name): terminal event was not consumed"
+    )
     try require(!tracker.consume(marker: marker, eventType: terminalType), "\(name): terminal receipt was retained")
 }
 
@@ -44,10 +47,28 @@ struct NativeActionInputDeliveryProof {
         try proveTerminalSequence(name: "key", marker: 103, terminalType: 11, nonterminalTypes: [10])
         try proveTerminalSequence(name: "type", marker: 104, terminalType: 11, nonterminalTypes: [10, 10])
 
+        let dragBoundaryTracker = AOSInputTerminalReceiptTracker()
+        dragBoundaryTracker.begin(marker: 105, eventType: 1)
+        dragBoundaryTracker.observe(marker: 105, eventType: 1)
+        try require(
+            dragBoundaryTracker.waitAndConsume(marker: 105, eventType: 1, timeout: 0),
+            "drag boundaries: down was not acknowledged"
+        )
+        dragBoundaryTracker.begin(marker: 105, eventType: 2)
+        dragBoundaryTracker.observe(marker: 105, eventType: 6)
+        dragBoundaryTracker.observe(marker: 105, eventType: 2)
+        try require(
+            dragBoundaryTracker.waitAndConsume(marker: 105, eventType: 2, timeout: 0),
+            "drag boundaries: up was not acknowledged"
+        )
+
         let timeoutTracker = AOSInputTerminalReceiptTracker()
         timeoutTracker.begin(marker: 201, eventType: 2)
         timeoutTracker.observe(marker: 201, eventType: 1)
-        try require(!timeoutTracker.consume(marker: 201, eventType: 2), "timeout: nonterminal event satisfied receipt")
+        try require(
+            !timeoutTracker.waitAndConsume(marker: 201, eventType: 2, timeout: 0),
+            "timeout: nonterminal event satisfied receipt"
+        )
         timeoutTracker.clearAll()
         timeoutTracker.observe(marker: 201, eventType: 2)
         try require(!timeoutTracker.consume(marker: 201, eventType: 2), "timeout: teardown retained expectation")
@@ -67,6 +88,24 @@ struct NativeActionInputDeliveryProof {
         let modifierUp = AOSModifierDeliveryTransition(before: ["shift", "cmd"], after: ["cmd"])
         try require(modifierUp.provisionalState == ["cmd"], "modifier up: provisional state retained released modifier")
         try require(modifierUp.uncertainState == ["shift", "cmd"], "modifier up: uncertain modifier escaped cleanup ownership")
+
+        var failedReleaseCount = 0
+        func simulateDragRelease(success: Bool) {
+            var obligation = AOSPointerReleaseObligation(point: CGPoint(x: 10, y: 20))
+            defer {
+                if obligation.isPending {
+                    failedReleaseCount += 1
+                }
+            }
+            obligation.advance(to: CGPoint(x: 30, y: 40))
+            if success {
+                obligation.fulfill()
+            }
+        }
+        simulateDragRelease(success: false)
+        try require(failedReleaseCount == 1, "drag release: failed transaction did not retain one release obligation")
+        simulateDragRelease(success: true)
+        try require(failedReleaseCount == 1, "drag release: successful transaction retained its release obligation")
 
         print("PASS: terminal receipts and modifier uncertainty remain transaction-owned")
     }

--- a/tests/native-action-terminal-receipt-live.sh
+++ b/tests/native-action-terminal-receipt-live.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT_DIR"
+
+if [[ "${AOS_REAL_INPUT_OK:-}" != "1" ]]; then
+  echo "SKIP: set AOS_REAL_INPUT_OK=1 to run the public long-drag receipt proof; incidental user input is permitted."
+  exit 77
+fi
+
+source tests/lib/harness-contracts.sh
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/aos-native-action-terminal-receipt.XXXXXX")"
+OBSERVER_PID=""
+cleanup() {
+  if [[ -n "$OBSERVER_PID" ]]; then
+    kill "$OBSERVER_PID" 2>/dev/null || true
+    wait "$OBSERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP"
+  aos_harness_contract_release_all
+}
+trap cleanup EXIT
+
+export AOS_HARNESS_CONTRACT_SCRIPT="$0"
+aos_harness_contract_acquire native-action-terminal-receipt \
+  --group repo-daemon-live \
+  --group real-input-pointer \
+  --blocks repo-service-mutator
+
+READY_RESULT="$(./aos ready --json)"
+read -r DAEMON_PID SOCKET_PATH <<EOF
+$(python3 - "$READY_RESULT" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+assert payload.get("ready") is True, payload
+runtime = payload.get("runtime") or {}
+print(runtime["daemon_pid"], runtime["socket_path"])
+PY
+)
+EOF
+
+OBSERVER_LOG="$TMP/input-events.ndjson"
+OBSERVER_READY="$TMP/input-observer.ready"
+node tests/lib/input-event-observer.mjs \
+  --socket "$SOCKET_PATH" \
+  --ready-file "$OBSERVER_READY" \
+  >"$OBSERVER_LOG" 2>"$TMP/input-observer.stderr" &
+OBSERVER_PID=$!
+
+for _ in $(seq 1 50); do
+  [[ -f "$OBSERVER_READY" ]] && break
+  kill -0 "$OBSERVER_PID" 2>/dev/null || {
+    cat "$OBSERVER_LOG" "$TMP/input-observer.stderr" >&2 || true
+    echo "FAIL: canonical observer exited before readiness" >&2
+    exit 1
+  }
+  sleep 0.1
+done
+[[ -f "$OBSERVER_READY" ]] || { echo "FAIL: canonical observer did not become ready" >&2; exit 1; }
+
+./aos do hover 400,500 >/dev/null
+DRAG_RESULT="$(./aos do drag 400,500 800,500 --speed 40)"
+
+python3 - "$DRAG_RESULT" "$OBSERVER_LOG" "$SOCKET_PATH" "$DAEMON_PID" <<'PY'
+import json
+import pathlib
+import socket
+import sys
+import time
+
+result = json.loads(sys.argv[1])
+assert result.get("status") == "success", result
+receipt = (result.get("execution") or {}).get("terminal_event_receipt")
+assert isinstance(receipt, str) and receipt.startswith("aos-input-"), result
+
+log_path = pathlib.Path(sys.argv[2])
+deadline = time.monotonic() + 8
+records = []
+while time.monotonic() < deadline:
+    records = [
+        json.loads(line)
+        for line in log_path.read_text().splitlines()
+        if line
+    ]
+    if any(
+        record.get("observer") == "input_event"
+        and record.get("event", {}).get("gesture_id") == receipt
+        and record.get("event", {}).get("phase") == "up"
+        for record in records
+    ):
+        break
+    time.sleep(0.05)
+
+errors = [record for record in records if record.get("observer") == "error"]
+assert not errors, errors
+events = [
+    record["event"]
+    for record in records
+    if record.get("observer") == "input_event"
+    and record.get("event", {}).get("gesture_id") == receipt
+]
+phases = [event.get("phase") for event in events]
+assert phases and phases[-1] == "up", phases
+assert phases.count("up") == 1, phases
+assert phases.count("down") <= 1, phases
+assert phases.count("drag") >= 100, len(phases)
+assert all(phase in {"down", "drag", "up"} for phase in phases), phases
+
+client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+client.settimeout(3)
+client.connect(sys.argv[3])
+client.sendall(b'{"v":1,"service":"system","action":"ping","data":{}}\n')
+payload = b""
+while b"\n" not in payload:
+    chunk = client.recv(65536)
+    if not chunk:
+        break
+    payload += chunk
+client.close()
+response = json.loads(payload.split(b"\n", 1)[0])
+data = response.get("data") or response
+assert data.get("pid") == int(sys.argv[4]), data
+tap = data.get("input_tap") or {}
+assert tap.get("status") == "active", tap
+assert tap.get("listen_access") is True, tap
+assert tap.get("post_access") is True, tap
+
+print(json.dumps({
+    "status": "passed",
+    "receipt": receipt,
+    "raw_down_events": phases.count("down"),
+    "raw_drag_events": phases.count("drag"),
+    "raw_up_events": phases.count("up"),
+    "daemon_pid": data.get("pid"),
+    "input_tap": tap.get("status"),
+}, sort_keys=True))
+PY
+
+echo "PASS: public 10-second drag retains its terminal receipt and managed input tap"


### PR DESCRIPTION
## Summary

- move the action receipt tap onto a dedicated continuously serviced run-loop thread
- wake terminal waits through the receipt tracker's condition instead of polling or fixed completion delays
- make native drag acknowledge down before motion, compensate with mouse-up when down delivery is uncertain, and acknowledge terminal up
- add deterministic transaction coverage and a guarded public 10-second drag proof against the managed repo daemon

## Context

The guarded #23 rebaseline exposed `CGEVENT_DELIVERY_UNCONFIRMED` for long native drags before any benchmark sample was accepted. Issue #23 remains inconclusive and resumes only after this prerequisite merges.

Closes #607.

## Validation

- `bash tests/build-rebuild-policy.sh`
- `bash tests/native-action-input-delivery.sh`
- `node --test tests/click-count-contract.test.mjs tests/aos-do-session-streaming.test.mjs tests/schemas/dev-test-proof-registry.test.mjs` (21/21)
- `bash tests/daemon-input-surface-ownership.sh`
- `AOS_REAL_INPUT_OK=1 bash tests/native-action-terminal-receipt-live.sh`
  - public 10-second drag succeeded
  - 1,053 receipt-tagged drag events and one terminal up reached the managed raw stream
  - managed daemon input tap remained active with listen/post access
- raw unsigned `bash build.sh --force --no-restart`
- workflow recommendation/proof-worth routing passed
- `./aos ready --json`: healthy, all five permission facts true, no blockers
- `git diff --check main...HEAD`

No changed file crosses 1,000 lines.
