### PR TITLE
Avoid stdin reads for voice inventory

### DIFF
--- a/scripts/aos-say.mjs
+++ b/scripts/aos-say.mjs
@@ -48,11 +48,13 @@ function validateSayArgs(args) {
 
 function runSayPrimitive(args) {
   validateSayArgs(args);
-  const stdin = process.stdin.isTTY ? undefined : fs.readFileSync(0);
+  const listsVoices = args.includes('--list-voices') || args.includes('--voices');
+  const readsStdin = !listsVoices && !process.stdin.isTTY;
+  const stdin = readsStdin ? fs.readFileSync(0) : undefined;
   const result = spawnSync(aosPath(), ['__say', ...args], {
     input: stdin,
     env: process.env,
-    stdio: process.stdin.isTTY ? ['inherit', 'pipe', 'pipe'] : ['pipe', 'pipe', 'pipe'],
+    stdio: [listsVoices ? 'ignore' : process.stdin.isTTY ? 'inherit' : 'pipe', 'pipe', 'pipe'],
   });
   if (result.stdout) process.stdout.write(result.stdout);
   if (result.stderr) process.stderr.write(result.stderr);

--- a/tests/voice-follow-cli.test.mjs
+++ b/tests/voice-follow-cli.test.mjs
@@ -63,6 +63,35 @@ function launch(script, args, stateRoot, extraEnv = {}) {
   return { child, completed };
 }
 
+test('say voice inventory completes without reading an open stdin pipe', async () => {
+  const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aos-say-inventory-'));
+  const fakeAos = path.join(stateRoot, 'aos');
+  await fs.writeFile(fakeAos, `#!/usr/bin/env node
+if (process.argv.slice(2).join(' ') !== '__say --list-voices') process.exit(9);
+process.stdout.write('[{"id":"voice.test","name":"Test","language":"en_US","provider":"system"}]\\n');
+`);
+  await fs.chmod(fakeAos, 0o700);
+  cleanups.push(async () => { await fs.rm(stateRoot, { recursive: true, force: true }); });
+
+  const run = launch('scripts/aos-say.mjs', ['--list-voices'], stateRoot, { AOS_PATH: fakeAos });
+  let timeoutId;
+  const timeout = new Promise((_, reject) => {
+    timeoutId = setTimeout(() => {
+      run.child.kill('SIGKILL');
+      reject(new Error('say --list-voices waited for stdin'));
+    }, 2_000);
+  });
+  const result = await Promise.race([run.completed, timeout]).finally(() => clearTimeout(timeoutId));
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), [{
+    id: 'voice.test',
+    name: 'Test',
+    language: 'en_US',
+    provider: 'system',
+  }]);
+});
+
 function success(ref) {
   return `${JSON.stringify({ v: 1, status: 'success', data: {}, ref })}\n`;
 }


### PR DESCRIPTION
## Summary
- keep `aos say --list-voices` and `--voices` independent of stdin
- prevent `EAGAIN` when consumers launch the inventory form with an open pipe
- add a regression that leaves stdin open and requires prompt completion

## Validation
- `node --test tests/voice-follow-cli.test.mjs` (10/10)
- `bash tests/external-command-dispatch.sh`
- `node --test tests/aos-dev-gh-help-parity.test.mjs` (3/3)
- `bash tests/help-contract.sh`
- `node --check scripts/aos-say.mjs`
- `git diff --check`

`tests/external-parser-flags.sh` returned no terminal status in this managed-Mac run; it is not claimed as passing and does not directly cover this stdin-ordering change. No AOS build, daemon operation, TCC change, or binary processing was performed.