### PR TITLE
Retire stale embedded Sigil content root

### DIFF
--- a/docs/dev/test-proof-registry.d/legacy-sigil-fixture.json
+++ b/docs/dev/test-proof-registry.d/legacy-sigil-fixture.json
@@ -25,6 +25,24 @@
       ],
       "guard": "static files and Node scripts only; no AOS binary, daemon, canvas, native input, or TCC",
       "status": "active"
+    },
+    {
+      "id": "legacy-sigil-content-root-retirement",
+      "path_patterns": [
+        "tests/legacy-sigil-content-root-retirement.test.mjs"
+      ],
+      "fixture_patterns": [],
+      "owner": "legacy-config-retirement",
+      "harness_level": "model_unit",
+      "proof_kind": "legacy_content_root_retirement",
+      "contract": "AOS retires only the historical Sigil content root that resolves to the frozen apps/sigil fixture and preserves every external or user-defined content root.",
+      "worth": "This prevents the frozen product fixture from remaining servable after authority moved to the external Sigil repository without broad or heuristic config deletion.",
+      "command": "node --test tests/legacy-sigil-content-root-retirement.test.mjs",
+      "replaces": [
+        "manual removal of the stale embedded Sigil content root"
+      ],
+      "guard": "disposable pure Swift helper compile only; no AOS binary, daemon, config mutation, fixture mutation, GUI, or TCC",
+      "status": "active"
     }
   ]
 }

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -24,6 +24,9 @@ needs, but public command policy and product UI policy belong above it:
   the owning external product repository;
 - product-specific daemon branches are prohibited unless an explicit temporary
   adapter names its external contract and removal gate.
+- Historical embedded-product config residue may be retired only through an
+  exact key and repo-path migration. Preserve external or user-defined content
+  roots and never mutate the frozen product fixture during config cleanup.
 
 Shared native response serialization lives in
 `src/shared/response-envelope.swift`; direct replies and daemon connection

--- a/src/shared/config.swift
+++ b/src/shared/config.swift
@@ -243,8 +243,15 @@ func normalizeHotkeyCombo(_ value: String) -> String? {
 /// Load config from disk, falling back to defaults if missing or invalid.
 func loadConfig() -> AosConfig {
     guard let data = FileManager.default.contents(atPath: kAosConfigPath),
-          let config = try? JSONDecoder().decode(AosConfig.self, from: data) else {
+          var config = try? JSONDecoder().decode(AosConfig.self, from: data) else {
         return .defaults
+    }
+    if let roots = config.content?.roots, let repoRoot = aosCurrentRepoRoot() {
+        let retirement = retireLegacySigilContentRoot(roots, repoRoot: repoRoot)
+        if retirement.retired {
+            config.content?.roots = retirement.roots
+            saveConfig(config)
+        }
     }
     return config
 }

--- a/src/shared/legacy-content-root-retirement.swift
+++ b/src/shared/legacy-content-root-retirement.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct LegacyContentRootRetirement {
+    let roots: [String: String]
+    let retired: Bool
+}
+
+func retireLegacySigilContentRoot(
+    _ roots: [String: String],
+    repoRoot: String
+) -> LegacyContentRootRetirement {
+    let rootName = "sigil"
+    guard let configuredPath = roots[rootName] else {
+        return LegacyContentRootRetirement(roots: roots, retired: false)
+    }
+
+    let repoURL = URL(fileURLWithPath: repoRoot, isDirectory: true).standardizedFileURL
+    let configuredURL: URL
+    if configuredPath.hasPrefix("/") {
+        configuredURL = URL(fileURLWithPath: configuredPath, isDirectory: true).standardizedFileURL
+    } else {
+        configuredURL = repoURL.appendingPathComponent(configuredPath, isDirectory: true).standardizedFileURL
+    }
+    let legacyFixtureURL = repoURL
+        .appendingPathComponent("apps/sigil", isDirectory: true)
+        .standardizedFileURL
+
+    guard configuredURL.path == legacyFixtureURL.path else {
+        return LegacyContentRootRetirement(roots: roots, retired: false)
+    }
+
+    var migrated = roots
+    migrated.removeValue(forKey: rootName)
+    return LegacyContentRootRetirement(roots: migrated, retired: true)
+}

--- a/tests/legacy-sigil-content-root-retirement.test.mjs
+++ b/tests/legacy-sigil-content-root-retirement.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import test from 'node:test'
+
+const repoRoot = path.resolve(import.meta.dirname, '..')
+
+test('legacy Sigil content-root retirement is exact and preserves user roots', () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'aos-legacy-sigil-root-'))
+  const mainPath = path.join(root, 'main.swift')
+  const binaryPath = path.join(root, 'retirement-test')
+  const moduleCachePath = path.join(root, 'module-cache')
+  mkdirSync(moduleCachePath)
+  writeFileSync(mainPath, `
+import Foundation
+
+func require(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if !condition() {
+        FileHandle.standardError.write(Data((message + "\\n").utf8))
+        exit(1)
+    }
+}
+
+let repo = "/tmp/agent-os"
+let preserved = [
+    "repo": "/tmp/agent-os",
+    "toolkit": "/tmp/agent-os/packages/toolkit",
+]
+
+for legacyPath in ["apps/sigil", "./apps/sigil", "/tmp/agent-os/apps/sigil", "/tmp/agent-os/apps/other/../sigil"] {
+    let result = retireLegacySigilContentRoot(preserved.merging(["sigil": legacyPath]) { _, right in right }, repoRoot: repo)
+    require(result.retired, "expected legacy path to retire: \\(legacyPath)")
+    require(result.roots == preserved, "migration changed unrelated roots")
+}
+
+for userPath in ["/tmp/external-sigil", "apps/sigil-copy", "/tmp/agent-os/apps/sigil-copy"] {
+    let roots = preserved.merging(["sigil": userPath]) { _, right in right }
+    let result = retireLegacySigilContentRoot(roots, repoRoot: repo)
+    require(!result.retired, "unexpected retirement: \\(userPath)")
+    require(result.roots == roots, "non-legacy roots changed")
+}
+
+let absent = retireLegacySigilContentRoot(preserved, repoRoot: repo)
+require(!absent.retired && absent.roots == preserved, "absent legacy root should be a no-op")
+`)
+
+  try {
+    const compile = spawnSync('swiftc', [
+      path.join(repoRoot, 'src/shared/legacy-content-root-retirement.swift'),
+      mainPath,
+      '-o',
+      binaryPath,
+    ], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CLANG_MODULE_CACHE_PATH: moduleCachePath,
+        SWIFT_MODULE_CACHE_PATH: moduleCachePath,
+      },
+    })
+    assert.equal(compile.status, 0, compile.stderr)
+    const run = spawnSync(binaryPath, [], { cwd: repoRoot, encoding: 'utf8' })
+    assert.equal(run.status, 0, run.stderr)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('AOS config load persists the exact retirement before daemon startup', () => {
+  const source = readFileSync(path.join(repoRoot, 'src/shared/config.swift'), 'utf8')
+  assert.match(source, /if let roots = config\.content\?\.roots, let repoRoot = aosCurrentRepoRoot\(\)/u)
+  assert.match(source, /retireLegacySigilContentRoot\(roots, repoRoot: repoRoot\)/u)
+  assert.match(source, /if retirement\.retired \{[\s\S]*config\.content\?\.roots = retirement\.roots[\s\S]*saveConfig\(config\)/u)
+})


### PR DESCRIPTION
## Summary
- retire only the historical `content.roots.sigil` value that resolves to this checkout's frozen `apps/sigil` fixture
- preserve external and user-defined Sigil roots plus every unrelated content root
- persist the one-time migration before the daemon starts serving content
- register the disposable pure-Swift proof without changing the sealed fixture

## Local validation
- `node --test tests/legacy-sigil-content-root-retirement.test.mjs` (2/2)
- `node --test tests/schemas/dev-test-proof-registry.test.mjs tests/schemas/dev-workflow-rules.test.mjs tests/schemas/dev-active-profile.test.mjs tests/schemas/dev-workflow-profiles.test.mjs` (30/30)
- `AOS_SKIP_LIVE_CLI_CHECKS=1 bash tests/dev-workflow-router.sh`
- `bash tests/dev-drift-lint.sh`
- full `swiftc -typecheck` over `src/**/*.swift` and shared IPC (existing warnings only)
- `git diff --check`

`tests/dev-audit.sh` completed three static assertions but its live `./aos help dev audit` assertion was intentionally deferred because this isolated clone has no binary. No AOS build, daemon operation, config mutation, GUI action, or TCC operation occurred.