### PR TITLE
Harden show create response and wait contracts

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -779,6 +779,13 @@ aos show create \
   --html '<div style="padding:16px;color:white">hello</div>'
 ```
 
+`show create` does not resend a mutation when the daemon response is lost. For
+a global canvas only, the CLI performs one bounded `show list` reconciliation
+and reports success only when the requested id carries the exact owner metadata
+from the still-running CLI process. Connection-scoped creates cannot be
+reconciled across sockets and fail closed. Unconfirmed-response errors identify
+the action and canvas id without echoing HTML or other request content.
+
 Common follow-ups:
 
 ```bash
@@ -829,6 +836,12 @@ For inline `--html` or `--file` canvases, `show update --html ...` or
 the CLI at update time, so repeat the `--file` update after editing the file.
 Use `show wait` after either form when the reloaded page has a readiness
 manifest or observable JavaScript condition.
+
+`show wait --manifest <name>` requires the AOS bridge and matching readiness
+manifest. `show wait --js <condition>` polls that JavaScript condition directly,
+so inline HTML does not need to install `window.headsup.receive`. When both flags
+are present, both conditions must pass. With neither flag, `show wait` retains
+the bridge-ready default.
 
 ### 3. Load Toolkit Content Through the Content Server
 

--- a/docs/dev/test-proof-registry.d/runtime-readiness.json
+++ b/docs/dev/test-proof-registry.d/runtime-readiness.json
@@ -108,6 +108,22 @@
       "status": "active"
     },
     {
+      "id": "show-client-response-contract",
+      "path_patterns": [
+        "tests/show-client-response-contract.test.mjs"
+      ],
+      "fixture_patterns": [],
+      "owner": "runtime-readiness",
+      "harness_level": "model_unit",
+      "proof_kind": "ipc_response_contract",
+      "contract": "Show create reconciles an unavailable response only through exact global owner metadata, connection-scoped outcomes fail closed, request content stays out of errors, and JavaScript-only show waits do not require the bridge.",
+      "worth": "This proves the cold-create and inline-HTML wait boundaries against a fake Unix socket without mutating a live daemon or canvas.",
+      "command": "node --test tests/show-client-response-contract.test.mjs tests/show-wait-timeout-boundary.test.mjs",
+      "replaces": [],
+      "guard": "none",
+      "status": "active"
+    },
+    {
       "id": "show-wait-isolated-smoke",
       "path_patterns": [
         "tests/show-wait.sh"

--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -2643,7 +2643,7 @@
               "id" : "js",
               "kind" : "flag",
               "required" : false,
-              "summary" : "Additional JavaScript readiness condition",
+              "summary" : "JavaScript readiness condition, standalone unless combined with --manifest",
               "token" : "--js",
               "value_type" : "string"
             },

--- a/manifests/commands/source/aos/04-show.json
+++ b/manifests/commands/source/aos/04-show.json
@@ -706,7 +706,7 @@
               "id": "js",
               "kind": "flag",
               "required": false,
-              "summary": "Additional JavaScript readiness condition",
+              "summary": "JavaScript readiness condition, standalone unless combined with --manifest",
               "token": "--js",
               "value_type": "string"
             },

--- a/scripts/aos-show-client.mjs
+++ b/scripts/aos-show-client.mjs
@@ -186,6 +186,8 @@ function readOneJSON(socket, timeoutMs = 3000) {
       clearTimeout(timer);
       socket.off('data', onData);
       socket.off('error', onError);
+      socket.off('end', onEnd);
+      socket.off('close', onClose);
     };
     const finish = (value) => {
       if (settled) return;
@@ -208,8 +210,12 @@ function readOneJSON(socket, timeoutMs = 3000) {
       }
     };
     const onError = () => finish(null);
+    const onEnd = () => finish(null);
+    const onClose = () => finish(null);
     socket.on('data', onData);
     socket.once('error', onError);
+    socket.once('end', onEnd);
+    socket.once('close', onClose);
   });
 }
 
@@ -227,7 +233,39 @@ function sleep(ms) {
 }
 
 function ipcFailureMessage(action, data) {
-  return `IPC failure while waiting for show.${action} response: ${JSON.stringify(data ?? {})}`;
+  const target = typeof data?.id === 'string' && data.id ? ` for canvas ${JSON.stringify(data.id)}` : '';
+  return `IPC response unavailable for show.${action}${target}; the outcome could not be confirmed.`;
+}
+
+function canvasOwnerMatches(actual, expected) {
+  if (!actual || typeof actual !== 'object' || !expected || typeof expected !== 'object') return false;
+  return [
+    'consumer_id',
+    'harness',
+    'pid',
+    'cwd',
+    'worktree_root',
+    'runtime_mode',
+  ].every((key) => (actual[key] ?? null) === (expected[key] ?? null));
+}
+
+async function reconcileOwnedGlobalCreate(data, timeoutMs) {
+  if (data?.scope === 'connection' || !data?.owner || typeof data?.id !== 'string') return null;
+
+  await sleep(100);
+  const socket = await connectOnce(Math.min(1000, timeoutMs));
+  if (!socket) return null;
+  const response = await sendEnvelope(socket, 'list', {}, timeoutMs);
+  socket.end();
+  if (!response || response.error || response.status === 'error') return null;
+
+  const body = response?.data && typeof response.data === 'object' ? response.data : response;
+  const canvas = Array.isArray(body?.canvases)
+    ? body.canvases.find((candidate) => candidate?.id === data.id)
+    : null;
+  if (!canvas || canvas.scope === 'connection' || !canvasOwnerMatches(canvas.owner, data.owner)) return null;
+
+  return { v: 1, status: 'success', data: {} };
 }
 
 function diagnosticVerdict(operationId, timeoutMs) {
@@ -245,6 +283,7 @@ async function oneShot(action, data, {
   emptyListOnNoDaemon = false,
   timeoutMs = 3000,
   retryNoResponse = 0,
+  recoverNoResponse = null,
   allowStart = false,
 } = {}) {
   if (RUNTIME_COUPLED_SHOW_ACTIONS.has(action)) {
@@ -269,8 +308,9 @@ async function oneShot(action, data, {
     response = await sendEnvelope(socket, action, data, timeoutMs);
     attemptsRemaining -= 1;
   }
+  if (!response && recoverNoResponse) response = await recoverNoResponse();
   socket?.end();
-  if (!response) error(ipcFailureMessage(action, data), 'INTERNAL');
+  if (!response) error(ipcFailureMessage(action, data), 'IPC_RESPONSE_UNAVAILABLE');
   if (response.error) {
     process.stderr.write(`${JSON.stringify(response)}\n`);
     process.exit(1);
@@ -567,10 +607,14 @@ async function mutationCommand(args, kind) {
     if (options.focus !== undefined) request.focus = options.focus;
   }
   applyCanvasMutationOptions(options, request, kind);
+  const timeoutMs = kind === 'create' ? 10000 : 3000;
   await oneShot(kind, request, {
     autoStart: kind === 'create',
     allowStart: Boolean(options.allowStart),
-    timeoutMs: kind === 'create' ? 10000 : 3000,
+    timeoutMs,
+    recoverNoResponse: kind === 'create'
+      ? () => reconcileOwnedGlobalCreate(request, timeoutMs)
+      : null,
   });
 }
 
@@ -616,9 +660,15 @@ async function waitCommand(args) {
 
   if (!id) error('wait requires --id <name>', 'MISSING_ARG');
   requireDefaultRepoRuntimePolicy('show.wait');
-  let condition = "window.headsup && typeof window.headsup.receive === 'function'";
-  if (manifest) condition += ` && window.headsup.manifest && window.headsup.manifest.name === ${JSON.stringify(manifest)}`;
-  if (js) condition += ` && (${js})`;
+  const bridgeCondition = "window.headsup && typeof window.headsup.receive === 'function'";
+  const conditions = [];
+  if (manifest) {
+    conditions.push(bridgeCondition);
+    conditions.push(`window.headsup.manifest && window.headsup.manifest.name === ${JSON.stringify(manifest)}`);
+  }
+  if (js) conditions.push(`(${js})`);
+  if (conditions.length === 0) conditions.push(bridgeCondition);
+  const condition = conditions.join(' && ');
   const evalJS = `(${condition}) ? 'ready' : 'wait'`;
 
   const deadline = Date.now() + timeoutMs;

--- a/tests/show-client-response-contract.test.mjs
+++ b/tests/show-client-response-contract.test.mjs
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+const repoRoot = path.resolve(import.meta.dirname, '..');
+
+async function runShowClient(stateRoot, args) {
+  const child = spawn(process.execPath, ['scripts/aos-show-client.mjs', ...args], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      AOS_STATE_ROOT: stateRoot,
+      AOS_DISABLE_DAEMON_AUTOSTART: '1',
+      AOS_SESSION_ID: 'show-client-contract',
+      AOS_SESSION_HARNESS: 'node-test',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => { stdout += chunk; });
+  child.stderr.on('data', (chunk) => { stderr += chunk; });
+  const exitCode = await new Promise((resolve) => child.once('exit', resolve));
+  return { exitCode, stdout, stderr };
+}
+
+async function withFakeDaemon(respond, run) {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'aos-show-client-contract-'));
+  const runtimeDir = path.join(root, 'repo');
+  const socketPath = path.join(runtimeDir, 'sock');
+  await mkdir(runtimeDir, { recursive: true });
+  const requests = [];
+  const sockets = new Set();
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.once('close', () => sockets.delete(socket));
+    let buffer = '';
+    socket.setEncoding('utf8');
+    socket.on('data', (chunk) => {
+      buffer += chunk;
+      for (;;) {
+        const newline = buffer.indexOf('\n');
+        if (newline < 0) break;
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        const request = JSON.parse(line);
+        requests.push(request);
+        respond(request, socket, requests);
+      }
+    });
+  });
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(socketPath, () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  try {
+    await run({ root, requests });
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    await new Promise((resolve) => server.close(resolve));
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function sendSuccess(socket, data = {}) {
+  socket.end(`${JSON.stringify({ v: 1, status: 'success', data })}\n`);
+}
+
+test('show create reconciles a lost response only against its exact global owner', async () => {
+  let createdOwner;
+  await withFakeDaemon((request, socket) => {
+    if (request.action === 'create') {
+      createdOwner = request.data.owner;
+      socket.end();
+      return;
+    }
+    assert.equal(request.action, 'list');
+    sendSuccess(socket, {
+      canvases: [{ id: 'cold-canvas', scope: 'global', owner: createdOwner }],
+    });
+  }, async ({ root, requests }) => {
+    const result = await runShowClient(root, [
+      'create', '--id', 'cold-canvas', '--at', '10,20,200,100',
+      '--html', '<main>cold create</main>',
+    ]);
+    assert.equal(result.exitCode, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), { status: 'success' });
+    assert.deepEqual(requests.map((request) => request.action), ['create', 'list']);
+    assert.equal(createdOwner.pid > 0, true);
+  });
+});
+
+test('show create fails closed when timeout reconciliation finds a different owner', async () => {
+  const secretHTML = '<main>private payload</main>';
+  let createdOwner;
+  await withFakeDaemon((request, socket) => {
+    if (request.action === 'create') {
+      createdOwner = request.data.owner;
+      socket.end();
+      return;
+    }
+    sendSuccess(socket, {
+      canvases: [{
+        id: 'owned-elsewhere',
+        scope: 'global',
+        owner: { ...createdOwner, pid: createdOwner.pid + 1 },
+      }],
+    });
+  }, async ({ root, requests }) => {
+    const result = await runShowClient(root, [
+      'create', '--id', 'owned-elsewhere', '--at', '10,20,200,100', '--html', secretHTML,
+    ]);
+    assert.equal(result.exitCode, 1);
+    const failure = JSON.parse(result.stderr);
+    assert.equal(failure.code, 'IPC_RESPONSE_UNAVAILABLE');
+    assert.match(failure.error, /show\.create/);
+    assert.doesNotMatch(result.stderr, /private payload/);
+    assert.deepEqual(requests.map((request) => request.action), ['create', 'list']);
+  });
+});
+
+test('show create does not reconcile connection-scoped ownership across sockets', async () => {
+  await withFakeDaemon((_request, socket) => socket.end(), async ({ root, requests }) => {
+    const result = await runShowClient(root, [
+      'create', '--id', 'connection-canvas', '--scope', 'connection',
+      '--at', '10,20,200,100', '--html', '<main>connection</main>',
+    ]);
+    assert.equal(result.exitCode, 1);
+    assert.equal(JSON.parse(result.stderr).code, 'IPC_RESPONSE_UNAVAILABLE');
+    assert.deepEqual(requests.map((request) => request.action), ['create']);
+  });
+});
+
+test('show wait evaluates a JavaScript predicate without requiring the headsup bridge', async () => {
+  await withFakeDaemon((request, socket) => {
+    assert.equal(request.action, 'eval');
+    assert.match(request.data.js, /document\.body\.dataset\.ready/);
+    assert.doesNotMatch(request.data.js, /window\.headsup/);
+    sendSuccess(socket, { result: 'ready' });
+  }, async ({ root, requests }) => {
+    const result = await runShowClient(root, [
+      'wait', '--id', 'inline-html',
+      '--js', 'document.body.dataset.ready === "yes"',
+      '--timeout', '500ms', '--json',
+    ]);
+    assert.equal(result.exitCode, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), {
+      status: 'success',
+      ready: true,
+      id: 'inline-html',
+    });
+    assert.equal(requests.length, 1);
+  });
+});
+
+test('show wait combines bridge, manifest, and JavaScript conditions when requested', async () => {
+  await withFakeDaemon((request, socket) => {
+    assert.equal(request.action, 'eval');
+    assert.match(request.data.js, /window\.headsup/);
+    assert.match(request.data.js, /window\.headsup\.manifest/);
+    assert.match(request.data.js, /inline-manifest/);
+    assert.match(request.data.js, /document\.body\.dataset\.ready/);
+    sendSuccess(socket, { result: 'ready' });
+  }, async ({ root, requests }) => {
+    const result = await runShowClient(root, [
+      'wait', '--id', 'bridged-html', '--manifest', 'inline-manifest',
+      '--js', 'document.body.dataset.ready === "yes"',
+      '--timeout', '500ms', '--json',
+    ]);
+    assert.equal(result.exitCode, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).ready, true);
+    assert.equal(requests.length, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- reconcile unavailable global `show.create` responses through exact same-ID owner metadata without replaying the mutation
- fail connection-scoped and ownership-mismatched creates closed with `IPC_RESPONSE_UNAVAILABLE`
- keep request HTML and payload content out of IPC errors
- make `show wait --js` a standalone DOM condition while preserving bridge requirements for manifest waits
- align public docs, generated command help, and proof routing

## Validation
- focused response/wait contracts: 6/6
- schemas: 159/159
- external dispatch, parser, help, manifest generation, and proof routing: passed
- root Node suite: 202/203
- `git diff --check`

The sole root-suite failure is the existing `browser-do-keyboard-contract` `UNEXPECTED_AOS` baseline and is untouched by this change.

No build, daemon operation, TCC change, Sigil change, or live runtime mutation was performed.