### PR TITLE
Add conditional wiki publication

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -2277,6 +2277,7 @@ Primary public verbs for knowledge-base consumers:
 | `show` | fetch one page by path or bare name |
 | `graph` | emit the canonical `wiki-kb` graph payload |
 | `search` | full-text search across indexed pages |
+| `put` | conditionally create or update one Markdown page from stdin |
 | `invoke` | invoke a workflow/plugin entry |
 
 `aos wiki graph --json` is the canonical graph projection for KB surfaces. It returns:
@@ -2290,6 +2291,34 @@ Primary public verbs for knowledge-base consumers:
 `subject_type` and not arbitrary raw frontmatter. The V0 page-kind vocabulary is
 `page`, `concept`, `entity`, `workflow`, and `reference`. Plugin pages under
 `references/` map to `reference`.
+
+`aos wiki put` is the conflict-safe publication boundary for consumers:
+
+```bash
+printf '# Reviewed fact\n' \
+  | aos wiki put consumer/concepts/reviewed-fact.md \
+      --stdin --if-match none --json
+
+printf '# Revised fact\n' \
+  | aos wiki put consumer/concepts/reviewed-fact.md \
+      --stdin --if-match "$CURRENT_SHA256" --json
+```
+
+Use `none` only to create a path that does not exist. Updating requires the
+current SHA-256 of the exact UTF-8 bytes, available from the prior successful
+`put` result or computed from the `raw` field returned by
+`aos wiki show <path> --json`. Input is limited to 1 MiB. Paths must be
+canonical relative `.md` paths beneath the mode-scoped wiki root; traversal,
+symlinks, and non-regular targets are rejected. Writes are serialized, atomic,
+and `0600`. A successful write reindexes the wiki and follows the normal wiki
+change-event path when the daemon watcher is active.
+
+JSON success uses the
+`shared/schemas/aos-wiki-put-result-v1.schema.json` contract and returns only
+the relative path, operation, byte count, previous/current hashes, and reindex
+status. Conflict errors use `WIKI_CONFLICT` with `exists`, `expected_sha256`,
+and `actual_sha256`; neither success nor error output includes Markdown content
+or an absolute filesystem path.
 
 ## Auxiliary Consumer Surfaces
 

--- a/docs/dev/reports/aos-command-capability-inventory-v0.md
+++ b/docs/dev/reports/aos-command-capability-inventory-v0.md
@@ -19,12 +19,12 @@ current command tree before public CLI and self-hosting boundary changes.
 ## Summary
 
 - Command paths: 41
-- Concrete forms: 201
-- Consumer-discoverable forms: 192
+- Concrete forms: 202
+- Consumer-discoverable forms: 193
 - Internal/transitional command paths: 1
-- Mutating or conditionally mutating forms: 111
+- Mutating or conditionally mutating forms: 112
 - Forms with unspecified mutability metadata: 0
-- Forms with JSON output path: 196
+- Forms with JSON output path: 197
 - Forms with dry-run support: 37
 
 ## Capability Group Counts
@@ -35,7 +35,7 @@ current command tree before public CLI and self-hosting boundary changes.
 | Canvas and vision | 5 |
 | Capture and perception | 7 |
 | CLI metadata | 2 |
-| Content/wiki | 17 |
+| Content/wiki | 18 |
 | Core desktop | 9 |
 | Core readiness | 7 |
 | Desktop discovery | 4 |
@@ -91,7 +91,7 @@ current command tree before public CLI and self-hosting boundary changes.
 | `permissions` | 4 | Core readiness, Runtime/service | yes | mutates, read-only | --json | `manifests/commands/source/aos/29-permissions.json` | `node scripts/aos-permissions.mjs` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `inspect` | 1 | Diagnostics/debug | yes | mutates | default | `manifests/commands/source/aos/30-inspect.json` | `node scripts/aos-inspect.mjs` | `docs/api/aos.md, docs/api/aos-capabilities.md, docs/dev/command-surface.md` |
 | `log` | 3 | Diagnostics/debug | yes | mutates, read-only | default | `manifests/commands/source/aos/31-log.json` | `node scripts/aos-log.mjs` | `docs/api/aos.md, docs/api/aos-capabilities.md, docs/dev/command-surface.md` |
-| `wiki` | 15 | Content/wiki | yes | mutates, read-only | --json | `manifests/commands/source/aos/32-wiki.json` | `node scripts/aos-wiki-router.mjs` | `docs/api/aos.md` |
+| `wiki` | 16 | Content/wiki | yes | mutates, read-only | --json | `manifests/commands/source/aos/32-wiki.json` | `node scripts/aos-wiki-router.mjs` | `docs/api/aos.md` |
 | `browser` | 9 | Browser companion | no | mutates, read-only | --json, default | `manifests/commands/source/aos/33-browser.json` | `node scripts/aos-browser-internal.mjs` | `docs/api/aos-capabilities.md, docs/dev/command-surface.md` |
 | `help` | 2 | CLI metadata | yes | read-only | --json | `manifests/commands/source/aos/34-help.json` | `node scripts/aos-help-proxy.mjs` | `docs/api/aos.md` |
 | `work-record` | 23 | Verification/evidence | yes | mutates, read-only | --json | `manifests/commands/source/aos/35-work-record.json, manifests/commands/source/aos/36-work-record-supersession.json, manifests/commands/source/aos/37-work-record-finalization.json` | `node scripts/aos-work-record.mjs` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
@@ -251,6 +251,7 @@ current command tree before public CLI and self-hosting boundary changes.
 | `log clear` | `log-clear` | Diagnostics/debug | yes | mutates | default | no | `manifests/commands/source/aos/31-log.json` | `node scripts/aos-log.mjs clear` | `docs/api/aos.md, docs/api/aos-capabilities.md, docs/dev/command-surface.md` |
 | `wiki create-plugin` | `wiki-create-plugin` | Content/wiki | yes | mutates | --json | no | `manifests/commands/source/aos/32-wiki.json` | `node scripts/aos-wiki-mutate.mjs create-plugin` | `docs/api/aos.md` |
 | `wiki add` | `wiki-add` | Content/wiki | yes | mutates | --json | no | `manifests/commands/source/aos/32-wiki.json` | `node scripts/aos-wiki-mutate.mjs add` | `docs/api/aos.md` |
+| `wiki put` | `wiki-put` | Content/wiki | yes | mutates | --json | no | `manifests/commands/source/aos/32-wiki.json` | `node scripts/aos-wiki-put.mjs` | `docs/api/aos.md` |
 | `wiki rm` | `wiki-rm` | Content/wiki | yes | mutates | --json | no | `manifests/commands/source/aos/32-wiki.json` | `node scripts/aos-wiki-mutate.mjs rm` | `docs/api/aos.md` |
 | `wiki list` | `wiki-list` | Content/wiki | yes | read-only | --json | no | `manifests/commands/source/aos/32-wiki.json` | `python3 scripts/aos-wiki-query.py list` | `docs/api/aos.md` |
 | `wiki search` | `wiki-search` | Content/wiki | yes | read-only | --json | no | `manifests/commands/source/aos/32-wiki.json` | `python3 scripts/aos-wiki-query.py search` | `docs/api/aos.md` |

--- a/docs/dev/test-proof-registry.d/substrate-reclassification.json
+++ b/docs/dev/test-proof-registry.d/substrate-reclassification.json
@@ -398,6 +398,26 @@
       "replaces": [],
       "guard": "uses temporary wiki fixtures and command fakes",
       "status": "active"
+    },
+    {
+      "id": "wiki-put-conditional-contract",
+      "path_patterns": [
+        "tests/wiki-put-contract.test.mjs",
+        "tests/wiki-put-external.sh",
+        "tests/schemas/aos-wiki-put-result-v1.test.mjs"
+      ],
+      "fixture_patterns": [
+        "shared/schemas/fixtures/aos-wiki-put-result-v1/**"
+      ],
+      "owner": "wiki-runtime",
+      "harness_level": "shell_router",
+      "proof_kind": "wiki_conditional_write_contract",
+      "contract": "Conditional wiki writes are bounded, atomic, owner-only, symlink-safe, hash-guarded, schema-valid, and content-redacted.",
+      "worth": "This lets first-party consumers publish reviewed knowledge without private socket access or silent lost updates.",
+      "command": "node --test tests/wiki-put-contract.test.mjs tests/schemas/aos-wiki-put-result-v1.test.mjs && bash tests/wiki-put-external.sh",
+      "replaces": [],
+      "guard": "uses disposable wiki state, a fake reindex executable for model tests, and the current public CLI for daemonless dispatch; no daemon, TCC, native input, or shared runtime mutation",
+      "status": "active"
     }
   ]
 }

--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -8900,6 +8900,67 @@
               "id" : "path",
               "kind" : "positional",
               "required" : true,
+              "summary" : "Canonical Markdown path beneath the wiki root",
+              "value_type" : "string"
+            },
+            {
+              "id" : "stdin",
+              "kind" : "flag",
+              "required" : true,
+              "summary" : "Read at most 1 MiB of UTF-8 Markdown from stdin",
+              "token" : "--stdin",
+              "value_type" : "bool"
+            },
+            {
+              "id" : "if-match",
+              "kind" : "flag",
+              "required" : true,
+              "summary" : "Use none to create or the current lowercase SHA-256 to update",
+              "token" : "--if-match",
+              "value_type" : "string"
+            },
+            {
+              "id" : "json",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Emit the aos.wiki.put-result.v1 envelope",
+              "token" : "--json",
+              "value_type" : "bool"
+            }
+          ],
+          "examples" : [
+            "printf '# Reviewed fact\\n' | aos wiki put consumer/concepts/reviewed-fact.md --stdin --if-match none --json"
+          ],
+          "execution" : {
+            "auto_starts_daemon" : false,
+            "interactive" : false,
+            "mutates_state" : true,
+            "read_only" : false,
+            "requires_permissions" : false,
+            "streaming" : false,
+            "supports_dry_run" : false
+          },
+          "id" : "wiki-put",
+          "summary" : "Conditionally create or update one Markdown page with optimistic concurrency.",
+          "output" : {
+            "default_mode" : "text",
+            "error_mode" : "json_stderr",
+            "streaming" : false,
+            "supports_json_flag" : true
+          },
+          "stdin" : {
+            "content_type" : "text/markdown; charset=utf-8",
+            "supported" : true,
+            "used_when" : "--stdin is required; input is bounded at 1 MiB"
+          },
+          "usage" : "aos wiki put <path> --stdin --if-match <sha256|none> [--json]"
+        },
+        {
+          "args" : [
+            {
+              "id" : "path",
+              "kind" : "positional",
+              "required" : true,
               "summary" : "Page path or name",
               "value_type" : "string"
             },

--- a/manifests/commands/aos-external-commands.json
+++ b/manifests/commands/aos-external-commands.json
@@ -1413,6 +1413,18 @@
       }
     },
     {
+      "path": ["wiki", "put"],
+      "summary": "Conditionally create or update one wiki Markdown page from bounded stdin.",
+      "executable": "/usr/bin/env",
+      "argv_prefix": ["node", "scripts/aos-wiki-put.mjs"],
+      "cwd": "repo",
+      "env": {
+        "AOS_PATH": "$AOS_PATH",
+        "AOS_RUNTIME_MODE": "$AOS_RUNTIME_MODE",
+        "AOS_STATE_ROOT": "$AOS_STATE_ROOT"
+      }
+    },
+    {
       "path": ["wiki", "rm"],
       "summary": "Remove wiki pages through the external wiki command.",
       "executable": "/usr/bin/env",

--- a/manifests/commands/source/aos/32-wiki.json
+++ b/manifests/commands/source/aos/32-wiki.json
@@ -109,6 +109,67 @@
               "id": "path",
               "kind": "positional",
               "required": true,
+              "summary": "Canonical Markdown path beneath the wiki root",
+              "value_type": "string"
+            },
+            {
+              "id": "stdin",
+              "kind": "flag",
+              "required": true,
+              "summary": "Read at most 1 MiB of UTF-8 Markdown from stdin",
+              "token": "--stdin",
+              "value_type": "bool"
+            },
+            {
+              "id": "if-match",
+              "kind": "flag",
+              "required": true,
+              "summary": "Use none to create or the current lowercase SHA-256 to update",
+              "token": "--if-match",
+              "value_type": "string"
+            },
+            {
+              "id": "json",
+              "kind": "flag",
+              "required": false,
+              "summary": "Emit the aos.wiki.put-result.v1 envelope",
+              "token": "--json",
+              "value_type": "bool"
+            }
+          ],
+          "examples": [
+            "printf '# Reviewed fact\\n' | aos wiki put consumer/concepts/reviewed-fact.md --stdin --if-match none --json"
+          ],
+          "execution": {
+            "auto_starts_daemon": false,
+            "interactive": false,
+            "mutates_state": true,
+            "read_only": false,
+            "requires_permissions": false,
+            "streaming": false,
+            "supports_dry_run": false
+          },
+          "id": "wiki-put",
+          "summary": "Conditionally create or update one Markdown page with optimistic concurrency.",
+          "output": {
+            "default_mode": "text",
+            "error_mode": "json_stderr",
+            "streaming": false,
+            "supports_json_flag": true
+          },
+          "stdin": {
+            "content_type": "text/markdown; charset=utf-8",
+            "supported": true,
+            "used_when": "--stdin is required; input is bounded at 1 MiB"
+          },
+          "usage": "aos wiki put <path> --stdin --if-match <sha256|none> [--json]"
+        },
+        {
+          "args": [
+            {
+              "id": "path",
+              "kind": "positional",
+              "required": true,
               "summary": "Page path or name",
               "value_type": "string"
             },

--- a/manifests/commands/source/external/16-wiki.json
+++ b/manifests/commands/source/external/16-wiki.json
@@ -91,6 +91,24 @@
     {
       "path": [
         "wiki",
+        "put"
+      ],
+      "summary": "Conditionally create or update one wiki Markdown page from bounded stdin.",
+      "executable": "/usr/bin/env",
+      "argv_prefix": [
+        "node",
+        "scripts/aos-wiki-put.mjs"
+      ],
+      "cwd": "repo",
+      "env": {
+        "AOS_PATH": "$AOS_PATH",
+        "AOS_RUNTIME_MODE": "$AOS_RUNTIME_MODE",
+        "AOS_STATE_ROOT": "$AOS_STATE_ROOT"
+      }
+    },
+    {
+      "path": [
+        "wiki",
         "rm"
       ],
       "summary": "Remove wiki pages through the external wiki command.",

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -98,6 +98,11 @@ commands, runtime helpers, wiki tools, and command adapters.
   output fail closed unless daemon health reports `microphone_state=authorized`.
   Denied recovery opens the Microphone settings pane and polls daemon health;
   it never teaches drag-add or runtime TCC reset for Microphone.
+- `aos-wiki-put.mjs` owns bounded conditional wiki publication. It accepts only
+  canonical Markdown paths and UTF-8 stdin, serializes writers, rejects
+  symlinks, commits owner-only files atomically, and exposes hashes without
+  echoing page content or absolute paths. `none` is create-only; updates require
+  the current SHA-256 and fail closed on conflicts.
 - `aos-show-client.mjs` owns any isolated daemon it starts for `show listen`.
   Install signal and parent-exit handling before auto-start, forward shutdown
   to that child, and await confirmed child exit before the listener exits.

--- a/scripts/aos-wiki-put.mjs
+++ b/scripts/aos-wiki-put.mjs
@@ -1,0 +1,496 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { createHash, randomBytes } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { TextDecoder } from 'node:util';
+
+const MAX_INPUT_BYTES = 1024 * 1024;
+const MAX_PATH_BYTES = 1024;
+const LOCK_STALE_AFTER_MS = 30_000;
+const NO_FOLLOW = fs.constants.O_NOFOLLOW ?? 0;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+
+class WikiPutError extends Error {
+  constructor(message, code, details = {}) {
+    super(message);
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function fail(message, code, details = {}) {
+  throw new WikiPutError(message, code, details);
+}
+
+function runtimeMode() {
+  return process.env.AOS_RUNTIME_MODE === 'installed' ? 'installed' : 'repo';
+}
+
+function stateRoot() {
+  return path.resolve(process.env.AOS_STATE_ROOT || path.join(os.homedir(), '.config/aos'));
+}
+
+function modeRoot() {
+  return path.join(stateRoot(), runtimeMode());
+}
+
+function wikiRoot() {
+  return path.join(modeRoot(), 'wiki');
+}
+
+function aosPath() {
+  return process.env.AOS_PATH || path.join(process.cwd(), 'aos');
+}
+
+function printHelp() {
+  process.stdout.write([
+    'Usage: aos wiki put <path> --stdin --if-match <sha256|none> [--json]',
+    '',
+    'Conditionally create or update one canonical Markdown page from stdin.',
+    'Use --if-match none to create and the current SHA-256 to update.',
+    '',
+  ].join('\n'));
+}
+
+function parseArgs(argv) {
+  if (argv.includes('--help') || argv.includes('-h')) return { help: true };
+
+  let relativePath = null;
+  let fromStdin = false;
+  let ifMatch = null;
+  let json = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--stdin') {
+      if (fromStdin) fail('Duplicate argument: --stdin', 'DUPLICATE_ARG');
+      fromStdin = true;
+      continue;
+    }
+    if (arg === '--json') {
+      if (json) fail('Duplicate argument: --json', 'DUPLICATE_ARG');
+      json = true;
+      continue;
+    }
+    if (arg === '--if-match') {
+      if (ifMatch !== null) fail('Duplicate argument: --if-match', 'DUPLICATE_ARG');
+      const value = argv[index + 1];
+      if (!value || value.startsWith('-')) {
+        fail('wiki put requires a value for --if-match', 'MISSING_ARG');
+      }
+      ifMatch = value;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('-')) fail(`Unknown flag: ${arg}`, 'UNKNOWN_FLAG');
+    if (relativePath !== null) fail(`Unknown argument: ${arg}`, 'UNKNOWN_ARG');
+    relativePath = arg;
+  }
+
+  if (!relativePath) {
+    fail('wiki put requires <path>. Usage: aos wiki put <path> --stdin --if-match <sha256|none>', 'MISSING_ARG');
+  }
+  if (!fromStdin) fail('wiki put requires --stdin', 'MISSING_ARG');
+  if (ifMatch === null) fail('wiki put requires --if-match <sha256|none>', 'MISSING_ARG');
+  if (ifMatch !== 'none' && !SHA256_PATTERN.test(ifMatch)) {
+    fail('--if-match must be none or a lowercase SHA-256 digest', 'WIKI_INVALID_MATCH');
+  }
+  return { help: false, ifMatch, json, relativePath: canonicalWikiPath(relativePath) };
+}
+
+function canonicalWikiPath(value) {
+  if (
+    value !== value.trim()
+    || Buffer.byteLength(value, 'utf8') > MAX_PATH_BYTES
+    || value.normalize('NFC') !== value
+    || value.startsWith('/')
+    || value.includes('\\')
+    || /[\u0000-\u001f\u007f]/.test(value)
+    || path.posix.normalize(value) !== value
+  ) {
+    fail('Wiki path must be a canonical relative Markdown path', 'WIKI_INVALID_PATH');
+  }
+  const segments = value.split('/');
+  if (
+    segments.length === 0
+    || segments.some((segment) => segment === '' || segment === '.' || segment === '..')
+    || !segments.at(-1)?.endsWith('.md')
+    || segments.at(-1) === '.md'
+  ) {
+    fail('Wiki path must be a canonical relative Markdown path', 'WIKI_INVALID_PATH');
+  }
+  return value;
+}
+
+async function readBoundedStdin() {
+  const chunks = [];
+  let bytes = 0;
+  for await (const chunk of process.stdin) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    bytes += buffer.length;
+    if (bytes > MAX_INPUT_BYTES) {
+      fail(`Wiki input exceeds the ${MAX_INPUT_BYTES}-byte limit`, 'WIKI_INPUT_TOO_LARGE');
+    }
+    chunks.push(buffer);
+  }
+  const content = Buffer.concat(chunks, bytes);
+  try {
+    new TextDecoder('utf-8', { fatal: true }).decode(content);
+  } catch {
+    fail('Wiki input must be valid UTF-8', 'WIKI_INVALID_CONTENT');
+  }
+  return content;
+}
+
+function ensureDirectory(directory, label) {
+  try {
+    fs.mkdirSync(directory, { mode: 0o700, recursive: true });
+  } catch (error) {
+    throw normalizeFilesystemError(error);
+  }
+  let stat;
+  try {
+    stat = fs.lstatSync(directory);
+  } catch (error) {
+    throw normalizeFilesystemError(error);
+  }
+  if (stat.isSymbolicLink()) fail(`${label} must not be a symlink`, 'WIKI_SYMLINK');
+  if (!stat.isDirectory()) fail(`${label} must be a directory`, 'WIKI_INVALID_PATH');
+}
+
+function resolveWikiTarget(root, relativePath, createParents) {
+  const targetPath = path.join(root, ...relativePath.split('/'));
+  let rootStat;
+  try {
+    rootStat = fs.lstatSync(root);
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw normalizeFilesystemError(error);
+    if (!createParents) return { parentExists: false, targetPath };
+    ensureDirectory(root, 'Wiki root');
+    rootStat = fs.lstatSync(root);
+  }
+  if (rootStat.isSymbolicLink()) fail('Wiki root must not be a symlink', 'WIKI_SYMLINK');
+  if (!rootStat.isDirectory()) fail('Wiki root must be a directory', 'WIKI_INVALID_PATH');
+
+  const parentSegments = relativePath.split('/').slice(0, -1);
+  let current = root;
+  for (const segment of parentSegments) {
+    current = path.join(current, segment);
+    let stat;
+    try {
+      stat = fs.lstatSync(current);
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw normalizeFilesystemError(error);
+      if (!createParents) return { parentExists: false, targetPath };
+      try {
+        fs.mkdirSync(current, { mode: 0o700 });
+      } catch (mkdirError) {
+        if (mkdirError?.code !== 'EEXIST') throw normalizeFilesystemError(mkdirError);
+      }
+      stat = fs.lstatSync(current);
+    }
+    if (stat.isSymbolicLink()) fail('Wiki path must not traverse symlinks', 'WIKI_SYMLINK');
+    if (!stat.isDirectory()) fail('Wiki parent must be a directory', 'WIKI_INVALID_PATH');
+  }
+  return { parentExists: true, targetPath };
+}
+
+function inspectTarget(targetPath) {
+  let stat;
+  try {
+    stat = fs.lstatSync(targetPath);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return null;
+    throw normalizeFilesystemError(error);
+  }
+  if (stat.isSymbolicLink()) fail('Wiki target must not be a symlink', 'WIKI_SYMLINK');
+  if (!stat.isFile()) fail('Wiki target must be a regular file', 'WIKI_INVALID_PATH');
+
+  let descriptor;
+  try {
+    descriptor = fs.openSync(targetPath, fs.constants.O_RDONLY | NO_FOLLOW);
+    const openStat = fs.fstatSync(descriptor);
+    if (!openStat.isFile()) fail('Wiki target must be a regular file', 'WIKI_INVALID_PATH');
+    const hash = createHash('sha256');
+    const chunk = Buffer.allocUnsafe(64 * 1024);
+    let bytes = 0;
+    while (true) {
+      const read = fs.readSync(descriptor, chunk, 0, chunk.length, null);
+      if (read === 0) break;
+      bytes += read;
+      hash.update(chunk.subarray(0, read));
+    }
+    return { bytes, sha256: hash.digest('hex') };
+  } catch (error) {
+    if (error instanceof WikiPutError) throw error;
+    if (error?.code === 'ELOOP') fail('Wiki target must not be a symlink', 'WIKI_SYMLINK');
+    if (error?.code === 'ENOENT') return null;
+    throw normalizeFilesystemError(error);
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+  }
+}
+
+function conflict(relativePath, ifMatch, current) {
+  fail('Wiki page does not match the requested version', 'WIKI_CONFLICT', {
+    actual_sha256: current?.sha256 ?? null,
+    exists: current !== null,
+    expected_sha256: ifMatch,
+    path: relativePath,
+  });
+}
+
+function verifyPrecondition(relativePath, ifMatch, current) {
+  if (ifMatch === 'none') {
+    if (current !== null) conflict(relativePath, ifMatch, current);
+    return 'created';
+  }
+  if (current === null || current.sha256 !== ifMatch) conflict(relativePath, ifMatch, current);
+  return 'updated';
+}
+
+function writeTemporaryFile(parent, basename, content) {
+  const temporaryPath = path.join(parent, `.${basename}.tmp-${process.pid}-${randomBytes(8).toString('hex')}`);
+  let descriptor;
+  let completed = false;
+  try {
+    descriptor = fs.openSync(
+      temporaryPath,
+      fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY | NO_FOLLOW,
+      0o600,
+    );
+    let offset = 0;
+    while (offset < content.length) {
+      const written = fs.writeSync(descriptor, content, offset, content.length - offset);
+      if (written <= 0) fail('Wiki write made no forward progress', 'WIKI_PUT_FAILED');
+      offset += written;
+    }
+    fs.fchmodSync(descriptor, 0o600);
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = undefined;
+    completed = true;
+    return temporaryPath;
+  } catch (error) {
+    throw normalizeFilesystemError(error);
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+    if (!completed) {
+      try {
+        fs.unlinkSync(temporaryPath);
+      } catch {
+        // Preserve the primary write error; owner-only temp cleanup is best effort.
+      }
+    }
+  }
+}
+
+function commitWrite({ content, ifMatch, operation, relativePath, targetPath }) {
+  const parent = path.dirname(targetPath);
+  const temporaryPath = writeTemporaryFile(parent, path.basename(targetPath), content);
+  try {
+    const current = inspectTarget(targetPath);
+    verifyPrecondition(relativePath, ifMatch, current);
+    if (operation === 'created') {
+      try {
+        fs.linkSync(temporaryPath, targetPath);
+      } catch (error) {
+        if (error?.code === 'EEXIST') conflict(relativePath, ifMatch, inspectTarget(targetPath));
+        throw normalizeFilesystemError(error);
+      }
+      fs.unlinkSync(temporaryPath);
+    } else {
+      fs.renameSync(temporaryPath, targetPath);
+    }
+    syncDirectory(parent);
+  } finally {
+    try {
+      fs.unlinkSync(temporaryPath);
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw normalizeFilesystemError(error);
+    }
+  }
+}
+
+function syncDirectory(directory) {
+  let descriptor;
+  try {
+    descriptor = fs.openSync(directory, fs.constants.O_RDONLY);
+    fs.fsyncSync(descriptor);
+  } catch (error) {
+    if (!['EINVAL', 'ENOTSUP'].includes(error?.code)) throw normalizeFilesystemError(error);
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+  }
+}
+
+function acquireLock() {
+  const root = modeRoot();
+  ensureDirectory(root, 'AOS mode root');
+  const lockPath = path.join(root, '.wiki-put.lock');
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      fs.mkdirSync(lockPath, { mode: 0o700 });
+    } catch (error) {
+      if (error?.code !== 'EEXIST') throw normalizeFilesystemError(error);
+      const stat = fs.lstatSync(lockPath);
+      if (stat.isSymbolicLink()) fail('Wiki write lock must not be a symlink', 'WIKI_SYMLINK');
+      if (!stat.isDirectory()) fail('Wiki write lock is invalid', 'WIKI_INVALID_PATH');
+      if (attempt === 0 && removeStaleLock(lockPath, stat)) continue;
+      fail('Another wiki put operation is active', 'WIKI_BUSY');
+    }
+    try {
+      fs.writeFileSync(
+        path.join(lockPath, 'owner.json'),
+        `${JSON.stringify({ pid: process.pid, started_at_ms: Date.now() })}\n`,
+        { encoding: 'utf8', flag: 'wx', mode: 0o600 },
+      );
+      return lockRelease(lockPath);
+    } catch (error) {
+      fs.rmSync(lockPath, { force: true, recursive: true });
+      throw normalizeFilesystemError(error);
+    }
+  }
+  fail('Another wiki put operation is active', 'WIKI_BUSY');
+}
+
+function removeStaleLock(lockPath, stat) {
+  let owner = null;
+  try {
+    owner = JSON.parse(fs.readFileSync(path.join(lockPath, 'owner.json'), 'utf8'));
+  } catch {
+    owner = null;
+  }
+  if (Number.isInteger(owner?.pid) && owner.pid > 0) {
+    if (processIsAlive(owner.pid)) return false;
+  } else if (Date.now() - stat.mtimeMs < LOCK_STALE_AFTER_MS) {
+    return false;
+  }
+  fs.rmSync(lockPath, { force: true, recursive: true });
+  return true;
+}
+
+function processIsAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code !== 'ESRCH';
+  }
+}
+
+function lockRelease(lockPath) {
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    for (const [signal, handler] of handlers) process.off(signal, handler);
+    try {
+      const owner = JSON.parse(fs.readFileSync(path.join(lockPath, 'owner.json'), 'utf8'));
+      if (owner?.pid === process.pid) fs.rmSync(lockPath, { force: true, recursive: true });
+    } catch {
+      // A missing or replaced lock is never removed without matching ownership.
+    }
+  };
+  const handlers = new Map();
+  for (const [signal, exitCode] of [['SIGHUP', 129], ['SIGINT', 130], ['SIGTERM', 143]]) {
+    const handler = () => {
+      release();
+      process.exit(exitCode);
+    };
+    handlers.set(signal, handler);
+    process.once(signal, handler);
+  }
+  return release;
+}
+
+function reindexCommittedWrite(relativePath, operation, sha256) {
+  const result = spawnSync(aosPath(), ['wiki', 'reindex', '--json'], {
+    encoding: 'utf8',
+    env: process.env,
+    maxBuffer: 1024 * 1024,
+    timeout: 30_000,
+  });
+  if (result.error || result.status !== 0) {
+    fail('Wiki page was committed but reindexing failed', 'WIKI_REINDEX_FAILED', {
+      committed: true,
+      operation,
+      path: relativePath,
+      reindex_exit: result.status,
+      sha256,
+    });
+  }
+}
+
+function normalizeFilesystemError(error) {
+  if (error instanceof WikiPutError) return error;
+  if (error?.code === 'ENOSPC') return new WikiPutError('Wiki write failed because storage is full', 'WIKI_NO_SPACE');
+  if (error?.code === 'EACCES' || error?.code === 'EPERM') {
+    return new WikiPutError('Wiki write permission was denied', 'WIKI_PERMISSION_DENIED');
+  }
+  return new WikiPutError('Wiki write failed', 'WIKI_PUT_FAILED', {
+    ...(typeof error?.code === 'string' ? { system_code: error.code } : {}),
+  });
+}
+
+function emitSuccess(result, json) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+  const verb = result.operation === 'created' ? 'Created' : 'Updated';
+  process.stdout.write(`${verb} ${result.path} (${result.bytes} bytes, sha256 ${result.sha256})\n`);
+}
+
+function emitError(error) {
+  const normalized = error instanceof WikiPutError ? error : normalizeFilesystemError(error);
+  process.stderr.write(`${JSON.stringify({
+    code: normalized.code,
+    error: normalized.message,
+    ...normalized.details,
+  }, null, 2)}\n`);
+  process.exitCode = 1;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+  const content = await readBoundedStdin();
+  const release = acquireLock();
+  try {
+    const initialTarget = resolveWikiTarget(wikiRoot(), options.relativePath, false);
+    const current = initialTarget.parentExists ? inspectTarget(initialTarget.targetPath) : null;
+    const operation = verifyPrecondition(options.relativePath, options.ifMatch, current);
+    const preparedTarget = resolveWikiTarget(wikiRoot(), options.relativePath, operation === 'created');
+    if (!preparedTarget.parentExists) conflict(options.relativePath, options.ifMatch, null);
+    const sha256 = createHash('sha256').update(content).digest('hex');
+    commitWrite({
+      content,
+      ifMatch: options.ifMatch,
+      operation,
+      relativePath: options.relativePath,
+      targetPath: preparedTarget.targetPath,
+    });
+    reindexCommittedWrite(options.relativePath, operation, sha256);
+    emitSuccess({
+      schema_version: 'aos.wiki.put-result.v1',
+      status: 'ok',
+      operation,
+      path: options.relativePath,
+      bytes: content.length,
+      previous_sha256: current?.sha256 ?? null,
+      sha256,
+      reindexed: true,
+    }, options.json);
+  } finally {
+    release();
+  }
+}
+
+main().catch(emitError);

--- a/scripts/aos-wiki-router.mjs
+++ b/scripts/aos-wiki-router.mjs
@@ -5,6 +5,7 @@ const subcommands = [
   'show',
   'graph',
   'add',
+  'put',
   'rm',
   'link',
   'search',

--- a/shared/schemas/aos-wiki-put-result-v1.schema.json
+++ b/shared/schemas/aos-wiki-put-result-v1.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/michaelblum/agent-os/shared/schemas/aos-wiki-put-result-v1.schema.json",
+  "title": "AOS Wiki Put Result v1",
+  "description": "Successful machine-readable result from aos wiki put. Content and absolute filesystem paths are intentionally absent.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "status",
+    "operation",
+    "path",
+    "bytes",
+    "previous_sha256",
+    "sha256",
+    "reindexed"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "aos.wiki.put-result.v1"
+    },
+    "status": {
+      "const": "ok"
+    },
+    "operation": {
+      "enum": [
+        "created",
+        "updated"
+      ]
+    },
+    "path": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 1024,
+      "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.?(?:/|$))(?!.*//)(?!.*\\\\).+\\.md$"
+    },
+    "bytes": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 1048576
+    },
+    "previous_sha256": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "reindexed": {
+      "const": true
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "operation": {
+            "const": "created"
+          }
+        },
+        "required": [
+          "operation"
+        ]
+      },
+      "then": {
+        "properties": {
+          "previous_sha256": {
+            "const": null
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "previous_sha256": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/shared/schemas/fixtures/aos-wiki-put-result-v1/invalid/content-leak.json
+++ b/shared/schemas/fixtures/aos-wiki-put-result-v1/invalid/content-leak.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": "aos.wiki.put-result.v1",
+  "status": "ok",
+  "operation": "created",
+  "path": "consumer/concepts/reviewed-fact.md",
+  "bytes": 128,
+  "previous_sha256": null,
+  "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "reindexed": true,
+  "content": "must never appear"
+}

--- a/shared/schemas/fixtures/aos-wiki-put-result-v1/invalid/stale-create-hash.json
+++ b/shared/schemas/fixtures/aos-wiki-put-result-v1/invalid/stale-create-hash.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "aos.wiki.put-result.v1",
+  "status": "ok",
+  "operation": "created",
+  "path": "consumer/concepts/reviewed-fact.md",
+  "bytes": 128,
+  "previous_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "reindexed": true
+}

--- a/shared/schemas/fixtures/aos-wiki-put-result-v1/valid/created.json
+++ b/shared/schemas/fixtures/aos-wiki-put-result-v1/valid/created.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "aos.wiki.put-result.v1",
+  "status": "ok",
+  "operation": "created",
+  "path": "consumer/concepts/reviewed-fact.md",
+  "bytes": 128,
+  "previous_sha256": null,
+  "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "reindexed": true
+}

--- a/shared/schemas/fixtures/aos-wiki-put-result-v1/valid/updated.json
+++ b/shared/schemas/fixtures/aos-wiki-put-result-v1/valid/updated.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "aos.wiki.put-result.v1",
+  "status": "ok",
+  "operation": "updated",
+  "path": "consumer/concepts/reviewed-fact.md",
+  "bytes": 256,
+  "previous_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "reindexed": true
+}

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -303,7 +303,9 @@ A per-mode content store at `~/.config/aos/{mode}/wiki/`. Used by product namesp
 aos wiki list [--namespace <ns>]      # List entries (defaults to all namespaces)
 aos wiki show <path>                  # Print an entry
 aos wiki graph [--raw]                # Emit canonical graph payload for KB surfaces
-aos wiki add <path> --file <src>      # Create or update an entry from a file
+aos wiki add <entity|concept> <name>  # Scaffold an entity or concept entry
+aos wiki put <path> --stdin --if-match <sha256|none>
+                                      # Conflict-safe create or update from stdin
 aos wiki rm <path>                    # Delete an entry
 aos wiki link <from> <to>             # Cross-link entries
 aos wiki search <query>               # Full-text search

--- a/tests/schemas/aos-wiki-put-result-v1.test.mjs
+++ b/tests/schemas/aos-wiki-put-result-v1.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const schemaPath = path.join(repoRoot, 'shared/schemas/aos-wiki-put-result-v1.schema.json');
+const fixtureRoot = path.join(repoRoot, 'shared/schemas/fixtures/aos-wiki-put-result-v1');
+
+async function jsonFiles(directory) {
+  return (await fs.readdir(directory, { withFileTypes: true }))
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+    .map((entry) => path.join(directory, entry.name))
+    .sort();
+}
+
+function validate(fixturePath) {
+  return spawnSync('python3', [
+    '-c',
+    `
+import json, sys
+from pathlib import Path
+from jsonschema import Draft202012Validator
+
+schema = json.loads(Path(sys.argv[1]).read_text())
+instance = json.loads(Path(sys.argv[2]).read_text())
+Draft202012Validator.check_schema(schema)
+errors = sorted(Draft202012Validator(schema).iter_errors(instance), key=lambda error: list(error.path))
+if errors:
+    for error in errors[:8]:
+        print(error.message)
+    sys.exit(1)
+`,
+    schemaPath,
+    fixturePath,
+  ], { encoding: 'utf8' });
+}
+
+test('valid wiki put results match the canonical schema', async () => {
+  for (const fixture of await jsonFiles(path.join(fixtureRoot, 'valid'))) {
+    const result = validate(fixture);
+    assert.equal(result.status, 0, `${path.relative(repoRoot, fixture)}\n${result.stdout}${result.stderr}`);
+  }
+});
+
+test('wiki put result schema rejects leaks and inconsistent create metadata', async () => {
+  for (const fixture of await jsonFiles(path.join(fixtureRoot, 'invalid'))) {
+    const result = validate(fixture);
+    assert.notEqual(result.status, 0, `${path.relative(repoRoot, fixture)} unexpectedly validated`);
+  }
+});

--- a/tests/wiki-put-contract.test.mjs
+++ b/tests/wiki-put-contract.test.mjs
@@ -1,0 +1,253 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterEach, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const scriptPath = path.join(repoRoot, 'scripts/aos-wiki-put.mjs');
+const roots = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { force: true, recursive: true })));
+});
+
+async function fixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'aos-wiki-put-'));
+  roots.push(root);
+  const fakeAos = path.join(root, 'fake-aos.mjs');
+  const reindexLog = path.join(root, 'reindex.ndjson');
+  await fs.writeFile(fakeAos, `#!/usr/bin/env node
+import fs from 'node:fs';
+fs.appendFileSync(process.env.AOS_FAKE_REINDEX_LOG, JSON.stringify(process.argv.slice(2)) + '\\n');
+if (process.env.AOS_FAKE_REINDEX_FAIL === '1') {
+  process.stderr.write('FAKE_REINDEX_PRIVATE_OUTPUT\\n');
+  process.exit(9);
+}
+process.stdout.write('{"status":"ok"}\\n');
+`, { mode: 0o700 });
+  await fs.chmod(fakeAos, 0o700);
+  return {
+    fakeAos,
+    reindexLog,
+    root,
+    wikiRoot: path.join(root, 'repo', 'wiki'),
+  };
+}
+
+function runPut(fx, args, input = '', env = {}) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      AOS_FAKE_REINDEX_LOG: fx.reindexLog,
+      AOS_PATH: fx.fakeAos,
+      AOS_RUNTIME_MODE: 'repo',
+      AOS_STATE_ROOT: fx.root,
+      ...env,
+    },
+    input,
+    maxBuffer: 4 * 1024 * 1024,
+    timeout: 10_000,
+  });
+}
+
+function digest(content) {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+async function reindexCalls(fx) {
+  try {
+    return (await fs.readFile(fx.reindexLog, 'utf8')).trim().split('\n').filter(Boolean).map(JSON.parse);
+  } catch (error) {
+    if (error.code === 'ENOENT') return [];
+    throw error;
+  }
+}
+
+test('creates and updates owner-only Markdown with conditional hashes', async () => {
+  const fx = await fixture();
+  const relativePath = 'consumer/concepts/voice-memory.md';
+  const initial = '# Voice memory\n';
+  const created = runPut(fx, [relativePath, '--stdin', '--if-match', 'none', '--json'], initial);
+  assert.equal(created.status, 0, created.stderr);
+  assert.deepEqual(JSON.parse(created.stdout), {
+    schema_version: 'aos.wiki.put-result.v1',
+    status: 'ok',
+    operation: 'created',
+    path: relativePath,
+    bytes: Buffer.byteLength(initial),
+    previous_sha256: null,
+    sha256: digest(initial),
+    reindexed: true,
+  });
+
+  const target = path.join(fx.wikiRoot, relativePath);
+  assert.equal(await fs.readFile(target, 'utf8'), initial);
+  assert.equal((await fs.stat(target)).mode & 0o777, 0o600);
+  assert.deepEqual(await reindexCalls(fx), [['wiki', 'reindex', '--json']]);
+  assert.deepEqual((await fs.readdir(path.dirname(target))).filter((name) => name.includes('.tmp-')), []);
+
+  await fs.chmod(target, 0o644);
+  const next = '# Voice memory\n\nReviewed fact.\n';
+  const updated = runPut(fx, [relativePath, '--stdin', '--if-match', digest(initial), '--json'], next);
+  assert.equal(updated.status, 0, updated.stderr);
+  assert.deepEqual(JSON.parse(updated.stdout), {
+    schema_version: 'aos.wiki.put-result.v1',
+    status: 'ok',
+    operation: 'updated',
+    path: relativePath,
+    bytes: Buffer.byteLength(next),
+    previous_sha256: digest(initial),
+    sha256: digest(next),
+    reindexed: true,
+  });
+  assert.equal(await fs.readFile(target, 'utf8'), next);
+  assert.equal((await fs.stat(target)).mode & 0o777, 0o600);
+  assert.deepEqual(await reindexCalls(fx), [
+    ['wiki', 'reindex', '--json'],
+    ['wiki', 'reindex', '--json'],
+  ]);
+});
+
+test('fails closed on create and stale-update conflicts without echoing content', async () => {
+  const fx = await fixture();
+  const relativePath = 'consumer/concepts/private.md';
+  const existing = 'EXISTING_PRIVATE_WIKI_CONTENT';
+  const attempted = 'ATTEMPTED_PRIVATE_WIKI_CONTENT';
+  const target = path.join(fx.wikiRoot, relativePath);
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.writeFile(target, existing, { mode: 0o600 });
+
+  for (const ifMatch of ['none', '0'.repeat(64)]) {
+    const result = runPut(fx, [relativePath, '--stdin', '--if-match', ifMatch, '--json'], attempted);
+    assert.equal(result.status, 1);
+    const failure = JSON.parse(result.stderr);
+    assert.deepEqual(failure, {
+      code: 'WIKI_CONFLICT',
+      error: 'Wiki page does not match the requested version',
+      actual_sha256: digest(existing),
+      exists: true,
+      expected_sha256: ifMatch,
+      path: relativePath,
+    });
+    assert.doesNotMatch(result.stderr, /EXISTING_PRIVATE|ATTEMPTED_PRIVATE/);
+    assert.equal(await fs.readFile(target, 'utf8'), existing);
+  }
+  assert.deepEqual(await reindexCalls(fx), []);
+});
+
+test('does not create wiki directories for an update precondition on a missing path', async () => {
+  const fx = await fixture();
+  const result = runPut(
+    fx,
+    ['missing/nested/page.md', '--stdin', '--if-match', 'a'.repeat(64), '--json'],
+    'content',
+  );
+  assert.equal(result.status, 1);
+  assert.deepEqual(JSON.parse(result.stderr), {
+    code: 'WIKI_CONFLICT',
+    error: 'Wiki page does not match the requested version',
+    actual_sha256: null,
+    exists: false,
+    expected_sha256: 'a'.repeat(64),
+    path: 'missing/nested/page.md',
+  });
+  await assert.rejects(fs.stat(fx.wikiRoot), { code: 'ENOENT' });
+  assert.deepEqual(await reindexCalls(fx), []);
+});
+
+test('rejects traversal, non-Markdown paths, invalid UTF-8, and oversized stdin before mutation', async () => {
+  const fx = await fixture();
+  const cases = [
+    { args: ['../outside.md', '--stdin', '--if-match', 'none'], code: 'WIKI_INVALID_PATH', input: 'x' },
+    { args: ['consumer/concepts/fact.txt', '--stdin', '--if-match', 'none'], code: 'WIKI_INVALID_PATH', input: 'x' },
+    { args: ['consumer\\concepts\\fact.md', '--stdin', '--if-match', 'none'], code: 'WIKI_INVALID_PATH', input: 'x' },
+    { args: ['consumer/concepts/invalid.md', '--stdin', '--if-match', 'none'], code: 'WIKI_INVALID_CONTENT', input: Buffer.from([0xc3, 0x28]) },
+    { args: ['consumer/concepts/large.md', '--stdin', '--if-match', 'none'], code: 'WIKI_INPUT_TOO_LARGE', input: Buffer.alloc(1024 * 1024 + 1, 0x61) },
+  ];
+  for (const item of cases) {
+    const result = runPut(fx, item.args, item.input);
+    assert.equal(result.status, 1);
+    assert.equal(JSON.parse(result.stderr).code, item.code, result.stderr);
+  }
+  assert.deepEqual(await reindexCalls(fx), []);
+  await assert.rejects(fs.stat(path.join(fx.root, 'outside.md')), { code: 'ENOENT' });
+});
+
+test('rejects symlinked parents and targets without changing their destinations', async () => {
+  const fx = await fixture();
+  const outside = path.join(fx.root, 'outside');
+  await fs.mkdir(outside, { recursive: true });
+  await fs.mkdir(fx.wikiRoot, { recursive: true });
+  await fs.symlink(outside, path.join(fx.wikiRoot, 'linked'));
+
+  const parentResult = runPut(fx, ['linked/page.md', '--stdin', '--if-match', 'none'], 'private');
+  assert.equal(parentResult.status, 1);
+  assert.equal(JSON.parse(parentResult.stderr).code, 'WIKI_SYMLINK');
+  await assert.rejects(fs.stat(path.join(outside, 'page.md')), { code: 'ENOENT' });
+
+  const destination = path.join(outside, 'destination.md');
+  await fs.writeFile(destination, 'keep', { mode: 0o600 });
+  const targetDir = path.join(fx.wikiRoot, 'safe');
+  await fs.mkdir(targetDir, { recursive: true });
+  await fs.symlink(destination, path.join(targetDir, 'page.md'));
+  const targetResult = runPut(fx, ['safe/page.md', '--stdin', '--if-match', digest('keep')], 'replace');
+  assert.equal(targetResult.status, 1);
+  assert.equal(JSON.parse(targetResult.stderr).code, 'WIKI_SYMLINK');
+  assert.equal(await fs.readFile(destination, 'utf8'), 'keep');
+  assert.deepEqual(await reindexCalls(fx), []);
+});
+
+test('serializes writers and removes a dead owner lock before proceeding', async () => {
+  const fx = await fixture();
+  const lockPath = path.join(fx.root, 'repo', '.wiki-put.lock');
+  await fs.mkdir(lockPath, { recursive: true, mode: 0o700 });
+  await fs.writeFile(path.join(lockPath, 'owner.json'), JSON.stringify({ pid: process.pid }), { mode: 0o600 });
+  const busy = runPut(fx, ['safe/busy.md', '--stdin', '--if-match', 'none'], 'x');
+  assert.equal(busy.status, 1);
+  assert.equal(JSON.parse(busy.stderr).code, 'WIKI_BUSY');
+  assert.deepEqual(await reindexCalls(fx), []);
+
+  await fs.writeFile(path.join(lockPath, 'owner.json'), JSON.stringify({ pid: 999_999_999 }), { mode: 0o600 });
+  const recovered = runPut(fx, ['safe/recovered.md', '--stdin', '--if-match', 'none', '--json'], 'ok');
+  assert.equal(recovered.status, 0, recovered.stderr);
+  await assert.rejects(fs.stat(lockPath), { code: 'ENOENT' });
+});
+
+test('reports a committed reindex failure without echoing content or child output', async () => {
+  const fx = await fixture();
+  const relativePath = 'consumer/concepts/reindex-failure.md';
+  const content = 'PRIVATE_WIKI_REINDEX_CONTENT';
+  const result = runPut(
+    fx,
+    [relativePath, '--stdin', '--if-match', 'none', '--json'],
+    content,
+    { AOS_FAKE_REINDEX_FAIL: '1' },
+  );
+  assert.equal(result.status, 1);
+  assert.deepEqual(JSON.parse(result.stderr), {
+    code: 'WIKI_REINDEX_FAILED',
+    error: 'Wiki page was committed but reindexing failed',
+    committed: true,
+    operation: 'created',
+    path: relativePath,
+    reindex_exit: 9,
+    sha256: digest(content),
+  });
+  assert.doesNotMatch(result.stderr, /PRIVATE_WIKI_REINDEX_CONTENT|FAKE_REINDEX_PRIVATE_OUTPUT/);
+  assert.equal(await fs.readFile(path.join(fx.wikiRoot, relativePath), 'utf8'), content);
+});
+
+test('help is read-only and does not require stdin or runtime state', async () => {
+  const fx = await fixture();
+  const result = runPut(fx, ['--help']);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /aos wiki put <path> --stdin --if-match <sha256\|none>/);
+  assert.deepEqual(await reindexCalls(fx), []);
+  await assert.rejects(fs.stat(path.join(fx.root, 'repo')), { code: 'ENOENT' });
+});

--- a/tests/wiki-put-external.sh
+++ b/tests/wiki-put-external.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(mktemp -d "${TMPDIR:-/tmp}/aos-wiki-put-external.XXXXXX")"
+ROOT="$(cd "$ROOT" && pwd -P)"
+export AOS_STATE_ROOT="$ROOT"
+trap 'rm -rf "$ROOT"' EXIT
+
+AOS_BIN="${AOS_BIN:-./aos}"
+RELATIVE_PATH="consumer/concepts/reviewed-fact.md"
+TARGET="$ROOT/repo/wiki/$RELATIVE_PATH"
+CREATE_INPUT="$ROOT/create.md"
+UPDATE_INPUT="$ROOT/update.md"
+CONFLICT_INPUT="$ROOT/conflict.md"
+
+printf '%s\n' '# Reviewed fact' 'Initial public command proof.' >"$CREATE_INPUT"
+printf '%s\n' '# Reviewed fact' 'Updated public command proof.' >"$UPDATE_INPUT"
+printf '%s\n' 'PRIVATE_CONFLICT_INPUT_MUST_NOT_ECHO' >"$CONFLICT_INPUT"
+
+CREATE_OUT="$("$AOS_BIN" wiki put "$RELATIVE_PATH" --stdin --if-match none --json <"$CREATE_INPUT")"
+CREATE_HASH="$(CREATE_OUT="$CREATE_OUT" TARGET="$TARGET" python3 - <<'PY'
+import hashlib
+import json
+import os
+import stat
+
+data = json.loads(os.environ["CREATE_OUT"])
+target = os.environ["TARGET"]
+content = open(target, "rb").read()
+assert data["schema_version"] == "aos.wiki.put-result.v1", data
+assert data["operation"] == "created", data
+assert data["path"] == "consumer/concepts/reviewed-fact.md", data
+assert data["previous_sha256"] is None, data
+assert data["sha256"] == hashlib.sha256(content).hexdigest(), data
+assert data["bytes"] == len(content), data
+assert stat.S_IMODE(os.stat(target).st_mode) == 0o600
+print(data["sha256"])
+PY
+)"
+
+UPDATE_OUT="$("$AOS_BIN" wiki put "$RELATIVE_PATH" --stdin --if-match "$CREATE_HASH" --json <"$UPDATE_INPUT")"
+CREATE_HASH="$CREATE_HASH" UPDATE_OUT="$UPDATE_OUT" TARGET="$TARGET" python3 - <<'PY'
+import hashlib
+import json
+import os
+
+data = json.loads(os.environ["UPDATE_OUT"])
+content = open(os.environ["TARGET"], "rb").read()
+assert data["operation"] == "updated", data
+assert data["previous_sha256"] == os.environ["CREATE_HASH"], data
+assert data["sha256"] == hashlib.sha256(content).hexdigest(), data
+PY
+
+LIST_OUT="$("$AOS_BIN" wiki list --json)"
+LIST_OUT="$LIST_OUT" python3 - <<'PY'
+import json
+import os
+
+pages = json.loads(os.environ["LIST_OUT"])
+assert any(page["path"] == "consumer/concepts/reviewed-fact.md" for page in pages), pages
+PY
+
+if "$AOS_BIN" wiki put "$RELATIVE_PATH" --stdin --if-match none --json \
+    <"$CONFLICT_INPUT" >"$ROOT/conflict.out" 2>"$ROOT/conflict.err"; then
+  echo "FAIL: wiki put accepted create-only precondition for an existing page"
+  exit 1
+fi
+
+python3 - "$ROOT/conflict.err" <<'PY'
+import json
+import pathlib
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text()
+data = json.loads(text)
+assert data["code"] == "WIKI_CONFLICT", data
+assert data["exists"] is True, data
+assert len(data["actual_sha256"]) == 64, data
+assert "PRIVATE_CONFLICT_INPUT_MUST_NOT_ECHO" not in text
+assert "Updated public command proof" not in text
+PY
+
+echo "PASS"


### PR DESCRIPTION
## Summary
- add `aos wiki put <path> --stdin --if-match <sha256|none> --json` as a product-neutral conditional publication boundary
- enforce canonical Markdown paths, 1 MiB valid UTF-8 input, symlink rejection, serialized preconditions, atomic owner-only writes, and content-redacted errors
- publish `aos.wiki.put-result.v1`, generated command/help manifests, API guidance, and proof ownership
- reindex only after a committed write; active daemon watchers retain the normal wiki change-event path

## Local validation
- Focused writer/schema/manifest/proof suite: 70/70
- Full schema suite: 165/165
- Command manifest generation and capability inventory: passed
- Static dev workflow routing: passed (`AOS_SKIP_LIVE_CLI_CHECKS=1`)
- JSON help contract for `wiki put`: passed
- Node and shell syntax checks: passed
- `git diff --check`: passed
- Full root Node suite: 226/245; 17 skills/companion and one content-wait failure require the absent repo `./aos`, and the unchanged browser keyboard fake-AOS baseline remains `UNEXPECTED_AOS`

## Deferred by scope
- `tests/wiki-put-external.sh`, `tests/help-contract.sh`, and `tests/external-command-dispatch.sh`: repo `./aos` is absent
- no rebuild, live binary operation, daemon operation, TCC change, native input, or packaging action

The missing binary is not rebuilt here because this contract PR explicitly preserves the managed-Mac ADR 0023 build boundary.