### PR TITLE
Export product-neutral scene toolkit

### DIFF
--- a/docs/api/toolkit.md
+++ b/docs/api/toolkit.md
@@ -9,6 +9,7 @@ Use this index when you are building an AOS canvas surface, composing reusable t
 | Boundary | Scoped reference | Use it for |
 | --- | --- | --- |
 | Runtime primitives | [toolkit/runtime.md](./toolkit/runtime.md) | runtime bridge, canvas lifecycle helpers, subscriptions, `createResourceScope`, DesktopWorld surface runtime, input regions/events |
+| Scene authoring | [toolkit/scene.md](./toolkit/scene.md) | external package facade, DesktopWorld Three adapter, bounded renderer lifecycle, visual-object descriptors and form bindings |
 | Controls | [toolkit/controls.md](./toolkit/controls.md) | plain DOM control factories, stock control CSS classes, timer bar, number-field enhancement |
 | Panel/window policy | [toolkit/panel-window.md](./toolkit/panel-window.md) | `mountChrome`, `createPanelWindowController`, drag/resize/maximize/minimize/restore, placement, `createStageAffordance`, split panes, tabs, single layout |
 | Workbench contracts | [toolkit/workbench.md](./toolkit/workbench.md) | `aos.workbench.subject`, human checkpoint, HTML/Markdown/work-record/artifact/playbook/wiki workbench contracts |
@@ -24,6 +25,7 @@ It is split into these layers:
 | Layer | Path | Purpose |
 | --- | --- | --- |
 | Runtime | `packages/toolkit/runtime/` | bridge, subscriptions, canvas mutation helpers, manifest handshake, DesktopWorld adapters, input-region helpers, resource scopes |
+| Scene facade | `packages/toolkit/scene/` | narrow external package exports and TypeScript declarations over reviewed runtime and visual-object contracts |
 | Controls | `packages/toolkit/controls/` | reusable app-control behavior for WKWebView surfaces |
 | Panel | `packages/toolkit/panel/` | panel/window policy, chrome, placement, StageAffordance, and composition primitives |
 | Workbench | `packages/toolkit/workbench/` | shared subject descriptors, workbench contracts, and stock workbench shell styling |
@@ -57,6 +59,7 @@ Before adding a WebView, daemon policy, app-private hit testing, or a new Deskto
 - `mountChrome`: [panel chrome](./toolkit/panel-window.md#mountchromecontainer-options).
 - controls: [controls API](./toolkit/controls.md#factories) and [form harness](./toolkit/panel-window.md#createformcontainer-fields-options).
 - DesktopWorld stage/surface runtime: [runtime DesktopWorld surface runtime](./toolkit/runtime.md#desktopworld-surface-runtime) and [components DesktopWorld stage](./toolkit/components.md#stock-components-snapshot).
+- external Three scene authoring: [scene API](./toolkit/scene.md).
 - input regions/events: [runtime input regions and events](./toolkit/runtime.md#input-regions-and-events).
 - workbench contracts: [workbench API](./toolkit/workbench.md#workbench-contracts).
 - Surface Inspector and Surface-Zoom Inspector: [components API](./toolkit/components.md#stock-components-snapshot) and [Surface-Zoom proof](./toolkit/components.md#surface-zoom-inspector-proof).

--- a/docs/api/toolkit/runtime.md
+++ b/docs/api/toolkit/runtime.md
@@ -235,6 +235,13 @@ remove-all cleanup, and snapshots.
 inject a telemetry state accessor, source label, target canvas id, visibility
 predicate, renderer stats, render-loop work classifier, and post function.
 
+`packages/toolkit/runtime/three-render-lifecycle.js` provides the generic,
+dependency-injected Three renderer lifecycle: bounded DPR/backing metrics,
+resize observation, hidden/context-loss suspension, frame scheduling, and
+owned-resource disposal. External package consumers use the narrow
+[`@agent-os/toolkit/scene` contract](./scene.md) instead of importing this file
+directly.
+
 ## Runtime API
 
 Convenience re-export:
@@ -264,6 +271,8 @@ import {
   createCanvasHostRuntime,
   createManagedInputRegionSet,
   createRenderPerformanceSampler,
+  createThreeRenderLifecycle,
+  resolveThreeRenderMetrics,
   createSemanticChildTargetSurface,
   createUtilitySurfaceManager,
   MENU_ACTIVATION_PHASES,

--- a/docs/api/toolkit/scene.md
+++ b/docs/api/toolkit/scene.md
@@ -1,0 +1,137 @@
+# Toolkit Scene API
+
+`@agent-os/toolkit/scene` is the narrow package boundary for external scene
+authors. It exposes product-neutral DesktopWorld, Three renderer lifecycle,
+canvas projection, and visual-object editing primitives without exposing the
+broader toolkit implementation tree.
+
+The package does not depend on or bundle Three.js. Consumers own their Three.js
+version and pass renderer-, scene-, camera-, and resource-like objects into the
+dependency-injected helpers.
+
+## Package Import
+
+```js
+import {
+  DesktopWorldSurfaceThree,
+  createThreeRenderLifecycle,
+  createVisualObjectDescriptor,
+  bindVisualObjectForm,
+} from '@agent-os/toolkit/scene'
+```
+
+The package export includes `scene/index.d.ts` for TypeScript consumers. Direct
+imports into `runtime/` or `workbench/` are not part of this external package
+contract.
+
+## Three Renderer Lifecycle
+
+`createThreeRenderLifecycle(options)` owns generic renderer mechanics:
+
+- element resize observation plus window-resize fallback;
+- effective device-pixel ratio capped at `2` by default;
+- backing dimensions capped at `4096` and total backing pixels capped at
+  `4,194,304` by default;
+- invalid or zero measurements skipped without mutating the renderer;
+- requestAnimationFrame suspension while hidden, explicitly suspended, or
+  WebGL context-lost;
+- context-loss prevention and restoration callbacks;
+- idempotent listener, observer, frame, scene-resource, renderer, and context
+  disposal.
+
+Use `resolveThreeRenderMetrics()` when a consumer needs the same pure sizing
+policy without lifecycle ownership. Product code may lower the limits but
+should not raise them without its own memory and canvas acceptance evidence.
+
+```js
+const lifecycle = createThreeRenderLifecycle({
+  renderer,
+  scene,
+  camera,
+  container,
+  onFrame: ({ deltaMs }) => {
+    animateScene(deltaMs)
+    renderer.render(scene, camera)
+  },
+  onContextLost: () => showFallback(),
+  onContextRestored: () => hideFallback(),
+})
+
+lifecycle.start()
+// lifecycle.suspend() while a product-owned stage is inactive
+// lifecycle.resume() when it becomes visible again
+lifecycle.dispose()
+```
+
+Only resources reachable from the supplied `scene` and entries explicitly
+listed in `additionalDisposables` are disposed. Do not pass shared textures,
+materials, controls, or render targets unless this lifecycle owns them.
+
+## DesktopWorld Three Adapter
+
+`DesktopWorldSurfaceThree` (alias `DesktopWorldSurface3D`) extends the generic
+DesktopWorld surface adapter with segment-aware orthographic and perspective
+camera refresh, viewport refresh, primary-surface state publication, and
+secondary-surface state latency measurements. `deriveOrthoCamera()` is the pure
+segment-to-frustum projection.
+
+The adapter and renderer lifecycle compose without sharing product policy:
+
+```js
+const surface = new DesktopWorldSurfaceThree({ canvasId })
+await surface.start({ onState: applySharedState })
+surface.mountScene({ scene, camera, renderer, manageViewport: false })
+
+const lifecycle = createThreeRenderLifecycle({
+  renderer,
+  scene,
+  camera,
+  container,
+  updateCamera: () => surface.refreshCamera(),
+  onFrame: () => renderer.render(scene, camera),
+})
+lifecycle.start()
+```
+
+`manageViewport: false` makes the bounded lifecycle the sole resize owner. The
+adapter's default remains `true` for existing standalone DesktopWorld consumers.
+
+Use the adapter only when the surface runs on an AOS DesktopWorld canvas.
+Product-owned editors can use the renderer lifecycle directly.
+
+## Canvas Lifecycle Projection
+
+The scene package exports the complete neutral projection helpers from
+`runtime/canvas-lifecycle.js`:
+
+- `canvasLifecycleCanvasID()` and `mergeCanvasLifecycleCanvas()`;
+- `canvasGeometryCanvasID()`, `normalizeCanvasGeometry()`, and
+  `mergeCanvasGeometryCanvas()`.
+
+These helpers normalize daemon lifecycle and geometry events. They do not
+create, mutate, suspend, or remove canvases.
+
+## Visual Objects And Forms
+
+Scene editors use `createVisualObjectDescriptor()` and the validation helpers
+to describe canonical editable state. `applyVisualObjectControllerUpdate()`
+performs the state mutation and dispatches injected route and renderer-sync
+handlers. `bindVisualObjectForm()` maps a compatible form's field-change events
+to those descriptors.
+
+Projection-only descriptors cannot mutate canonical state. Routed editable
+descriptors require a state path, route, coercion policy, renderer-sync labels,
+group key, and object identities. State remains plain JSON; Three resources are
+never stored in descriptors or serialized scene state.
+
+The resource-lifecycle evidence helpers describe rebuilds, retained resources,
+disposal balance, renderer synchronization, and JSON serializability. They are
+proof contracts, not a resource manager.
+
+## Ownership Boundary
+
+This API owns reusable renderer and binding mechanics only. External products
+own persona, representation selection, scene schema, materials, effects,
+animation mapping, editor layout, persistence, authority, and approval policy.
+Importing this package grants no AOS command execution, daemon socket access,
+native input, TCC permission, or product identity.

--- a/docs/dev/test-proof-registry.d/substrate-reclassification.json
+++ b/docs/dev/test-proof-registry.d/substrate-reclassification.json
@@ -187,6 +187,27 @@
       "status": "active"
     },
     {
+      "id": "scene-toolkit-public-contract",
+      "path_patterns": [
+        "tests/toolkit/desktop-world-surface-three.test.mjs",
+        "tests/toolkit/scene-public-contract.test.mjs",
+        "tests/toolkit/three-render-lifecycle.test.mjs",
+        "tests/toolkit/toolkit-api-docs-contract.test.mjs"
+      ],
+      "fixture_patterns": [],
+      "owner": "toolkit-scene",
+      "harness_level": "model_unit",
+      "proof_kind": "scene_toolkit_contract",
+      "contract": "The external scene facade exposes only product-neutral DesktopWorld, bounded Three lifecycle, canvas projection, and visual-object primitives.",
+      "worth": "This lets external first-party consumers reuse renderer mechanics and editing contracts without copying toolkit source or restoring product authority to AOS.",
+      "command": "node --test tests/toolkit/desktop-world-surface-three.test.mjs tests/toolkit/scene-public-contract.test.mjs tests/toolkit/three-render-lifecycle.test.mjs tests/toolkit/toolkit-api-docs-contract.test.mjs",
+      "replaces": [
+        "embedded product avatar renderer lifecycle tests"
+      ],
+      "guard": "dependency-injected model tests only; no daemon, GPU, TCC, or product fixture",
+      "status": "active"
+    },
+    {
       "id": "runtime-surface-model-contract",
       "path_patterns": [
         "tests/toolkit/render-performance-model.test.mjs",

--- a/packages/toolkit/AGENTS.md
+++ b/packages/toolkit/AGENTS.md
@@ -23,6 +23,8 @@ Layer intent:
 - `workbench/`: subject descriptors and reusable workbench contracts.
 - `components/`: reusable content units and stock surfaces built from the lower
   layers.
+- `scene/`: narrow external package facade over reviewed Three lifecycle,
+  DesktopWorld, canvas lifecycle, and visual-object contracts.
 
 Toolkit policy must stay generic. If a behavior only makes sense for a
 specific external product, it belongs in that product repository. If toolkit
@@ -48,7 +50,8 @@ as a pointer to that canonical tree instead of copying the full policy here.
 Consumer-facing toolkit contracts are indexed at `docs/api/toolkit.md`. Prefer
 the scoped API file for the layer you are changing:
 `docs/api/toolkit/runtime.md`, `docs/api/toolkit/panel-window.md`,
-`docs/api/toolkit/workbench.md`, `docs/api/toolkit/components.md`, or
+`docs/api/toolkit/workbench.md`, `docs/api/toolkit/scene.md`,
+`docs/api/toolkit/components.md`, or
 `docs/api/toolkit/content-host.md`.
 
 For `workbench/` Work Record filesystem paths, preserve raw path strings in
@@ -69,6 +72,7 @@ public facade for testing convenience.
 - `panel/AGENTS.md` governs reusable panel/windowing policy.
 - `runtime/AGENTS.md` governs the generic in-canvas bridge to daemon
   primitives.
+- `scene/AGENTS.md` governs the narrow external scene-authoring package facade.
 - `contracts/`, `components/`, `workbench/`, `adapters/`, `markdown/`, and
-  `shell/` do not have child `AGENTS.md` files yet; follow this toolkit
-  contract plus scoped API docs when editing them.
+  `shell/` do not have child `AGENTS.md` files yet; follow this toolkit contract
+  plus scoped API docs when editing them.

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -3,6 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "exports": {
+    "./scene": {
+      "types": "./scene/index.d.ts",
+      "import": "./scene/index.js",
+      "default": "./scene/index.js"
+    }
+  },
   "dependencies": {
     "@zag-js/accordion": "^1.40.0",
     "@zag-js/collapsible": "^1.40.0",

--- a/packages/toolkit/runtime/AGENTS.md
+++ b/packages/toolkit/runtime/AGENTS.md
@@ -24,6 +24,9 @@ Good runtime responsibilities:
   `packages/toolkit/contracts/`, operator annotation menu filtering/routing,
   and selection evidence helpers that stay app-neutral and consume manifest
   data supplied by activation.
+- dependency-injected Three renderer lifecycle mechanics: bounded sizing,
+  visibility and context-loss suspension, frame scheduling, and disposal of
+  explicitly owned resources.
 
 Keep windowing and product policy out of runtime. A helper here may expose a
 generic capability, but default panel state, chip placement, workbench layout,

--- a/packages/toolkit/runtime/desktop-world-surface-three.js
+++ b/packages/toolkit/runtime/desktop-world-surface-three.js
@@ -43,6 +43,7 @@ export class DesktopWorldSurfaceThree extends DesktopWorldSurfaceAdapter {
     this.camera = null
     this.renderer = null
     this.scene = null
+    this.managesViewport = true
     this._threeHandlers = {}
     this._stateLatencies = []
     this._lastStateReceivedAt = 0
@@ -127,13 +128,17 @@ export class DesktopWorldSurfaceThree extends DesktopWorldSurfaceAdapter {
     }
   }
 
-  mountScene({ scene = null, camera = null, renderer = null } = {}) {
+  mountScene({ scene = null, camera = null, renderer = null, manageViewport = true } = {}) {
+    globalThis.window?.removeEventListener?.('resize', this._resizeHandler)
     this.scene = scene
     this.camera = camera
     this.renderer = renderer
+    this.managesViewport = manageViewport !== false
     this.refreshCamera()
-    this.refreshViewport()
-    globalThis.window?.addEventListener?.('resize', this._resizeHandler)
+    if (this.managesViewport) {
+      this.refreshViewport()
+      globalThis.window?.addEventListener?.('resize', this._resizeHandler)
+    }
   }
 
   refreshCamera(camera = this.camera, segment = this.segment) {

--- a/packages/toolkit/runtime/index.js
+++ b/packages/toolkit/runtime/index.js
@@ -25,6 +25,13 @@ export {
   deriveOrthoCamera,
 } from './desktop-world-surface-three.js'
 export {
+  DEFAULT_THREE_RENDER_LIMITS,
+  createThreeRenderLifecycle,
+  disposeThreeObjectTree,
+  disposeThreeRenderer,
+  resolveThreeRenderMetrics,
+} from './three-render-lifecycle.js'
+export {
   createCanvasOriginInputEvent,
   isCanvasInputEventType,
   normalizeCanvasInputMessage,

--- a/packages/toolkit/runtime/three-render-lifecycle.js
+++ b/packages/toolkit/runtime/three-render-lifecycle.js
@@ -1,0 +1,390 @@
+const DEFAULT_MAX_DEVICE_PIXEL_RATIO = 2
+const DEFAULT_MAX_BACKING_DIMENSION = 4096
+const DEFAULT_MAX_BACKING_PIXELS = 4_194_304
+
+export const DEFAULT_THREE_RENDER_LIMITS = Object.freeze({
+  maxDevicePixelRatio: DEFAULT_MAX_DEVICE_PIXEL_RATIO,
+  maxBackingDimension: DEFAULT_MAX_BACKING_DIMENSION,
+  maxBackingPixels: DEFAULT_MAX_BACKING_PIXELS,
+})
+
+function positiveFinite(value, fallback) {
+  const number = Number(value)
+  return Number.isFinite(number) && number > 0 ? number : fallback
+}
+
+export function resolveThreeRenderMetrics({
+  width,
+  height,
+  devicePixelRatio = 1,
+  maxDevicePixelRatio = DEFAULT_MAX_DEVICE_PIXEL_RATIO,
+  maxBackingDimension = DEFAULT_MAX_BACKING_DIMENSION,
+  maxBackingPixels = DEFAULT_MAX_BACKING_PIXELS,
+} = {}) {
+  const cssWidth = Number(width)
+  const cssHeight = Number(height)
+  if (!Number.isFinite(cssWidth) || cssWidth <= 0) return null
+  if (!Number.isFinite(cssHeight) || cssHeight <= 0) return null
+
+  const requestedDevicePixelRatio = positiveFinite(devicePixelRatio, 1)
+  const devicePixelRatioLimit = positiveFinite(
+    maxDevicePixelRatio,
+    DEFAULT_MAX_DEVICE_PIXEL_RATIO,
+  )
+  const backingDimensionLimit = Math.max(1, Math.floor(positiveFinite(
+    maxBackingDimension,
+    DEFAULT_MAX_BACKING_DIMENSION,
+  )))
+  const backingPixelLimit = Math.max(1, Math.floor(positiveFinite(
+    maxBackingPixels,
+    DEFAULT_MAX_BACKING_PIXELS,
+  )))
+  const cappedDevicePixelRatio = Math.min(requestedDevicePixelRatio, devicePixelRatioLimit)
+  const dimensionScale = Math.min(
+    backingDimensionLimit / cssWidth,
+    backingDimensionLimit / cssHeight,
+  )
+  const pixelScale = Math.sqrt(backingPixelLimit / (cssWidth * cssHeight))
+  const effectiveDevicePixelRatio = Math.min(
+    cappedDevicePixelRatio,
+    dimensionScale,
+    pixelScale,
+  )
+  if (!Number.isFinite(effectiveDevicePixelRatio) || effectiveDevicePixelRatio <= 0) return null
+
+  const backingWidth = Math.max(
+    1,
+    Math.min(backingDimensionLimit, Math.floor(cssWidth * effectiveDevicePixelRatio)),
+  )
+  const backingHeight = Math.max(
+    1,
+    Math.min(backingDimensionLimit, Math.floor(cssHeight * effectiveDevicePixelRatio)),
+  )
+
+  return {
+    cssWidth,
+    cssHeight,
+    requestedDevicePixelRatio,
+    effectiveDevicePixelRatio,
+    backingWidth,
+    backingHeight,
+    backingPixels: backingWidth * backingHeight,
+    constrained: effectiveDevicePixelRatio < requestedDevicePixelRatio,
+    limits: {
+      maxDevicePixelRatio: devicePixelRatioLimit,
+      maxBackingDimension: backingDimensionLimit,
+      maxBackingPixels: backingPixelLimit,
+    },
+  }
+}
+
+function disposeOnce(resource, disposed) {
+  if (!resource || typeof resource.dispose !== 'function' || disposed.has(resource)) return false
+  disposed.add(resource)
+  resource.dispose()
+  return true
+}
+
+function disposeTextureValue(value, disposed, counts, seen) {
+  if (!value || typeof value !== 'object' || seen.has(value)) return
+  seen.add(value)
+  if (value.isTexture === true) {
+    if (disposeOnce(value, disposed)) counts.textures += 1
+    return
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) disposeTextureValue(entry, disposed, counts, seen)
+    return
+  }
+  if ('value' in value) disposeTextureValue(value.value, disposed, counts, seen)
+}
+
+function disposeMaterial(material, disposed, counts) {
+  if (!material || typeof material !== 'object') return
+  const materials = Array.isArray(material) ? material : [material]
+  for (const entry of materials) {
+    if (!entry || typeof entry !== 'object') continue
+    const seen = new Set()
+    for (const value of Object.values(entry)) {
+      disposeTextureValue(value, disposed, counts, seen)
+    }
+    for (const uniform of Object.values(entry.uniforms ?? {})) {
+      disposeTextureValue(uniform, disposed, counts, seen)
+    }
+    if (disposeOnce(entry, disposed)) counts.materials += 1
+  }
+}
+
+function visitObjectTree(root, visitor) {
+  if (!root || typeof root !== 'object') return
+  if (typeof root.traverse === 'function') {
+    root.traverse(visitor)
+    return
+  }
+  const pending = [root]
+  const seen = new Set()
+  while (pending.length > 0) {
+    const object = pending.pop()
+    if (!object || typeof object !== 'object' || seen.has(object)) continue
+    seen.add(object)
+    visitor(object)
+    if (Array.isArray(object.children)) pending.push(...object.children)
+  }
+}
+
+export function disposeThreeObjectTree(root, { clear = true } = {}) {
+  const disposed = new Set()
+  const counts = { objects: 0, geometries: 0, materials: 0, textures: 0 }
+  visitObjectTree(root, (object) => {
+    counts.objects += 1
+    if (disposeOnce(object.geometry, disposed)) counts.geometries += 1
+    disposeMaterial(object.material, disposed, counts)
+    disposeMaterial(object.customDepthMaterial, disposed, counts)
+    disposeMaterial(object.customDistanceMaterial, disposed, counts)
+    disposeTextureValue(object.background, disposed, counts, new Set())
+    disposeTextureValue(object.environment, disposed, counts, new Set())
+    if (object.skeleton?.boneTexture?.isTexture === true) {
+      if (disposeOnce(object.skeleton.boneTexture, disposed)) counts.textures += 1
+    }
+  })
+  if (clear) root?.clear?.()
+  return counts
+}
+
+export function disposeThreeRenderer(renderer, { forceContextLoss = true } = {}) {
+  if (!renderer) return { disposed: false, contextLost: false }
+  renderer.setAnimationLoop?.(null)
+  renderer.renderLists?.dispose?.()
+  renderer.dispose?.()
+  if (forceContextLoss) renderer.forceContextLoss?.()
+  return {
+    disposed: typeof renderer.dispose === 'function',
+    contextLost: forceContextLoss && typeof renderer.forceContextLoss === 'function',
+  }
+}
+
+function measureContainer(container) {
+  const rect = container?.getBoundingClientRect?.()
+  return {
+    width: Number(rect?.width ?? container?.clientWidth),
+    height: Number(rect?.height ?? container?.clientHeight),
+  }
+}
+
+function defaultCameraUpdate(camera, metrics) {
+  if (!camera?.isPerspectiveCamera) return
+  camera.aspect = metrics.cssWidth / metrics.cssHeight
+  camera.updateProjectionMatrix?.()
+}
+
+export function createThreeRenderLifecycle({
+  renderer,
+  scene = null,
+  camera = null,
+  canvas = renderer?.domElement ?? null,
+  container = canvas?.parentElement ?? canvas,
+  document: documentObject = globalThis.document,
+  window: windowObject = globalThis.window,
+  ResizeObserver: ResizeObserverClass = globalThis.ResizeObserver,
+  requestAnimationFrame: requestFrame = windowObject?.requestAnimationFrame?.bind(windowObject),
+  cancelAnimationFrame: cancelFrame = windowObject?.cancelAnimationFrame?.bind(windowObject),
+  measure = () => measureContainer(container),
+  updateCamera = defaultCameraUpdate,
+  onFrame = null,
+  onResize = null,
+  onContextLost = null,
+  onContextRestored = null,
+  onVisibilityChange = null,
+  additionalDisposables = [],
+  limits = {},
+} = {}) {
+  if (!renderer || typeof renderer.setSize !== 'function') {
+    throw new TypeError('Three render lifecycle requires a renderer with setSize().')
+  }
+
+  const frameHandler = typeof onFrame === 'function'
+    ? onFrame
+    : scene && camera && typeof renderer.render === 'function'
+      ? () => renderer.render(scene, camera)
+      : null
+  let started = false
+  let disposed = false
+  let suspended = false
+  let contextLost = false
+  let frameId = null
+  let previousFrameAt = null
+  let metrics = null
+  let observer = null
+  let disposalResult = null
+
+  const documentHidden = () => (
+    documentObject?.hidden === true || documentObject?.visibilityState === 'hidden'
+  )
+
+  const rendererContextLost = () => {
+    try {
+      return renderer.getContext?.().isContextLost?.() === true
+    } catch {
+      return false
+    }
+  }
+
+  const canRender = () => (
+    started && !disposed && !suspended && !contextLost && !documentHidden()
+  )
+
+  const snapshot = () => ({
+    started,
+    disposed,
+    suspended,
+    contextLost,
+    hidden: documentHidden(),
+    frameScheduled: frameId !== null,
+    metrics,
+  })
+
+  const cancelScheduledFrame = () => {
+    if (frameId === null) return
+    cancelFrame?.(frameId)
+    frameId = null
+  }
+
+  const scheduleFrame = () => {
+    if (!frameHandler || !canRender() || frameId !== null || typeof requestFrame !== 'function') return
+    frameId = requestFrame((at) => {
+      frameId = null
+      if (!canRender()) return
+      const deltaMs = previousFrameAt === null ? 0 : Math.max(0, Number(at) - previousFrameAt)
+      previousFrameAt = Number(at)
+      frameHandler({ at: Number(at), deltaMs, metrics, renderer, scene, camera })
+      scheduleFrame()
+    })
+  }
+
+  const resize = () => {
+    if (disposed) return null
+    const measured = measure?.() ?? {}
+    const next = resolveThreeRenderMetrics({
+      width: measured.width,
+      height: measured.height,
+      devicePixelRatio: windowObject?.devicePixelRatio ?? 1,
+      ...limits,
+    })
+    if (!next) return null
+    metrics = next
+    renderer.setPixelRatio?.(next.effectiveDevicePixelRatio)
+    renderer.setSize(next.cssWidth, next.cssHeight, false)
+    updateCamera?.(camera, next)
+    onResize?.(next)
+    return next
+  }
+
+  const handleVisibilityChange = () => {
+    previousFrameAt = null
+    if (documentHidden()) cancelScheduledFrame()
+    else {
+      resize()
+      scheduleFrame()
+    }
+    onVisibilityChange?.(snapshot())
+  }
+
+  const handleContextLost = (event) => {
+    event?.preventDefault?.()
+    contextLost = true
+    previousFrameAt = null
+    cancelScheduledFrame()
+    onContextLost?.(snapshot())
+  }
+
+  const handleContextRestored = () => {
+    contextLost = false
+    if (canRender()) resize()
+    onContextRestored?.(snapshot())
+    scheduleFrame()
+  }
+
+  const handleResize = () => {
+    if (canRender()) resize()
+  }
+
+  const start = () => {
+    if (disposed) throw new Error('Three render lifecycle is disposed.')
+    if (started) return snapshot()
+    started = true
+    contextLost = rendererContextLost()
+    documentObject?.addEventListener?.('visibilitychange', handleVisibilityChange)
+    windowObject?.addEventListener?.('resize', handleResize)
+    canvas?.addEventListener?.('webglcontextlost', handleContextLost)
+    canvas?.addEventListener?.('webglcontextrestored', handleContextRestored)
+    if (typeof ResizeObserverClass === 'function' && container) {
+      observer = new ResizeObserverClass(handleResize)
+      observer.observe(container)
+    }
+    if (!suspended && !documentHidden() && !contextLost) resize()
+    scheduleFrame()
+    return snapshot()
+  }
+
+  const stop = () => {
+    if (!started) return snapshot()
+    started = false
+    previousFrameAt = null
+    cancelScheduledFrame()
+    observer?.disconnect?.()
+    observer = null
+    documentObject?.removeEventListener?.('visibilitychange', handleVisibilityChange)
+    windowObject?.removeEventListener?.('resize', handleResize)
+    canvas?.removeEventListener?.('webglcontextlost', handleContextLost)
+    canvas?.removeEventListener?.('webglcontextrestored', handleContextRestored)
+    return snapshot()
+  }
+
+  const suspend = () => {
+    suspended = true
+    previousFrameAt = null
+    cancelScheduledFrame()
+    return snapshot()
+  }
+
+  const resume = () => {
+    if (disposed) throw new Error('Three render lifecycle is disposed.')
+    suspended = false
+    if (!documentHidden() && !contextLost) resize()
+    scheduleFrame()
+    return snapshot()
+  }
+
+  const dispose = ({ forceContextLoss = true } = {}) => {
+    if (disposalResult) return disposalResult
+    stop()
+    disposed = true
+    const sceneResources = disposeThreeObjectTree(scene)
+    let additionalResources = 0
+    const disposedAdditionalResources = new Set()
+    for (const resource of additionalDisposables) {
+      if (
+        resource
+        && typeof resource.dispose === 'function'
+        && !disposedAdditionalResources.has(resource)
+      ) {
+        disposedAdditionalResources.add(resource)
+        resource.dispose()
+        additionalResources += 1
+      }
+    }
+    const rendererResult = disposeThreeRenderer(renderer, { forceContextLoss })
+    disposalResult = { sceneResources, additionalResources, renderer: rendererResult }
+    return disposalResult
+  }
+
+  return {
+    start,
+    stop,
+    resize,
+    suspend,
+    resume,
+    snapshot,
+    dispose,
+  }
+}

--- a/packages/toolkit/scene/AGENTS.md
+++ b/packages/toolkit/scene/AGENTS.md
@@ -1,0 +1,34 @@
+@../../../AGENTS.md
+@../AGENTS.md
+
+# Scene Toolkit
+
+## Purpose
+
+`scene/` is the narrow package facade for product-neutral scene authoring. It
+exposes the DesktopWorld Three adapter, bounded Three renderer lifecycle,
+canvas lifecycle projections, and visual-object editing contracts needed by
+external consumers.
+
+## Ownership
+
+- Runtime implementations remain owned by `runtime/`.
+- Visual-object implementations remain owned by `workbench/`.
+- This folder owns only the reviewed external package surface and its types.
+- Product representation, scene state, materials, animation policy, and editor
+  UX remain in the consuming product.
+
+## Local Contracts
+
+- Export named, dependency-injected primitives only. Do not bundle Three.js or
+  expose private toolkit indexes through this facade.
+- Keep `index.js`, `index.d.ts`, `package.json` exports, tests, and
+  `docs/api/toolkit/scene.md` synchronized.
+- Renderer disposal applies only to resources the consumer explicitly gives
+  the lifecycle; shared resource ownership remains with the consumer.
+
+## Verification
+
+- `node --test tests/toolkit/desktop-world-surface-three.test.mjs tests/toolkit/scene-public-contract.test.mjs tests/toolkit/three-render-lifecycle.test.mjs tests/toolkit/toolkit-api-docs-contract.test.mjs`
+
+## Child DOX Index

--- a/packages/toolkit/scene/index.d.ts
+++ b/packages/toolkit/scene/index.d.ts
@@ -1,0 +1,323 @@
+export interface ThreeRenderLimits {
+  maxDevicePixelRatio: number;
+  maxBackingDimension: number;
+  maxBackingPixels: number;
+}
+
+export interface ThreeRenderMetrics {
+  cssWidth: number;
+  cssHeight: number;
+  requestedDevicePixelRatio: number;
+  effectiveDevicePixelRatio: number;
+  backingWidth: number;
+  backingHeight: number;
+  backingPixels: number;
+  constrained: boolean;
+  limits: ThreeRenderLimits;
+}
+
+export interface DisposableResource {
+  dispose(): void;
+}
+
+export interface ThreeRendererLike {
+  domElement?: EventTarget & { parentElement?: Element | null };
+  render?(scene: unknown, camera: unknown): void;
+  getContext?(): { isContextLost?(): boolean };
+  setAnimationLoop?(callback: null): void;
+  setPixelRatio?(ratio: number): void;
+  setSize(width: number, height: number, updateStyle?: boolean): void;
+  renderLists?: { dispose?(): void };
+  dispose?(): void;
+  forceContextLoss?(): void;
+}
+
+export interface ThreeCameraLike {
+  isPerspectiveCamera?: boolean;
+  aspect?: number;
+  updateProjectionMatrix?(): void;
+  [key: string]: unknown;
+}
+
+export interface ThreeRenderLifecycleSnapshot {
+  started: boolean;
+  disposed: boolean;
+  suspended: boolean;
+  contextLost: boolean;
+  hidden: boolean;
+  frameScheduled: boolean;
+  metrics: ThreeRenderMetrics | null;
+}
+
+export interface ThreeObjectDisposalSummary {
+  objects: number;
+  geometries: number;
+  materials: number;
+  textures: number;
+}
+
+export interface ThreeRendererDisposalSummary {
+  disposed: boolean;
+  contextLost: boolean;
+}
+
+export interface ThreeRenderDisposalSummary {
+  sceneResources: ThreeObjectDisposalSummary;
+  additionalResources: number;
+  renderer: ThreeRendererDisposalSummary;
+}
+
+export interface ThreeRenderFrame {
+  at: number;
+  deltaMs: number;
+  metrics: ThreeRenderMetrics | null;
+  renderer: ThreeRendererLike;
+  scene: unknown;
+  camera: ThreeCameraLike | null;
+}
+
+export interface ThreeRenderLifecycleOptions {
+  renderer: ThreeRendererLike;
+  scene?: unknown;
+  camera?: ThreeCameraLike | null;
+  canvas?: EventTarget | null;
+  container?: Element | null;
+  document?: Document;
+  window?: Window;
+  ResizeObserver?: typeof ResizeObserver;
+  requestAnimationFrame?: (callback: FrameRequestCallback) => number;
+  cancelAnimationFrame?: (handle: number) => void;
+  measure?: () => { width?: number; height?: number };
+  updateCamera?: (camera: ThreeCameraLike | null, metrics: ThreeRenderMetrics) => void;
+  onFrame?: (frame: ThreeRenderFrame) => void;
+  onResize?: (metrics: ThreeRenderMetrics) => void;
+  onContextLost?: (snapshot: ThreeRenderLifecycleSnapshot) => void;
+  onContextRestored?: (snapshot: ThreeRenderLifecycleSnapshot) => void;
+  onVisibilityChange?: (snapshot: ThreeRenderLifecycleSnapshot) => void;
+  additionalDisposables?: readonly DisposableResource[];
+  limits?: Partial<ThreeRenderLimits>;
+}
+
+export interface ThreeRenderLifecycle {
+  start(): ThreeRenderLifecycleSnapshot;
+  stop(): ThreeRenderLifecycleSnapshot;
+  resize(): ThreeRenderMetrics | null;
+  suspend(): ThreeRenderLifecycleSnapshot;
+  resume(): ThreeRenderLifecycleSnapshot;
+  snapshot(): ThreeRenderLifecycleSnapshot;
+  dispose(options?: { forceContextLoss?: boolean }): ThreeRenderDisposalSummary;
+}
+
+export const DEFAULT_THREE_RENDER_LIMITS: Readonly<ThreeRenderLimits>;
+
+export function resolveThreeRenderMetrics(input?: Partial<ThreeRenderLimits> & {
+  width?: number;
+  height?: number;
+  devicePixelRatio?: number;
+}): ThreeRenderMetrics | null;
+
+export function disposeThreeObjectTree(
+  root: unknown,
+  options?: { clear?: boolean },
+): ThreeObjectDisposalSummary;
+
+export function disposeThreeRenderer(
+  renderer: ThreeRendererLike | null,
+  options?: { forceContextLoss?: boolean },
+): ThreeRendererDisposalSummary;
+
+export function createThreeRenderLifecycle(
+  options: ThreeRenderLifecycleOptions,
+): ThreeRenderLifecycle;
+
+export interface DesktopWorldSegment {
+  display_id?: string | number;
+  dw_bounds?: readonly number[];
+  dwBounds?: readonly number[];
+  [key: string]: unknown;
+}
+
+export interface OrthoCameraProjection {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  near: number;
+  far: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export function deriveOrthoCamera(
+  segmentOrBounds: DesktopWorldSegment | readonly number[],
+  options?: { near?: number; far?: number },
+): OrthoCameraProjection;
+
+export class DesktopWorldSurfaceThree {
+  constructor(options?: Record<string, unknown>);
+  channelName: string;
+  camera: ThreeCameraLike | null;
+  renderer: ThreeRendererLike | null;
+  scene: unknown;
+  segment?: DesktopWorldSegment | null;
+  isPrimary?: boolean;
+  start(handlers?: Record<string, (...args: readonly unknown[]) => unknown>): Promise<unknown>;
+  stop(): void;
+  publishState(state: unknown): boolean;
+  stateLatencySnapshot(): {
+    samples: number;
+    median_ms: number | null;
+    p95_ms: number | null;
+    last_receive_age_ms: number | null;
+  };
+  mountScene(input?: {
+    scene?: unknown;
+    camera?: ThreeCameraLike | null;
+    renderer?: ThreeRendererLike | null;
+    manageViewport?: boolean;
+  }): void;
+  refreshCamera(
+    camera?: ThreeCameraLike | null,
+    segment?: DesktopWorldSegment | null,
+  ): OrthoCameraProjection | { type: 'perspective'; aspect: number; width: number | null; height: number | null } | null;
+  refreshViewport(): void;
+}
+
+export const DesktopWorldSurface3D: typeof DesktopWorldSurfaceThree;
+
+export interface CanvasLifecycleProjection {
+  id: string;
+  at: unknown;
+  parent: unknown;
+  track: unknown;
+  interactive: boolean;
+  scope: unknown;
+  ttl: unknown;
+  cascade: unknown;
+  suspended: unknown;
+  lifecycle_state: unknown;
+  [key: string]: unknown;
+}
+
+export interface CanvasGeometryProjection {
+  canvas_id: string;
+  change: string;
+  cause: string;
+  phase: string;
+  transaction_id: unknown;
+  frame: readonly unknown[];
+  previous_frame: readonly unknown[] | null;
+  canvas: Record<string, unknown> | null;
+}
+
+export function canvasLifecycleCanvasID(data: unknown): string | null;
+export function mergeCanvasLifecycleCanvas(
+  existing: Record<string, unknown> | null,
+  data: unknown,
+): CanvasLifecycleProjection | null;
+export function canvasGeometryCanvasID(data: unknown): string | null;
+export function normalizeCanvasGeometry(data?: unknown): CanvasGeometryProjection | null;
+export function mergeCanvasGeometryCanvas(
+  existing: Record<string, unknown> | null,
+  data: unknown,
+): CanvasLifecycleProjection | null;
+
+export type VisualObjectTechnology = 'threejs-3d' | 'canvas-2d' | 'dom-toolkit';
+export type VisualObjectProjectionClassification = 'editable' | 'projection_only';
+
+export interface VisualObjectDescriptor {
+  contract: string;
+  id: string;
+  label: string;
+  kind: string;
+  technology: string;
+  state_path: string | null;
+  route: string | null;
+  coerce: string | null;
+  renderer_sync: string[];
+  group_key: string | null;
+  object_ids: string[];
+  projection: {
+    classification: VisualObjectProjectionClassification;
+    reason: string | null;
+  };
+  range?: { min?: unknown; max?: unknown; step?: unknown };
+  options?: Array<Record<string, unknown>>;
+  [key: string]: unknown;
+}
+
+export interface VisualObjectValidationError {
+  code: string;
+  field: string;
+  message: string;
+}
+
+export interface VisualObjectValidationResult {
+  ok: boolean;
+  errors: VisualObjectValidationError[];
+}
+
+export const VISUAL_OBJECT_DESCRIPTOR_CONTRACT_ID: string;
+export const VISUAL_OBJECT_SUPPORTED_TECHNOLOGIES: readonly VisualObjectTechnology[];
+export const VISUAL_OBJECT_PROJECTION_REASONS: readonly string[];
+
+export function createVisualObjectDescriptor(
+  source?: Record<string, unknown>,
+): VisualObjectDescriptor;
+export function visualObjectDescriptorRequiredFields(
+  descriptor?: Partial<VisualObjectDescriptor>,
+): readonly string[];
+export function validateVisualObjectDescriptor(
+  descriptor?: Partial<VisualObjectDescriptor>,
+): VisualObjectValidationResult;
+export function validateVisualObjectDescriptors(
+  descriptors?: readonly Partial<VisualObjectDescriptor>[],
+): {
+  ok: boolean;
+  results: Array<VisualObjectValidationResult & { id: string | null }>;
+  errors: Array<VisualObjectValidationError & { id: string | null }>;
+};
+export function coerceVisualObjectDescriptorValue(
+  descriptor: Partial<VisualObjectDescriptor>,
+  value: unknown,
+): unknown;
+export function applyVisualObjectDescriptorMutation(
+  state: Record<string, unknown>,
+  descriptor: VisualObjectDescriptor,
+  value: unknown,
+  options?: { validate?: boolean },
+): Record<string, unknown>;
+export function applyVisualObjectControllerUpdate(
+  descriptor: VisualObjectDescriptor,
+  value: unknown,
+  state?: Record<string, unknown>,
+  options?: {
+    routeHandlers?: Record<string, (context: unknown) => unknown> | Map<string, (context: unknown) => unknown>;
+    rendererSyncHandlers?: Record<string, (context: unknown) => unknown> | Map<string, (context: unknown) => unknown>;
+    validate?: boolean;
+  },
+): Record<string, unknown>;
+
+export function findVisualObjectFormDescriptor(
+  change: Record<string, unknown>,
+  descriptors?: readonly VisualObjectDescriptor[],
+): VisualObjectDescriptor | null;
+export function applyVisualObjectFormFieldChange(
+  change: Record<string, unknown>,
+  options?: Record<string, unknown>,
+): Record<string, unknown>;
+export function bindVisualObjectForm(
+  form: Record<string, unknown>,
+  options?: Record<string, unknown>,
+): unknown;
+
+export const VISUAL_OBJECT_RESOURCE_LIFECYCLE_CONTRACT_ID: string;
+export const VISUAL_OBJECT_RESOURCE_LIFECYCLE_TERMS: readonly string[];
+export function createVisualObjectResourceLifecycleEvidence(
+  input?: Record<string, unknown>,
+): Record<string, unknown>;
+export function validateVisualObjectResourceLifecycleEvidence(
+  evidence?: Record<string, unknown>,
+): { ok: boolean; errors: Array<{ code: string; field: string }> };

--- a/packages/toolkit/scene/index.js
+++ b/packages/toolkit/scene/index.js
@@ -1,0 +1,48 @@
+export {
+  DesktopWorldSurface3D,
+  DesktopWorldSurfaceThree,
+  deriveOrthoCamera,
+} from '../runtime/desktop-world-surface-three.js'
+
+export {
+  canvasGeometryCanvasID,
+  canvasLifecycleCanvasID,
+  mergeCanvasGeometryCanvas,
+  mergeCanvasLifecycleCanvas,
+  normalizeCanvasGeometry,
+} from '../runtime/canvas-lifecycle.js'
+
+export {
+  DEFAULT_THREE_RENDER_LIMITS,
+  createThreeRenderLifecycle,
+  disposeThreeObjectTree,
+  disposeThreeRenderer,
+  resolveThreeRenderMetrics,
+} from '../runtime/three-render-lifecycle.js'
+
+export {
+  VISUAL_OBJECT_DESCRIPTOR_CONTRACT_ID,
+  VISUAL_OBJECT_PROJECTION_REASONS,
+  VISUAL_OBJECT_SUPPORTED_TECHNOLOGIES,
+  applyVisualObjectDescriptorMutation,
+  coerceVisualObjectDescriptorValue,
+  createVisualObjectDescriptor,
+  validateVisualObjectDescriptor,
+  validateVisualObjectDescriptors,
+  visualObjectDescriptorRequiredFields,
+} from '../workbench/visual-object-contract.js'
+
+export { applyVisualObjectControllerUpdate } from '../workbench/visual-object-controller.js'
+
+export {
+  applyVisualObjectFormFieldChange,
+  bindVisualObjectForm,
+  findVisualObjectFormDescriptor,
+} from '../workbench/visual-object-form-binding.js'
+
+export {
+  VISUAL_OBJECT_RESOURCE_LIFECYCLE_CONTRACT_ID,
+  VISUAL_OBJECT_RESOURCE_LIFECYCLE_TERMS,
+  createVisualObjectResourceLifecycleEvidence,
+  validateVisualObjectResourceLifecycleEvidence,
+} from '../workbench/visual-object-resource-lifecycle.js'

--- a/tests/toolkit/desktop-world-surface-three.test.mjs
+++ b/tests/toolkit/desktop-world-surface-three.test.mjs
@@ -58,3 +58,31 @@ test('refreshCamera updates perspective cameras without applying orthographic bo
     globalThis.window = priorWindow
   }
 })
+
+test('mountScene can delegate viewport ownership to a bounded external lifecycle', () => {
+  const priorWindow = globalThis.window
+  const listeners = []
+  const removedListeners = []
+  globalThis.window = {
+    innerWidth: 1200,
+    innerHeight: 800,
+    addEventListener: (...args) => listeners.push(args),
+    removeEventListener: (...args) => removedListeners.push(args),
+  }
+  try {
+    const adapter = new DesktopWorldSurfaceThree({ canvasId: 'consumer-stage' })
+    adapter.segment = { dw_bounds: [0, 0, 1200, 800] }
+    const renderer = {
+      sizes: [],
+      setSize(...args) { this.sizes.push(args) },
+    }
+    adapter.mountScene({ renderer, manageViewport: false })
+
+    assert.equal(adapter.managesViewport, false)
+    assert.deepEqual(renderer.sizes, [])
+    assert.deepEqual(listeners, [])
+    assert.equal(removedListeners.length, 1)
+  } finally {
+    globalThis.window = priorWindow
+  }
+})

--- a/tests/toolkit/scene-public-contract.test.mjs
+++ b/tests/toolkit/scene-public-contract.test.mjs
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+import * as sceneToolkit from '../../packages/toolkit/scene/index.js'
+
+const EXPECTED_EXPORTS = [
+  'DEFAULT_THREE_RENDER_LIMITS',
+  'DesktopWorldSurface3D',
+  'DesktopWorldSurfaceThree',
+  'VISUAL_OBJECT_DESCRIPTOR_CONTRACT_ID',
+  'VISUAL_OBJECT_PROJECTION_REASONS',
+  'VISUAL_OBJECT_RESOURCE_LIFECYCLE_CONTRACT_ID',
+  'VISUAL_OBJECT_RESOURCE_LIFECYCLE_TERMS',
+  'VISUAL_OBJECT_SUPPORTED_TECHNOLOGIES',
+  'applyVisualObjectControllerUpdate',
+  'applyVisualObjectDescriptorMutation',
+  'applyVisualObjectFormFieldChange',
+  'bindVisualObjectForm',
+  'canvasGeometryCanvasID',
+  'canvasLifecycleCanvasID',
+  'coerceVisualObjectDescriptorValue',
+  'createThreeRenderLifecycle',
+  'createVisualObjectDescriptor',
+  'createVisualObjectResourceLifecycleEvidence',
+  'deriveOrthoCamera',
+  'disposeThreeObjectTree',
+  'disposeThreeRenderer',
+  'findVisualObjectFormDescriptor',
+  'mergeCanvasGeometryCanvas',
+  'mergeCanvasLifecycleCanvas',
+  'normalizeCanvasGeometry',
+  'resolveThreeRenderMetrics',
+  'validateVisualObjectDescriptor',
+  'validateVisualObjectDescriptors',
+  'validateVisualObjectResourceLifecycleEvidence',
+  'visualObjectDescriptorRequiredFields',
+].sort()
+
+test('scene package facade exposes only the reviewed scene-authoring contract', async () => {
+  assert.deepEqual(Object.keys(sceneToolkit).sort(), EXPECTED_EXPORTS)
+  const packageJson = JSON.parse(await readFile(
+    new URL('../../packages/toolkit/package.json', import.meta.url),
+    'utf8',
+  ))
+  assert.deepEqual(packageJson.exports, {
+    './scene': {
+      types: './scene/index.d.ts',
+      import: './scene/index.js',
+      default: './scene/index.js',
+    },
+  })
+})
+
+test('scene facade drives descriptor, form, and renderer synchronization without product policy', () => {
+  const descriptor = sceneToolkit.createVisualObjectDescriptor({
+    id: 'shape.scale',
+    label: 'Scale',
+    kind: 'slider',
+    technology: 'threejs-3d',
+    state_path: 'shape.scale',
+    route: 'scene.shape.patch',
+    coerce: 'number',
+    min: 0.25,
+    max: 4,
+    step: 0.05,
+    renderer_sync: ['syncShapeScale'],
+    group_key: 'shape',
+    object_ids: ['shape-root'],
+    projection: { classification: 'editable', reason: null },
+  })
+  assert.equal(sceneToolkit.validateVisualObjectDescriptor(descriptor).ok, true)
+
+  const state = { shape: { scale: 1 } }
+  const calls = []
+  let listener = null
+  const unsubscribe = sceneToolkit.bindVisualObjectForm({
+    onFieldChange(callback) {
+      listener = callback
+      return () => { listener = null }
+    },
+  }, {
+    descriptors: [descriptor],
+    state,
+    routeHandlers: {
+      'scene.shape.patch': ({ mutation }) => calls.push(['route', mutation.value]),
+    },
+    rendererSyncHandlers: {
+      syncShapeScale: ({ mutation }) => calls.push(['render', mutation.value]),
+    },
+  })
+
+  const result = listener({ descriptor_id: descriptor.id, value: '1.75' })
+  assert.equal(state.shape.scale, 1.75)
+  assert.equal(result.update.route_outcome.status, 'called')
+  assert.deepEqual(calls, [['route', 1.75], ['render', 1.75]])
+  unsubscribe()
+  assert.equal(listener, null)
+})
+
+test('scene facade retains canvas lifecycle normalization and bounded render metrics', () => {
+  const canvas = sceneToolkit.mergeCanvasLifecycleCanvas(null, {
+    canvas_id: 'consumer-stage',
+    at: [10, 20, 800, 600],
+    scope: 'connection',
+  })
+  assert.equal(canvas.id, 'consumer-stage')
+  assert.deepEqual(canvas.at, [10, 20, 800, 600])
+
+  const metrics = sceneToolkit.resolveThreeRenderMetrics({
+    width: 1800,
+    height: 1200,
+    devicePixelRatio: 4,
+  })
+  assert.ok(metrics.effectiveDevicePixelRatio <= 2)
+  assert.ok(metrics.backingPixels <= metrics.limits.maxBackingPixels)
+})

--- a/tests/toolkit/three-render-lifecycle.test.mjs
+++ b/tests/toolkit/three-render-lifecycle.test.mjs
@@ -1,0 +1,243 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  createThreeRenderLifecycle,
+  disposeThreeObjectTree,
+  resolveThreeRenderMetrics,
+} from '../../packages/toolkit/runtime/three-render-lifecycle.js'
+
+class FakeEventTarget {
+  constructor() {
+    this.listeners = new Map()
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? new Set()
+    listeners.add(listener)
+    this.listeners.set(type, listeners)
+  }
+
+  removeEventListener(type, listener) {
+    this.listeners.get(type)?.delete(listener)
+  }
+
+  emit(type, event = {}) {
+    for (const listener of this.listeners.get(type) ?? []) listener(event)
+  }
+}
+
+test('resolveThreeRenderMetrics caps DPR, dimensions, pixels, and invalid measurements', () => {
+  assert.deepEqual(resolveThreeRenderMetrics({ width: 0, height: 400 }), null)
+  assert.deepEqual(resolveThreeRenderMetrics({ width: 400, height: Number.NaN }), null)
+
+  const normal = resolveThreeRenderMetrics({
+    width: 800,
+    height: 600,
+    devicePixelRatio: 3,
+  })
+  assert.equal(normal.effectiveDevicePixelRatio, 2)
+  assert.equal(normal.backingWidth, 1600)
+  assert.equal(normal.backingHeight, 1200)
+  assert.equal(normal.constrained, true)
+
+  const bounded = resolveThreeRenderMetrics({
+    width: 3000,
+    height: 3000,
+    devicePixelRatio: 2,
+  })
+  assert.ok(bounded.effectiveDevicePixelRatio < 1)
+  assert.ok(bounded.backingWidth <= 4096)
+  assert.ok(bounded.backingHeight <= 4096)
+  assert.ok(bounded.backingPixels <= 4_194_304)
+})
+
+test('createThreeRenderLifecycle owns resize, visibility, context, and frame suspension', () => {
+  const canvas = new FakeEventTarget()
+  const documentObject = new FakeEventTarget()
+  documentObject.hidden = false
+  documentObject.visibilityState = 'visible'
+  const windowObject = new FakeEventTarget()
+  windowObject.devicePixelRatio = 3
+  const container = { width: 400, height: 300 }
+  const resizeObservers = []
+  class FakeResizeObserver {
+    constructor(callback) {
+      this.callback = callback
+      this.observed = null
+      this.disconnected = false
+      resizeObservers.push(this)
+    }
+
+    observe(target) {
+      this.observed = target
+    }
+
+    disconnect() {
+      this.disconnected = true
+    }
+  }
+  let nextFrameId = 1
+  const frameCallbacks = new Map()
+  const canceledFrames = []
+  const requestAnimationFrame = (callback) => {
+    const id = nextFrameId
+    nextFrameId += 1
+    frameCallbacks.set(id, callback)
+    return id
+  }
+  const cancelAnimationFrame = (id) => {
+    canceledFrames.push(id)
+    frameCallbacks.delete(id)
+  }
+  const renderer = {
+    pixelRatios: [],
+    sizes: [],
+    getContext: () => ({ isContextLost: () => false }),
+    setPixelRatio(value) { this.pixelRatios.push(value) },
+    setSize(...value) { this.sizes.push(value) },
+  }
+  const camera = {
+    isPerspectiveCamera: true,
+    aspect: 0,
+    projectionUpdates: 0,
+    updateProjectionMatrix() { this.projectionUpdates += 1 },
+  }
+  const frames = []
+  const lost = []
+  const restored = []
+  const lifecycle = createThreeRenderLifecycle({
+    renderer,
+    camera,
+    canvas,
+    container,
+    document: documentObject,
+    window: windowObject,
+    ResizeObserver: FakeResizeObserver,
+    requestAnimationFrame,
+    cancelAnimationFrame,
+    measure: () => ({ width: container.width, height: container.height }),
+    onFrame: (frame) => frames.push(frame),
+    onContextLost: (snapshot) => lost.push(snapshot),
+    onContextRestored: (snapshot) => restored.push(snapshot),
+  })
+
+  const started = lifecycle.start()
+  assert.equal(started.started, true)
+  assert.equal(started.frameScheduled, true)
+  assert.deepEqual(renderer.sizes.at(-1), [400, 300, false])
+  assert.equal(renderer.pixelRatios.at(-1), 2)
+  assert.equal(camera.aspect, 4 / 3)
+  assert.equal(resizeObservers[0].observed, container)
+
+  const firstFrameId = lifecycle.snapshot().frameScheduled && [...frameCallbacks.keys()][0]
+  const firstFrame = frameCallbacks.get(firstFrameId)
+  frameCallbacks.delete(firstFrameId)
+  firstFrame(100)
+  assert.equal(frames.length, 1)
+  assert.equal(frames[0].deltaMs, 0)
+  assert.equal(lifecycle.snapshot().frameScheduled, true)
+
+  documentObject.hidden = true
+  documentObject.visibilityState = 'hidden'
+  documentObject.emit('visibilitychange')
+  assert.equal(lifecycle.snapshot().hidden, true)
+  assert.equal(lifecycle.snapshot().frameScheduled, false)
+  assert.ok(canceledFrames.length >= 1)
+
+  container.width = 900
+  container.height = 500
+  resizeObservers[0].callback()
+  assert.deepEqual(renderer.sizes.at(-1), [400, 300, false])
+
+  documentObject.hidden = false
+  documentObject.visibilityState = 'visible'
+  documentObject.emit('visibilitychange')
+  assert.deepEqual(renderer.sizes.at(-1), [900, 500, false])
+  assert.equal(lifecycle.snapshot().frameScheduled, true)
+
+  let prevented = false
+  canvas.emit('webglcontextlost', { preventDefault: () => { prevented = true } })
+  assert.equal(prevented, true)
+  assert.equal(lifecycle.snapshot().contextLost, true)
+  assert.equal(lifecycle.snapshot().frameScheduled, false)
+  assert.equal(lost.length, 1)
+
+  container.width = 640
+  container.height = 360
+  canvas.emit('webglcontextrestored')
+  assert.equal(lifecycle.snapshot().contextLost, false)
+  assert.deepEqual(renderer.sizes.at(-1), [640, 360, false])
+  assert.equal(restored.length, 1)
+  assert.equal(lifecycle.snapshot().frameScheduled, true)
+
+  lifecycle.suspend()
+  assert.equal(lifecycle.snapshot().suspended, true)
+  assert.equal(lifecycle.snapshot().frameScheduled, false)
+  lifecycle.resume()
+  assert.equal(lifecycle.snapshot().suspended, false)
+  assert.equal(lifecycle.snapshot().frameScheduled, true)
+
+  resizeObservers[0].callback()
+  assert.deepEqual(renderer.sizes.at(-1), [640, 360, false])
+  lifecycle.stop()
+  assert.equal(lifecycle.snapshot().started, false)
+  assert.equal(resizeObservers[0].disconnected, true)
+  assert.equal(documentObject.listeners.get('visibilitychange').size, 0)
+  assert.equal(canvas.listeners.get('webglcontextlost').size, 0)
+})
+
+test('Three disposal releases owned resources exactly once and is idempotent', () => {
+  const calls = { texture: 0, geometry: 0, material: 0, clear: 0 }
+  const texture = { isTexture: true, dispose: () => { calls.texture += 1 } }
+  const uniformTexture = { isTexture: true, dispose: () => { calls.texture += 1 } }
+  const geometry = { dispose: () => { calls.geometry += 1 } }
+  const material = {
+    map: texture,
+    uniforms: { shared: { value: uniformTexture } },
+    dispose: () => { calls.material += 1 },
+  }
+  const child = { geometry, material, children: [] }
+  const scene = {
+    children: [child, { geometry, material, children: [] }],
+    clear: () => { calls.clear += 1 },
+  }
+
+  assert.deepEqual(disposeThreeObjectTree(scene), {
+    objects: 3,
+    geometries: 1,
+    materials: 1,
+    textures: 2,
+  })
+  assert.deepEqual(calls, { texture: 2, geometry: 1, material: 1, clear: 1 })
+
+  const canvas = new FakeEventTarget()
+  const rendererCalls = { dispose: 0, force: 0, lists: 0, additional: 0 }
+  const renderer = {
+    domElement: canvas,
+    setSize() {},
+    setAnimationLoop(value) { assert.equal(value, null) },
+    renderLists: { dispose: () => { rendererCalls.lists += 1 } },
+    dispose: () => { rendererCalls.dispose += 1 },
+    forceContextLoss: () => { rendererCalls.force += 1 },
+  }
+  const lifecycle = createThreeRenderLifecycle({
+    renderer,
+    canvas,
+    container: { getBoundingClientRect: () => ({ width: 100, height: 100 }) },
+    document: new FakeEventTarget(),
+    window: new FakeEventTarget(),
+    ResizeObserver: null,
+    additionalDisposables: (() => {
+      const resource = { dispose: () => { rendererCalls.additional += 1 } }
+      return [resource, resource]
+    })(),
+  })
+  lifecycle.start()
+  const first = lifecycle.dispose()
+  const second = lifecycle.dispose()
+  assert.equal(first, second)
+  assert.deepEqual(rendererCalls, { dispose: 1, force: 1, lists: 1, additional: 1 })
+  assert.throws(() => lifecycle.start(), /disposed/)
+  assert.throws(() => lifecycle.resume(), /disposed/)
+})

--- a/tests/toolkit/toolkit-api-docs-contract.test.mjs
+++ b/tests/toolkit/toolkit-api-docs-contract.test.mjs
@@ -18,6 +18,7 @@ function lineCount(doc) {
 
 const scopedFiles = [
   'docs/api/toolkit/runtime.md',
+  'docs/api/toolkit/scene.md',
   'docs/api/toolkit/controls.md',
   'docs/api/toolkit/panel-window.md',
   'docs/api/toolkit/workbench.md',
@@ -44,6 +45,7 @@ test('toolkit API index is an overview with links to scoped references', async (
     'mountChrome',
     'controls API',
     'DesktopWorld stage/surface runtime',
+    'external Three scene authoring',
     'input regions/events',
     'workbench contracts',
     'Surface Inspector and Surface-Zoom Inspector',
@@ -62,6 +64,13 @@ test('toolkit scoped API files exist and own expected stable terms', async () =>
   assert.match(docs['docs/api/toolkit/runtime.md'], /registerInputRegion/);
   assert.match(docs['docs/api/toolkit/runtime.md'], /input_region\.event/);
   assert.match(docs['docs/api/toolkit/runtime.md'], /subscribe\(events, options\?\)/);
+
+  assert.match(docs['docs/api/toolkit/scene.md'], /@agent-os\/toolkit\/scene/);
+  assert.match(docs['docs/api/toolkit/scene.md'], /createThreeRenderLifecycle/);
+  assert.match(docs['docs/api/toolkit/scene.md'], /DesktopWorldSurfaceThree/);
+  assert.match(docs['docs/api/toolkit/scene.md'], /createVisualObjectDescriptor/);
+  assert.match(docs['docs/api/toolkit/scene.md'], /bindVisualObjectForm/);
+  assert.match(docs['docs/api/toolkit/scene.md'], /grants no AOS command execution/);
 
   assert.match(docs['docs/api/toolkit/controls.md'], /createButton/);
   assert.match(docs['docs/api/toolkit/controls.md'], /createButtonGroup/);


### PR DESCRIPTION
## Summary

- add the narrow `@agent-os/toolkit/scene` package export with strict TypeScript declarations
- expose only the product-neutral DesktopWorld Three adapter, canvas lifecycle projections, visual-object descriptors/form bindings, and resource-lifecycle evidence helpers
- add a dependency-injected Three lifecycle with bounded DPR/backing pixels, hidden and context-loss suspension, sole resize ownership, and idempotent GPU/resource disposal
- document and register the external consumer contract without restoring embedded product policy

## Validation

- focused scene/toolkit/docs contract: 16/16
- static toolkit suite excluding binary-spawning `work-record*` tests: 1,083 passed, 3 skipped
- workflow/proof schemas: 30/30
- proof registry final rerun: 20/20
- strict TypeScript declaration check: passed
- Node package self-reference resolved `@agent-os/toolkit/scene` with exactly 30 exports
- static-only dev workflow router: passed
- dev drift lint: passed
- proof-worth routing: passed for all five changed proof assets
- `git diff --check`: passed

A broad `node --test tests/toolkit/*.test.mjs` attempt completed 1,251 tests with 3 skips and 24 failures. Every failure was an existing Work Record CLI test whose `./aos` subprocess returned `exit=null`; none touched this scene contract. The run was not repeated. `help-contract`, `dev-audit`, `dev-situation`, live canvas checks, and all runtime acceptance were intentionally deferred because they invoke the raw AOS binary.

No AOS build, daemon operation, TCC action, native input, packaging, or Sigil source change was performed.
