### PR TITLE
Repair managed post-permission readiness recovery

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -2335,9 +2335,13 @@ Consumers:
   `ready --post-permission` are read-only: each collects facts once, reports
   `startup.attempted:false`, and never starts, restarts, cleans, opens Settings,
   changes permissions, or writes a TCC-alert marker. `--post-permission` labels
-  the bounded verification performed after the human re-grants Accessibility or
-  Input Monitoring; remaining blockers route explicitly to `ready --repair` or
-  direct service/permission commands.
+  verification after the human re-grants Accessibility or Input Monitoring.
+  The generated resume command is
+  `aos ready --repair --post-permission`: that exact combination may perform at
+  most one same-mode launchd-managed restart, then requires fresh live daemon
+  tap/listen/post facts during a bounded recheck. It fails closed without
+  mutation when ownership is unmanaged or mismatched, runtime/service modes
+  differ, or the launchd target does not match the expected binary path.
   `--repair` is the only readiness form allowed to clean, start or restart the
   runtime, wait for recovery, play the stale-TCC alert, or write its one-shot
   marker. All readiness forms may report the same read-only `terminal_handoff`
@@ -2362,7 +2366,8 @@ Consumers:
   classifies targeted reset as unavailable for a bare repo binary that is not a
   LaunchServices app bundle. It returns next actions:
   `aos permissions setup --once` to request fresh prompts and
-  `aos ready --post-permission` to verify the recovered daemon. Service-wide TCC
+  `aos ready --repair --post-permission` to refresh and verify the recovered
+  daemon after the human grant. Service-wide TCC
   reset is not part of normal recovery because it can affect other apps. It is a
   break-glass capability only: `--allow-service-reset` requires
   `--emergency-ack-other-apps` and should be used only when Michael explicitly
@@ -2406,7 +2411,7 @@ Consumers:
   remedy. `aos ready --json` also exposes the same object at top-level
   `tcc_staleness` plus a top-level `terminal_handoff` telling agents to stop
   the current turn, wait for the user signal `finished`, and then run
-  `./aos ready --post-permission`.
+  `./aos ready --repair --post-permission`.
 - When `runtime.ownership_state` is `"unmanaged"`, JSON exposes
   `runtime.owner_process` and `runtime_verdict.ownership.owner_process`.
   The process command line is either present as `command_line` or explicitly

--- a/docs/design/permission-bearing-runtime-boundary.md
+++ b/docs/design/permission-bearing-runtime-boundary.md
@@ -67,7 +67,7 @@ After a real repo-mode binary rebuild, the user must manually reset/regrant the
 needed macOS TCC permissions before TCC-backed daemon, capture, input, or native
 proof is valid. Automation must stop at that handoff instead of treating the
 post-rebuild permission failures as source regressions, then verify with
-`./aos ready --post-permission` after the user confirms the reset.
+`./aos ready --repair --post-permission` after the user confirms the reset.
 
 If a content-only task appears to require a daemon rebuild, pause and identify
 which missing primitive is forcing the boundary crossing.

--- a/docs/dev/test-proof-registry.d/runtime-readiness.json
+++ b/docs/dev/test-proof-registry.d/runtime-readiness.json
@@ -197,11 +197,27 @@
       "owner": "runtime-readiness",
       "harness_level": "isolated_daemon",
       "proof_kind": "readiness_mutation_contract",
-      "contract": "Plain ready and post-permission verification execute no service actions, while explicit repair owns bounded cleanup, start, restart, and recovery.",
+      "contract": "Plain ready and plain post-permission verification execute no service actions, while explicit repair owns bounded cleanup, start, restart, and recovery.",
       "worth": "This proves the public mutation boundary through fake service argv and isolated runtime state instead of relying on source shape.",
       "command": "bash tests/ready-explicit-repair-flow.sh",
       "replaces": [],
       "guard": "uses isolated AOS_STATE_ROOT, mock daemons, fake service actions, and the shared lockf process-cleanup boundary",
+      "status": "active"
+    },
+    {
+      "id": "ready-post-permission-recovery",
+      "path_patterns": [
+        "tests/ready-post-permission-recovery.test.mjs"
+      ],
+      "fixture_patterns": [],
+      "owner": "runtime-readiness",
+      "harness_level": "model_unit",
+      "proof_kind": "post_user_signal_recovery_contract",
+      "contract": "Ready repair plus post-permission performs at most one same-mode launchd-managed restart, requires fresh live tap facts, and fails closed on ownership or binary target mismatch.",
+      "worth": "This reproduces the CLI-green/live-stale TCC loop and proves exact fake service argv without rebuilding AOS, touching launchd, or changing TCC.",
+      "command": "node --test tests/ready-post-permission-recovery.test.mjs",
+      "replaces": [],
+      "guard": "temporary fake AOS primitive and service responses only; no live runtime or TCC mutation",
       "status": "active"
     },
     {
@@ -236,6 +252,22 @@
       "replaces": [],
       "guard": "uses isolated AOS_STATE_ROOT, mock daemon health, fake repair service actions, and no live TCC mutation",
       "status": "active"
+    },
+    {
+      "id": "tcc-reset-agent-user-path-manual",
+      "path_patterns": [
+        "tests/manual/tcc-reset-agent-user-path.sh"
+      ],
+      "fixture_patterns": [],
+      "owner": "runtime-readiness",
+      "harness_level": "manual",
+      "proof_kind": "tcc_recovery_contract",
+      "contract": "The disruptive repo-mode TCC reset path preserves the explicit human signal and resumes through one guarded managed restart plus bounded live readiness check.",
+      "worth": "This is the end-to-end operator recovery proof, but it must never run in unattended or default validation because it stops the runtime and changes TCC state.",
+      "command": "AOS_RUN_DISRUPTIVE_TCC_TEST=1 bash tests/manual/tcc-reset-agent-user-path.sh",
+      "replaces": [],
+      "guard": "requires explicit disruptive-TCC approval, interactive typed confirmations, and manual macOS permission actions",
+      "status": "manual_only"
     },
     {
       "id": "permissions-marker-worktree-contract",

--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -7877,7 +7877,7 @@
               "id" : "post-permission",
               "kind" : "flag",
               "required" : false,
-              "summary" : "Read-only bounded verification after the human re-adds macOS permissions",
+              "summary" : "Read-only bounded verification after the human re-adds permissions; combine with --repair for one guarded managed restart",
               "token" : "--post-permission",
               "value_type" : "bool"
             }
@@ -7886,6 +7886,7 @@
             "aos ready",
             "aos ready --repair",
             "aos ready --post-permission",
+            "aos ready --repair --post-permission",
             "aos ready --json"
           ],
           "execution" : {

--- a/manifests/commands/source/aos/24-ready.json
+++ b/manifests/commands/source/aos/24-ready.json
@@ -29,7 +29,7 @@
               "id": "post-permission",
               "kind": "flag",
               "required": false,
-              "summary": "Read-only bounded verification after the human re-adds macOS permissions",
+              "summary": "Read-only bounded verification after the human re-adds permissions; combine with --repair for one guarded managed restart",
               "token": "--post-permission",
               "value_type": "bool"
             }
@@ -38,6 +38,7 @@
             "aos ready",
             "aos ready --repair",
             "aos ready --post-permission",
+            "aos ready --repair --post-permission",
             "aos ready --json"
           ],
           "execution": {

--- a/scripts/aos-permissions.mjs
+++ b/scripts/aos-permissions.mjs
@@ -374,8 +374,8 @@ function resetPostActions() {
     },
     {
       type: 'command',
-      label: 'bounded readiness check after permissions have been granted',
-      command: `${prefix} ready --post-permission`,
+      label: 'guarded managed restart and bounded readiness check after permissions have been granted',
+      command: `${prefix} ready --repair --post-permission`,
     },
   ];
 }
@@ -386,7 +386,7 @@ function resetFallbackLines(mode, targetPath) {
     `Confirm the managed daemon is stopped: ${prefix} service status --mode ${mode}`,
     `Normal fallback only if running=false: remove/re-add ${targetPath} in Accessibility and/or Input Monitoring.`,
     'Service-wide TCC reset is break-glass only; do not run it unless Michael explicitly asks for emergency recovery.',
-    `Return to the waiting session and say: finished; the session then runs ${prefix} ready --post-permission.`,
+    `Return to the waiting session and say: finished; the session then runs ${prefix} ready --repair --post-permission.`,
   ];
 }
 

--- a/scripts/aos-ready.mjs
+++ b/scripts/aos-ready.mjs
@@ -8,6 +8,7 @@ import path from 'node:path';
 import {
   compactProcessDetail,
   currentMode,
+  expectedBinaryPath,
   exitError,
   invocationName,
   printJSON,
@@ -15,7 +16,11 @@ import {
   runNodeScript,
 } from './lib/aos-cli.mjs';
 import { brokerFacts } from './lib/aos-facts.mjs';
-import { nextReadyExecutionStep } from './lib/aos-ready-execution.mjs';
+import {
+  enforcePostPermissionLiveReadiness,
+  nextReadyExecutionStep,
+  postPermissionRecoveryAuthority,
+} from './lib/aos-ready-execution.mjs';
 import {
   permissionFixLines,
   permissionResetSafeSequenceLines,
@@ -42,10 +47,10 @@ function currentFacts() {
   });
 }
 
-function buildReadyResponse(startup, actionTrace, mode, prefix) {
+function buildReadyResponse(startup, actionTrace, mode, prefix, { postPermissionRepair = false } = {}) {
   const facts = currentFacts();
   const verdict = runtimeVerdict(facts, mode, prefix);
-  return {
+  const response = {
     status: verdict.status,
     ready: verdict.ready,
     phase: verdict.phase,
@@ -65,6 +70,9 @@ function buildReadyResponse(startup, actionTrace, mode, prefix) {
     action_trace: actionTrace,
     notes: verdict.notes,
   };
+  return postPermissionRepair
+    ? enforcePostPermissionLiveReadiness(response, { prefix, mode })
+    : response;
 }
 
 function stateDir(mode) {
@@ -181,6 +189,29 @@ function runReadyServiceAction(action, mode) {
   return runNodeScript('scripts/aos-service.mjs', [action, '--mode', mode, '--json']);
 }
 
+function readyServiceStatus(mode) {
+  if (process.env.AOS_TEST_READY_SERVICE_STATUS_JSON) {
+    try {
+      return JSON.parse(process.env.AOS_TEST_READY_SERVICE_STATUS_JSON);
+    } catch (err) {
+      return { status: 'unavailable', mode, error: `invalid test service status JSON: ${err.message}` };
+    }
+  }
+  const result = runNodeScript('scripts/aos-service.mjs', ['status', '--mode', mode, '--json']);
+  if (result.exitCode !== 0) {
+    return {
+      status: 'unavailable',
+      mode,
+      error: compactProcessDetail(result) || 'service status failed',
+    };
+  }
+  try {
+    return JSON.parse(result.stdout);
+  } catch (err) {
+    return { status: 'unavailable', mode, error: `service status returned invalid JSON: ${err.message}` };
+  }
+}
+
 function skippedReadyStartup(mode, prefix) {
   return {
     attempted: false,
@@ -207,17 +238,17 @@ function runReadyStartup(mode, prefix, actionTrace) {
   };
 }
 
-function waitForReadyResponse(startup, actionTrace, mode, prefix, budgetMs, pollMs = 500) {
+function waitForReadyResponse(startup, actionTrace, mode, prefix, budgetMs, pollMs = 500, responseOptions = {}) {
   const deadline = Date.now() + budgetMs;
   while (Date.now() < deadline) {
-    const response = buildReadyResponse(startup, actionTrace, mode, prefix);
+    const response = buildReadyResponse(startup, actionTrace, mode, prefix, responseOptions);
     if (response.ready) {
       const trace = [...actionTrace, {
         step: 'wait_for_recovery',
         result: 'ready',
         detail: 'daemon became ready during repair wait',
       }];
-      return buildReadyResponse(startup, trace, mode, prefix);
+      return buildReadyResponse(startup, trace, mode, prefix, responseOptions);
     }
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, pollMs);
   }
@@ -226,10 +257,10 @@ function waitForReadyResponse(startup, actionTrace, mode, prefix, budgetMs, poll
     result: 'timed_out',
     detail: `daemon did not become ready within ${budgetMs}ms`,
   }];
-  return buildReadyResponse(startup, trace, mode, prefix);
+  return buildReadyResponse(startup, trace, mode, prefix, responseOptions);
 }
 
-function runReadyRuntimeRepair(startup, actionTrace, mode, prefix, budgetMs, reason) {
+function runReadyRuntimeRepair(startup, actionTrace, mode, prefix, budgetMs, reason, responseOptions) {
   const result = runReadyServiceAction('restart', mode);
   const detail = [reason, compactProcessDetail(result)].filter(Boolean).join('\n');
   const trace = [...actionTrace, {
@@ -246,17 +277,18 @@ function runReadyRuntimeRepair(startup, actionTrace, mode, prefix, budgetMs, rea
     prefix,
     Number.isFinite(testBudget) ? testBudget : budgetMs,
     Number.isFinite(testPoll) ? testPoll : 500,
+    responseOptions,
   );
 }
 
-function runReadyCleanRepair(startup, actionTrace, mode, prefix) {
+function runReadyCleanRepair(startup, actionTrace, mode, prefix, responseOptions) {
   const result = runAOS(['clean', '--json']);
   const trace = [...actionTrace, {
     step: 'clean',
     result: result.exitCode === 0 ? 'ok' : 'failed',
     detail: compactProcessDetail(result),
   }];
-  return buildReadyResponse(startup, trace, mode, prefix);
+  return buildReadyResponse(startup, trace, mode, prefix, responseOptions);
 }
 
 function printReadyHumanHandoff(response, mode, prefix) {
@@ -269,7 +301,7 @@ function printReadyHumanHandoff(response, mode, prefix) {
     process.stdout.write(`  Target binary: ${response.terminal_handoff.target_path}\n`);
     process.stdout.write('  Agent: end this turn now; do not run reset-runtime, setup, ready, service restart, or other TCC-backed probes.\n');
     process.stdout.write(`  Human: ${response.terminal_handoff.human_action}\n`);
-    process.stdout.write(`  Session: after the user says ${response.terminal_handoff.next_user_signal}, run ${prefix} ready --post-permission\n`);
+    process.stdout.write(`  Session: after the user says ${response.terminal_handoff.next_user_signal}, run ${prefix} ready --repair --post-permission\n`);
     return;
   }
   const permissionBlockers = response.blockers.filter((blocker) => blocker.kind === 'permission');
@@ -325,13 +357,22 @@ function printText(response, mode, prefix) {
 const options = parseArgs(process.argv.slice(2));
 const mode = currentMode();
 const prefix = invocationName();
+const postPermissionRepair = Boolean(options.repair && options.postPermission);
+const responseOptions = { postPermissionRepair };
 let startup = skippedReadyStartup(mode, prefix);
-let response = buildReadyResponse(startup, [], mode, prefix);
+let response = buildReadyResponse(startup, [], mode, prefix, responseOptions);
+const postPermissionAuthority = postPermissionRepair
+  ? postPermissionRecoveryAuthority(response.runtime, readyServiceStatus(mode), {
+      mode,
+      expectedBinaryPath: expectedBinaryPath(mode),
+    })
+  : null;
 let stopped = false;
 for (let stepCount = 0; stepCount < 8; stepCount += 1) {
   const step = nextReadyExecutionStep(response, {
     repair: options.repair,
     postPermission: options.postPermission,
+    postPermissionAuthority,
     prefix,
     mode,
   });
@@ -345,17 +386,26 @@ for (let stepCount = 0; stepCount < 8; stepCount += 1) {
   if (step.type === 'start') {
     const started = runReadyStartup(mode, prefix, response.action_trace);
     startup = started.startup;
-    response = buildReadyResponse(startup, started.actionTrace, mode, prefix);
+    response = buildReadyResponse(startup, started.actionTrace, mode, prefix, responseOptions);
   } else if (step.type === 'clean') {
-    response = runReadyCleanRepair(startup, response.action_trace, mode, prefix);
+    response = runReadyCleanRepair(startup, response.action_trace, mode, prefix, responseOptions);
   } else if (step.type === 'restart') {
-    response = runReadyRuntimeRepair(startup, response.action_trace, mode, prefix, 20_000, null);
+    response = runReadyRuntimeRepair(
+      startup,
+      response.action_trace,
+      mode,
+      prefix,
+      20_000,
+      step.reason,
+      responseOptions,
+    );
   } else if (step.type === 'permission_handoff') {
     response = buildReadyResponse(
       startup,
       [...response.action_trace, step.trace],
       mode,
       prefix,
+      responseOptions,
     );
   } else {
     exitError(`Unknown readiness execution step: ${step.type}`, 'READY_EXECUTION_STEP_INVALID');

--- a/scripts/lib/aos-readiness.mjs
+++ b/scripts/lib/aos-readiness.mjs
@@ -164,7 +164,7 @@ export function postRebuildTccStalenessFor(facts, mode, prefix = invocationName(
       type: 'manual_tcc_reset',
       summary: 'Play the stale-TCC handoff alert, end the current turn, and wait for the user to manually reset/regrant macOS TCC permissions for the rebuilt aos binary.',
       commands: [
-        `${prefix} ready --post-permission`,
+        `${prefix} ready --repair --post-permission`,
       ],
       human_action: 'Remove/re-add or regrant the aos entry in macOS Privacy & Security, then return to the waiting session and say: finished.',
       target_path: targetPath,
@@ -232,7 +232,7 @@ export function inputMonitoringSubGuidance(tap, daemonBinaryPath) {
     'In repo mode, prefer:',
     '  ./aos permissions reset-runtime --mode repo',
     '  ./aos permissions setup --once',
-    '  ./aos ready --post-permission',
+    '  ./aos ready --repair --post-permission',
     'Manual Settings fallback: Privacy & Security > Input Monitoring for daemon binary:',
     `  ${daemonBinaryPath}`,
   ].join('\n');
@@ -278,7 +278,7 @@ export function permissionResetSafeSequenceLines(blockers, mode, prefix = invoca
     `2. Agent: run ${prefix} permissions setup --once`,
     '3. Human: grant the macOS permission prompt, or physically remove/re-add the repo-mode aos runtime in System Settings if the grant remains stale.',
     '4. Human: return to the waiting session and say: finished',
-    `5. Session: run ${prefix} ready --post-permission`,
+    `5. Session: run ${prefix} ready --repair --post-permission`,
     'Manual Settings removal is required when reset-runtime reports targeted reset unavailable or the grant remains stale.',
   ];
   if (blockers.some((blocker) => blocker.id === 'screen_recording')) {
@@ -298,7 +298,7 @@ export function staleTccTerminalHandoff(tccStaleness, prefix = invocationName())
     next_user_signal: 'finished',
     human_action: tccStaleness.remedy.human_action,
     target_path: tccStaleness.remedy.target_path,
-    resume_command: `${prefix} ready --post-permission`,
+    resume_command: `${prefix} ready --repair --post-permission`,
   };
 }
 
@@ -630,8 +630,8 @@ export function readyNextActions(decision, blockers, setup, mode, prefix = invoc
     });
     appendAction(actions, seen, {
       type: 'command',
-      label: 'after the user says finished, run the bounded post-permission readiness check',
-      command: `${prefix} ready --post-permission`,
+      label: 'after the user says finished, run one guarded managed restart and bounded post-permission recheck',
+      command: `${prefix} ready --repair --post-permission`,
       after_user_signal: 'finished',
     });
     return actions;
@@ -674,8 +674,8 @@ export function readyNextActions(decision, blockers, setup, mode, prefix = invoc
     });
     appendAction(actions, seen, {
       type: 'command',
-      label: 'bounded handoff check after permissions have been granted',
-      command: `${prefix} ready --post-permission`,
+      label: 'guarded managed restart and bounded handoff check after permissions have been granted',
+      command: `${prefix} ready --repair --post-permission`,
     });
   }
 
@@ -715,7 +715,7 @@ export function readyNotes({ runtime, daemon, permissions, setup, cleanReport },
   if (tccStaleness) {
     notes.push(tccStaleness.reason);
     notes.push(tccStaleness.remedy.summary);
-    notes.push(`After the user says ${tccStaleness.remedy.next_user_signal}, run '${prefix} ready --post-permission'.`);
+    notes.push(`After the user says ${tccStaleness.remedy.next_user_signal}, run '${prefix} ready --repair --post-permission'.`);
     return notes;
   }
   if (!runtime.daemon_running) notes.push('Daemon is not running.');
@@ -853,7 +853,7 @@ export function permissionRecoveryNotes(missing, mode, prefix = invocationName()
     notes.push('Microphone permission is still not granted.');
   }
   notes.push(`Run '${prefix} permissions reset-runtime --mode ${mode}' before requesting fresh prompts.`);
-  notes.push(`Then run '${prefix} permissions setup --once' and '${prefix} ready --post-permission'.`);
+  notes.push(`Then run '${prefix} permissions setup --once' and '${prefix} ready --repair --post-permission'.`);
   return notes;
 }
 

--- a/scripts/lib/aos-ready-execution.mjs
+++ b/scripts/lib/aos-ready-execution.mjs
@@ -12,9 +12,208 @@ function stop(trace = undefined) {
   return trace ? { type: 'stop', trace } : { type: 'stop' };
 }
 
+function blockedPostPermissionRecovery(reason, detail) {
+  return stop({
+    step: 'post_permission_recovery',
+    result: 'blocked',
+    detail: `${reason}: ${detail}`,
+  });
+}
+
+export function postPermissionRecoveryAuthority(
+  runtime,
+  service,
+  { mode, expectedBinaryPath } = {},
+) {
+  if (!runtime || runtime.mode !== mode) {
+    return {
+      allowed: false,
+      reason: 'runtime_mode_mismatch',
+      detail: `requested mode=${mode ?? 'unknown'}, runtime mode=${runtime?.mode ?? 'unknown'}`,
+    };
+  }
+  if (runtime.ownership_state !== 'consistent' || runtime.owner_launchd_managed !== true) {
+    return {
+      allowed: false,
+      reason: runtime.ownership_state === 'mismatch'
+        ? 'daemon_ownership_mismatch'
+        : 'daemon_not_launchd_managed',
+      detail: `ownership state=${runtime.ownership_state ?? 'unknown'}, launchd_managed=${runtime.owner_launchd_managed === true}`,
+    };
+  }
+  if (!service || service.status === 'unavailable') {
+    return {
+      allowed: false,
+      reason: 'service_identity_unavailable',
+      detail: service?.error ?? 'managed service status could not be read',
+    };
+  }
+  if (service.mode !== mode) {
+    return {
+      allowed: false,
+      reason: 'service_mode_mismatch',
+      detail: `requested mode=${mode}, service mode=${service.mode ?? 'unknown'}`,
+    };
+  }
+  if (!service.installed || !service.loaded || !service.running) {
+    return {
+      allowed: false,
+      reason: 'managed_service_not_running',
+      detail: `installed=${Boolean(service.installed)}, loaded=${Boolean(service.loaded)}, running=${Boolean(service.running)}`,
+    };
+  }
+  const targetMatches = service.target_matches_expected === true
+    && service.actual_binary_path === service.expected_binary_path
+    && service.expected_binary_path === expectedBinaryPath;
+  if (!targetMatches) {
+    return {
+      allowed: false,
+      reason: 'binary_identity_mismatch',
+      detail: `actual=${service.actual_binary_path ?? 'unknown'}, service_expected=${service.expected_binary_path ?? 'unknown'}, ready_expected=${expectedBinaryPath ?? 'unknown'}`,
+    };
+  }
+  return {
+    allowed: true,
+    mode,
+    binary_path: expectedBinaryPath,
+    service_pid: service.pid,
+    daemon_pid: runtime.serving_pid ?? runtime.daemon_pid,
+  };
+}
+
+function liveInputTapConfirmed(response) {
+  const tap = response.runtime?.input_tap;
+  return response.ready_source === 'daemon'
+    && (tap?.status ?? response.runtime?.input_tap_status) === 'active'
+    && tap?.listen_access === true
+    && tap?.post_access === true;
+}
+
+export function enforcePostPermissionLiveReadiness(response, { prefix = './aos', mode = response.mode } = {}) {
+  if (!response.ready || liveInputTapConfirmed(response)) return response;
+
+  const blocker = {
+    kind: 'runtime',
+    id: 'post_permission_live_readiness_unconfirmed',
+    scope: 'daemon',
+    message: 'Post-permission recovery requires fresh live daemon input-tap, listen, and post facts; passive CLI grants alone are insufficient.',
+    blocks: ['see', 'do', 'listen'],
+  };
+  const blockers = [...(response.blockers ?? [])];
+  if (!blockers.some((item) => item.id === blocker.id)) blockers.push(blocker);
+  const blockedCapabilities = [...new Set([
+    ...(response.blocked_capabilities ?? []),
+    ...blocker.blocks,
+  ])].sort();
+  const nextActions = [
+    {
+      type: 'command',
+      label: 'inspect the launchd target before any post-permission restart',
+      command: `${prefix} service status --mode ${mode} --json`,
+    },
+    {
+      type: 'command',
+      label: 'inspect fresh live daemon input-tap facts',
+      command: `${prefix} status --json`,
+    },
+  ];
+  const notes = [
+    ...(response.notes ?? []),
+    'Post-permission readiness stayed fail-closed because the live daemon tap view was unavailable or stale.',
+  ];
+  const verdict = {
+    ...response.runtime_verdict,
+    ready: false,
+    status: 'degraded',
+    phase: 'runtime_blocked',
+    diagnosis: blocker.id,
+    blockers,
+    blocked_capabilities: blockedCapabilities,
+    next_actions: nextActions,
+    notes,
+  };
+  return {
+    ...response,
+    ready: false,
+    status: 'degraded',
+    phase: 'runtime_blocked',
+    diagnosis: blocker.id,
+    blockers,
+    blocked_capabilities: blockedCapabilities,
+    next_actions: nextActions,
+    notes,
+    runtime_verdict: verdict,
+  };
+}
+
+function nextPostPermissionRepairStep(response, authority) {
+  if (!authority?.allowed) {
+    return blockedPostPermissionRecovery(
+      authority?.reason ?? 'service_identity_unavailable',
+      authority?.detail ?? 'post-permission recovery authority was not established',
+    );
+  }
+  if (response.ready) {
+    return stop(response.action_trace?.length ? undefined : {
+      step: 'ready_preflight',
+      result: 'ready',
+      detail: 'live daemon input tap is active after the post-permission user signal',
+    });
+  }
+  if (hasTrace(response, 'service_restart')) {
+    return stop({
+      step: 'post_permission_recovery',
+      result: 'exhausted',
+      detail: 'the single managed restart was already attempted; no restart loop will run',
+    });
+  }
+
+  const blockerIDs = new Set((response.blockers ?? []).map((blocker) => blocker.id));
+  for (const id of [
+    'agent_os_worktree_default_runtime',
+    'daemon_ownership_mismatch',
+    'daemon_unmanaged',
+    'daemon_foreground_dev_default',
+    'stale_daemons',
+  ]) {
+    if (blockerIDs.has(id)) {
+      return blockedPostPermissionRecovery(id, 'runtime ownership must be resolved before post-permission recovery');
+    }
+  }
+
+  const passive = response.permissions ?? {};
+  const missingPassive = ['accessibility', 'listen_access', 'post_access']
+    .filter((id) => passive[id] !== true);
+  if (missingPassive.length) {
+    return blockedPostPermissionRecovery(
+      'post_permission_signal_unconfirmed',
+      `passive grants still missing: ${missingPassive.join(', ')}`,
+    );
+  }
+
+  const tap = response.runtime?.input_tap;
+  const tapStatus = tap?.status ?? response.runtime?.input_tap_status;
+  const needsLiveRefresh = blockerIDs.has('post_permission_live_readiness_unconfirmed')
+    || blockerIDs.has('input_tap_not_active')
+    || (response.blockers ?? []).some((blocker) => blocker.reason === 'post_rebuild_tcc_stale')
+    || (tapStatus && tapStatus !== 'active');
+  if (!needsLiveRefresh) return stop();
+
+  return {
+    type: 'restart',
+    reason: 'refresh the launchd-managed daemon event tap after the explicit post-permission user signal',
+  };
+}
+
 export function nextReadyExecutionStep(
   response,
-  { repair = false, postPermission = false, prefix = './aos', mode = response.mode } = {},
+  {
+    repair = false,
+    postPermission = false,
+    postPermissionAuthority = null,
+    prefix = './aos',
+    mode = response.mode,
+  } = {},
 ) {
   if (!repair) {
     return stop({
@@ -25,6 +224,8 @@ export function nextReadyExecutionStep(
         : `${postPermission ? 'post-permission verification' : 'readiness check'} is read-only; no runtime mutation attempted`,
     });
   }
+
+  if (postPermission) return nextPostPermissionRepairStep(response, postPermissionAuthority);
 
   if (response.ready) {
     return stop(response.action_trace?.length ? undefined : {

--- a/scripts/lib/aos-ready-execution.mjs
+++ b/scripts/lib/aos-ready-execution.mjs
@@ -32,7 +32,15 @@ export function postPermissionRecoveryAuthority(
       detail: `requested mode=${mode ?? 'unknown'}, runtime mode=${runtime?.mode ?? 'unknown'}`,
     };
   }
-  if (runtime.ownership_state !== 'consistent' || runtime.owner_launchd_managed !== true) {
+  const managedRuntime = runtime.ownership_state === 'consistent'
+    && runtime.owner_launchd_managed === true;
+  const absentRuntime = runtime.ownership_state === 'absent'
+    && runtime.daemon_running !== true
+    && runtime.socket_reachable !== true
+    && runtime.owner_pid == null
+    && runtime.serving_pid == null
+    && runtime.lock_owner_pid == null;
+  if (!managedRuntime && !absentRuntime) {
     return {
       allowed: false,
       reason: runtime.ownership_state === 'mismatch'
@@ -55,11 +63,11 @@ export function postPermissionRecoveryAuthority(
       detail: `requested mode=${mode}, service mode=${service.mode ?? 'unknown'}`,
     };
   }
-  if (!service.installed || !service.loaded || !service.running) {
+  if (!service.installed) {
     return {
       allowed: false,
-      reason: 'managed_service_not_running',
-      detail: `installed=${Boolean(service.installed)}, loaded=${Boolean(service.loaded)}, running=${Boolean(service.running)}`,
+      reason: 'managed_service_not_installed',
+      detail: 'the expected launchd service definition is not installed',
     };
   }
   const targetMatches = service.target_matches_expected === true
@@ -72,12 +80,27 @@ export function postPermissionRecoveryAuthority(
       detail: `actual=${service.actual_binary_path ?? 'unknown'}, service_expected=${service.expected_binary_path ?? 'unknown'}, ready_expected=${expectedBinaryPath ?? 'unknown'}`,
     };
   }
+  if (managedRuntime && (!service.loaded || !service.running)) {
+    return {
+      allowed: false,
+      reason: 'managed_service_state_mismatch',
+      detail: `runtime is launchd-managed but service loaded=${Boolean(service.loaded)}, running=${Boolean(service.running)}`,
+    };
+  }
+  if (absentRuntime && service.running) {
+    return {
+      allowed: false,
+      reason: 'managed_service_state_mismatch',
+      detail: 'runtime ownership is absent but service status reports a running process',
+    };
+  }
   return {
     allowed: true,
     mode,
     binary_path: expectedBinaryPath,
     service_pid: service.pid,
     daemon_pid: runtime.serving_pid ?? runtime.daemon_pid,
+    requires_restart: absentRuntime,
   };
 }
 
@@ -193,7 +216,8 @@ function nextPostPermissionRepairStep(response, authority) {
 
   const tap = response.runtime?.input_tap;
   const tapStatus = tap?.status ?? response.runtime?.input_tap_status;
-  const needsLiveRefresh = blockerIDs.has('post_permission_live_readiness_unconfirmed')
+  const needsLiveRefresh = authority.requires_restart === true
+    || blockerIDs.has('post_permission_live_readiness_unconfirmed')
     || blockerIDs.has('input_tap_not_active')
     || (response.blockers ?? []).some((blocker) => blocker.reason === 'post_rebuild_tcc_stale')
     || (tapStatus && tapStatus !== 'active');

--- a/skills/aos-verification/SKILL.md
+++ b/skills/aos-verification/SKILL.md
@@ -48,7 +48,7 @@ Stop on stale identity, missing permissions, fallback-only refs, unsupported
 actions, known native limits, command recommendations that require recapture, or
 live proof that would mutate UI/TCC/native state without authorization. After a
 real repo-mode `./aos` rebuild, stop until the user resets/regrants TCC and
-`./aos ready --post-permission` is green.
+`./aos ready --repair --post-permission` is green.
 
 ## References
 

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -26,7 +26,7 @@ binary. If a later live TCC-backed readiness check reports
 `post_rebuild_tcc_stale`, the command plays the three-chime handoff alert,
 prints a terminal handoff, and the agent must end the current turn. The next
 user response is the signal that they manually reset/regranted TCC; resume with
-`./aos ready --post-permission`.
+`./aos ready --repair --post-permission`.
 
 When you are unsure which loop applies, ask the router first:
 
@@ -80,7 +80,8 @@ Before interactive commands (`do`, `see cursor/observe/capture`, `inspect`) will
 ```bash
 ./aos permissions setup --once   # One-time Accessibility, Screen Recording, Input Monitoring, and Microphone flow
 ./aos ready                      # Primary readiness gate
-./aos ready --post-permission    # Bounded check after human re-grants Accessibility/Input Monitoring/Microphone
+./aos ready --post-permission    # Read-only check after human re-grants permissions
+./aos ready --repair --post-permission # One guarded managed restart + bounded live recheck after the human signal
 ./aos ready --repair             # Safe repair loop: restart/recheck, then human instructions if needed
 ./aos status                     # Read-only runtime/session snapshot
 ./aos doctor --json              # Deeper runtime diagnostics when needed
@@ -93,7 +94,7 @@ three-chime handoff. Do not run reset-runtime, setup, service restart, another
 ready probe, or any other TCC-backed command in the same turn. The human
 physically removes and re-adds the repo-mode `aos` runtime in System Settings,
 then says `finished` in the waiting session. The session then runs
-`./aos ready --post-permission` to verify.
+`./aos ready --repair --post-permission` to refresh and verify the live tap.
 Service-wide TCC reset affects other apps and is a break-glass capability only;
 do not use `--allow-service-reset --emergency-ack-other-apps` unless Michael
 explicitly asks for emergency recovery.
@@ -106,7 +107,8 @@ See root `AGENTS.md` for the runtime model (repo vs installed modes, mode-scoped
 
 ```bash
 ./aos ready                       # Start/check AOS and report readiness blockers
-./aos ready --post-permission     # Post-permission handoff check; no repeated ad-hoc repair loops
+./aos ready --post-permission     # Read-only post-permission diagnostic
+./aos ready --repair --post-permission # Guarded one-restart post-user-signal recovery
 ./aos ready --repair              # Restart/wait/recheck, then human instructions if needed
 ./aos status                      # Read-only runtime/session snapshot
 ./aos introspect review           # Self-review / recovery after failed attempts

--- a/src/shared/input-tap-health.swift
+++ b/src/shared/input-tap-health.swift
@@ -236,7 +236,7 @@ func inputMonitoringSubGuidance(
     In repo mode, prefer:
       ./aos permissions reset-runtime --mode repo
       ./aos permissions setup --once
-      ./aos ready --post-permission
+      ./aos ready --repair --post-permission
     Manual Settings fallback: Privacy & Security > Input Monitoring for daemon binary:
       \(daemonBinaryPath)
     """

--- a/tests/README.md
+++ b/tests/README.md
@@ -143,7 +143,8 @@ proof. The stop point is a readiness result that reports
 `post_rebuild_tcc_stale`: it plays
 the three-chime handoff alert, returns a terminal handoff, and agents must end
 the turn. After the user manually resets/regrants TCC and replies `finished`,
-verify with `./aos ready --post-permission`.
+verify with `./aos ready --repair --post-permission`. That resume path performs
+at most one identity-checked managed restart before its bounded live recheck.
 
 Run this rebuild only from the primary checkout. If the current task cannot
 mutate the native binary, return the work to the maintainer.

--- a/tests/aos-readiness-composition.test.mjs
+++ b/tests/aos-readiness-composition.test.mjs
@@ -163,7 +163,7 @@ test('permission recovery owns mixed input-tap and microphone blockers', () => {
     [
       './aos permissions reset-runtime --mode repo',
       './aos permissions setup --once',
-      './aos ready --post-permission',
+      './aos ready --repair --post-permission',
       './aos ready',
     ],
   );
@@ -212,7 +212,7 @@ test('passive-green live-fail daemon input monitoring names post-rebuild stale T
   assert.equal(verdict.tcc_staleness.daemon_live.input_tap_status, 'unavailable');
   assert.equal(verdict.tcc_staleness.binary_identity.cdhash, 'abc123def456');
   assert.deepEqual(verdict.tcc_staleness.remedy.commands, [
-    './aos ready --post-permission',
+    './aos ready --repair --post-permission',
   ]);
   assert.deepEqual(verdict.terminal_handoff, {
     type: 'manual_tcc_reset',
@@ -223,7 +223,7 @@ test('passive-green live-fail daemon input monitoring names post-rebuild stale T
     next_user_signal: 'finished',
     human_action: 'Remove/re-add or regrant the aos entry in macOS Privacy & Security, then return to the waiting session and say: finished.',
     target_path: '/repo/aos',
-    resume_command: './aos ready --post-permission',
+    resume_command: './aos ready --repair --post-permission',
   });
   assert.deepEqual(verdict.next_actions, [
     {
@@ -235,8 +235,8 @@ test('passive-green live-fail daemon input monitoring names post-rebuild stale T
     },
     {
       type: 'command',
-      label: 'after the user says finished, run the bounded post-permission readiness check',
-      command: './aos ready --post-permission',
+      label: 'after the user says finished, run one guarded managed restart and bounded post-permission recheck',
+      command: './aos ready --repair --post-permission',
       after_user_signal: 'finished',
     },
   ]);

--- a/tests/input-tap-readiness.sh
+++ b/tests/input-tap-readiness.sh
@@ -159,10 +159,10 @@ assert "passive checks pass" in stale.get("reason", ""), stale
 assert stale.get("binary_identity", {}).get("path") == target, stale
 actions = d.get("next_actions", [])
 commands = [a.get("command", "") for a in actions]
-assert "./aos ready --post-permission" in commands, actions
+assert "./aos ready --repair --post-permission" in commands, actions
 manual = [a for a in actions if a.get("type") == "manual_tcc_reset" and a.get("reason") == "post_rebuild_tcc_stale"]
 assert len(manual) == 1 and manual[0].get("terminal") is True, actions
-post_index = commands.index("./aos ready --post-permission")
+post_index = commands.index("./aos ready --repair --post-permission")
 assert actions[post_index].get("after_user_signal") == "finished", actions
 assert not any(a.get("command") == "./aos permissions reset-runtime --mode repo" for a in actions), actions
 assert not any(a.get("command") == "./aos permissions setup --once" for a in actions), actions
@@ -171,7 +171,7 @@ handoff = d.get("terminal_handoff") or {}
 assert handoff.get("terminal") is True, handoff
 assert handoff.get("reason") == "post_rebuild_tcc_stale", handoff
 assert handoff.get("next_user_signal") == "finished", handoff
-assert handoff.get("resume_command") == "./aos ready --post-permission", handoff
+assert handoff.get("resume_command") == "./aos ready --repair --post-permission", handoff
 blockers = d.get("blockers", [])
 assert any(b.get("target_path") == target for b in blockers), blockers
 PY
@@ -269,7 +269,7 @@ if [[ "$READY_TEXT" == *"Post-rebuild TCC reset checkpoint:"* ]] &&
    [[ "$READY_TEXT" == *"Target binary: $ROOT/aos"* ]] &&
    [[ "$READY_TEXT" == *"Agent: end this turn now; do not run reset-runtime, setup, ready, service restart, or other TCC-backed probes."* ]] &&
    [[ "$READY_TEXT" == *"Human: Remove/re-add or regrant the aos entry in macOS Privacy & Security, then return to the waiting session and say: finished."* ]] &&
-   [[ "$READY_TEXT" == *"Session: after the user says finished, run ./aos ready --post-permission"* ]]; then
+   [[ "$READY_TEXT" == *"Session: after the user says finished, run ./aos ready --repair --post-permission"* ]]; then
   echo "PASS: ready text terminal TCC handoff"
 else
   echo "FAIL: ready text missing terminal TCC handoff:"
@@ -296,7 +296,7 @@ assert d.get("service_resets", []) == [], d
 assert any("emergency-only" in note for note in d.get("notes", [])), d
 commands = [a.get("command") for a in d.get("next_actions", [])]
 assert "./aos permissions setup --once" in commands, d
-assert "./aos ready --post-permission" in commands, d
+assert "./aos ready --repair --post-permission" in commands, d
 PY
 echo "PASS: permissions reset-runtime dry-run"
 

--- a/tests/manual/tcc-reset-agent-user-path.sh
+++ b/tests/manual/tcc-reset-agent-user-path.sh
@@ -124,7 +124,7 @@ reset path instead of asking you to remove rows in System Settings by hand.
    Michael to explicitly ask for emergency recovery.
 4. After the reset, I will run `./aos permissions setup --once`.
 5. When you finish the macOS prompts and say `finished`, I will run
-   `./aos ready --post-permission`.
+   `./aos ready --repair --post-permission`.
 
 I will not open Settings for you, run repeated repair loops, or ask you to
 remove an active daemon from Input Monitoring.
@@ -152,7 +152,7 @@ actions = data.get("next_actions") or []
 commands = [action.get("command") for action in actions]
 if "./aos permissions setup --once" not in commands:
     raise SystemExit("dry-run omitted permissions setup next_action")
-if "./aos ready --post-permission" not in commands:
+if "./aos ready --repair --post-permission" not in commands:
     raise SystemExit("dry-run omitted post-permission ready next_action")
 if data.get("service_resets", []) != []:
     raise SystemExit(f"normal dry-run unexpectedly advertised service resets: {data.get('service_resets')}")
@@ -185,12 +185,12 @@ if "./aos permissions reset-runtime --mode repo" not in commands:
     raise SystemExit("ready output omitted permissions reset-runtime next_action")
 if "./aos permissions setup --once" not in commands:
     raise SystemExit("ready output omitted permissions setup next_action")
-if "./aos ready --post-permission" not in commands:
+if "./aos ready --repair --post-permission" not in commands:
     raise SystemExit("ready output omitted ready post-permission next_action")
 
 reset_index = commands.index("./aos permissions reset-runtime --mode repo")
 setup_index = commands.index("./aos permissions setup --once")
-post_index = commands.index("./aos ready --post-permission")
+post_index = commands.index("./aos ready --repair --post-permission")
 if not reset_index < setup_index < post_index:
     raise SystemExit(f"unsafe next_action order: {commands}")
 
@@ -267,7 +267,7 @@ from pathlib import Path
 data = json.loads(Path(sys.argv[1]).read_text())
 if data.get("ready") is not True:
     raise SystemExit(f"post-permission readiness did not pass: {data}")
-print("PASS: ./aos ready --post-permission reported ready=true")
+print("PASS: ./aos ready --repair --post-permission reported ready=true")
 PY
 }
 
@@ -330,7 +330,7 @@ fi
 
 ./aos permissions setup --once
 require_phrase "After completing the macOS prompts, type finished to run the post-permission check." "finished"
-capture_json ready-after ./aos ready --post-permission --json
+capture_json ready-after ./aos ready --repair --post-permission --json
 validate_ready_after
 
 echo "PASS: disruptive agent/user TCC reset path completed"

--- a/tests/ready-post-permission-recovery.test.mjs
+++ b/tests/ready-post-permission-recovery.test.mjs
@@ -168,14 +168,50 @@ test('post-permission restart authority fails closed on ownership, mode, and bin
   ).reason, 'binary_identity_mismatch');
 });
 
+test('post-permission repair authorizes one exact-target restart after reset-runtime stops launchd', () => {
+  const authority = postPermissionRecoveryAuthority({
+    mode: 'repo',
+    daemon_running: false,
+    socket_reachable: false,
+    ownership_state: 'absent',
+    ownership_kind: 'absent',
+  }, {
+    status: 'degraded',
+    mode: 'repo',
+    installed: true,
+    loaded: false,
+    running: false,
+    actual_binary_path: '/repo/aos',
+    expected_binary_path: '/repo/aos',
+    target_matches_expected: true,
+  }, { mode: 'repo', expectedBinaryPath: '/repo/aos' });
+
+  assert.equal(authority.allowed, true);
+  assert.equal(authority.requires_restart, true);
+  const step = nextReadyExecutionStep({
+    ready: false,
+    mode: 'repo',
+    runtime: { ownership_state: 'absent' },
+    permissions: grantedPermissions(),
+    blockers: [{ id: 'daemon_socket_unreachable', kind: 'runtime' }],
+    action_trace: [],
+  }, {
+    repair: true,
+    postPermission: true,
+    postPermissionAuthority: authority,
+  });
+  assert.equal(step.type, 'restart');
+});
+
 const fakeAOSSource = `#!/usr/bin/env node
 const fs = require('node:fs');
 const args = process.argv.slice(2);
 const actionLog = process.env.AOS_TEST_READY_SERVICE_ACTION_LOG;
 const restarted = Boolean(actionLog && fs.existsSync(actionLog));
 const active = restarted && process.env.AOS_FAKE_NEVER_READY !== '1';
+const absent = process.env.AOS_FAKE_RUNTIME_ABSENT === '1' && !restarted;
 const ownership = process.env.AOS_FAKE_OWNERSHIP || 'consistent';
-const launchdManaged = ownership === 'consistent';
+const launchdManaged = !absent && ownership === 'consistent';
 const tap = active
   ? { status: 'active', attempts: 1, listen_access: true, post_access: true }
   : { status: 'unavailable', attempts: 1, listen_access: false, post_access: false, last_error_at: '2026-07-12T01:16:34Z' };
@@ -194,16 +230,16 @@ if (args.join(' ') === '__permissions facts --json') {
 } else if (args.join(' ') === '__runtime status-facts --json') {
   payload = {
     mode: 'repo',
-    daemon_pid: active ? 72167 : 51075,
-    serving_pid: active ? 72167 : 51075,
-    daemon_running: true,
-    socket_reachable: true,
-    ownership_state: ownership,
-    ownership_kind: launchdManaged ? 'launchd_managed' : 'unmanaged',
+    daemon_pid: absent ? undefined : active ? 72167 : 51075,
+    serving_pid: absent ? undefined : active ? 72167 : 51075,
+    daemon_running: !absent,
+    socket_reachable: !absent,
+    ownership_state: absent ? 'absent' : ownership,
+    ownership_kind: absent ? 'absent' : launchdManaged ? 'launchd_managed' : 'unmanaged',
     owner_launchd_managed: launchdManaged,
-    owner_pid: active ? 72167 : 51075,
-    lock_owner_pid: active ? 72167 : 51075,
-    service_pid: 51065,
+    owner_pid: absent ? undefined : active ? 72167 : 51075,
+    lock_owner_pid: absent ? undefined : active ? 72167 : 51075,
+    service_pid: absent ? undefined : 51065,
     input_tap_status: tap.status,
     input_tap_attempts: tap.attempts,
     input_tap: tap,
@@ -219,7 +255,7 @@ if (args.join(' ') === '__permissions facts --json') {
 process.stdout.write(JSON.stringify(payload) + '\\n');
 `;
 
-async function runCase({ neverReady = false, ownership = 'consistent', service = {} } = {}) {
+async function runCase({ absent = false, neverReady = false, ownership = 'consistent', service = {} } = {}) {
   const root = await mkdtemp(path.join(os.tmpdir(), 'aos-ready-post-permission-'));
   const fakeAOS = path.join(root, 'aos');
   const actionLog = path.join(root, 'actions.jsonl');
@@ -229,8 +265,8 @@ async function runCase({ neverReady = false, ownership = 'consistent', service =
     status: 'ok',
     mode: 'repo',
     installed: true,
-    loaded: true,
-    running: true,
+    loaded: !absent,
+    running: !absent,
     pid: 51065,
     actual_binary_path: fakeAOS,
     expected_binary_path: fakeAOS,
@@ -248,6 +284,7 @@ async function runCase({ neverReady = false, ownership = 'consistent', service =
       AOS_STATE_ROOT: root,
       AOS_RUNTIME_MODE: 'repo',
       AOS_FAKE_NEVER_READY: neverReady ? '1' : '0',
+      AOS_FAKE_RUNTIME_ABSENT: absent ? '1' : '0',
       AOS_FAKE_OWNERSHIP: ownership,
       AOS_TEST_READY_MOCK_SERVICE_ACTIONS: '1',
       AOS_TEST_READY_SERVICE_ACTION_LOG: actionLog,
@@ -286,6 +323,15 @@ test('post-permission repair performs one managed restart and requires fresh liv
   assert.equal(result.response.runtime.input_tap.listen_access, true);
   assert.equal(result.response.runtime.input_tap.post_access, true);
   assert.equal(result.response.action_trace.some((entry) => entry.step === 'wait_for_recovery' && entry.result === 'ready'), true);
+});
+
+test('post-permission repair restarts an exact-target service stopped by reset-runtime', async () => {
+  const result = await runCase({ absent: true });
+  assert.equal(result.exitCode, 0, result.stderr);
+  assert.deepEqual(result.actions, [{ action: 'restart', mode: 'repo' }]);
+  assert.equal(result.response.ready, true);
+  assert.equal(result.response.ready_source, 'daemon');
+  assert.equal(result.response.runtime.input_tap.status, 'active');
 });
 
 test('post-permission repair never performs a second restart when live facts stay stale', async () => {

--- a/tests/ready-post-permission-recovery.test.mjs
+++ b/tests/ready-post-permission-recovery.test.mjs
@@ -1,0 +1,333 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  enforcePostPermissionLiveReadiness,
+  nextReadyExecutionStep,
+  postPermissionRecoveryAuthority,
+} from '../scripts/lib/aos-ready-execution.mjs';
+
+const repoRoot = path.resolve(import.meta.dirname, '..');
+
+function grantedPermissions() {
+  return {
+    accessibility: true,
+    screen_recording: true,
+    listen_access: true,
+    post_access: true,
+    microphone: true,
+  };
+}
+
+test('post-permission repair requires live daemon tap facts and schedules one managed restart', () => {
+  const cliReady = {
+    ready: true,
+    status: 'ok',
+    phase: 'ready',
+    diagnosis: 'ready',
+    mode: 'repo',
+    ready_source: 'cli',
+    runtime: {
+      mode: 'repo',
+      ownership_state: 'consistent',
+      owner_launchd_managed: true,
+      serving_pid: 51075,
+      input_tap_status: 'unavailable',
+      input_tap: {
+        status: 'unavailable',
+        attempts: 1,
+        listen_access: false,
+        post_access: false,
+      },
+    },
+    runtime_verdict: {
+      ready: true,
+      status: 'ok',
+      phase: 'ready',
+      diagnosis: 'ready',
+      blockers: [],
+      blocked_capabilities: [],
+      next_actions: [],
+      notes: [],
+    },
+    permissions: grantedPermissions(),
+    blockers: [],
+    blocked_capabilities: [],
+    next_actions: [],
+    action_trace: [],
+    notes: [],
+  };
+  const response = enforcePostPermissionLiveReadiness(cliReady, { prefix: './aos', mode: 'repo' });
+  assert.equal(response.ready, false);
+  assert.equal(response.runtime_verdict.ready, false);
+  assert.equal(response.diagnosis, 'post_permission_live_readiness_unconfirmed');
+  assert.deepEqual(response.next_actions.map((action) => action.command), [
+    './aos service status --mode repo --json',
+    './aos status --json',
+  ]);
+
+  const authority = postPermissionRecoveryAuthority(response.runtime, {
+    status: 'ok',
+    mode: 'repo',
+    installed: true,
+    loaded: true,
+    running: true,
+    pid: 51065,
+    actual_binary_path: '/repo/aos',
+    expected_binary_path: '/repo/aos',
+    target_matches_expected: true,
+  }, { mode: 'repo', expectedBinaryPath: '/repo/aos' });
+  assert.equal(authority.allowed, true);
+  assert.deepEqual(
+    nextReadyExecutionStep(response, {
+      repair: true,
+      postPermission: true,
+      postPermissionAuthority: authority,
+    }),
+    {
+      type: 'restart',
+      reason: 'refresh the launchd-managed daemon event tap after the explicit post-permission user signal',
+    },
+  );
+
+  const afterRestart = {
+    ...response,
+    action_trace: [{ step: 'service_restart', result: 'degraded' }],
+  };
+  const exhausted = nextReadyExecutionStep(afterRestart, {
+    repair: true,
+    postPermission: true,
+    postPermissionAuthority: authority,
+  });
+  assert.equal(exhausted.type, 'stop');
+  assert.equal(exhausted.trace.result, 'exhausted');
+});
+
+test('post-permission repair skips restart when fresh live tap facts are already ready', () => {
+  const response = {
+    ready: true,
+    mode: 'repo',
+    ready_source: 'daemon',
+    runtime: {
+      input_tap_status: 'active',
+      input_tap: { status: 'active', listen_access: true, post_access: true },
+    },
+    blockers: [],
+    action_trace: [],
+  };
+  assert.equal(enforcePostPermissionLiveReadiness(response), response);
+  const step = nextReadyExecutionStep(response, {
+    repair: true,
+    postPermission: true,
+    postPermissionAuthority: { allowed: true },
+  });
+  assert.equal(step.type, 'stop');
+  assert.equal(step.trace.result, 'ready');
+});
+
+test('post-permission restart authority fails closed on ownership, mode, and binary mismatch', () => {
+  const managedRuntime = {
+    mode: 'repo',
+    ownership_state: 'consistent',
+    owner_launchd_managed: true,
+  };
+  const service = {
+    status: 'ok',
+    mode: 'repo',
+    installed: true,
+    loaded: true,
+    running: true,
+    actual_binary_path: '/repo/aos',
+    expected_binary_path: '/repo/aos',
+    target_matches_expected: true,
+  };
+
+  assert.equal(postPermissionRecoveryAuthority(
+    { ...managedRuntime, ownership_state: 'unmanaged', owner_launchd_managed: false },
+    service,
+    { mode: 'repo', expectedBinaryPath: '/repo/aos' },
+  ).reason, 'daemon_not_launchd_managed');
+  assert.equal(postPermissionRecoveryAuthority(
+    { ...managedRuntime, mode: 'installed' },
+    service,
+    { mode: 'repo', expectedBinaryPath: '/repo/aos' },
+  ).reason, 'runtime_mode_mismatch');
+  assert.equal(postPermissionRecoveryAuthority(
+    managedRuntime,
+    { ...service, mode: 'installed' },
+    { mode: 'repo', expectedBinaryPath: '/repo/aos' },
+  ).reason, 'service_mode_mismatch');
+  assert.equal(postPermissionRecoveryAuthority(
+    managedRuntime,
+    { ...service, actual_binary_path: '/tmp/other-aos', target_matches_expected: false },
+    { mode: 'repo', expectedBinaryPath: '/repo/aos' },
+  ).reason, 'binary_identity_mismatch');
+});
+
+const fakeAOSSource = `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const actionLog = process.env.AOS_TEST_READY_SERVICE_ACTION_LOG;
+const restarted = Boolean(actionLog && fs.existsSync(actionLog));
+const active = restarted && process.env.AOS_FAKE_NEVER_READY !== '1';
+const ownership = process.env.AOS_FAKE_OWNERSHIP || 'consistent';
+const launchdManaged = ownership === 'consistent';
+const tap = active
+  ? { status: 'active', attempts: 1, listen_access: true, post_access: true }
+  : { status: 'unavailable', attempts: 1, listen_access: false, post_access: false, last_error_at: '2026-07-12T01:16:34Z' };
+let payload;
+if (args.join(' ') === '__permissions facts --json') {
+  payload = {
+    permissions: { accessibility: true, screen_recording: true, listen_access: true, post_access: true, microphone: true },
+    identity: { executable_path: process.argv[1] },
+  };
+} else if (args.join(' ') === '__permissions setup-marker get --json') {
+  payload = { marker_exists: true, setup_completed: true, bundle_matches_current: true };
+} else if (args.join(' ') === '__daemon health --json') {
+  payload = active
+    ? { reachable: true, input_tap: tap, permissions: { accessibility: true } }
+    : { reachable: true };
+} else if (args.join(' ') === '__runtime status-facts --json') {
+  payload = {
+    mode: 'repo',
+    daemon_pid: active ? 72167 : 51075,
+    serving_pid: active ? 72167 : 51075,
+    daemon_running: true,
+    socket_reachable: true,
+    ownership_state: ownership,
+    ownership_kind: launchdManaged ? 'launchd_managed' : 'unmanaged',
+    owner_launchd_managed: launchdManaged,
+    owner_pid: active ? 72167 : 51075,
+    lock_owner_pid: active ? 72167 : 51075,
+    service_pid: 51065,
+    input_tap_status: tap.status,
+    input_tap_attempts: tap.attempts,
+    input_tap: tap,
+    state_dir: process.env.AOS_STATE_ROOT + '/repo',
+    socket_path: process.env.AOS_STATE_ROOT + '/repo/sock',
+  };
+} else if (args.join(' ') === 'clean --dry-run --json') {
+  payload = { status: 'clean', foreground_dev_owners: [], stale_daemons: [], stale_locks: [], canvases: [], notes: [] };
+} else {
+  process.stderr.write(JSON.stringify({ code: 'UNEXPECTED_AOS', args }) + '\\n');
+  process.exit(1);
+}
+process.stdout.write(JSON.stringify(payload) + '\\n');
+`;
+
+async function runCase({ neverReady = false, ownership = 'consistent', service = {} } = {}) {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'aos-ready-post-permission-'));
+  const fakeAOS = path.join(root, 'aos');
+  const actionLog = path.join(root, 'actions.jsonl');
+  await writeFile(fakeAOS, fakeAOSSource);
+  await chmod(fakeAOS, 0o755);
+  const serviceStatus = {
+    status: 'ok',
+    mode: 'repo',
+    installed: true,
+    loaded: true,
+    running: true,
+    pid: 51065,
+    actual_binary_path: fakeAOS,
+    expected_binary_path: fakeAOS,
+    target_matches_expected: true,
+    ...service,
+  };
+  const child = spawn(process.execPath, [
+    'scripts/aos-ready.mjs', '--repair', '--post-permission', '--json',
+  ], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      AOS_PATH: fakeAOS,
+      AOS_SERVICE_BINARY: fakeAOS,
+      AOS_STATE_ROOT: root,
+      AOS_RUNTIME_MODE: 'repo',
+      AOS_FAKE_NEVER_READY: neverReady ? '1' : '0',
+      AOS_FAKE_OWNERSHIP: ownership,
+      AOS_TEST_READY_MOCK_SERVICE_ACTIONS: '1',
+      AOS_TEST_READY_SERVICE_ACTION_LOG: actionLog,
+      AOS_TEST_READY_SERVICE_STATUS_JSON: JSON.stringify(serviceStatus),
+      AOS_TEST_READY_WAIT_BUDGET_MS: '120',
+      AOS_TEST_READY_WAIT_POLL_MS: '10',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => { stdout += chunk; });
+  child.stderr.on('data', (chunk) => { stderr += chunk; });
+  const exitCode = await new Promise((resolve) => child.once('exit', resolve));
+  let actions = [];
+  try {
+    actions = (await readFile(actionLog, 'utf8')).trim().split('\n').filter(Boolean).map(JSON.parse);
+  } catch {
+    actions = [];
+  }
+  const result = { exitCode, response: JSON.parse(stdout), stderr, actions };
+  await rm(root, { recursive: true, force: true });
+  return result;
+}
+
+test('post-permission repair performs one managed restart and requires fresh live tap facts', async () => {
+  const result = await runCase();
+  assert.equal(result.exitCode, 0, result.stderr);
+  assert.deepEqual(result.actions, [{ action: 'restart', mode: 'repo' }]);
+  assert.equal(result.response.ready, true);
+  assert.equal(result.response.ready_source, 'daemon');
+  assert.equal(result.response.runtime.daemon_pid, 72167);
+  assert.equal(result.response.runtime.input_tap.status, 'active');
+  assert.equal(result.response.runtime.input_tap.listen_access, true);
+  assert.equal(result.response.runtime.input_tap.post_access, true);
+  assert.equal(result.response.action_trace.some((entry) => entry.step === 'wait_for_recovery' && entry.result === 'ready'), true);
+});
+
+test('post-permission repair never performs a second restart when live facts stay stale', async () => {
+  const result = await runCase({ neverReady: true });
+  assert.equal(result.exitCode, 1);
+  assert.deepEqual(result.actions, [{ action: 'restart', mode: 'repo' }]);
+  assert.equal(result.response.ready, false);
+  assert.equal(result.response.action_trace.some((entry) => entry.step === 'wait_for_recovery' && entry.result === 'timed_out'), true);
+  assert.equal(result.response.action_trace.some((entry) => entry.step === 'post_permission_recovery' && entry.result === 'exhausted'), true);
+});
+
+test('post-permission repair fails closed before restart for unmanaged ownership', async () => {
+  const result = await runCase({ ownership: 'unmanaged' });
+  assert.equal(result.exitCode, 1);
+  assert.deepEqual(result.actions, []);
+  assert.equal(result.response.action_trace.some((entry) => (
+    entry.step === 'post_permission_recovery'
+      && entry.result === 'blocked'
+      && entry.detail.includes('daemon_not_launchd_managed')
+  )), true);
+});
+
+test('post-permission repair fails closed before restart for service mode mismatch', async () => {
+  const result = await runCase({ service: { mode: 'installed' } });
+  assert.equal(result.exitCode, 1);
+  assert.deepEqual(result.actions, []);
+  assert.equal(result.response.action_trace.some((entry) => (
+    entry.step === 'post_permission_recovery'
+      && entry.result === 'blocked'
+      && entry.detail.includes('service_mode_mismatch')
+  )), true);
+});
+
+test('post-permission repair fails closed before restart for binary target mismatch', async () => {
+  const result = await runCase({
+    service: { actual_binary_path: '/tmp/other-aos', target_matches_expected: false },
+  });
+  assert.equal(result.exitCode, 1);
+  assert.deepEqual(result.actions, []);
+  assert.equal(result.response.action_trace.some((entry) => (
+    entry.step === 'post_permission_recovery'
+      && entry.result === 'blocked'
+      && entry.detail.includes('binary_identity_mismatch')
+  )), true);
+});


### PR DESCRIPTION
## Summary

- generate `ready --repair --post-permission` as the explicit resume command after the human TCC handoff
- authorize at most one same-mode launchd recovery after verifying runtime ownership and the exact expected service target
- require fresh daemon-sourced input-tap, listen, and post facts after recovery
- fail closed for unmanaged ownership, mode drift, target mismatch, and exhausted recovery
- support both an already-running stale daemon and the canonical stopped service left by `permissions reset-runtime`

## Local validation

- readiness/recovery Node tests: passed, including running, stopped, stale, unmanaged, mode-mismatch, and target-mismatch cases
- `bash tests/input-tap-readiness.sh`: passed
- `bash tests/ready-explicit-repair-flow.sh`: passed
- proof registry: 19/19
- external command manifest: 37/37
- command-manifest generation, help contract, workflow router, drift lint, skills validation, and `git diff --check`: passed
- live `./aos ready --repair --post-permission --json`: `ready=true`, daemon source, active tap, listen/post true, no healthy-path restart

The broad root Node suite retains the existing `browser-do-keyboard-contract` `UNEXPECTED_AOS` failure. Its concurrent passive-probe timeout also failed in the broad run but passed in isolation. No AOS rebuild or TCC reset was performed. The disruptive manual TCC proof remains deferred; the stopped-service recovery path is covered with fake service/runtime facts.