### PR TITLE
Add companion desktop control contracts

### DIFF
--- a/docs/adr/0022-public-voice-transport-boundary.md
+++ b/docs/adr/0022-public-voice-transport-boundary.md
@@ -16,6 +16,7 @@ The initial public forms are:
 - `aos listen --source microphone --output <absolute.wav> --follow`
 - `aos listen --source microphone --segments <absolute-directory> --follow`
 - `aos say --follow`, with text read from stdin
+- `aos play --audio <absolute.wav> --follow`
 
 These forms are connection-scoped leases over the existing unified daemon.
 They do not expose the private socket as a consumer API.
@@ -30,6 +31,7 @@ The broker owns the behavior that requires its stable permissioned identity:
 - continuous capture with atomically published, deterministic WAV checkpoints;
 - capture and playback meter calculation;
 - system speech buffers and playback;
+- bounded owner-only WAV validation and playback;
 - cancellation, disconnect, daemon-shutdown, and barge-in cleanup.
 
 The managed daemon is the microphone permission holder because it owns capture.
@@ -54,6 +56,9 @@ translation, and NDJSON presentation.
 - Capture is globally singleton, at most 120 seconds, at most 4 MiB, and is
   removed on cancellation, disconnect, failure, or daemon shutdown.
 - Speech text enters through stdin and never appears in events or errors.
+- WAV playback requires a canonical `0600` regular file beneath a canonical,
+  non-symlinked, owner-owned `0700` parent. Input is at most 4 MiB and 120
+  seconds, with mono or stereo PCM at 8 to 192 kHz.
 - Events never contain audio bytes, spoken text, or local paths.
 - There is no raw PCM socket stream and no AOS-owned transcription.
 
@@ -72,7 +77,9 @@ Existing channel/session `aos listen`, hotkey, one-shot microphone, and
 one-shot `aos say` behavior are unchanged. Segmented microphone capture is a
 separate form selected by `--segments`. `say --follow` remains a separate form
 using streamed system speech; provider-backed non-system speech remains behind
-its existing provider seam.
+its existing provider seam. `aos play --follow` shares the singleton output
+lease with streamed speech, so capture, barge-in, cancellation, owner loss, and
+daemon shutdown retain one cleanup boundary.
 
 ## Consumer Permission Contract
 

--- a/docs/adr/0025-native-annotation-selection-and-shortcut-execution.md
+++ b/docs/adr/0025-native-annotation-selection-and-shortcut-execution.md
@@ -1,0 +1,57 @@
+# ADR 0025: Native Annotation Selection And Shortcut Execution
+
+**Status:** Accepted
+**Date:** 2026-07-16
+
+## Decision
+
+AOS exposes two product-neutral native primitives for first-party consumers:
+
+- `aos see annotation select --mode <point|rectangle|freehand|text> --follow`
+  starts one connection-scoped desktop selection lease and persists the result
+  through the existing pending-annotation queue.
+- `aos shortcut run <name> --json` invokes one exact Apple Shortcut name through
+  `/usr/bin/shortcuts` without a shell.
+
+AOS owns native presentation, operating-system invocation, bounded transport,
+and cleanup. Consumers own project routing, agent policy, command phrases,
+skills, approval, and any model turn that uses the resulting evidence.
+
+## Annotation Boundary
+
+The daemon permits one annotation-selection lease at a time. It displays one
+transparent panel per screen, supports point, rectangle, freehand, and bounded
+text input, restores the previously active application, and releases the lease
+on completion, cancellation, owner disconnect, or daemon shutdown.
+
+Geometry uses desktop top-left logical points. Freehand paths are capped at 256
+points and text at 4 KiB. The daemon emits bounded application and window facts,
+but owns no project, conversation, saved-ref, or product-session policy. The
+public adapter validates the native event, persists a pending annotation, then
+emits only the annotation id, geometry, application/window facts, and
+`has_text`. Annotation text remains in the pending record and is never repeated
+through the public follow stream.
+
+Native selection evidence starts as `fallback_only`. Consumers may separately
+capture and resolve a saved ref through existing public perception contracts;
+the selector does not claim semantic actionability from coordinates alone.
+
+## Shortcut Boundary
+
+Shortcut execution accepts one exact name of at most 256 UTF-8 bytes, passes it
+as one argv item, and has a configurable 1 to 120 second timeout. Combined
+stdout and stderr are capped at 64 KiB and are never returned as content. The
+result exposes only status, duration, and byte counts.
+
+The primitive does not discover Shortcuts, interpret voice phrases, infer
+parameters, or bypass consumer approvals. A product must authorize an explicit
+Shortcut name before invoking this form.
+
+## Consequences
+
+- Renderers do not receive the daemon socket or raw native authority.
+- Operator-created annotations may remain pending without triggering an agent.
+- Annotation selection and Shortcut execution can be accepted against fake
+  transports; live desktop and TCC evidence remains a separate manual lane.
+- Product-specific companion commands, wake phrases, and Help/Demo recipes stay
+  outside AOS.

--- a/docs/api/aos-capabilities.md
+++ b/docs/api/aos-capabilities.md
@@ -204,7 +204,7 @@ apps cannot safely reconstruct from the current JSON surfaces.
 | Desktop discovery | Displays, windows, cursor, selection, and active surfaces | `graph displays`, `graph windows`, `see list`, `see cursor`, `see selection` |
 | Capture and perception | Screenshots, window/region/canvas/channel capture, xray, labels, saved refs | `see capture`, `see capture --save`, `see snapshots`, `see refs` |
 | Saved workspace | Snapshot/ref storage, ref lookup, diffs, expectations, cleanup | `see workspaces`, `see workspace`, `see refs --diff --expect`, workspace prune/delete |
-| Desktop/native control | App activate/quit/hide/unhide, window raise/move/resize/close/minimize/maximize/restore, app menu invocation, and native AX press/focus/set-value | `do activate`, `do quit`, `do hide`, `do unhide`, `do raise`, `do move`, `do resize`, `do close`, `do minimize`, `do maximize`, `do restore`, `do menu`, `do press`, `do focus`, `do set-value` |
+| Desktop/native control | App activate/quit/hide/unhide, window raise/move/resize/close/minimize/maximize/restore, app menu invocation, explicit Apple Shortcut execution, and native AX press/focus/set-value | `do activate`, `do quit`, `do hide`, `do unhide`, `do raise`, `do move`, `do resize`, `do close`, `do minimize`, `do maximize`, `do restore`, `do menu`, `do press`, `do focus`, `do set-value`, `shortcut run` |
 | AOS-owned status-item menus | Experience-owned status-item/operator annotation menu invocation | `experience status`, `experience menu invoke` |
 | Pointer and keyboard | Mouse, keyboard, scrolling, dragging, text, browser ref actions | `do click`, `do hover`, `do drag`, `do scroll`, `do type`, `do key`, `do fill`, `do navigate` |
 | Canvas and vision | Canvas refs, regions, coordinates, labels, xray, visual proof | `see capture --canvas`, `see capture --region`, `see capture --xray --label`, `do click canvas:...`, coordinate actions |
@@ -212,7 +212,7 @@ apps cannot safely reconstruct from the current JSON surfaces.
 | Overlay/display | Canvases, panels, stage surfaces, render/list/wait/readback | `show create/update/remove/list/audit/render/wait/get/to-front/post` |
 | Diagnostics/debug | Debug readbacks and diagnostic displays for active AOS/runtime work | `daemon-snapshot`, `service logs`, `inspect`, `introspect review`, `log` |
 | Verification/evidence | Recapture, refs diff/expect, gates, Work Records | `see refs --diff --expect`, `gate`, `work-record read/verify/status/plan-repair` |
-| Operator input | Pending operator annotations and saved-ref handoff | `see annotation create/list/read/consume/link-work-record/delete` |
+| Operator input | Native desktop selection, pending operator annotations, and saved-ref handoff | `see annotation select/create/list/read/consume/link-work-record/delete` |
 | Skills and recipes | Installable guidance versus executable source-backed procedures | `skills list/check/install`, `skills companion ...`, `recipe list/explain/dry-run/run` |
 | Runtime/service | Daemon ownership, mode, permissions, cleanup | `service`, `runtime`, `content`, `clean`, `reset` |
 

--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -124,9 +124,11 @@ The current top-level commands are:
 | `aos introspect` | Session self-review over recent `./aos` usage |
 | `aos help` | Registry and command-specific help |
 | `aos say` | Voice output |
+| `aos play` | Bounded owner-only audio playback with exact meter events |
 | `aos voice` | registry-backed voice catalog, assignments, providers, and session bindings |
 | `aos tell` | Communication output: human, channel, or direct session routing |
 | `aos listen` | Communication input: channel/direct-session reads, global hotkeys, and bounded microphone capture |
+| `aos shortcut` | Bounded execution of one explicitly named Apple Shortcut |
 | `aos wiki` | local knowledge-base workflows |
 | `aos config` | Discoverable runtime configuration (`get`, `set`, dump) |
 | `aos set` | Runtime configuration |
@@ -318,7 +320,10 @@ daemon runtime state.
 Pending operator annotations live under
 `~/.config/aos/{repo|installed}/pending-annotations/`, or
 `$AOS_STATE_ROOT/{repo|installed}/pending-annotations/` when the state root is
-overridden. Use `aos see annotation create` to create or ingest one pending
+overridden. Use `aos see annotation select --mode
+<point|rectangle|freehand|text> --follow` to collect one native desktop
+selection and persist it before completion, `aos see annotation create` to
+create or ingest one pending
 record, `aos see annotation list` for compact summaries, `aos see annotation
 read <id>` for one compact record, `aos see annotation consume <id>` to drain it
 once, `aos see annotation link-work-record <id> --work-record <ref>` to attach
@@ -340,6 +345,13 @@ rebuildable cache, and read/list derives from records without repairing state
 so an index write failure cannot make a successful record mutation look failed.
 Pending annotations are evidence state in the user-facing vocabulary, not
 agent sessions, focus channels, or saved workspaces.
+
+The native selector is a connection-scoped lease. Freehand evidence is capped
+at 256 points, text at 4 KiB, and geometry uses desktop top-left logical points.
+The public completion event strips text and exposes only `has_text`; read the
+created pending record by its returned annotation id to consume the comment.
+Selection evidence is initially `fallback_only` and does not manufacture a
+semantic saved ref.
 
 Experience manifests can declare app-owned operator selection affordances in
 their status-item `menu[]` with `kind: "operator_annotation"` and a target
@@ -2020,6 +2032,37 @@ speakable voices, normal CLI use fails with `VOICE_FILTER_EMPTY`.
 text only from stdin, emits strict `voice` lifecycle and `audio_frame` NDJSON,
 and supports cancellation and microphone barge-in. Events and errors never
 echo the spoken text. Existing one-shot `aos say` behavior is unchanged.
+
+## `aos play`
+
+Play one bounded local PCM WAV through the same daemon-owned output broker used
+for streamed system speech:
+
+```bash
+aos play --audio /private/tmp/aos-command/audio.wav --follow
+```
+
+The input must be a canonical owner-only `0600` regular file beneath a
+canonical owner-owned `0700` directory. Symlinks, files over 4 MiB, durations
+over 120 seconds, more than two channels, and unsupported PCM formats fail
+before playback. Follow output includes lifecycle facts and the exact
+`audio_frame` meter stream used for playback, but never the input path or audio
+content. The lease is connection-scoped and shares cancellation, barge-in, and
+daemon-shutdown cleanup with streamed speech.
+
+## `aos shortcut`
+
+Run one explicitly authorized Apple Shortcut by exact name:
+
+```bash
+aos shortcut run 'Prepare Focus Mode' --timeout 30s --json
+```
+
+The adapter invokes `/usr/bin/shortcuts` without a shell, bounds execution to 1
+through 120 seconds, caps combined output at 64 KiB, and returns only status,
+duration, and byte counts. It never returns Shortcut output content. AOS does
+not discover commands, interpret voice phrases, or grant product authority;
+consumer policy must authorize the exact name before invocation.
 
 ## `aos voice`
 

--- a/docs/dev/reports/aos-command-capability-inventory-v0.md
+++ b/docs/dev/reports/aos-command-capability-inventory-v0.md
@@ -18,13 +18,13 @@ current command tree before public CLI and self-hosting boundary changes.
 
 ## Summary
 
-- Command paths: 42
-- Concrete forms: 204
-- Consumer-discoverable forms: 195
+- Command paths: 44
+- Concrete forms: 207
+- Consumer-discoverable forms: 198
 - Internal/transitional command paths: 1
-- Mutating or conditionally mutating forms: 114
+- Mutating or conditionally mutating forms: 117
 - Forms with unspecified mutability metadata: 0
-- Forms with JSON output path: 199
+- Forms with JSON output path: 202
 - Forms with dry-run support: 37
 
 ## Capability Group Counts
@@ -39,9 +39,9 @@ current command tree before public CLI and self-hosting boundary changes.
 | Core desktop | 9 |
 | Core readiness | 7 |
 | Desktop discovery | 4 |
-| Desktop/native control | 18 |
+| Desktop/native control | 19 |
 | Diagnostics/debug | 6 |
-| Operator input | 6 |
+| Operator input | 7 |
 | Operator messaging | 10 |
 | Overlay/display | 16 |
 | Pointer and keyboard | 9 |
@@ -50,7 +50,7 @@ current command tree before public CLI and self-hosting boundary changes.
 | Skills and recipes | 7 |
 | Storage/config | 5 |
 | Verification/evidence | 28 |
-| Voice and speech | 10 |
+| Voice and speech | 11 |
 
 ## Command Paths
 
@@ -64,10 +64,11 @@ current command tree before public CLI and self-hosting boundary changes.
 | `experience deactivate` | 1 | Core desktop | yes | mutates | --json | `manifests/commands/source/aos/02-experience.json` | `node scripts/aos-experience.mjs deactivate` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `see` | 13 | Capture and perception, Saved workspace | yes | conditional --save, mutates, read-only | --json, default | `manifests/commands/source/aos/03-see-01-capture.json, manifests/commands/source/aos/03-see-02-workspace.json` | `node scripts/aos-help-proxy.mjs see [missing child]; node scripts/aos-see-native.mjs capture [not capture/observe/cursor/list...]` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `see zone` | 4 | Canvas and vision | yes | mutates | default | `manifests/commands/source/aos/03-see-03-zone.json` | `node scripts/aos-subcommand-router.mjs see zone MISSING_SUBCOMMAND see zone requires a subcommand. Usage: aos see zone <save\|define\|list\|delete> ... UNKNOWN_SUBCOMMAND see zone subcommand` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
-| `see annotation` | 6 | Operator input | yes | mutates, read-only | --json | `manifests/commands/source/aos/03-see-04-annotation.json` | `node scripts/aos-subcommand-router.mjs see annotation MISSING_SUBCOMMAND see annotation requires a subcommand. Usage: aos see annotation <create\|list\|read\|consume\|link-work-record\|delete> ... UNKNOWN_SUBCOMMAND see annotation subcommand` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
+| `see annotation` | 7 | Operator input | yes | mutates, read-only | --json, default | `manifests/commands/source/aos/03-see-04-annotation.json` | `node scripts/aos-subcommand-router.mjs see annotation MISSING_SUBCOMMAND see annotation requires a subcommand. Usage: aos see annotation <select\|create\|list\|read\|consume\|link-work-record\|delete> ... UNKNOWN_SUBCOMMAND see annotation subcommand` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `show` | 15 | Overlay/display | yes | mutates, read-only | --json, default, no | `manifests/commands/source/aos/04-show.json` | `node scripts/aos-family-router.mjs show UNKNOWN_SUBCOMMAND show subcommand [not render/create/update/remove...]` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `recipe` | 4 | Skills and recipes | yes | mutates, read-only | --json | `manifests/commands/source/aos/06-recipe.json` | `node scripts/aos-recipe.mjs` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `do` | 32 | Pointer and keyboard, Canvas and vision, Browser companion, Desktop/native control | yes | mutates, read-only | default | `manifests/commands/source/aos/07-do-01-pointing.json, manifests/commands/source/aos/07-do-02-text.json, manifests/commands/source/aos/07-do-03-controls.json, manifests/commands/source/aos/07-do-04-window.json, manifests/commands/source/aos/07-do-05-script-session.json, manifests/commands/source/aos/07-do-06-app-lifecycle.json, manifests/commands/source/aos/07-do-07-menu.json` | `node scripts/aos-help-proxy.mjs do [missing child]; node scripts/aos-family-router.mjs do UNKNOWN_SUBCOMMAND do subcommand [not click/hover/drag/fill...]` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
+| `play` | 1 | Voice and speech | yes | mutates | default | `manifests/commands/source/aos/08-play.json` | `node scripts/aos-play.mjs` | `docs/api/aos.md` |
 | `say` | 3 | Voice and speech | yes | mutates, read-only | default | `manifests/commands/source/aos/08-say.json` | `node scripts/aos-say.mjs` | `docs/api/aos.md` |
 | `voice` | 7 | Voice and speech | yes | mutates, read-only | default | `manifests/commands/source/aos/09-voice.json` | `node scripts/aos-family-router.mjs voice UNKNOWN_COMMAND voice command [child 0]` | `docs/api/aos.md` |
 | `gate` | 5 | Verification/evidence | yes | mutates, read-only | default | `manifests/commands/source/aos/10-gate.json` | `node scripts/aos-family-router.mjs gate UNKNOWN_SUBCOMMAND gate subcommand [child 0]` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
@@ -82,6 +83,7 @@ current command tree before public CLI and self-hosting boundary changes.
 | `content` | 2 | Content/wiki | yes | read-only | --json | `manifests/commands/source/aos/19-content.json` | `node scripts/aos-family-router.mjs content UNKNOWN_COMMAND content command [child 0]` | `docs/api/aos.md` |
 | `service` | 6 | Runtime/service | yes | mutates, read-only | --json, no | `manifests/commands/source/aos/20-service.json` | `node scripts/aos-subcommand-router.mjs service MISSING_SUBCOMMAND service requires a subcommand. Usage: aos service <install\|start\|stop\|restart\|status\|logs> ... UNKNOWN_SUBCOMMAND service subcommand` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `runtime` | 6 | Runtime/service | yes | mutates, read-only | --json, no | `manifests/commands/source/aos/21-runtime.json` | `node scripts/aos-subcommand-router.mjs runtime MISSING_SUBCOMMAND runtime requires a subcommand. Usage: aos runtime <status\|build-attestation\|path\|sign\|install\|display-union [--native]> ... UNKNOWN_SUBCOMMAND runtime subcommand` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
+| `shortcut` | 1 | Desktop/native control | yes | mutates | --json | `manifests/commands/source/aos/22-shortcut.json` | `node scripts/aos-shortcut.mjs` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `status` | 1 | Core readiness | yes | read-only | --json | `manifests/commands/source/aos/23-status.json` | `node scripts/aos-status.mjs` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `ready` | 1 | Core readiness | yes | conditional --repair | --json | `manifests/commands/source/aos/24-ready.json` | `node scripts/aos-ready.mjs` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `doctor` | 2 | Core readiness | yes | read-only | --json | `manifests/commands/source/aos/25-doctor.json` | `node scripts/aos-doctor.mjs` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
@@ -125,6 +127,7 @@ current command tree before public CLI and self-hosting boundary changes.
 | `see zone define` | `zone-define` | Canvas and vision | yes | mutates | default | no | `manifests/commands/source/aos/03-see-03-zone.json` | `node scripts/aos-see-zone.mjs define` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `see zone list` | `zone-list` | Canvas and vision | yes | mutates | default | no | `manifests/commands/source/aos/03-see-03-zone.json` | `node scripts/aos-see-zone.mjs list` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `see zone delete` | `zone-delete` | Canvas and vision | yes | mutates | default | no | `manifests/commands/source/aos/03-see-03-zone.json` | `node scripts/aos-see-zone.mjs delete` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
+| `see annotation select` | `annotation-select-follow` | Operator input | yes | mutates | default | no | `manifests/commands/source/aos/03-see-04-annotation.json` | `node scripts/aos-annotation-select.mjs` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `see annotation create` | `see-annotation-create` | Operator input | yes | mutates | --json | no | `manifests/commands/source/aos/03-see-04-annotation.json` | `node scripts/aos-pending-annotation.mjs create` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `see annotation list` | `see-annotation-list` | Operator input | yes | read-only | --json | no | `manifests/commands/source/aos/03-see-04-annotation.json` | `node scripts/aos-pending-annotation.mjs list` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `see annotation read` | `see-annotation-read` | Operator input | yes | read-only | --json | no | `manifests/commands/source/aos/03-see-04-annotation.json` | `node scripts/aos-pending-annotation.mjs read` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
@@ -182,6 +185,7 @@ current command tree before public CLI and self-hosting boundary changes.
 | `do hide` | `do-hide` | Desktop/native control | yes | mutates | default | yes | `manifests/commands/source/aos/07-do-06-app-lifecycle.json` | `node scripts/aos-do-native.mjs hide` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `do unhide` | `do-unhide` | Desktop/native control | yes | mutates | default | yes | `manifests/commands/source/aos/07-do-06-app-lifecycle.json` | `node scripts/aos-do-native.mjs unhide` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `do menu` | `do-menu` | Desktop/native control | yes | mutates | default | yes | `manifests/commands/source/aos/07-do-07-menu.json` | `node scripts/aos-do-native.mjs menu` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
+| `play` | `play-audio-follow` | Voice and speech | yes | mutates | default | no | `manifests/commands/source/aos/08-play.json` | `node scripts/aos-play.mjs` | `docs/api/aos.md` |
 | `say` | `say-text` | Voice and speech | yes | mutates | default | no | `manifests/commands/source/aos/08-say.json` | `node scripts/aos-say.mjs` | `docs/api/aos.md` |
 | `say` | `say-follow` | Voice and speech | yes | mutates | default | no | `manifests/commands/source/aos/08-say.json` | `node scripts/aos-say.mjs` | `docs/api/aos.md` |
 | `say` | `say-list-voices` | Voice and speech | yes | read-only | default | no | `manifests/commands/source/aos/08-say.json` | `node scripts/aos-say.mjs` | `docs/api/aos.md` |
@@ -236,6 +240,7 @@ current command tree before public CLI and self-hosting boundary changes.
 | `runtime path` | `runtime-path` | Runtime/service | yes | read-only | --json | no | `manifests/commands/source/aos/21-runtime.json` | `scripts/aos-runtime-path` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `runtime sign` | `runtime-sign` | Runtime/service | yes | mutates | no | no | `manifests/commands/source/aos/21-runtime.json` | `scripts/sign-aos-runtime` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `runtime display-union` | `runtime-display-union` | Runtime/service | yes | read-only | no | no | `manifests/commands/source/aos/21-runtime.json` | `scripts/aos-runtime-display-union` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
+| `shortcut run` | `shortcut-run` | Desktop/native control | yes | mutates | --json | no | `manifests/commands/source/aos/22-shortcut.json` | `node scripts/aos-shortcut.mjs run` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `status` | `status` | Core readiness | yes | read-only | --json | no | `manifests/commands/source/aos/23-status.json` | `node scripts/aos-status.mjs` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `ready` | `ready` | Core readiness | yes | conditional --repair | --json | no | `manifests/commands/source/aos/24-ready.json` | `node scripts/aos-ready.mjs` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `doctor` | `doctor` | Core readiness | yes | read-only | --json | no | `manifests/commands/source/aos/25-doctor.json` | `node scripts/aos-doctor.mjs` | `docs/api/aos.md, docs/api/aos-capabilities.md` |

--- a/docs/dev/test-proof-registry.d/voice-io.json
+++ b/docs/dev/test-proof-registry.d/voice-io.json
@@ -24,6 +24,7 @@
     {
       "id": "voice-transport-native-proof",
       "path_patterns": [
+        "src/daemon/audio-playback.swift",
         "src/daemon/microphone-authorization.swift",
         "src/daemon/segmented-microphone-capture.swift",
         "src/daemon/voice-transport.swift",
@@ -45,6 +46,7 @@
     {
       "id": "voice-follow-cli-proof",
       "path_patterns": [
+        "scripts/aos-play.mjs",
         "scripts/aos-say.mjs",
         "scripts/aos-tell-listen.mjs",
         "scripts/lib/aos-daemon-client.mjs",
@@ -60,6 +62,65 @@
       "command": "node --test tests/voice-follow-cli.test.mjs",
       "replaces": [],
       "guard": "uses a temporary fake Unix-socket daemon",
+      "status": "active"
+    },
+    {
+      "id": "annotation-selection-schema-proof",
+      "path_patterns": [
+        "scripts/lib/pending-annotations-model.mjs",
+        "shared/schemas/aos-pending-annotation-v0.schema.json",
+        "tests/schemas/aos-pending-annotation-v0.test.mjs",
+        "tests/schemas/daemon-event.test.mjs",
+        "tests/toolkit/pending-annotation-model.test.mjs"
+      ],
+      "fixture_patterns": [
+        "shared/schemas/fixtures/daemon-event/**/annotation-*.json"
+      ],
+      "owner": "desktop-annotation",
+      "harness_level": "schema",
+      "proof_kind": "annotation_selection_schema_contract",
+      "contract": "Native annotation selections persist as a closed, bounded desktop-selection record while public daemon events expose only canonical IDs, geometry, application facts, and a text-presence flag.",
+      "worth": "This catches malformed geometry, leaked paths or text, noncanonical selection IDs, and schema/model drift before Sigil consumes annotation evidence.",
+      "command": "node --test tests/schemas/aos-pending-annotation-v0.test.mjs tests/schemas/daemon-event.test.mjs tests/toolkit/pending-annotation-model.test.mjs",
+      "replaces": [],
+      "guard": "schema and model validation only; no desktop overlay, daemon, or TCC use",
+      "status": "active"
+    },
+    {
+      "id": "annotation-selection-adapter-proof",
+      "path_patterns": [
+        "scripts/aos-annotation-select.mjs",
+        "src/daemon/annotation-selection.swift",
+        "tests/annotation-select-cli.test.mjs",
+        "tests/annotation-selection-native.sh"
+      ],
+      "fixture_patterns": [],
+      "owner": "desktop-annotation",
+      "harness_level": "model_unit",
+      "proof_kind": "annotation_selection_adapter_contract",
+      "contract": "The public annotation-selection follower validates strict path-free events, persists completion before publication, and the native selector enforces one connection-scoped bounded point, rectangle, freehand, or text lease.",
+      "worth": "This proves adapter redaction, cancellation, ownership, geometry normalization, and native lifecycle behavior without showing a real overlay or touching the shared daemon.",
+      "command": "node --test tests/annotation-select-cli.test.mjs && bash tests/annotation-selection-native.sh",
+      "replaces": [],
+      "guard": "uses a fake Unix-socket daemon and a disposable Swift model harness; no repo binary, live desktop overlay, or TCC use",
+      "status": "active"
+    },
+    {
+      "id": "shortcut-execution-proof",
+      "path_patterns": [
+        "scripts/aos-shortcut.mjs",
+        "scripts/lib/aos-shortcut-run.mjs",
+        "tests/shortcut-command.test.mjs"
+      ],
+      "fixture_patterns": [],
+      "owner": "desktop-native-control",
+      "harness_level": "shell_router",
+      "proof_kind": "shortcut_execution_contract",
+      "contract": "Explicit Apple Shortcut execution uses argv-only process invocation, bounded and redacted output, timeout and cancellation escalation, and process-group teardown.",
+      "worth": "This prevents shell injection, Shortcut-name disclosure, unbounded output, and orphaned child processes while keeping invocation explicit and auditable.",
+      "command": "node --test tests/shortcut-command.test.mjs",
+      "replaces": [],
+      "guard": "injects a fake shortcuts executable; no real Apple Shortcut is invoked",
       "status": "active"
     },
     {

--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -1498,8 +1498,78 @@
         "see",
         "annotation"
       ],
-      "summary" : "Create, list, read, consume, and delete compact pending operator annotations",
+      "summary" : "Select, create, list, read, consume, and delete compact pending operator annotations",
       "forms" : [
+        {
+          "id" : "annotation-select-follow",
+          "summary" : "Select a bounded desktop point, rectangle, freehand path, or text annotation and persist it as pending evidence",
+          "usage" : "aos see annotation select --mode <point|rectangle|freehand|text> [--source <token>] --follow",
+          "args" : [
+            {
+              "id" : "mode",
+              "kind" : "flag",
+              "required" : true,
+              "summary" : "Desktop selection geometry",
+              "token" : "--mode",
+              "value_type" : {
+                "enum" : [
+                  {
+                    "value" : "point",
+                    "summary" : "Select one desktop point"
+                  },
+                  {
+                    "value" : "rectangle",
+                    "summary" : "Drag one desktop rectangle"
+                  },
+                  {
+                    "value" : "freehand",
+                    "summary" : "Draw one bounded desktop path"
+                  },
+                  {
+                    "value" : "text",
+                    "summary" : "Select one point and enter bounded annotation text"
+                  }
+                ]
+              }
+            },
+            {
+              "id" : "source",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Bounded product-neutral annotation source token",
+              "token" : "--source",
+              "value_type" : "string"
+            },
+            {
+              "id" : "follow",
+              "kind" : "flag",
+              "required" : true,
+              "summary" : "Stream selection lifecycle and the persisted annotation id",
+              "token" : "--follow",
+              "value_type" : "bool"
+            }
+          ],
+          "examples" : [
+            "aos see annotation select --mode point --follow",
+            "aos see annotation select --mode rectangle --source companion --follow",
+            "aos see annotation select --mode text --follow"
+          ],
+          "execution" : {
+            "auto_starts_daemon" : true,
+            "interactive" : true,
+            "mutates_state" : true,
+            "read_only" : false,
+            "requires_permissions" : true,
+            "streaming" : true,
+            "supports_dry_run" : false
+          },
+          "output" : {
+            "default_mode" : "ndjson",
+            "error_mode" : "json_stderr",
+            "streaming" : true,
+            "supports_json_flag" : false
+          }
+        },
         {
           "id" : "see-annotation-create",
           "summary" : "Create or ingest one pending operator annotation record under the runtime-mode state root",
@@ -5095,6 +5165,55 @@
       "summary" : "Action — execute mouse, keyboard, AX actions"
     },
     {
+      "path" : [
+        "play"
+      ],
+      "summary" : "Play bounded owner-only audio through the daemon output broker",
+      "forms" : [
+        {
+          "id" : "play-audio-follow",
+          "summary" : "Play one canonical owner-only WAV while streaming lifecycle and meter events",
+          "usage" : "aos play --audio <absolute.wav> --follow",
+          "args" : [
+            {
+              "id" : "audio",
+              "kind" : "flag",
+              "required" : true,
+              "summary" : "Canonical WAV in an owner-only directory",
+              "token" : "--audio",
+              "value_type" : "path"
+            },
+            {
+              "id" : "follow",
+              "kind" : "flag",
+              "required" : true,
+              "summary" : "Stream playback lifecycle and meter events",
+              "token" : "--follow",
+              "value_type" : "bool"
+            }
+          ],
+          "examples" : [
+            "aos play --audio /private/tmp/aos-command/audio.wav --follow"
+          ],
+          "execution" : {
+            "auto_starts_daemon" : true,
+            "interactive" : false,
+            "mutates_state" : true,
+            "read_only" : false,
+            "requires_permissions" : false,
+            "streaming" : true,
+            "supports_dry_run" : false
+          },
+          "output" : {
+            "default_mode" : "ndjson",
+            "error_mode" : "json_stderr",
+            "streaming" : true,
+            "supports_json_flag" : false
+          }
+        }
+      ]
+    },
+    {
       "forms" : [
         {
           "args" : [
@@ -8079,6 +8198,63 @@
         "runtime"
       ],
       "summary" : "Package/sign/install the stable AOS.app runtime"
+    },
+    {
+      "path" : [
+        "shortcut"
+      ],
+      "summary" : "Run one named Apple Shortcut without a shell",
+      "forms" : [
+        {
+          "id" : "shortcut-run",
+          "summary" : "Run one explicit Apple Shortcut with bounded time and output",
+          "usage" : "aos shortcut run <name> [--timeout <duration>] [--json]",
+          "args" : [
+            {
+              "id" : "name",
+              "kind" : "positional",
+              "required" : true,
+              "summary" : "Exact Apple Shortcut name",
+              "value_type" : "string"
+            },
+            {
+              "id" : "timeout",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Execution timeout from 1s to 120s",
+              "token" : "--timeout",
+              "value_type" : "duration"
+            },
+            {
+              "id" : "json",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Return JSON",
+              "token" : "--json",
+              "value_type" : "bool"
+            }
+          ],
+          "examples" : [
+            "aos shortcut run 'Prepare Focus Mode' --json",
+            "aos shortcut run 'Open Daily Note' --timeout 30s --json"
+          ],
+          "execution" : {
+            "auto_starts_daemon" : false,
+            "interactive" : false,
+            "mutates_state" : true,
+            "read_only" : false,
+            "requires_permissions" : false,
+            "streaming" : false,
+            "supports_dry_run" : false
+          },
+          "output" : {
+            "default_mode" : "json",
+            "error_mode" : "json_stderr",
+            "streaming" : false,
+            "supports_json_flag" : true
+          }
+        }
+      ]
     },
     {
       "forms" : [

--- a/manifests/commands/aos-external-commands.json
+++ b/manifests/commands/aos-external-commands.json
@@ -1036,11 +1036,24 @@
         "scripts/aos-subcommand-router.mjs",
         "see annotation",
         "MISSING_SUBCOMMAND",
-        "see annotation requires a subcommand. Usage: aos see annotation <create|list|read|consume|link-work-record|delete> ...",
+        "see annotation requires a subcommand. Usage: aos see annotation <select|create|list|read|consume|link-work-record|delete> ...",
         "UNKNOWN_SUBCOMMAND",
         "see annotation subcommand"
       ],
       "cwd": "repo"
+    },
+    {
+      "path": ["see", "annotation", "select"],
+      "summary": "Select bounded desktop annotation evidence and persist it through the pending-annotation queue.",
+      "executable": "/usr/bin/env",
+      "argv_prefix": ["node", "scripts/aos-annotation-select.mjs"],
+      "cwd": "repo",
+      "stdio": "inherit",
+      "env": {
+        "AOS_PATH": "$AOS_PATH",
+        "AOS_RUNTIME_MODE": "$AOS_RUNTIME_MODE",
+        "AOS_STATE_ROOT": "$AOS_STATE_ROOT"
+      }
     },
     {
       "path": ["see", "annotation", "create"],
@@ -1569,6 +1582,19 @@
       "cwd": "repo"
     },
     {
+      "path": ["play"],
+      "summary": "Stream bounded audio playback through the daemon voice-output broker.",
+      "executable": "/usr/bin/env",
+      "argv_prefix": ["node", "scripts/aos-play.mjs"],
+      "cwd": "repo",
+      "stdio": "inherit",
+      "env": {
+        "AOS_PATH": "$AOS_PATH",
+        "AOS_RUNTIME_MODE": "$AOS_RUNTIME_MODE",
+        "AOS_STATE_ROOT": "$AOS_STATE_ROOT"
+      }
+    },
+    {
       "path": ["say"],
       "summary": "Speak text through one-shot or streamed system-speech forms.",
       "executable": "/usr/bin/env",
@@ -2068,6 +2094,22 @@
         "AOS_STATE_ROOT": "$AOS_STATE_ROOT",
         "AOS_PATH": "$AOS_PATH"
       }
+    },
+    {
+      "path": ["shortcut"],
+      "summary": "Run explicitly named Apple Shortcuts through a bounded shell-free adapter.",
+      "executable": "/usr/bin/env",
+      "argv_prefix": ["node", "scripts/aos-shortcut.mjs"],
+      "cwd": "repo",
+      "stdio": "inherit"
+    },
+    {
+      "path": ["shortcut", "run"],
+      "summary": "Run one exact Apple Shortcut through the bounded adapter.",
+      "executable": "/usr/bin/env",
+      "argv_prefix": ["node", "scripts/aos-shortcut.mjs", "run"],
+      "cwd": "repo",
+      "stdio": "inherit"
     },
     {
       "path": ["recipe"],

--- a/manifests/commands/source/aos/03-see-04-annotation.json
+++ b/manifests/commands/source/aos/03-see-04-annotation.json
@@ -10,8 +10,66 @@
         "see",
         "annotation"
       ],
-      "summary": "Create, list, read, consume, and delete compact pending operator annotations",
+      "summary": "Select, create, list, read, consume, and delete compact pending operator annotations",
       "forms": [
+        {
+          "id": "annotation-select-follow",
+          "summary": "Select a bounded desktop point, rectangle, freehand path, or text annotation and persist it as pending evidence",
+          "usage": "aos see annotation select --mode <point|rectangle|freehand|text> [--source <token>] --follow",
+          "args": [
+            {
+              "id": "mode",
+              "kind": "flag",
+              "required": true,
+              "summary": "Desktop selection geometry",
+              "token": "--mode",
+              "value_type": {
+                "enum": [
+                  { "value": "point", "summary": "Select one desktop point" },
+                  { "value": "rectangle", "summary": "Drag one desktop rectangle" },
+                  { "value": "freehand", "summary": "Draw one bounded desktop path" },
+                  { "value": "text", "summary": "Select one point and enter bounded annotation text" }
+                ]
+              }
+            },
+            {
+              "id": "source",
+              "kind": "flag",
+              "required": false,
+              "summary": "Bounded product-neutral annotation source token",
+              "token": "--source",
+              "value_type": "string"
+            },
+            {
+              "id": "follow",
+              "kind": "flag",
+              "required": true,
+              "summary": "Stream selection lifecycle and the persisted annotation id",
+              "token": "--follow",
+              "value_type": "bool"
+            }
+          ],
+          "examples": [
+            "aos see annotation select --mode point --follow",
+            "aos see annotation select --mode rectangle --source companion --follow",
+            "aos see annotation select --mode text --follow"
+          ],
+          "execution": {
+            "auto_starts_daemon": true,
+            "interactive": true,
+            "mutates_state": true,
+            "read_only": false,
+            "requires_permissions": true,
+            "streaming": true,
+            "supports_dry_run": false
+          },
+          "output": {
+            "default_mode": "ndjson",
+            "error_mode": "json_stderr",
+            "streaming": true,
+            "supports_json_flag": false
+          }
+        },
         {
           "id": "see-annotation-create",
           "summary": "Create or ingest one pending operator annotation record under the runtime-mode state root",

--- a/manifests/commands/source/aos/08-play.json
+++ b/manifests/commands/source/aos/08-play.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": 1,
+  "id": "play",
+  "path_prefix": [
+    "play"
+  ],
+  "commands": [
+    {
+      "path": [
+        "play"
+      ],
+      "summary": "Play bounded owner-only audio through the daemon output broker",
+      "forms": [
+        {
+          "id": "play-audio-follow",
+          "summary": "Play one canonical owner-only WAV while streaming lifecycle and meter events",
+          "usage": "aos play --audio <absolute.wav> --follow",
+          "args": [
+            {
+              "id": "audio",
+              "kind": "flag",
+              "required": true,
+              "summary": "Canonical WAV in an owner-only directory",
+              "token": "--audio",
+              "value_type": "path"
+            },
+            {
+              "id": "follow",
+              "kind": "flag",
+              "required": true,
+              "summary": "Stream playback lifecycle and meter events",
+              "token": "--follow",
+              "value_type": "bool"
+            }
+          ],
+          "examples": [
+            "aos play --audio /private/tmp/aos-command/audio.wav --follow"
+          ],
+          "execution": {
+            "auto_starts_daemon": true,
+            "interactive": false,
+            "mutates_state": true,
+            "read_only": false,
+            "requires_permissions": false,
+            "streaming": true,
+            "supports_dry_run": false
+          },
+          "output": {
+            "default_mode": "ndjson",
+            "error_mode": "json_stderr",
+            "streaming": true,
+            "supports_json_flag": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/manifests/commands/source/aos/22-shortcut.json
+++ b/manifests/commands/source/aos/22-shortcut.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": 1,
+  "id": "shortcut",
+  "path_prefix": [
+    "shortcut"
+  ],
+  "commands": [
+    {
+      "path": [
+        "shortcut"
+      ],
+      "summary": "Run one named Apple Shortcut without a shell",
+      "forms": [
+        {
+          "id": "shortcut-run",
+          "summary": "Run one explicit Apple Shortcut with bounded time and output",
+          "usage": "aos shortcut run <name> [--timeout <duration>] [--json]",
+          "args": [
+            {
+              "id": "name",
+              "kind": "positional",
+              "required": true,
+              "summary": "Exact Apple Shortcut name",
+              "value_type": "string"
+            },
+            {
+              "id": "timeout",
+              "kind": "flag",
+              "required": false,
+              "summary": "Execution timeout from 1s to 120s",
+              "token": "--timeout",
+              "value_type": "duration"
+            },
+            {
+              "id": "json",
+              "kind": "flag",
+              "required": false,
+              "summary": "Return JSON",
+              "token": "--json",
+              "value_type": "bool"
+            }
+          ],
+          "examples": [
+            "aos shortcut run 'Prepare Focus Mode' --json",
+            "aos shortcut run 'Open Daily Note' --timeout 30s --json"
+          ],
+          "execution": {
+            "auto_starts_daemon": false,
+            "interactive": false,
+            "mutates_state": true,
+            "read_only": false,
+            "requires_permissions": false,
+            "streaming": false,
+            "supports_dry_run": false
+          },
+          "output": {
+            "default_mode": "json",
+            "error_mode": "json_stderr",
+            "streaming": false,
+            "supports_json_flag": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/manifests/commands/source/external/11-see.json
+++ b/manifests/commands/source/external/11-see.json
@@ -229,11 +229,31 @@
         "scripts/aos-subcommand-router.mjs",
         "see annotation",
         "MISSING_SUBCOMMAND",
-        "see annotation requires a subcommand. Usage: aos see annotation <create|list|read|consume|link-work-record|delete> ...",
+        "see annotation requires a subcommand. Usage: aos see annotation <select|create|list|read|consume|link-work-record|delete> ...",
         "UNKNOWN_SUBCOMMAND",
         "see annotation subcommand"
       ],
       "cwd": "repo"
+    },
+    {
+      "path": [
+        "see",
+        "annotation",
+        "select"
+      ],
+      "summary": "Select bounded desktop annotation evidence and persist it through the pending-annotation queue.",
+      "executable": "/usr/bin/env",
+      "argv_prefix": [
+        "node",
+        "scripts/aos-annotation-select.mjs"
+      ],
+      "cwd": "repo",
+      "stdio": "inherit",
+      "env": {
+        "AOS_PATH": "$AOS_PATH",
+        "AOS_RUNTIME_MODE": "$AOS_RUNTIME_MODE",
+        "AOS_STATE_ROOT": "$AOS_STATE_ROOT"
+      }
     },
     {
       "path": [

--- a/manifests/commands/source/external/18-play.json
+++ b/manifests/commands/source/external/18-play.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "id": "play",
+  "commands": [
+    {
+      "path": [
+        "play"
+      ],
+      "summary": "Stream bounded audio playback through the daemon voice-output broker.",
+      "executable": "/usr/bin/env",
+      "argv_prefix": [
+        "node",
+        "scripts/aos-play.mjs"
+      ],
+      "cwd": "repo",
+      "stdio": "inherit",
+      "env": {
+        "AOS_PATH": "$AOS_PATH",
+        "AOS_RUNTIME_MODE": "$AOS_RUNTIME_MODE",
+        "AOS_STATE_ROOT": "$AOS_STATE_ROOT"
+      }
+    }
+  ]
+}

--- a/manifests/commands/source/external/25-shortcut.json
+++ b/manifests/commands/source/external/25-shortcut.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "id": "shortcut",
+  "commands": [
+    {
+      "path": [
+        "shortcut"
+      ],
+      "summary": "Run explicitly named Apple Shortcuts through a bounded shell-free adapter.",
+      "executable": "/usr/bin/env",
+      "argv_prefix": [
+        "node",
+        "scripts/aos-shortcut.mjs"
+      ],
+      "cwd": "repo",
+      "stdio": "inherit"
+    },
+    {
+      "path": [
+        "shortcut",
+        "run"
+      ],
+      "summary": "Run one exact Apple Shortcut through the bounded adapter.",
+      "executable": "/usr/bin/env",
+      "argv_prefix": [
+        "node",
+        "scripts/aos-shortcut.mjs",
+        "run"
+      ],
+      "cwd": "repo",
+      "stdio": "inherit"
+    }
+  ]
+}

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -85,8 +85,10 @@ commands, runtime helpers, wiki tools, and command adapters.
   new behavior there.
 - Native capability stays in `src/`; public schema contracts stay in
   `shared/schemas/`.
-- `lib/aos-voice-follow.mjs` owns the public streaming adapters for
-  `listen --source hotkey|microphone --follow` and `say --follow`. Keep daemon
+- `lib/aos-voice-follow.mjs` owns the bounded daemon-follow lifecycle used by
+  public connection-scoped streaming adapters, including
+  `listen --source hotkey|microphone --follow`, `say --follow`, `play --follow`,
+  and native annotation selection. Keep daemon
   connection mechanics in `lib/aos-daemon-client.mjs`, keep speech text on
   stdin, do not echo speech text or capture paths through events or errors, and
   cancel the connection-scoped lease when the native external-dispatch owner
@@ -109,6 +111,17 @@ commands, runtime helpers, wiki tools, and command adapters.
 - `aos-scene.mjs` owns the bounded public NDJSON adapter for connection-scoped
   DesktopWorld scene leases. It accepts only the documented operation set,
   bounds input/output, and never exposes the daemon socket to consumers.
+- `aos-shortcut.mjs` owns explicit Apple Shortcut execution through
+  `/usr/bin/shortcuts`. It passes one exact shortcut name as an argv item,
+  never invokes a shell, bounds time and output, and never returns captured
+  Shortcut output content.
+- `aos-play.mjs` owns bounded connection-scoped WAV playback through the
+  daemon voice-output broker. Input paths stay private to the request; public
+  events expose only lifecycle, format, byte-count, and meter facts.
+- `aos-annotation-select.mjs` owns the public connection-scoped desktop
+  annotation adapter. It validates native point, rectangle, freehand, or text
+  evidence, persists one pending-annotation record before completion, and
+  strips annotation text from the public follow event.
 
 ## Local Contracts
 

--- a/scripts/aos-annotation-select.mjs
+++ b/scripts/aos-annotation-select.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+
+import { Buffer } from 'node:buffer';
+import {
+  followDaemonLease,
+} from './lib/aos-voice-follow.mjs';
+import {
+  createPendingAnnotation,
+} from './lib/pending-annotations-lifecycle.mjs';
+import {
+  normalizeDesktopSelection,
+} from './lib/pending-annotations-model.mjs';
+
+const MODES = new Set(['point', 'rectangle', 'freehand', 'text']);
+const TERMINAL_EVENTS = new Set(['selection_completed', 'selection_canceled', 'selection_failed']);
+const FAILURE_EVENTS = new Set(['selection_failed']);
+const SAFE_ERRORS = new Map([
+  ['ANNOTATION_SELECTION_BUSY', 'another desktop annotation selection is active'],
+  ['ANNOTATION_SELECTION_CANCELED', 'desktop annotation selection was canceled before startup'],
+  ['ANNOTATION_SELECTION_NOT_OWNED', 'desktop annotation selection is not owned by this command'],
+  ['ANNOTATION_DISPLAY_UNAVAILABLE', 'no desktop display is available for annotation selection'],
+  ['ANNOTATION_SELECTION_FAILED', 'desktop annotation selection failed'],
+  ['INVALID_ANNOTATION_MODE', 'annotation mode must be point, rectangle, freehand, or text'],
+  ['INVALID_ANNOTATION_EVENT', 'daemon returned an invalid annotation event'],
+  ['PENDING_ANNOTATION_EXISTS', 'the selected annotation already exists'],
+  ['PENDING_ANNOTATION_STATE_CORRUPT', 'pending annotation storage is unavailable'],
+  ['INVALID_ARG', 'desktop annotation evidence is invalid'],
+]);
+const SOURCE = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/;
+
+function fail(message, code = 'INVALID_ARG') {
+  const error = new Error(message);
+  error.code = code;
+  throw error;
+}
+
+function valueAfter(args, token) {
+  const index = args.indexOf(token);
+  if (index < 0) return undefined;
+  const value = args[index + 1];
+  if (!value || value.startsWith('--')) fail(`${token} requires a value`, 'MISSING_ARG');
+  return value;
+}
+
+function parseArgs(args) {
+  const values = new Map();
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--follow') {
+      values.set(arg, true);
+      continue;
+    }
+    if (arg === '--mode' || arg === '--source') {
+      const value = args[index + 1];
+      if (!value || value.startsWith('--')) fail(`${arg} requires a value`, 'MISSING_ARG');
+      values.set(arg, value);
+      index += 1;
+      continue;
+    }
+    if (arg === '--help' || arg === '-h') {
+      values.set('--help', true);
+      continue;
+    }
+    if (arg.startsWith('--')) fail(`Unknown flag: ${arg}`, 'UNKNOWN_FLAG');
+    fail(`Unexpected positional argument: ${arg}`, 'UNKNOWN_ARG');
+  }
+  return values;
+}
+
+function assertExactKeys(value, expected, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(`${label} must be an object`, 'INVALID_ANNOTATION_EVENT');
+  const keys = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (keys.length !== wanted.length || keys.some((key, index) => key !== wanted[index])) {
+    fail(`${label} has an unexpected shape`, 'INVALID_ANNOTATION_EVENT');
+  }
+}
+
+function normalizedText(value) {
+  if (value === null) return null;
+  if (typeof value !== 'string' || value.length === 0 || Buffer.byteLength(value, 'utf8') > 4 * 1024) {
+    fail('annotation text is invalid', 'INVALID_ANNOTATION_EVENT');
+  }
+  return value;
+}
+
+function transformAnnotationEvent(payload, source) {
+  const data = payload.data;
+  if (payload.event === 'selection_started') {
+    assertExactKeys(data, ['mode'], 'selection_started data');
+    if (!MODES.has(data.mode)) fail('annotation mode is invalid', 'INVALID_ANNOTATION_EVENT');
+    return payload;
+  }
+  if (payload.event === 'selection_canceled') {
+    assertExactKeys(data, ['reason'], 'selection_canceled data');
+    if (!['escape', 'canceled', 'owner_disconnect', 'daemon_shutdown', 'invalid_selection'].includes(data.reason)) {
+      fail('annotation cancellation reason is invalid', 'INVALID_ANNOTATION_EVENT');
+    }
+    return payload;
+  }
+  if (payload.event === 'selection_failed') {
+    assertExactKeys(data, ['code'], 'selection_failed data');
+    if (typeof data.code !== 'string' || !/^[A-Z][A-Z0-9_]{1,63}$/.test(data.code)) {
+      fail('annotation failure code is invalid', 'INVALID_ANNOTATION_EVENT');
+    }
+    return payload;
+  }
+  if (payload.event !== 'selection_completed') fail('annotation event is unknown', 'INVALID_ANNOTATION_EVENT');
+  assertExactKeys(data, ['application', 'geometry', 'mode', 'selection_id', 'text', 'window'], 'selection_completed data');
+  const text = normalizedText(data.text);
+  const desktopSelection = normalizeDesktopSelection({
+    kind: 'desktop_annotation_selection',
+    selection_id: data.selection_id,
+    mode: data.mode,
+    geometry: data.geometry,
+    application: data.application,
+    window: data.window,
+  });
+  if ((desktopSelection.mode === 'text') !== (text !== null)) {
+    fail('annotation text does not match selection mode', 'INVALID_ANNOTATION_EVENT');
+  }
+  const targetSummary = `Desktop ${desktopSelection.mode} annotation`;
+  const created = createPendingAnnotation({
+    source,
+    comment: text,
+    target_kind: 'region',
+    target_summary: targetSummary,
+    capability: {
+      status: 'fallback_only',
+      reasons: ['native_selection_without_saved_ref'],
+    },
+    fallback_evidence: [{
+      kind: desktopSelection.geometry.kind,
+      reason: 'semantic_ref_unavailable',
+      summary: targetSummary,
+    }],
+    desktop_selection: desktopSelection,
+  });
+  return {
+    ...payload,
+    data: {
+      annotation_id: created.annotation.id,
+      selection_id: desktopSelection.selection_id,
+      mode: desktopSelection.mode,
+      geometry: desktopSelection.geometry,
+      application: desktopSelection.application,
+      window: desktopSelection.window,
+      has_text: text !== null,
+    },
+  };
+}
+
+function usage() {
+  process.stdout.write('Usage: aos see annotation select --mode <point|rectangle|freehand|text> [--source <token>] --follow\n');
+}
+
+async function main(args) {
+  const values = parseArgs(args);
+  if (values.has('--help')) {
+    usage();
+    return;
+  }
+  if (!values.has('--follow')) fail('annotation selection requires --follow', 'MISSING_ARG');
+  const mode = valueAfter(args, '--mode');
+  if (!MODES.has(mode)) fail('annotation mode must be point, rectangle, freehand, or text', 'INVALID_ANNOTATION_MODE');
+  const source = valueAfter(args, '--source') ?? 'operator_annotation';
+  if (!SOURCE.test(source)) fail('annotation source is invalid', 'INVALID_ARG');
+  await followDaemonLease({
+    service: 'annotation',
+    action: 'select',
+    data: { mode },
+    stopAction: { service: 'annotation', action: 'cancel' },
+    cancelAction: { service: 'annotation', action: 'cancel' },
+    eventService: 'annotation',
+    terminalEvents: TERMINAL_EVENTS,
+    failureEvents: FAILURE_EVENTS,
+    safeDaemonErrors: SAFE_ERRORS,
+    eventTooLargeCode: 'ANNOTATION_EVENT_TOO_LARGE',
+    eventTooLargeMessage: 'annotation event exceeded the line limit',
+    invalidEventCode: 'INVALID_ANNOTATION_EVENT',
+    invalidEventMessage: 'daemon returned malformed annotation JSON',
+    fallbackErrorCode: 'ANNOTATION_SELECTION_FAILED',
+    fallbackErrorMessage: 'desktop annotation selection failed',
+    transformEvent: (payload) => transformAnnotationEvent(payload, source),
+  });
+}
+
+main(process.argv.slice(2)).catch((error) => {
+  const code = error?.code ?? 'ANNOTATION_SELECTION_FAILED';
+  process.stderr.write(`${JSON.stringify({ code, error: SAFE_ERRORS.get(code) ?? 'desktop annotation selection failed' })}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/aos-play.mjs
+++ b/scripts/aos-play.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+import {
+  playAudioFollow,
+  writeVoiceCLIError,
+} from './lib/aos-voice-follow.mjs';
+
+if (process.argv.slice(2).some((arg) => arg === '--help' || arg === '-h')) {
+  process.stdout.write('Usage: aos play --audio <absolute.wav> --follow\n');
+  process.exit(0);
+}
+
+try {
+  await playAudioFollow(process.argv.slice(2));
+} catch (error) {
+  writeVoiceCLIError(error);
+}

--- a/scripts/aos-shortcut.mjs
+++ b/scripts/aos-shortcut.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+import {
+  parseShortcutRunArgs,
+  runAppleShortcut,
+} from './lib/aos-shortcut-run.mjs';
+
+const abortController = new AbortController();
+process.once('SIGINT', () => abortController.abort());
+process.once('SIGTERM', () => abortController.abort());
+
+const SAFE_ERRORS = new Map([
+  ['MISSING_SUBCOMMAND', 'shortcut requires a subcommand'],
+  ['UNKNOWN_SUBCOMMAND', 'unknown shortcut subcommand'],
+  ['MISSING_ARG', 'shortcut run requires one exact name'],
+  ['UNKNOWN_ARG', 'shortcut run accepts one exact name'],
+  ['UNKNOWN_FLAG', 'shortcut run received an unknown flag'],
+  ['INVALID_SHORTCUT_NAME', 'shortcut name must contain 1 to 256 UTF-8 bytes'],
+  ['INVALID_TIMEOUT', 'shortcut timeout must be from 1 to 120 seconds'],
+  ['SHORTCUT_CANCELED', 'Apple Shortcut execution was canceled'],
+  ['SHORTCUT_TIMEOUT', 'Apple Shortcut execution timed out'],
+  ['SHORTCUT_OUTPUT_LIMIT', 'Apple Shortcut output exceeded the limit'],
+  ['SHORTCUT_FAILED', 'Apple Shortcut execution failed'],
+]);
+
+if (process.argv.slice(2).some((arg) => arg === '--help' || arg === '-h')) {
+  process.stdout.write('Usage: aos shortcut run <name> [--timeout <duration>] [--json]\n');
+  process.exit(0);
+}
+
+try {
+  const options = parseShortcutRunArgs(process.argv.slice(2));
+  const result = await runAppleShortcut({ ...options, signal: abortController.signal });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+} catch (error) {
+  const code = error?.code ?? 'SHORTCUT_FAILED';
+  process.stderr.write(`${JSON.stringify({
+    code,
+    error: SAFE_ERRORS.get(code) ?? 'Apple Shortcut execution failed',
+  })}\n`);
+  process.exitCode = 1;
+}

--- a/scripts/generate-command-inventory.mjs
+++ b/scripts/generate-command-inventory.mjs
@@ -224,7 +224,8 @@ function capabilityGroup(command, form) {
   if (top === 'skills' || top === 'recipe') return 'Skills and recipes';
   if (top === 'gate' || top === 'work-record') return 'Verification/evidence';
   if (top === 'tell' || top === 'listen') return 'Operator messaging';
-  if (top === 'say' || top === 'voice') return 'Voice and speech';
+  if (top === 'say' || top === 'voice' || top === 'play') return 'Voice and speech';
+  if (top === 'shortcut') return 'Desktop/native control';
   if (top === 'wiki' || top === 'content') return 'Content/wiki';
   if (top === 'config' || top === 'set') return 'Storage/config';
   if (top === 'service' || top === 'runtime' || top === 'serve' || top === 'reset' || top === 'clean') return 'Runtime/service';

--- a/scripts/lib/aos-shortcut-run.mjs
+++ b/scripts/lib/aos-shortcut-run.mjs
@@ -1,0 +1,156 @@
+import { spawn } from 'node:child_process';
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+const MAX_TIMEOUT_MS = 120_000;
+const MAX_OUTPUT_BYTES = 64 * 1024;
+const MAX_SHORTCUT_NAME_BYTES = 256;
+
+function failure(message, code) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function valueAfter(args, token) {
+  const index = args.indexOf(token);
+  if (index < 0) return undefined;
+  const value = args[index + 1];
+  if (!value || value.startsWith('--')) throw failure(`${token} requires a value`, 'MISSING_ARG');
+  return value;
+}
+
+function parseDuration(value) {
+  if (value === undefined) return DEFAULT_TIMEOUT_MS;
+  const match = /^(\d+(?:\.\d+)?)(ms|s)?$/.exec(value);
+  if (!match) throw failure('--timeout must be a duration from 1s to 120s', 'INVALID_TIMEOUT');
+  const amount = Number(match[1]);
+  const milliseconds = match[2] === 'ms' ? amount : amount * 1000;
+  if (!Number.isFinite(milliseconds) || milliseconds < 1000 || milliseconds > MAX_TIMEOUT_MS) {
+    throw failure('--timeout must be a duration from 1s to 120s', 'INVALID_TIMEOUT');
+  }
+  return Math.floor(milliseconds);
+}
+
+export function parseShortcutRunArgs(args) {
+  const [command, ...rest] = args;
+  if (command !== 'run') {
+    throw failure(command ? `Unknown shortcut subcommand: ${command}` : 'shortcut requires a subcommand', command ? 'UNKNOWN_SUBCOMMAND' : 'MISSING_SUBCOMMAND');
+  }
+
+  const positionals = [];
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    if (arg === '--json') continue;
+    if (arg === '--timeout') {
+      index += 1;
+      if (index >= rest.length || rest[index].startsWith('--')) {
+        throw failure('--timeout requires a value', 'MISSING_ARG');
+      }
+      continue;
+    }
+    if (arg.startsWith('--')) throw failure(`Unknown flag: ${arg}`, 'UNKNOWN_FLAG');
+    positionals.push(arg);
+  }
+
+  if (positionals.length === 0) throw failure('shortcut run requires a shortcut name', 'MISSING_ARG');
+  if (positionals.length > 1) throw failure('shortcut run accepts exactly one shortcut name', 'UNKNOWN_ARG');
+  const name = positionals[0].trim();
+  if (!name || name.includes('\0') || Buffer.byteLength(name) > MAX_SHORTCUT_NAME_BYTES) {
+    throw failure('shortcut name must contain 1 to 256 UTF-8 bytes', 'INVALID_SHORTCUT_NAME');
+  }
+  return {
+    name,
+    timeoutMs: parseDuration(valueAfter(rest, '--timeout')),
+  };
+}
+
+export async function runAppleShortcut({
+  name,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  signal,
+  executable = '/usr/bin/shortcuts',
+  spawnImpl = spawn,
+}) {
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 1000 || timeoutMs > MAX_TIMEOUT_MS) {
+    throw failure('shortcut timeout must be from 1000 to 120000 milliseconds', 'INVALID_TIMEOUT');
+  }
+
+  const startedAt = Date.now();
+  const child = spawnImpl(executable, ['run', name], {
+    env: process.env,
+    detached: true,
+    shell: false,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdoutBytes = 0;
+  let stderrBytes = 0;
+  let outputExceeded = false;
+  let timedOut = false;
+  let aborted = false;
+  let escalationTimer = null;
+
+  const signalProcessGroup = (signalName) => {
+    try {
+      process.kill(-child.pid, signalName);
+    } catch {
+      child.kill(signalName);
+    }
+  };
+
+  const terminate = () => {
+    signalProcessGroup('SIGTERM');
+    if (escalationTimer === null) {
+      escalationTimer = setTimeout(() => signalProcessGroup('SIGKILL'), 1_000);
+    }
+  };
+
+  const count = (stream, kind) => {
+    stream?.on('data', (chunk) => {
+      const bytes = Buffer.byteLength(chunk);
+      if (kind === 'stdout') stdoutBytes += bytes;
+      else stderrBytes += bytes;
+      if (!outputExceeded && stdoutBytes + stderrBytes > MAX_OUTPUT_BYTES) {
+        outputExceeded = true;
+        terminate();
+      }
+    });
+  };
+  count(child.stdout, 'stdout');
+  count(child.stderr, 'stderr');
+
+  const abort = () => {
+    aborted = true;
+    terminate();
+  };
+  if (signal?.aborted) abort();
+  else signal?.addEventListener('abort', abort, { once: true });
+
+  const timer = setTimeout(() => {
+    timedOut = true;
+    terminate();
+  }, timeoutMs);
+  timer.unref();
+
+  try {
+    const result = await new Promise((resolve, reject) => {
+      child.once('error', reject);
+      child.once('close', (code, childSignal) => resolve({ code, signal: childSignal }));
+    });
+    if (aborted) throw failure('Apple Shortcut execution was canceled', 'SHORTCUT_CANCELED');
+    if (timedOut) throw failure('Apple Shortcut execution timed out', 'SHORTCUT_TIMEOUT');
+    if (outputExceeded) throw failure('Apple Shortcut output exceeded the limit', 'SHORTCUT_OUTPUT_LIMIT');
+    if (result.code !== 0) throw failure('Apple Shortcut execution failed', 'SHORTCUT_FAILED');
+    return {
+      status: 'ok',
+      duration_ms: Date.now() - startedAt,
+      output: {
+        stdout_bytes: stdoutBytes,
+        stderr_bytes: stderrBytes,
+      },
+    };
+  } finally {
+    clearTimeout(timer);
+    if (escalationTimer !== null) clearTimeout(escalationTimer);
+    signal?.removeEventListener('abort', abort);
+  }
+}

--- a/scripts/lib/aos-voice-follow.mjs
+++ b/scripts/lib/aos-voice-follow.mjs
@@ -18,8 +18,11 @@ const TERMINAL_EVENTS = new Set([
   'speech_finished',
   'speech_canceled',
   'speech_failed',
+  'playback_finished',
+  'playback_canceled',
+  'playback_failed',
 ]);
-const FAILURE_EVENTS = new Set(['capture_failed', 'capture_segmented_failed', 'speech_failed']);
+const FAILURE_EVENTS = new Set(['capture_failed', 'capture_segmented_failed', 'speech_failed', 'playback_failed']);
 const SAFE_DAEMON_ERRORS = new Map([
   ['MICROPHONE_PERMISSION_DENIED', 'microphone permission is not granted'],
   ['MICROPHONE_PERMISSION_NOT_DETERMINED', 'microphone permission has not been requested'],
@@ -46,6 +49,23 @@ const SAFE_DAEMON_ERRORS = new Map([
   ['INVALID_VOICE_ID', 'voice identifier is malformed'],
   ['INVALID_VOICE_PROVIDER', 'streamed speech requires a system voice'],
   ['VOICE_NOT_FOUND', 'requested system voice is unavailable'],
+  ['INVALID_AUDIO_PATH', 'audio playback input path is invalid'],
+  ['UNSAFE_AUDIO_PARENT', 'audio playback input parent is unsafe'],
+  ['UNSAFE_AUDIO_INPUT', 'audio playback input is unsafe'],
+  ['AUDIO_INPUT_UNAVAILABLE', 'audio playback input is unavailable'],
+  ['AUDIO_INPUT_LIMIT', 'audio playback input exceeds the supported size'],
+  ['INVALID_AUDIO_FILE', 'audio playback input is not readable PCM audio'],
+  ['UNSUPPORTED_AUDIO_FILE', 'audio playback format or duration is unsupported'],
+  ['AUDIO_OUTPUT_UNAVAILABLE', 'audio playback output is unavailable'],
+  ['PLAYBACK_CANCELED', 'audio playback was canceled before startup'],
+]);
+const SAFE_CLI_ERRORS = new Map([
+  ['MISSING_ARG', 'required voice argument is missing'],
+  ['UNKNOWN_ARG', 'voice command received an unexpected argument'],
+  ['UNKNOWN_FLAG', 'voice command received an unknown flag'],
+  ['INVALID_ARG', 'voice command argument is invalid'],
+  ['INVALID_AUDIO_PATH', 'audio playback input path is invalid'],
+  ['DAEMON_UNREACHABLE', 'AOS daemon is unavailable'],
 ]);
 
 function fail(message, code) {
@@ -105,7 +125,12 @@ function request(service, action, data, ref) {
 function monitorExternalDispatchParent(onDisconnect) {
   const parentPID = Number(process.env[EXTERNAL_DISPATCH_PARENT_PID_ENV]);
   if (!Number.isInteger(parentPID) || parentPID <= 1) return null;
+  const testDelay = process.env.NODE_ENV === 'test'
+    ? Number(process.env.AOS_TEST_PARENT_MONITOR_DELAY_MS ?? 0)
+    : 0;
+  const firstCheckAt = Date.now() + (Number.isFinite(testDelay) && testDelay > 0 ? Math.min(testDelay, 2_000) : 0);
   const timer = setInterval(() => {
+    if (Date.now() < firstCheckAt) return;
     let alive = process.ppid === parentPID;
     if (alive) {
       try {
@@ -120,7 +145,24 @@ function monitorExternalDispatchParent(onDisconnect) {
   return timer;
 }
 
-async function followVoice({ service, action, data, stopAction, cancelAction, terminalEvents = TERMINAL_EVENTS }) {
+export async function followDaemonLease({
+  service,
+  action,
+  data,
+  stopAction,
+  cancelAction,
+  eventService,
+  terminalEvents,
+  failureEvents,
+  safeDaemonErrors,
+  eventTooLargeCode,
+  eventTooLargeMessage,
+  invalidEventCode,
+  invalidEventMessage,
+  fallbackErrorCode,
+  fallbackErrorMessage,
+  transformEvent = (payload) => payload,
+}) {
   const startupAbort = new AbortController();
   let startupCanceled = false;
   let ownedDaemon = null;
@@ -186,7 +228,7 @@ async function followVoice({ service, action, data, stopAction, cancelAction, te
   socket.on('data', (chunk) => {
     buffer += chunk.toString('utf8');
     if (Buffer.byteLength(buffer) > MAX_LINE_BYTES && !buffer.includes('\n')) {
-      process.stderr.write(`${JSON.stringify({ code: 'VOICE_EVENT_TOO_LARGE', error: 'voice event exceeded the line limit' })}\n`);
+      process.stderr.write(`${JSON.stringify({ code: eventTooLargeCode, error: eventTooLargeMessage })}\n`);
       cleanup(1);
       return;
     }
@@ -196,7 +238,7 @@ async function followVoice({ service, action, data, stopAction, cancelAction, te
       const line = buffer.slice(0, newline);
       buffer = buffer.slice(newline + 1);
       if (Buffer.byteLength(line) > MAX_LINE_BYTES) {
-        process.stderr.write(`${JSON.stringify({ code: 'VOICE_EVENT_TOO_LARGE', error: 'voice event exceeded the line limit' })}\n`);
+        process.stderr.write(`${JSON.stringify({ code: eventTooLargeCode, error: eventTooLargeMessage })}\n`);
         cleanup(1);
         return;
       }
@@ -204,24 +246,49 @@ async function followVoice({ service, action, data, stopAction, cancelAction, te
       try {
         payload = JSON.parse(line);
       } catch {
-        process.stderr.write(`${JSON.stringify({ code: 'INVALID_VOICE_EVENT', error: 'daemon returned malformed JSON' })}\n`);
+        process.stderr.write(`${JSON.stringify({ code: invalidEventCode, error: invalidEventMessage })}\n`);
         cleanup(1);
         return;
       }
       if (payload.status === 'error' || payload.error) {
-        const code = payload.code ?? 'VOICE_TRANSPORT_FAILED';
-        process.stderr.write(`${JSON.stringify({ code, error: SAFE_DAEMON_ERRORS.get(code) ?? 'voice transport failed' })}\n`);
+        const code = payload.code ?? fallbackErrorCode;
+        process.stderr.write(`${JSON.stringify({ code, error: safeDaemonErrors.get(code) ?? fallbackErrorMessage })}\n`);
         cleanup(1);
         return;
       }
-      if (payload.v !== 1 || payload.service !== 'voice' || typeof payload.event !== 'string') continue;
-      process.stdout.write(`${JSON.stringify(payload)}\n`);
-      if (terminalEvents.has(payload.event)) cleanup(FAILURE_EVENTS.has(payload.event) ? 1 : 0);
+      if (payload.v !== 1 || payload.service !== eventService || typeof payload.event !== 'string') continue;
+      let output;
+      try {
+        output = transformEvent(payload);
+      } catch (error) {
+        const code = error?.code ?? invalidEventCode;
+        process.stderr.write(`${JSON.stringify({ code, error: safeDaemonErrors.get(code) ?? fallbackErrorMessage })}\n`);
+        cleanup(1);
+        return;
+      }
+      if (output !== null && output !== undefined) process.stdout.write(`${JSON.stringify(output)}\n`);
+      if (terminalEvents.has(payload.event)) cleanup(failureEvents.has(payload.event) ? 1 : 0);
     }
   });
   socket.once('error', () => cleanup(1));
   socket.once('close', () => cleanup(controlSent ? 0 : 1));
   socket.write(request(service, action, data, ref));
+}
+
+function followVoice(options) {
+  return followDaemonLease({
+    ...options,
+    eventService: 'voice',
+    terminalEvents: options.terminalEvents ?? TERMINAL_EVENTS,
+    failureEvents: FAILURE_EVENTS,
+    safeDaemonErrors: SAFE_DAEMON_ERRORS,
+    eventTooLargeCode: 'VOICE_EVENT_TOO_LARGE',
+    eventTooLargeMessage: 'voice event exceeded the line limit',
+    invalidEventCode: 'INVALID_VOICE_EVENT',
+    invalidEventMessage: 'daemon returned malformed JSON',
+    fallbackErrorCode: 'VOICE_TRANSPORT_FAILED',
+    fallbackErrorMessage: 'voice transport failed',
+  });
 }
 
 export async function listenVoice(args) {
@@ -317,7 +384,31 @@ export async function sayFollow(args) {
   });
 }
 
+export async function playAudioFollow(args) {
+  assertOnlyFlags(args, new Set(['--audio']), new Set(['--follow']));
+  if (!args.includes('--follow')) fail('audio playback requires --follow', 'MISSING_ARG');
+  const audioPath = valueAfter(args, '--audio');
+  if (!audioPath) fail('audio playback requires --audio', 'MISSING_ARG');
+  if (!audioPath.startsWith('/')) fail('audio playback input must be absolute', 'INVALID_AUDIO_PATH');
+  await followVoice({
+    service: 'voice',
+    action: 'playback',
+    data: { audio_path: audioPath },
+    stopAction: { service: 'voice', action: 'cancel' },
+    cancelAction: { service: 'voice', action: 'cancel' },
+  });
+}
+
+export function voiceCLIErrorEnvelope(error) {
+  const candidate = typeof error?.code === 'string' ? error.code : '';
+  const code = /^[A-Z][A-Z0-9_]{1,63}$/.test(candidate) ? candidate : 'VOICE_TRANSPORT_FAILED';
+  return {
+    code,
+    error: SAFE_DAEMON_ERRORS.get(code) ?? SAFE_CLI_ERRORS.get(code) ?? 'voice transport failed',
+  };
+}
+
 export function writeVoiceCLIError(error) {
-  process.stderr.write(`${JSON.stringify({ code: error?.code ?? 'VOICE_TRANSPORT_FAILED', error: error?.message ?? 'voice transport failed' })}\n`);
+  process.stderr.write(`${JSON.stringify(voiceCLIErrorEnvelope(error))}\n`);
   process.exitCode = 1;
 }

--- a/scripts/lib/pending-annotations-model.mjs
+++ b/scripts/lib/pending-annotations-model.mjs
@@ -1,5 +1,6 @@
 import crypto from 'node:crypto';
 import path from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
 import {
   array,
   fail,
@@ -193,6 +194,123 @@ export function normalizeSourceCapture(value) {
   };
 }
 
+const DESKTOP_SELECTION_MODES = new Set(['point', 'rectangle', 'freehand', 'text']);
+const DESKTOP_SELECTION_COORDINATE_SPACE = 'desktop_points_top_left';
+const DESKTOP_SELECTION_MAX_POINTS = 256;
+const DESKTOP_SELECTION_ID = /^sel-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+function finiteNumber(value, label) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    fail(`${label} must be a finite number`, 'INVALID_ARG');
+  }
+  return value;
+}
+
+function boundedNullableString(value, label, maxBytes) {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== 'string' || Buffer.byteLength(value, 'utf8') > maxBytes) {
+    fail(`${label} must be null or at most ${maxBytes} UTF-8 bytes`, 'INVALID_ARG');
+  }
+  return value;
+}
+
+function normalizeDesktopBounds(value, label) {
+  if (!isObject(value)) fail(`${label} must be an object`, 'INVALID_ARG');
+  return {
+    x: finiteNumber(value.x, `${label}.x`),
+    y: finiteNumber(value.y, `${label}.y`),
+    width: finiteNumber(value.width, `${label}.width`),
+    height: finiteNumber(value.height, `${label}.height`),
+  };
+}
+
+function normalizeDesktopGeometry(value, mode) {
+  if (!isObject(value)) fail('desktop_selection.geometry must be an object', 'INVALID_ARG');
+  if (value.coordinate_space !== DESKTOP_SELECTION_COORDINATE_SPACE) {
+    fail(`desktop_selection.geometry.coordinate_space must be ${DESKTOP_SELECTION_COORDINATE_SPACE}`, 'INVALID_ARG');
+  }
+  const kind = requiredText(value.kind, 'desktop_selection.geometry.kind');
+  if ((mode === 'point' || mode === 'text') && kind !== 'point') {
+    fail('point and text selections require point geometry', 'INVALID_ARG');
+  }
+  if (mode === 'rectangle' && kind !== 'rectangle') {
+    fail('rectangle selections require rectangle geometry', 'INVALID_ARG');
+  }
+  if (mode === 'freehand' && kind !== 'freehand') {
+    fail('freehand selections require freehand geometry', 'INVALID_ARG');
+  }
+  if (kind === 'point') {
+    return {
+      kind,
+      coordinate_space: DESKTOP_SELECTION_COORDINATE_SPACE,
+      x: finiteNumber(value.x, 'desktop_selection.geometry.x'),
+      y: finiteNumber(value.y, 'desktop_selection.geometry.y'),
+    };
+  }
+  if (kind === 'rectangle') {
+    const geometry = normalizeDesktopBounds(value, 'desktop_selection.geometry');
+    if (geometry.width < 0 || geometry.height < 0) {
+      fail('desktop_selection rectangle dimensions must be non-negative', 'INVALID_ARG');
+    }
+    return { kind, coordinate_space: DESKTOP_SELECTION_COORDINATE_SPACE, ...geometry };
+  }
+  if (kind === 'freehand') {
+    if (!Array.isArray(value.points) || value.points.length < 1 || value.points.length > DESKTOP_SELECTION_MAX_POINTS) {
+      fail(`desktop_selection freehand points must contain 1 to ${DESKTOP_SELECTION_MAX_POINTS} points`, 'INVALID_ARG');
+    }
+    const points = value.points.map((point, index) => {
+      if (!isObject(point)) fail(`desktop_selection.geometry.points[${index}] must be an object`, 'INVALID_ARG');
+      return {
+        x: finiteNumber(point.x, `desktop_selection.geometry.points[${index}].x`),
+        y: finiteNumber(point.y, `desktop_selection.geometry.points[${index}].y`),
+      };
+    });
+    const bounds = normalizeDesktopBounds(value.bounds, 'desktop_selection.geometry.bounds');
+    if (bounds.width < 0 || bounds.height < 0) {
+      fail('desktop_selection freehand bounds must be non-negative', 'INVALID_ARG');
+    }
+    return { kind, coordinate_space: DESKTOP_SELECTION_COORDINATE_SPACE, points, bounds };
+  }
+  fail(`Unsupported desktop selection geometry: ${kind}`, 'INVALID_ARG');
+}
+
+export function normalizeDesktopSelection(value) {
+  if (value === null || value === undefined) return null;
+  if (!isObject(value)) fail('desktop_selection must be an object or null', 'INVALID_ARG');
+  const mode = requiredText(value.mode, 'desktop_selection.mode');
+  if (!DESKTOP_SELECTION_MODES.has(mode)) fail(`Unsupported desktop selection mode: ${mode}`, 'INVALID_ARG');
+  if (!DESKTOP_SELECTION_ID.test(value.selection_id)) {
+    fail('desktop selection id must be a canonical sel-prefixed UUID', 'INVALID_ARG');
+  }
+  if (!isObject(value.application)) fail('desktop_selection.application must be an object', 'INVALID_ARG');
+  if (!Number.isInteger(value.application.pid) || value.application.pid < -1) {
+    fail('desktop_selection.application.pid must be an integer >= -1', 'INVALID_ARG');
+  }
+  let window = null;
+  if (value.window !== null && value.window !== undefined) {
+    if (!isObject(value.window) || !Number.isInteger(value.window.window_id) || value.window.window_id < -1) {
+      fail('desktop_selection.window must contain window_id >= -1', 'INVALID_ARG');
+    }
+    window = {
+      window_id: value.window.window_id,
+      title: boundedNullableString(value.window.title, 'desktop_selection.window.title', 512),
+      bounds: normalizeDesktopBounds(value.window.bounds, 'desktop_selection.window.bounds'),
+    };
+  }
+  return {
+    kind: 'desktop_annotation_selection',
+    selection_id: value.selection_id,
+    mode,
+    geometry: normalizeDesktopGeometry(value.geometry, mode),
+    application: {
+      pid: value.application.pid,
+      name: boundedNullableString(value.application.name, 'desktop_selection.application.name', 256),
+      bundle_id: boundedNullableString(value.application.bundle_id, 'desktop_selection.application.bundle_id', 256),
+    },
+    window,
+  };
+}
+
 function recordContext(context = {}) {
   return {
     runtime_mode: requiredText(context.runtime_mode, 'record context runtime_mode'),
@@ -228,6 +346,7 @@ export function normalizeRecordInput(input, context = {}) {
     fallbackOnly: capability.status !== 'saved_ref',
     workspace: workspaceForNext,
   });
+  const desktopSelection = normalizeDesktopSelection(input.desktop_selection);
   return {
     schema_version: SCHEMA_VERSION,
     id,
@@ -257,6 +376,7 @@ export function normalizeRecordInput(input, context = {}) {
     artifact_refs: normalizeArtifactRefs(input.artifact_refs ?? []),
     recommended_next: recommendedNext,
     source_capture: normalizeSourceCapture(input.source_capture),
+    ...(desktopSelection ? { desktop_selection: desktopSelection } : {}),
     work_record_links: normalizeWorkRecordLinks(input.work_record_links),
     paths: {
       root: ctx.pending_root,
@@ -333,6 +453,16 @@ function assertSourceCapture(value) {
   );
 }
 
+function assertDesktopSelection(value) {
+  if (value === undefined) return true;
+  if (value === null) return false;
+  try {
+    return isDeepStrictEqual(value, normalizeDesktopSelection(value));
+  } catch {
+    return false;
+  }
+}
+
 export function validateCapabilityInvariants(value) {
   const savedRefAvailable = value.target.saved_ref !== null;
   if (value.capability.saved_ref_available !== savedRefAvailable) return false;
@@ -383,6 +513,7 @@ export function isPendingAnnotationRecord(value) {
     || value.recommended_next.length < 1
     || !Object.hasOwn(value, 'source_capture')
     || !assertSourceCapture(value.source_capture)
+    || !assertDesktopSelection(value.desktop_selection)
     || !Array.isArray(value.work_record_links)
     || !isObject(value.paths)
     || !nonEmptyString(value.paths.root)

--- a/shared/schemas/aos-pending-annotation-v0.md
+++ b/shared/schemas/aos-pending-annotation-v0.md
@@ -74,6 +74,8 @@ Each record includes:
 - `capability.status` and reasons;
 - `source_capture` metadata when the record was projected from a saved
   perception capture or refs readback, or `null` when no source capture exists;
+- optional `desktop_selection` metadata with bounded mode, top-left desktop
+  geometry, application/window facts, and the native selection id;
 - `artifact_refs[]` for disk-backed heavy evidence;
 - `recommended_next[]` as structured argv arrays;
 - `work_record_links[]` for later action/readback evidence connection.
@@ -87,6 +89,7 @@ normalizer does not invent fallback rows for missing refs.
 ## CLI
 
 ```bash
+aos see annotation select --mode rectangle --source companion --follow
 aos see annotation create --target-kind region --target-summary "top-right button" --comment "Use this one" --json
 aos see annotation create --target-kind browser --target-summary "Save button" --workspace default --snapshot snap1 --ref r2 --json
 aos see annotation create --from-capture-json capture.json --ref r2 --json
@@ -96,6 +99,14 @@ aos see annotation consume ann-example --actor agent --json
 aos see annotation link-work-record ann-example --work-record work-record:annotation-action-proof --relation annotation_action_evidence --json
 aos see annotation delete ann-example --json
 ```
+
+The native select form persists one record before emitting
+`selection_completed`. Its public event includes the pending annotation id and
+`has_text`, but never repeats entered text. The durable record keeps text only
+in `comment.text`; `desktop_selection` contains no text or filesystem path.
+Freehand paths are limited to 256 points, and native selection starts as honest
+`fallback_only` evidence until a consumer resolves a semantic saved ref through
+the separate perception contract.
 
 `create --from-json <path|->` accepts create-time annotation fields and
 normalizes missing ids, lifecycle timestamps, default recommended next

--- a/shared/schemas/aos-pending-annotation-v0.schema.json
+++ b/shared/schemas/aos-pending-annotation-v0.schema.json
@@ -129,6 +129,147 @@
         "selected_resolution_class": { "$ref": "#/$defs/nullable_string" }
       }
     },
+    "desktop_bounds": {
+      "type": "object",
+      "required": ["x", "y", "width", "height"],
+      "additionalProperties": false,
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" },
+        "width": { "type": "number", "minimum": 0 },
+        "height": { "type": "number", "minimum": 0 }
+      }
+    },
+    "desktop_point": {
+      "type": "object",
+      "required": ["x", "y"],
+      "additionalProperties": false,
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" }
+      }
+    },
+    "desktop_geometry": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind", "coordinate_space", "x", "y"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "point" },
+            "coordinate_space": { "const": "desktop_points_top_left" },
+            "x": { "type": "number" },
+            "y": { "type": "number" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "coordinate_space", "x", "y", "width", "height"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "rectangle" },
+            "coordinate_space": { "const": "desktop_points_top_left" },
+            "x": { "type": "number" },
+            "y": { "type": "number" },
+            "width": { "type": "number", "minimum": 0 },
+            "height": { "type": "number", "minimum": 0 }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "coordinate_space", "points", "bounds"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "freehand" },
+            "coordinate_space": { "const": "desktop_points_top_left" },
+            "points": {
+              "type": "array",
+              "minItems": 1,
+              "maxItems": 256,
+              "items": { "$ref": "#/$defs/desktop_point" }
+            },
+            "bounds": { "$ref": "#/$defs/desktop_bounds" }
+          }
+        }
+      ]
+    },
+    "desktop_selection": {
+      "type": "object",
+      "allOf": [
+        {
+          "if": {
+            "properties": { "mode": { "enum": ["point", "text"] } },
+            "required": ["mode"]
+          },
+          "then": {
+            "properties": {
+              "geometry": {
+                "properties": { "kind": { "const": "point" } }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "mode": { "const": "rectangle" } },
+            "required": ["mode"]
+          },
+          "then": {
+            "properties": {
+              "geometry": {
+                "properties": { "kind": { "const": "rectangle" } }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "mode": { "const": "freehand" } },
+            "required": ["mode"]
+          },
+          "then": {
+            "properties": {
+              "geometry": {
+                "properties": { "kind": { "const": "freehand" } }
+              }
+            }
+          }
+        }
+      ],
+      "required": ["kind", "selection_id", "mode", "geometry", "application", "window"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "desktop_annotation_selection" },
+        "selection_id": { "type": "string", "pattern": "^sel-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$" },
+        "mode": { "enum": ["point", "rectangle", "freehand", "text"] },
+        "geometry": { "$ref": "#/$defs/desktop_geometry" },
+        "application": {
+          "type": "object",
+          "required": ["pid", "name", "bundle_id"],
+          "additionalProperties": false,
+          "properties": {
+            "pid": { "type": "integer", "minimum": -1 },
+            "name": { "type": ["string", "null"], "maxLength": 256 },
+            "bundle_id": { "type": ["string", "null"], "maxLength": 256 }
+          }
+        },
+        "window": {
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "required": ["window_id", "title", "bounds"],
+              "additionalProperties": false,
+              "properties": {
+                "window_id": { "type": "integer", "minimum": -1 },
+                "title": { "type": ["string", "null"], "maxLength": 512 },
+                "bounds": { "$ref": "#/$defs/desktop_bounds" }
+              }
+            }
+          ]
+        }
+      }
+    },
     "work_record_link": {
       "type": "object",
       "required": ["ref", "relationship", "status", "artifact_refs"],
@@ -314,6 +455,7 @@
           "items": { "$ref": "#/$defs/recommended_next" }
         },
         "source_capture": { "$ref": "#/$defs/source_capture" },
+        "desktop_selection": { "$ref": "#/$defs/desktop_selection" },
         "work_record_links": {
           "type": "array",
           "items": { "$ref": "#/$defs/work_record_link" }

--- a/shared/schemas/daemon-event.schema.json
+++ b/shared/schemas/daemon-event.schema.json
@@ -32,6 +32,10 @@
               "capture_segmented_canceled",
               "capture_segmented_failed",
               "audio_frame",
+              "playback_started",
+              "playback_finished",
+              "playback_canceled",
+              "playback_failed",
               "speech_started",
               "speech_finished",
               "speech_canceled",
@@ -200,7 +204,7 @@
         "required": ["service", "event"],
         "properties": {
           "service": { "const": "voice" },
-          "event": { "enum": ["capture_failed", "capture_segmented_failed", "speech_failed"] }
+          "event": { "enum": ["capture_failed", "capture_segmented_failed", "playback_failed", "speech_failed"] }
         }
       },
       "then": {
@@ -220,6 +224,48 @@
       "then": {
         "properties": {
           "data": { "$ref": "#/$defs/VoiceAudioFrameData" }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["service", "event"],
+        "properties": {
+          "service": { "const": "voice" },
+          "event": { "const": "playback_started" }
+        }
+      },
+      "then": {
+        "properties": {
+          "data": { "$ref": "#/$defs/VoicePlaybackStartedData" }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["service", "event"],
+        "properties": {
+          "service": { "const": "voice" },
+          "event": { "const": "playback_finished" }
+        }
+      },
+      "then": {
+        "properties": {
+          "data": { "$ref": "#/$defs/VoicePlaybackFinishedData" }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["service", "event"],
+        "properties": {
+          "service": { "const": "voice" },
+          "event": { "const": "playback_canceled" }
+        }
+      },
+      "then": {
+        "properties": {
+          "data": { "$ref": "#/$defs/VoicePlaybackCanceledData" }
         }
       }
     },
@@ -271,6 +317,45 @@
         "properties": { "service": { "const": "scene" }, "event": { "const": "result" } }
       },
       "then": { "properties": { "data": { "$ref": "#/$defs/SceneResultData" } } }
+    },
+    {
+      "if": {
+        "required": ["service"],
+        "properties": { "service": { "const": "annotation" } }
+      },
+      "then": {
+        "properties": {
+          "event": { "enum": ["selection_started", "selection_completed", "selection_canceled", "selection_failed"] }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["service", "event"],
+        "properties": { "service": { "const": "annotation" }, "event": { "const": "selection_started" } }
+      },
+      "then": { "properties": { "data": { "$ref": "#/$defs/AnnotationSelectionStartedData" } } }
+    },
+    {
+      "if": {
+        "required": ["service", "event"],
+        "properties": { "service": { "const": "annotation" }, "event": { "const": "selection_completed" } }
+      },
+      "then": { "properties": { "data": { "$ref": "#/$defs/AnnotationSelectionCompletedData" } } }
+    },
+    {
+      "if": {
+        "required": ["service", "event"],
+        "properties": { "service": { "const": "annotation" }, "event": { "const": "selection_canceled" } }
+      },
+      "then": { "properties": { "data": { "$ref": "#/$defs/AnnotationSelectionCanceledData" } } }
+    },
+    {
+      "if": {
+        "required": ["service", "event"],
+        "properties": { "service": { "const": "annotation" }, "event": { "const": "selection_failed" } }
+      },
+      "then": { "properties": { "data": { "$ref": "#/$defs/AnnotationSelectionFailureData" } } }
     }
   ],
   "properties": {
@@ -280,7 +365,7 @@
     },
     "service": {
       "type": "string",
-      "enum": ["perceive", "display", "act", "voice", "scene"],
+      "enum": ["perceive", "display", "act", "voice", "scene", "annotation"],
       "description": "Which aos subsystem emitted this event."
     },
     "event": {
@@ -431,10 +516,40 @@
       "required": ["stream", "rms", "peak", "sequence"],
       "additionalProperties": false,
       "properties": {
-        "stream": { "type": "string", "enum": ["capture", "speech"] },
+        "stream": { "type": "string", "enum": ["capture", "playback", "speech"] },
         "rms": { "type": "number", "minimum": 0, "maximum": 1 },
         "peak": { "type": "number", "minimum": 0, "maximum": 1 },
         "sequence": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "VoicePlaybackStartedData": {
+      "type": "object",
+      "required": ["duration_ms", "bytes", "sample_rate", "channels"],
+      "additionalProperties": false,
+      "properties": {
+        "duration_ms": { "type": "integer", "minimum": 1, "maximum": 120000 },
+        "bytes": { "type": "integer", "minimum": 45, "maximum": 4194304 },
+        "sample_rate": { "type": "integer", "minimum": 8000, "maximum": 192000 },
+        "channels": { "type": "integer", "minimum": 1, "maximum": 2 }
+      }
+    },
+    "VoicePlaybackFinishedData": {
+      "type": "object",
+      "required": ["reason"],
+      "additionalProperties": false,
+      "properties": {
+        "reason": { "const": "completed" }
+      }
+    },
+    "VoicePlaybackCanceledData": {
+      "type": "object",
+      "required": ["reason"],
+      "additionalProperties": false,
+      "properties": {
+        "reason": {
+          "type": "string",
+          "enum": ["canceled", "owner_disconnect", "daemon_shutdown", "superseded", "barge_in"]
+        }
       }
     },
     "VoiceSpeechStartedData": {
@@ -462,6 +577,141 @@
           "enum": ["canceled", "owner_disconnect", "daemon_shutdown", "barge_in"]
         }
       }
+    },
+    "AnnotationSelectionMode": {
+      "enum": ["point", "rectangle", "freehand", "text"]
+    },
+    "AnnotationDesktopPoint": {
+      "type": "object",
+      "required": ["x", "y"],
+      "additionalProperties": false,
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" }
+      }
+    },
+    "AnnotationDesktopBounds": {
+      "type": "object",
+      "required": ["x", "y", "width", "height"],
+      "additionalProperties": false,
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" },
+        "width": { "type": "number", "minimum": 0 },
+        "height": { "type": "number", "minimum": 0 }
+      }
+    },
+    "AnnotationGeometry": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind", "coordinate_space", "x", "y"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "point" },
+            "coordinate_space": { "const": "desktop_points_top_left" },
+            "x": { "type": "number" },
+            "y": { "type": "number" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "coordinate_space", "x", "y", "width", "height"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "rectangle" },
+            "coordinate_space": { "const": "desktop_points_top_left" },
+            "x": { "type": "number" },
+            "y": { "type": "number" },
+            "width": { "type": "number", "minimum": 0 },
+            "height": { "type": "number", "minimum": 0 }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "coordinate_space", "points", "bounds"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "freehand" },
+            "coordinate_space": { "const": "desktop_points_top_left" },
+            "points": {
+              "type": "array",
+              "minItems": 1,
+              "maxItems": 256,
+              "items": { "$ref": "#/$defs/AnnotationDesktopPoint" }
+            },
+            "bounds": { "$ref": "#/$defs/AnnotationDesktopBounds" }
+          }
+        }
+      ]
+    },
+    "AnnotationApplication": {
+      "type": "object",
+      "required": ["pid", "name", "bundle_id"],
+      "additionalProperties": false,
+      "properties": {
+        "pid": { "type": "integer", "minimum": -1 },
+        "name": { "type": ["string", "null"], "maxLength": 256 },
+        "bundle_id": { "type": ["string", "null"], "maxLength": 256 }
+      }
+    },
+    "AnnotationWindow": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "required": ["window_id", "title", "bounds"],
+          "additionalProperties": false,
+          "properties": {
+            "window_id": { "type": "integer", "minimum": -1 },
+            "title": { "type": ["string", "null"], "maxLength": 512 },
+            "bounds": { "$ref": "#/$defs/AnnotationDesktopBounds" }
+          }
+        }
+      ]
+    },
+    "AnnotationSelectionStartedData": {
+      "type": "object",
+      "required": ["mode"],
+      "additionalProperties": false,
+      "properties": { "mode": { "$ref": "#/$defs/AnnotationSelectionMode" } }
+    },
+    "AnnotationSelectionCompletedData": {
+      "type": "object",
+      "allOf": [
+        {
+          "if": {
+            "properties": { "mode": { "const": "text" } },
+            "required": ["mode"]
+          },
+          "then": { "properties": { "text": { "type": "string", "minLength": 1, "maxLength": 4096 } } },
+          "else": { "properties": { "text": { "type": "null" } } }
+        }
+      ],
+      "required": ["selection_id", "mode", "geometry", "application", "window", "text"],
+      "additionalProperties": false,
+      "properties": {
+        "selection_id": { "type": "string", "pattern": "^sel-[a-f0-9-]{36}$" },
+        "mode": { "$ref": "#/$defs/AnnotationSelectionMode" },
+        "geometry": { "$ref": "#/$defs/AnnotationGeometry" },
+        "application": { "$ref": "#/$defs/AnnotationApplication" },
+        "window": { "$ref": "#/$defs/AnnotationWindow" },
+        "text": { "type": ["string", "null"], "minLength": 1, "maxLength": 4096 }
+      }
+    },
+    "AnnotationSelectionCanceledData": {
+      "type": "object",
+      "required": ["reason"],
+      "additionalProperties": false,
+      "properties": {
+        "reason": { "enum": ["escape", "canceled", "owner_disconnect", "daemon_shutdown", "invalid_selection"] }
+      }
+    },
+    "AnnotationSelectionFailureData": {
+      "type": "object",
+      "required": ["code"],
+      "additionalProperties": false,
+      "properties": { "code": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]{1,63}$" } }
     }
   }
 }

--- a/shared/schemas/fixtures/daemon-event/invalid/annotation-selection-leaks-path.json
+++ b/shared/schemas/fixtures/daemon-event/invalid/annotation-selection-leaks-path.json
@@ -1,0 +1,20 @@
+{
+  "v": 1,
+  "service": "annotation",
+  "event": "selection_completed",
+  "ts": 1784160000.125,
+  "data": {
+    "selection_id": "sel-123e4567-e89b-12d3-a456-426614174000",
+    "mode": "point",
+    "geometry": {
+      "kind": "point",
+      "coordinate_space": "desktop_points_top_left",
+      "x": 120,
+      "y": 80
+    },
+    "application": { "pid": 42, "name": "Fixture App", "bundle_id": null },
+    "window": null,
+    "text": null,
+    "capture_path": "/private/tmp/capture.png"
+  }
+}

--- a/shared/schemas/fixtures/daemon-event/invalid/annotation-text-mode-without-text.json
+++ b/shared/schemas/fixtures/daemon-event/invalid/annotation-text-mode-without-text.json
@@ -1,0 +1,19 @@
+{
+  "v": 1,
+  "service": "annotation",
+  "event": "selection_completed",
+  "ts": 1784160000.125,
+  "data": {
+    "selection_id": "sel-123e4567-e89b-12d3-a456-426614174000",
+    "mode": "text",
+    "geometry": {
+      "kind": "point",
+      "coordinate_space": "desktop_points_top_left",
+      "x": 120,
+      "y": 80
+    },
+    "application": { "pid": 42, "name": "Fixture App", "bundle_id": null },
+    "window": null,
+    "text": null
+  }
+}

--- a/shared/schemas/fixtures/daemon-event/invalid/voice-playback-event-leaks-path.json
+++ b/shared/schemas/fixtures/daemon-event/invalid/voice-playback-event-leaks-path.json
@@ -1,0 +1,13 @@
+{
+  "v": 1,
+  "service": "voice",
+  "event": "playback_started",
+  "ts": 1,
+  "data": {
+    "duration_ms": 1000,
+    "bytes": 32044,
+    "sample_rate": 16000,
+    "channels": 1,
+    "path": "/private/tmp/private.wav"
+  }
+}

--- a/shared/schemas/fixtures/daemon-event/valid/annotation-selection-completed.json
+++ b/shared/schemas/fixtures/daemon-event/valid/annotation-selection-completed.json
@@ -1,0 +1,30 @@
+{
+  "v": 1,
+  "service": "annotation",
+  "event": "selection_completed",
+  "ts": 1784160000.125,
+  "ref": "annotation-proof",
+  "data": {
+    "selection_id": "sel-123e4567-e89b-12d3-a456-426614174000",
+    "mode": "rectangle",
+    "geometry": {
+      "kind": "rectangle",
+      "coordinate_space": "desktop_points_top_left",
+      "x": 120,
+      "y": 80,
+      "width": 320,
+      "height": 180
+    },
+    "application": {
+      "pid": 42,
+      "name": "Fixture App",
+      "bundle_id": "io.example.fixture"
+    },
+    "window": {
+      "window_id": 17,
+      "title": "Fixture Window",
+      "bounds": { "x": 20, "y": 40, "width": 800, "height": 600 }
+    },
+    "text": null
+  }
+}

--- a/shared/schemas/fixtures/daemon-event/valid/voice-playback-canceled-barge-in.json
+++ b/shared/schemas/fixtures/daemon-event/valid/voice-playback-canceled-barge-in.json
@@ -1,0 +1,9 @@
+{
+  "v": 1,
+  "service": "voice",
+  "event": "playback_canceled",
+  "ts": 1784160000.25,
+  "data": {
+    "reason": "barge_in"
+  }
+}

--- a/shared/schemas/fixtures/daemon-event/valid/voice-playback-started.json
+++ b/shared/schemas/fixtures/daemon-event/valid/voice-playback-started.json
@@ -1,0 +1,12 @@
+{
+  "v": 1,
+  "service": "voice",
+  "event": "playback_started",
+  "ts": 1,
+  "data": {
+    "duration_ms": 1000,
+    "bytes": 32044,
+    "sample_rate": 16000,
+    "channels": 1
+  }
+}

--- a/src/daemon/AGENTS.md
+++ b/src/daemon/AGENTS.md
@@ -32,7 +32,8 @@ Allowed daemon-side surface work:
 
 Voice transport follows ADR 0022. `voice-transport.swift` owns exact global
 hotkey leases, bounded microphone-to-WAV capture, streamed system-speech
-playback, meters, and connection cleanup. It must not own transcription,
+playback, bounded owner-only WAV playback, meters, and connection cleanup. It
+must not own transcription,
 conversation policy, product presence state, or branded voice behavior. Voice
 events must never carry audio bytes, spoken text, or local paths.
 `microphone-authorization.swift` owns the daemon process's four-state macOS
@@ -46,6 +47,11 @@ authorization.
 has one bounded serial writer for responses and events; slow-client timeout or
 overflow shuts down only that connection, and queued work must quiesce before
 its file descriptor is closed or reusable.
+
+`annotation-selection.swift` owns one connection-scoped native desktop
+selection lease for point, rectangle, freehand, or text geometry. It emits
+bounded product-neutral evidence and never owns pending-annotation persistence,
+consumer routing, or project policy.
 
 Avoid daemon-side surface policy:
 

--- a/src/daemon/annotation-selection.swift
+++ b/src/daemon/annotation-selection.swift
@@ -1,0 +1,445 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+let aosAnnotationMaximumPoints = 256
+let aosAnnotationMaximumTextBytes = 4 * 1024
+
+struct AOSAnnotationSelectionFailure: Error {
+    let code: String
+    let message: String
+}
+
+enum AOSAnnotationSelectionMode: String, CaseIterable {
+    case point
+    case rectangle
+    case freehand
+    case text
+
+    static func parse(_ value: String) -> AOSAnnotationSelectionMode? {
+        AOSAnnotationSelectionMode(rawValue: value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased())
+    }
+}
+
+func aosBoundAnnotationPoints(_ points: [CGPoint], limit: Int = aosAnnotationMaximumPoints) -> [CGPoint] {
+    guard limit > 1, points.count > limit else { return points }
+    let last = points.count - 1
+    return (0..<limit).map { index in
+        points[Int((Double(index) * Double(last) / Double(limit - 1)).rounded())]
+    }
+}
+
+private func finitePoint(_ point: CGPoint) -> Bool {
+    point.x.isFinite && point.y.isFinite
+}
+
+private func annotationCGPoint(_ screenPoint: NSPoint) -> CGPoint {
+    let mainHeight = CGDisplayBounds(CGMainDisplayID()).height
+    return CGPoint(x: screenPoint.x, y: mainHeight - screenPoint.y)
+}
+
+func aosAnnotationGeometry(mode: AOSAnnotationSelectionMode, screenPoints: [CGPoint]) -> [String: Any]? {
+    let points = aosBoundAnnotationPoints(screenPoints.filter(finitePoint))
+    guard !points.isEmpty else { return nil }
+    let converted = points.map(annotationCGPoint)
+    switch mode {
+    case .point, .text:
+        return [
+            "kind": "point",
+            "coordinate_space": "desktop_points_top_left",
+            "x": converted[0].x,
+            "y": converted[0].y,
+        ]
+    case .rectangle:
+        guard let last = converted.last else { return nil }
+        return [
+            "kind": "rectangle",
+            "coordinate_space": "desktop_points_top_left",
+            "x": min(converted[0].x, last.x),
+            "y": min(converted[0].y, last.y),
+            "width": abs(last.x - converted[0].x),
+            "height": abs(last.y - converted[0].y),
+        ]
+    case .freehand:
+        let minX = converted.map(\.x).min() ?? converted[0].x
+        let minY = converted.map(\.y).min() ?? converted[0].y
+        let maxX = converted.map(\.x).max() ?? converted[0].x
+        let maxY = converted.map(\.y).max() ?? converted[0].y
+        return [
+            "kind": "freehand",
+            "coordinate_space": "desktop_points_top_left",
+            "points": converted.map { ["x": $0.x, "y": $0.y] },
+            "bounds": [
+                "x": minX,
+                "y": minY,
+                "width": maxX - minX,
+                "height": maxY - minY,
+            ],
+        ]
+    }
+}
+
+private func number(_ value: Any?) -> CGFloat? {
+    if let number = value as? NSNumber { return CGFloat(number.doubleValue) }
+    return nil
+}
+
+func aosAnnotationWindowFacts(
+    at point: CGPoint,
+    windowList: [[String: Any]]? = nil,
+    excludingPID: pid_t = getpid()
+) -> [String: Any]? {
+    let entries = windowList ?? (CGWindowListCopyWindowInfo(.optionOnScreenOnly, kCGNullWindowID) as? [[String: Any]] ?? [])
+    for entry in entries {
+        let ownerPID = (entry[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value ?? -1
+        guard ownerPID != excludingPID,
+              (entry[kCGWindowLayer as String] as? NSNumber)?.intValue == 0,
+              let bounds = entry[kCGWindowBounds as String] as? [String: Any],
+              let x = number(bounds["X"]),
+              let y = number(bounds["Y"]),
+              let width = number(bounds["Width"]),
+              let height = number(bounds["Height"]),
+              CGRect(x: x, y: y, width: width, height: height).contains(point) else { continue }
+        let running = NSRunningApplication(processIdentifier: ownerPID)
+        let applicationName: Any = (entry[kCGWindowOwnerName as String] as? String) ?? running?.localizedName ?? NSNull()
+        let bundleID: Any = running?.bundleIdentifier ?? NSNull()
+        return [
+            "window_id": (entry[kCGWindowNumber as String] as? NSNumber)?.intValue ?? -1,
+            "title": entry[kCGWindowName as String] as? String ?? NSNull(),
+            "bounds": ["x": x, "y": y, "width": width, "height": height],
+            "application": [
+                "pid": Int(ownerPID),
+                "name": applicationName,
+                "bundle_id": bundleID,
+            ],
+        ]
+    }
+    return nil
+}
+
+private final class AOSAnnotationTextField: NSTextField {
+    var onCommit: ((String) -> Void)?
+    var onCancel: (() -> Void)?
+
+    override func insertNewline(_ sender: Any?) { onCommit?(stringValue) }
+    override func cancelOperation(_ sender: Any?) { onCancel?() }
+}
+
+private final class AOSAnnotationSelectionView: NSView {
+    let mode: AOSAnnotationSelectionMode
+    let onComplete: ([CGPoint], String?) -> Void
+    let onCancel: (String) -> Void
+    private var points: [CGPoint] = []
+    private var textField: AOSAnnotationTextField?
+
+    init(
+        frame: NSRect,
+        mode: AOSAnnotationSelectionMode,
+        onComplete: @escaping ([CGPoint], String?) -> Void,
+        onCancel: @escaping (String) -> Void
+    ) {
+        self.mode = mode
+        self.onComplete = onComplete
+        self.onCancel = onCancel
+        super.init(frame: frame)
+        wantsLayer = true
+    }
+
+    required init?(coder: NSCoder) { nil }
+    override var acceptsFirstResponder: Bool { true }
+
+    private func screenPoint(_ event: NSEvent) -> CGPoint {
+        window?.convertPoint(toScreen: event.locationInWindow) ?? event.locationInWindow
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        let point = screenPoint(event)
+        if mode == .text {
+            beginText(at: event.locationInWindow, screenPoint: point)
+            return
+        }
+        points = [point]
+        needsDisplay = true
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard mode != .point, mode != .text, !points.isEmpty else { return }
+        let point = screenPoint(event)
+        if mode == .rectangle {
+            points = [points[0], point]
+        } else if let last = points.last, hypot(last.x - point.x, last.y - point.y) >= 2 {
+            points.append(point)
+            if points.count > aosAnnotationMaximumPoints * 2 {
+                points = aosBoundAnnotationPoints(points)
+            }
+        }
+        needsDisplay = true
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard mode != .text, let first = points.first else { return }
+        let point = screenPoint(event)
+        if mode == .point {
+            onComplete([point], nil)
+        } else if mode == .rectangle {
+            onComplete([first, point], nil)
+        } else {
+            if points.last != point { points.append(point) }
+            onComplete(aosBoundAnnotationPoints(points), nil)
+        }
+    }
+
+    override func keyDown(with event: NSEvent) {
+        if event.keyCode == 53 {
+            onCancel("escape")
+            return
+        }
+        super.keyDown(with: event)
+    }
+
+    private func beginText(at localPoint: CGPoint, screenPoint: CGPoint) {
+        textField?.removeFromSuperview()
+        points = [screenPoint]
+        let width: CGFloat = min(320, max(160, bounds.width - 24))
+        let origin = CGPoint(
+            x: min(max(12, localPoint.x), max(12, bounds.width - width - 12)),
+            y: min(max(12, localPoint.y - 34), max(12, bounds.height - 44))
+        )
+        let field = AOSAnnotationTextField(frame: NSRect(x: origin.x, y: origin.y, width: width, height: 30))
+        field.placeholderString = "Annotation"
+        field.font = .systemFont(ofSize: 14)
+        field.focusRingType = .none
+        field.onCommit = { [weak self] value in
+            guard let self else { return }
+            let text = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty, text.utf8.count <= aosAnnotationMaximumTextBytes else {
+                NSSound.beep()
+                return
+            }
+            self.onComplete(self.points, text)
+        }
+        field.onCancel = { [weak self] in self?.onCancel("escape") }
+        addSubview(field)
+        textField = field
+        window?.makeFirstResponder(field)
+        needsDisplay = true
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        NSColor.black.withAlphaComponent(0.14).setFill()
+        dirtyRect.fill()
+        guard !points.isEmpty, let window else { return }
+        let local = points.map { window.convertPoint(fromScreen: $0) }
+        NSColor.white.withAlphaComponent(0.95).setStroke()
+        let path = NSBezierPath()
+        path.lineWidth = 2
+        path.setLineDash([6, 4], count: 2, phase: 0)
+        if mode == .rectangle, local.count > 1 {
+            path.appendRect(NSRect(
+                x: min(local[0].x, local[1].x),
+                y: min(local[0].y, local[1].y),
+                width: abs(local[1].x - local[0].x),
+                height: abs(local[1].y - local[0].y)
+            ))
+        } else if mode == .freehand {
+            path.move(to: local[0])
+            for point in local.dropFirst() { path.line(to: point) }
+        } else {
+            path.appendOval(in: NSRect(x: local[0].x - 8, y: local[0].y - 8, width: 16, height: 16))
+        }
+        path.stroke()
+    }
+}
+
+private final class AOSAnnotationSelectionPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
+}
+
+private final class AOSAnnotationSelectionSession {
+    let token = UUID()
+    let owner: UUID
+    let ref: String?
+    let mode: AOSAnnotationSelectionMode
+
+    private let emit: (String, [String: Any]) -> Void
+    private let terminal: (UUID) -> Void
+    private var panels: [AOSAnnotationSelectionPanel] = []
+    private var finished = false
+    private var originalApplication: NSRunningApplication?
+
+    init(
+        owner: UUID,
+        ref: String?,
+        mode: AOSAnnotationSelectionMode,
+        emit: @escaping (String, [String: Any]) -> Void,
+        terminal: @escaping (UUID) -> Void
+    ) {
+        self.owner = owner
+        self.ref = ref
+        self.mode = mode
+        self.emit = emit
+        self.terminal = terminal
+    }
+
+    func start() throws {
+        var startupError: AOSAnnotationSelectionFailure?
+        aosRunOnMainSync {
+            guard !finished else {
+                startupError = AOSAnnotationSelectionFailure(
+                    code: "ANNOTATION_SELECTION_CANCELED",
+                    message: "annotation selection was canceled before startup"
+                )
+                return
+            }
+            guard !NSScreen.screens.isEmpty else {
+                startupError = AOSAnnotationSelectionFailure(code: "ANNOTATION_DISPLAY_UNAVAILABLE", message: "no display is available for annotation selection")
+                return
+            }
+            originalApplication = NSWorkspace.shared.frontmostApplication
+            for screen in NSScreen.screens {
+                let panel = AOSAnnotationSelectionPanel(
+                    contentRect: screen.frame,
+                    styleMask: [.borderless],
+                    backing: .buffered,
+                    defer: false
+                )
+                panel.setFrame(screen.frame, display: true)
+                panel.level = .screenSaver
+                panel.isOpaque = false
+                panel.backgroundColor = .clear
+                panel.hasShadow = false
+                panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+                panel.contentView = AOSAnnotationSelectionView(
+                    frame: NSRect(origin: .zero, size: screen.frame.size),
+                    mode: mode,
+                    onComplete: { [weak self] points, text in self?.complete(points: points, text: text) },
+                    onCancel: { [weak self] reason in self?.cancel(reason: reason) }
+                )
+                panels.append(panel)
+                panel.orderFrontRegardless()
+            }
+            NSApp.activate(ignoringOtherApps: true)
+            panels.first?.makeKey()
+            panels.first?.makeFirstResponder(panels.first?.contentView)
+            emit("selection_started", ["mode": mode.rawValue])
+        }
+        if let startupError { throw startupError }
+    }
+
+    func cancel(reason: String) {
+        aosRunOnMainSync {
+            guard !finished else { return }
+            finished = true
+            closePanels()
+            emit("selection_canceled", ["reason": reason])
+            terminal(token)
+        }
+    }
+
+    private func complete(points: [CGPoint], text: String?) {
+        guard !finished,
+              let geometry = aosAnnotationGeometry(mode: mode, screenPoints: points) else {
+            cancel(reason: "invalid_selection")
+            return
+        }
+        finished = true
+        let cgPoints = points.map(annotationCGPoint)
+        let targetPoint = cgPoints[cgPoints.count / 2]
+        let window = aosAnnotationWindowFacts(at: targetPoint)
+        let application: [String: Any]
+        if let windowApplication = window?["application"] as? [String: Any] {
+            application = windowApplication
+        } else {
+            let applicationName: Any = originalApplication?.localizedName ?? NSNull()
+            let bundleID: Any = originalApplication?.bundleIdentifier ?? NSNull()
+            application = [
+                "pid": originalApplication.map { Int($0.processIdentifier) } ?? -1,
+                "name": applicationName,
+                "bundle_id": bundleID,
+            ]
+        }
+        closePanels()
+        emit("selection_completed", [
+            "selection_id": "sel-\(UUID().uuidString.lowercased())",
+            "mode": mode.rawValue,
+            "geometry": geometry,
+            "application": application,
+            "window": window ?? NSNull(),
+            "text": text ?? NSNull(),
+        ])
+        terminal(token)
+    }
+
+    private func closePanels() {
+        for panel in panels { panel.orderOut(nil) }
+        panels.removeAll()
+        originalApplication?.activate()
+    }
+}
+
+final class AOSAnnotationSelectionTransport {
+    typealias EventEmitter = (UUID, String, [String: Any], String?) -> Void
+
+    private let lock = NSLock()
+    private let emit: EventEmitter
+    private var session: AOSAnnotationSelectionSession?
+
+    init(emit: @escaping EventEmitter) { self.emit = emit }
+
+    func start(owner: UUID, mode value: String, ref: String?) throws {
+        guard let mode = AOSAnnotationSelectionMode.parse(value) else {
+            throw AOSAnnotationSelectionFailure(code: "INVALID_ANNOTATION_MODE", message: "annotation mode must be point, rectangle, freehand, or text")
+        }
+        lock.lock()
+        guard session == nil else {
+            lock.unlock()
+            throw AOSAnnotationSelectionFailure(code: "ANNOTATION_SELECTION_BUSY", message: "an annotation selection is already active")
+        }
+        let next = AOSAnnotationSelectionSession(
+            owner: owner,
+            ref: ref,
+            mode: mode,
+            emit: { [emit] event, data in emit(owner, event, data, ref) },
+            terminal: { [weak self] token in self?.didTerminate(token: token) }
+        )
+        session = next
+        lock.unlock()
+        do {
+            try next.start()
+        } catch {
+            didTerminate(token: next.token)
+            throw error
+        }
+    }
+
+    func cancel(owner: UUID, reason: String) throws {
+        lock.lock()
+        guard let session, session.owner == owner else {
+            lock.unlock()
+            throw AOSAnnotationSelectionFailure(code: "ANNOTATION_SELECTION_NOT_OWNED", message: "this connection does not own annotation selection")
+        }
+        lock.unlock()
+        session.cancel(reason: reason)
+    }
+
+    func connectionClosed(_ owner: UUID) {
+        lock.lock()
+        let owned = session?.owner == owner ? session : nil
+        lock.unlock()
+        owned?.cancel(reason: "owner_disconnect")
+    }
+
+    func shutdown() {
+        lock.lock()
+        let active = session
+        lock.unlock()
+        active?.cancel(reason: "daemon_shutdown")
+    }
+
+    private func didTerminate(token: UUID) {
+        lock.lock()
+        if session?.token == token { session = nil }
+        lock.unlock()
+    }
+}

--- a/src/daemon/audio-playback.swift
+++ b/src/daemon/audio-playback.swift
@@ -1,0 +1,194 @@
+import AVFoundation
+import Darwin
+import Foundation
+
+let aosAudioPlaybackMaximumBytes = 4 * 1024 * 1024
+let aosAudioPlaybackMaximumDuration: TimeInterval = 120
+
+protocol AOSVoiceOutputLease: AnyObject {
+    var token: UUID { get }
+    var owner: UUID { get }
+
+    func cancel(reason: String)
+}
+struct AOSAudioPlaybackSource {
+    let url: URL
+    let file: AVAudioFile
+    let bytes: Int
+    let durationMilliseconds: Int
+    let sampleRate: Double
+    let channels: Int
+}
+
+func aosValidateAudioPlaybackSource(_ inputPath: String) throws -> AOSAudioPlaybackSource {
+    guard inputPath.hasPrefix("/") else {
+        throw AOSVoiceTransportFailure(code: "INVALID_AUDIO_PATH", message: "audio playback input must be absolute")
+    }
+    let url = URL(fileURLWithPath: inputPath).standardizedFileURL
+    guard url.path == inputPath,
+          url.pathExtension.lowercased() == "wav",
+          url.resolvingSymlinksInPath().path == inputPath else {
+        throw AOSVoiceTransportFailure(code: "INVALID_AUDIO_PATH", message: "audio playback input must be a canonical WAV path")
+    }
+
+    let parent = url.deletingLastPathComponent()
+    guard parent.resolvingSymlinksInPath().path == parent.path else {
+        throw AOSVoiceTransportFailure(code: "UNSAFE_AUDIO_PARENT", message: "audio playback parent must not contain symlinks")
+    }
+    let parentAttributes: [FileAttributeKey: Any]
+    let fileAttributes: [FileAttributeKey: Any]
+    do {
+        parentAttributes = try FileManager.default.attributesOfItem(atPath: parent.path)
+        fileAttributes = try FileManager.default.attributesOfItem(atPath: inputPath)
+    } catch {
+        throw AOSVoiceTransportFailure(code: "AUDIO_INPUT_UNAVAILABLE", message: "audio playback input is unavailable")
+    }
+    guard parentAttributes[.type] as? FileAttributeType == .typeDirectory,
+          (parentAttributes[.ownerAccountID] as? NSNumber)?.uint32Value == geteuid(),
+          ((parentAttributes[.posixPermissions] as? NSNumber)?.intValue ?? -1) & 0o777 == 0o700 else {
+        throw AOSVoiceTransportFailure(code: "UNSAFE_AUDIO_PARENT", message: "audio playback parent must be owner-only mode 0700")
+    }
+    guard fileAttributes[.type] as? FileAttributeType == .typeRegular,
+          (fileAttributes[.ownerAccountID] as? NSNumber)?.uint32Value == geteuid(),
+          ((fileAttributes[.posixPermissions] as? NSNumber)?.intValue ?? -1) & 0o777 == 0o600 else {
+        throw AOSVoiceTransportFailure(code: "UNSAFE_AUDIO_INPUT", message: "audio playback input must be an owner-only regular file")
+    }
+    let bytes = (fileAttributes[.size] as? NSNumber)?.intValue ?? -1
+    guard bytes > 44, bytes <= aosAudioPlaybackMaximumBytes else {
+        throw AOSVoiceTransportFailure(code: "AUDIO_INPUT_LIMIT", message: "audio playback input exceeds the supported size")
+    }
+
+    let file: AVAudioFile
+    do {
+        file = try AVAudioFile(forReading: url)
+    } catch {
+        throw AOSVoiceTransportFailure(code: "INVALID_AUDIO_FILE", message: "audio playback input is not readable PCM audio")
+    }
+    let sampleRate = file.processingFormat.sampleRate
+    let channels = Int(file.processingFormat.channelCount)
+    let duration = sampleRate > 0 ? Double(file.length) / sampleRate : 0
+    guard sampleRate.isFinite,
+          sampleRate >= 8_000,
+          sampleRate <= 192_000,
+          (1...2).contains(channels),
+          duration.isFinite,
+          duration > 0,
+          duration <= aosAudioPlaybackMaximumDuration else {
+        throw AOSVoiceTransportFailure(code: "UNSUPPORTED_AUDIO_FILE", message: "audio playback format or duration is unsupported")
+    }
+    return AOSAudioPlaybackSource(
+        url: url,
+        file: file,
+        bytes: bytes,
+        durationMilliseconds: Int((duration * 1000).rounded()),
+        sampleRate: sampleRate,
+        channels: channels
+    )
+}
+
+final class AOSAudioPlaybackSession: AOSVoiceOutputLease {
+    let token = UUID()
+    let owner: UUID
+    let ref: String?
+
+    private let source: AOSAudioPlaybackSource
+    private let emit: (String, [String: Any]) -> Void
+    private let terminal: (UUID) -> Void
+    private let engine = AVAudioEngine()
+    private let player = AVAudioPlayerNode()
+    private let queue = DispatchQueue(label: "aos.voice.audio-playback")
+    private var finished = false
+    private var tapInstalled = false
+    private var sequence = 0
+    private var lastMeterAt = Date.distantPast
+
+    init(
+        owner: UUID,
+        ref: String?,
+        inputPath: String,
+        emit: @escaping (String, [String: Any]) -> Void,
+        terminal: @escaping (UUID) -> Void
+    ) throws {
+        self.owner = owner
+        self.ref = ref
+        self.source = try aosValidateAudioPlaybackSource(inputPath)
+        self.emit = emit
+        self.terminal = terminal
+    }
+
+    func start() throws {
+        try queue.sync {
+            guard !finished else {
+                throw AOSVoiceTransportFailure(code: "PLAYBACK_CANCELED", message: "audio playback was canceled before startup")
+            }
+            do {
+                engine.attach(player)
+                engine.connect(player, to: engine.mainMixerNode, format: source.file.processingFormat)
+                engine.mainMixerNode.installTap(onBus: 0, bufferSize: 1024, format: nil) { [weak self] buffer, _ in
+                    self?.receiveMeter(buffer)
+                }
+                tapInstalled = true
+                engine.prepare()
+                try engine.start()
+                player.scheduleFile(source.file, at: nil) { [weak self] in
+                    self?.queue.async { self?.finishLocked() }
+                }
+                player.play()
+            } catch {
+                cleanupLocked()
+                throw AOSVoiceTransportFailure(code: "AUDIO_OUTPUT_UNAVAILABLE", message: "audio playback output is unavailable")
+            }
+            emit("playback_started", [
+                "duration_ms": source.durationMilliseconds,
+                "bytes": source.bytes,
+                "sample_rate": Int(source.sampleRate.rounded()),
+                "channels": source.channels,
+            ])
+        }
+    }
+
+    func cancel(reason: String) {
+        queue.sync {
+            guard !finished else { return }
+            finished = true
+            cleanupLocked()
+            emit("playback_canceled", ["reason": reason])
+            terminal(token)
+        }
+    }
+
+    private func receiveMeter(_ buffer: AVAudioPCMBuffer) {
+        guard let copy = aosCopyPCMBuffer(buffer) else { return }
+        queue.async { [weak self] in
+            guard let self, !self.finished else { return }
+            let now = Date()
+            guard now.timeIntervalSince(self.lastMeterAt) >= 0.1,
+                  let metrics = aosAudioFrameMetrics(copy) else { return }
+            self.lastMeterAt = now
+            self.sequence += 1
+            self.emit("audio_frame", [
+                "stream": "playback",
+                "rms": metrics.rms,
+                "peak": metrics.peak,
+                "sequence": self.sequence,
+            ])
+        }
+    }
+
+    private func finishLocked() {
+        guard !finished else { return }
+        finished = true
+        cleanupLocked()
+        emit("playback_finished", ["reason": "completed"])
+        terminal(token)
+    }
+
+    private func cleanupLocked() {
+        if tapInstalled {
+            engine.mainMixerNode.removeTap(onBus: 0)
+            tapInstalled = false
+        }
+        player.stop()
+        engine.stop()
+    }
+}

--- a/src/daemon/unified.swift
+++ b/src/daemon/unified.swift
@@ -109,6 +109,9 @@ class UnifiedDaemon {
     private lazy var voiceTransport = AOSVoiceTransport { [weak self] owner, event, data, ref in
         self?.emitVoiceTransportEvent(to: owner, event: event, data: data, ref: ref)
     }
+    private lazy var annotationSelection = AOSAnnotationSelectionTransport { [weak self] owner, event, data, ref in
+        self?.emitConnectionEvent(service: "annotation", to: owner, event: event, data: data, ref: ref)
+    }
     private var contentServer: ContentServer?
     let coordination = CoordinationBus()
 
@@ -589,7 +592,17 @@ class UnifiedDaemon {
         data: [String: Any],
         ref: String?
     ) {
-        guard let bytes = envelopeBytes(service: "voice", event: event, data: data, ref: ref) else { return }
+        emitConnectionEvent(service: "voice", to: connectionID, event: event, data: data, ref: ref)
+    }
+
+    private func emitConnectionEvent(
+        service: String,
+        to connectionID: UUID,
+        event: String,
+        data: [String: Any],
+        ref: String?
+    ) {
+        guard let bytes = envelopeBytes(service: service, event: event, data: data, ref: ref) else { return }
         subscriberLock.lock()
         let writer = subscribers[connectionID]?.outbound
         subscriberLock.unlock()
@@ -2501,6 +2514,7 @@ class UnifiedDaemon {
 
         defer {
             voiceTransport.connectionClosed(connectionID)
+            annotationSelection.connectionClosed(connectionID)
             cleanupSceneLeases(connectionID)
             subscriberLock.lock()
             if let conn = subscribers[connectionID] {
@@ -2774,7 +2788,10 @@ class UnifiedDaemon {
         case ("voice", "next"):               return "voice-next"
         case ("voice", "final_response"):     return "voice-final-response"
         case ("voice", "speak"):              return "voice-speak"
+        case ("voice", "playback"):           return "voice-playback"
         case ("voice", "cancel"):             return "voice-speech-cancel"
+        case ("annotation", "select"):        return "annotation-select"
+        case ("annotation", "cancel"):        return "annotation-select-cancel"
         case ("scene", "follow"):             return "scene-follow"
         case ("system", "ping"):              return "ping"
         // Content server actions
@@ -2867,7 +2884,7 @@ class UnifiedDaemon {
                 return
             }
             // Check that the service is one of the known namespaces.
-            let knownServices: Set<String> = ["see", "do", "show", "tell", "listen", "session", "voice", "scene", "system", "focus", "graph", "content"]
+            let knownServices: Set<String> = ["see", "do", "show", "tell", "listen", "session", "voice", "annotation", "scene", "system", "focus", "graph", "content"]
             if !knownServices.contains(env.service) {
                 sendResponseJSON(to: outbound, envelopeError(
                     error: "Unknown service: \(env.service)",
@@ -3161,6 +3178,24 @@ class UnifiedDaemon {
                 sendVoiceTransportError(to: outbound, message: "speech playback failed", code: "VOICE_TRANSPORT_FAILED", envelopeActive: envelopeActive, envelopeRef: envelopeRef)
             }
 
+        case "voice-playback":
+            guard let inputPath = json["audio_path"] as? String, !inputPath.isEmpty else {
+                sendVoiceTransportError(to: outbound, message: "audio path required", code: "MISSING_ARG", envelopeActive: envelopeActive, envelopeRef: envelopeRef)
+                return
+            }
+            do {
+                try voiceTransport.startPlayback(
+                    owner: connectionID,
+                    inputPath: inputPath,
+                    ref: envelopeRef
+                )
+                sendResponseJSON(to: outbound, ["status": "ok"], envelopeActive: envelopeActive, envelopeRef: envelopeRef)
+            } catch let failure as AOSVoiceTransportFailure {
+                sendVoiceTransportError(to: outbound, message: failure.message, code: failure.code, envelopeActive: envelopeActive, envelopeRef: envelopeRef)
+            } catch {
+                sendVoiceTransportError(to: outbound, message: "audio playback failed", code: "VOICE_TRANSPORT_FAILED", envelopeActive: envelopeActive, envelopeRef: envelopeRef)
+            }
+
         case "voice-speech-cancel":
             do {
                 try voiceTransport.stopSpeech(owner: connectionID, reason: "canceled")
@@ -3169,6 +3204,30 @@ class UnifiedDaemon {
                 sendVoiceTransportError(to: outbound, message: failure.message, code: failure.code, envelopeActive: envelopeActive, envelopeRef: envelopeRef)
             } catch {
                 sendVoiceTransportError(to: outbound, message: "speech cancellation failed", code: "VOICE_TRANSPORT_FAILED", envelopeActive: envelopeActive, envelopeRef: envelopeRef)
+            }
+
+        case "annotation-select":
+            guard let mode = json["mode"] as? String, !mode.isEmpty else {
+                sendResponseJSON(to: outbound, ["error": "annotation mode required", "code": "MISSING_ARG"], envelopeActive: envelopeActive, envelopeRef: envelopeRef)
+                return
+            }
+            do {
+                try annotationSelection.start(owner: connectionID, mode: mode, ref: envelopeRef)
+                sendResponseJSON(to: outbound, ["status": "ok"], envelopeActive: envelopeActive, envelopeRef: envelopeRef)
+            } catch let failure as AOSAnnotationSelectionFailure {
+                sendResponseJSON(to: outbound, ["error": failure.message, "code": failure.code], envelopeActive: envelopeActive, envelopeRef: envelopeRef)
+            } catch {
+                sendResponseJSON(to: outbound, ["error": "annotation selection failed", "code": "ANNOTATION_SELECTION_FAILED"], envelopeActive: envelopeActive, envelopeRef: envelopeRef)
+            }
+
+        case "annotation-select-cancel":
+            do {
+                try annotationSelection.cancel(owner: connectionID, reason: "canceled")
+                sendResponseJSON(to: outbound, ["status": "ok"], envelopeActive: envelopeActive, envelopeRef: envelopeRef)
+            } catch let failure as AOSAnnotationSelectionFailure {
+                sendResponseJSON(to: outbound, ["error": failure.message, "code": failure.code], envelopeActive: envelopeActive, envelopeRef: envelopeRef)
+            } catch {
+                sendResponseJSON(to: outbound, ["error": "annotation cancellation failed", "code": "ANNOTATION_SELECTION_FAILED"], envelopeActive: envelopeActive, envelopeRef: envelopeRef)
             }
 
         case "voice-assignments":
@@ -4189,6 +4248,7 @@ class UnifiedDaemon {
         isShuttingDown = true
         fputs("aos daemon shutting down (\(reason))\n", stderr)
         voiceTransport.shutdown()
+        annotationSelection.shutdown()
         restoreNativeCursorSuppressionForExit()
         perception.stop()
         spatial.stopPolling()

--- a/src/daemon/voice-transport.swift
+++ b/src/daemon/voice-transport.swift
@@ -471,7 +471,7 @@ func aosRunOnMainSync(_ operation: () -> Void) {
     }
 }
 
-private final class AOSStreamingSpeechSession {
+private final class AOSStreamingSpeechSession: AOSVoiceOutputLease {
     let token = UUID()
     let owner: UUID
     let ref: String?
@@ -662,7 +662,7 @@ final class AOSVoiceTransport {
     private let microphoneAuthorization: AOSMicrophoneAuthorizationProviding
     private var hotkey: HotkeyLease?
     private var capture: (any AOSMicrophoneCaptureLease)?
-    private var speech: AOSStreamingSpeechSession?
+    private var output: (any AOSVoiceOutputLease)?
 
     init(
         emit: @escaping EventEmitter,
@@ -733,7 +733,6 @@ final class AOSVoiceTransport {
             lock.unlock()
             throw AOSVoiceTransportFailure(code: "CAPTURE_LEASE_BUSY", message: "microphone capture is already active")
         }
-        let activeSpeech = speech
         lock.unlock()
 
         var authorization = microphoneAuthorization.status()
@@ -743,8 +742,6 @@ final class AOSVoiceTransport {
         if let failure = authorization.failure {
             throw AOSVoiceTransportFailure(code: failure.code, message: failure.message)
         }
-        activeSpeech?.cancel(reason: "barge_in")
-
         let session = try AOSMicrophoneCaptureSession(
             owner: owner,
             ref: ref,
@@ -760,8 +757,10 @@ final class AOSVoiceTransport {
             session.cancel(reason: "superseded")
             throw AOSVoiceTransportFailure(code: "CAPTURE_LEASE_BUSY", message: "microphone capture is already active")
         }
+        let outputToCancel = output
         capture = session
         lock.unlock()
+        outputToCancel?.cancel(reason: "barge_in")
         do {
             try session.start()
         } catch {
@@ -782,7 +781,6 @@ final class AOSVoiceTransport {
             lock.unlock()
             throw AOSVoiceTransportFailure(code: "CAPTURE_LEASE_BUSY", message: "microphone capture is already active")
         }
-        let activeSpeech = speech
         lock.unlock()
 
         var authorization = microphoneAuthorization.status()
@@ -792,8 +790,6 @@ final class AOSVoiceTransport {
         if let failure = authorization.failure {
             throw AOSVoiceTransportFailure(code: failure.code, message: failure.message)
         }
-        activeSpeech?.cancel(reason: "barge_in")
-
         let session = try AOSSegmentedMicrophoneCaptureSession(
             owner: owner,
             ref: ref,
@@ -810,8 +806,10 @@ final class AOSVoiceTransport {
             session.cancel(reason: "superseded")
             throw AOSVoiceTransportFailure(code: "CAPTURE_LEASE_BUSY", message: "microphone capture is already active")
         }
+        let outputToCancel = output
         capture = session
         lock.unlock()
+        outputToCancel?.cancel(reason: "barge_in")
         do {
             try session.start()
         } catch {
@@ -836,7 +834,7 @@ final class AOSVoiceTransport {
             lock.unlock()
             throw AOSVoiceTransportFailure(code: "CAPTURE_ACTIVE", message: "speech cannot start during microphone capture")
         }
-        guard speech == nil else {
+        guard output == nil else {
             lock.unlock()
             throw AOSVoiceTransportFailure(code: "SPEECH_LEASE_BUSY", message: "speech playback is already active")
         }
@@ -849,21 +847,64 @@ final class AOSVoiceTransport {
             voiceID: voiceID,
             rateWPM: rateWPM,
             emit: { [emit] event, data in emit(owner, event, data, ref) },
-            terminal: { [weak self] token in self?.speechDidTerminate(token: token) }
+            terminal: { [weak self] token in self?.outputDidTerminate(token: token) }
         )
         lock.lock()
-        guard speech == nil else {
+        guard capture == nil else {
+            lock.unlock()
+            throw AOSVoiceTransportFailure(code: "CAPTURE_ACTIVE", message: "speech cannot start during microphone capture")
+        }
+        guard output == nil else {
             lock.unlock()
             throw AOSVoiceTransportFailure(code: "SPEECH_LEASE_BUSY", message: "speech playback is already active")
         }
-        speech = session
+        output = session
         lock.unlock()
         session.start()
     }
 
+    func startPlayback(owner: UUID, inputPath: String, ref: String?) throws {
+        lock.lock()
+        guard capture == nil else {
+            lock.unlock()
+            throw AOSVoiceTransportFailure(code: "CAPTURE_ACTIVE", message: "audio playback cannot start during microphone capture")
+        }
+        guard output == nil else {
+            lock.unlock()
+            throw AOSVoiceTransportFailure(code: "SPEECH_LEASE_BUSY", message: "voice output is already active")
+        }
+        lock.unlock()
+
+        let session = try AOSAudioPlaybackSession(
+            owner: owner,
+            ref: ref,
+            inputPath: inputPath,
+            emit: { [emit] event, data in emit(owner, event, data, ref) },
+            terminal: { [weak self] token in self?.outputDidTerminate(token: token) }
+        )
+        lock.lock()
+        guard capture == nil else {
+            lock.unlock()
+            throw AOSVoiceTransportFailure(code: "CAPTURE_ACTIVE", message: "audio playback cannot start during microphone capture")
+        }
+        guard output == nil else {
+            lock.unlock()
+            session.cancel(reason: "superseded")
+            throw AOSVoiceTransportFailure(code: "SPEECH_LEASE_BUSY", message: "voice output is already active")
+        }
+        output = session
+        lock.unlock()
+        do {
+            try session.start()
+        } catch {
+            outputDidTerminate(token: session.token)
+            throw error
+        }
+    }
+
     func stopSpeech(owner: UUID, reason: String) throws {
         lock.lock()
-        guard let session = speech, session.owner == owner else {
+        guard let session = output, session.owner == owner else {
             lock.unlock()
             throw AOSVoiceTransportFailure(code: "SPEECH_NOT_OWNED", message: "this connection does not own speech playback")
         }
@@ -875,20 +916,20 @@ final class AOSVoiceTransport {
         lock.lock()
         if hotkey?.owner == owner { hotkey = nil }
         let captureToCancel = capture?.owner == owner ? capture : nil
-        let speechToCancel = speech?.owner == owner ? speech : nil
+        let outputToCancel = output?.owner == owner ? output : nil
         lock.unlock()
         captureToCancel?.cancel(reason: "owner_disconnect")
-        speechToCancel?.cancel(reason: "owner_disconnect")
+        outputToCancel?.cancel(reason: "owner_disconnect")
     }
 
     func shutdown() {
         lock.lock()
         hotkey = nil
         let captureToCancel = capture
-        let speechToCancel = speech
+        let outputToCancel = output
         lock.unlock()
         captureToCancel?.cancel(reason: "daemon_shutdown")
-        speechToCancel?.cancel(reason: "daemon_shutdown")
+        outputToCancel?.cancel(reason: "daemon_shutdown")
     }
 
     private func captureDidTerminate(token: UUID) {
@@ -897,9 +938,9 @@ final class AOSVoiceTransport {
         lock.unlock()
     }
 
-    private func speechDidTerminate(token: UUID) {
+    private func outputDidTerminate(token: UUID) {
         lock.lock()
-        if speech?.token == token { speech = nil }
+        if output?.token == token { output = nil }
         lock.unlock()
     }
 }

--- a/tests/annotation-select-cli.test.mjs
+++ b/tests/annotation-select-cli.test.mjs
@@ -1,0 +1,196 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const cleanups = [];
+
+afterEach(async () => {
+  while (cleanups.length) await cleanups.pop()();
+});
+
+async function fakeDaemon(onRequest) {
+  const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aos-annotation-select-'));
+  const modeRoot = path.join(stateRoot, 'repo');
+  await fs.mkdir(modeRoot, { recursive: true });
+  const socketPath = path.join(modeRoot, 'sock');
+  const server = net.createServer((socket) => {
+    let buffer = '';
+    socket.on('data', (chunk) => {
+      buffer += chunk.toString('utf8');
+      for (;;) {
+        const newline = buffer.indexOf('\n');
+        if (newline < 0) break;
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        onRequest(JSON.parse(line), socket);
+      }
+    });
+  });
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(socketPath, resolve);
+  });
+  cleanups.push(async () => {
+    await new Promise((resolve) => server.close(resolve));
+    await fs.rm(stateRoot, { recursive: true, force: true });
+  });
+  return stateRoot;
+}
+
+function launch(args, stateRoot) {
+  const child = spawn(process.execPath, [path.join(repoRoot, 'scripts/aos-annotation-select.mjs'), ...args], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      AOS_STATE_ROOT: stateRoot,
+      AOS_RUNTIME_MODE: 'repo',
+      AOS_DISABLE_DAEMON_AUTOSTART: '1',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', (chunk) => { stdout += chunk; });
+  child.stderr.on('data', (chunk) => { stderr += chunk; });
+  return {
+    child,
+    stdout: () => stdout,
+    completed: new Promise((resolve) => child.once('close', (code, signal) => resolve({ code, signal, stdout, stderr }))),
+  };
+}
+
+function response(ref) {
+  return `${JSON.stringify({ v: 1, status: 'success', data: {}, ref })}\n`;
+}
+
+function event(name, data, ref) {
+  return `${JSON.stringify({ v: 1, service: 'annotation', event: name, ts: 1, data, ref })}\n`;
+}
+
+function completedData(overrides = {}) {
+  return {
+    selection_id: 'sel-123e4567-e89b-12d3-a456-426614174000',
+    mode: 'text',
+    geometry: {
+      kind: 'point',
+      coordinate_space: 'desktop_points_top_left',
+      x: 120,
+      y: 80,
+    },
+    application: {
+      pid: 42,
+      name: 'Fixture App',
+      bundle_id: 'io.example.fixture',
+    },
+    window: {
+      window_id: 17,
+      title: 'Fixture Window',
+      bounds: { x: 20, y: 40, width: 800, height: 600 },
+    },
+    text: 'Private operator annotation',
+    ...overrides,
+  };
+}
+
+function ndjson(value) {
+  return value.trim().split('\n').filter(Boolean).map((line) => JSON.parse(line));
+}
+
+test('desktop annotation selection persists bounded evidence and redacts public text', async () => {
+  const stateRoot = await fakeDaemon((request, socket) => {
+    assert.equal(request.service, 'annotation');
+    assert.equal(request.action, 'select');
+    assert.deepEqual(request.data, { mode: 'text' });
+    socket.write(response(request.ref));
+    socket.write(event('selection_started', { mode: 'text' }, request.ref));
+    socket.write(event('selection_completed', completedData(), request.ref));
+  });
+  const run = launch(['--mode', 'text', '--source', 'companion', '--follow'], stateRoot);
+  const result = await run.completed;
+
+  assert.equal(result.code, 0, result.stderr);
+  const events = ndjson(result.stdout);
+  assert.deepEqual(events.map((item) => item.event), ['selection_started', 'selection_completed']);
+  const completion = events[1].data;
+  assert.match(completion.annotation_id, /^ann-/);
+  assert.equal(completion.has_text, true);
+  assert.equal(JSON.stringify(events).includes('Private operator annotation'), false);
+  assert.equal(JSON.stringify(events).includes('path'), false);
+
+  const recordPath = path.join(stateRoot, 'repo', 'pending-annotations', 'records', `${completion.annotation_id}.json`);
+  const record = JSON.parse(await fs.readFile(recordPath, 'utf8'));
+  assert.equal(record.actor.source, 'companion');
+  assert.equal(record.comment.text, 'Private operator annotation');
+  assert.equal(record.desktop_selection.selection_id, completion.selection_id);
+  assert.equal(record.desktop_selection.geometry.coordinate_space, 'desktop_points_top_left');
+  assert.equal(record.capability.status, 'fallback_only');
+});
+
+test('desktop annotation selection rejects malformed native evidence without persistence', async () => {
+  const stateRoot = await fakeDaemon((request, socket) => {
+    socket.write(response(request.ref));
+    socket.write(event('selection_completed', {
+      ...completedData({ mode: 'point', text: null }),
+      capture_path: '/private/tmp/private-capture.png',
+    }, request.ref));
+  });
+  const run = launch(['--mode', 'point', '--follow'], stateRoot);
+  const result = await run.completed;
+
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /"code":"INVALID_ANNOTATION_EVENT"/);
+  assert.equal(result.stderr.includes('private-capture.png'), false);
+  const records = path.join(stateRoot, 'repo', 'pending-annotations', 'records');
+  await assert.rejects(fs.readdir(records), { code: 'ENOENT' });
+});
+
+test('desktop annotation selection forwards cancellation and creates no record', async () => {
+  let cancelSeen = false;
+  let run;
+  const stateRoot = await fakeDaemon((request, socket) => {
+    socket.write(response(request.ref));
+    if (request.action === 'select') {
+      socket.write(event('selection_started', { mode: 'rectangle' }, request.ref));
+      setTimeout(() => run.child.kill('SIGINT'), 10);
+      return;
+    }
+    assert.equal(request.action, 'cancel');
+    cancelSeen = true;
+    socket.write(event('selection_canceled', { reason: 'canceled' }, request.ref));
+  });
+  run = launch(['--mode', 'rectangle', '--follow'], stateRoot);
+  const result = await run.completed;
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(cancelSeen, true);
+  assert.deepEqual(ndjson(result.stdout).map((item) => item.event), ['selection_started', 'selection_canceled']);
+  const records = path.join(stateRoot, 'repo', 'pending-annotations', 'records');
+  await assert.rejects(fs.readdir(records), { code: 'ENOENT' });
+});
+
+test('desktop annotation selection validates mode and source before daemon startup', async () => {
+  const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aos-annotation-select-args-'));
+  cleanups.push(async () => { await fs.rm(stateRoot, { recursive: true, force: true }); });
+
+  const badMode = await launch(['--mode', 'polygon', '--follow'], stateRoot).completed;
+  assert.equal(badMode.code, 1);
+  assert.match(badMode.stderr, /"code":"INVALID_ANNOTATION_MODE"/);
+
+  const badSource = await launch(['--mode', 'point', '--source', 'contains space', '--follow'], stateRoot).completed;
+  assert.equal(badSource.code, 1);
+  assert.match(badSource.stderr, /"code":"INVALID_ARG"/);
+});
+
+test('desktop annotation selection help is passive', async () => {
+  const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aos-annotation-select-help-'));
+  cleanups.push(async () => { await fs.rm(stateRoot, { recursive: true, force: true }); });
+  const result = await launch(['--help'], stateRoot).completed;
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /^Usage: aos see annotation select/);
+});

--- a/tests/annotation-selection-native.sh
+++ b/tests/annotation-selection-native.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cat >"$TMP/main.swift" <<'SWIFT'
+import AppKit
+import CoreGraphics
+import Darwin
+import Foundation
+
+func aosRunOnMainSync(_ operation: () -> Void) {
+    if Thread.isMainThread { operation() }
+    else { DispatchQueue.main.sync(execute: operation) }
+}
+
+private func require(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if !condition() {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+private func number(_ value: Any?) -> Double? {
+    (value as? NSNumber)?.doubleValue
+}
+
+@main
+struct AnnotationSelectionNativeTest {
+    static func main() {
+        require(AOSAnnotationSelectionMode.parse(" RECTANGLE ") == .rectangle, "mode normalization drifted")
+        require(AOSAnnotationSelectionMode.parse("polygon") == nil, "unsupported mode was accepted")
+
+        let source = (0..<1_000).map { CGPoint(x: $0, y: $0 * 2) }
+        let bounded = aosBoundAnnotationPoints(source)
+        require(bounded.count == 256, "freehand point cap drifted")
+        require(bounded.first == source.first && bounded.last == source.last, "freehand bounds lost endpoints")
+
+        let displayHeight = CGDisplayBounds(CGMainDisplayID()).height
+        let point = aosAnnotationGeometry(mode: .point, screenPoints: [CGPoint(x: 20, y: 30)])!
+        require(point["kind"] as? String == "point", "point geometry kind drifted")
+        require(number(point["x"]) == 20, "point x drifted")
+        require(number(point["y"]) == Double(displayHeight - 30), "point y was not converted to desktop top-left space")
+
+        let rectangle = aosAnnotationGeometry(
+            mode: .rectangle,
+            screenPoints: [CGPoint(x: 300, y: 200), CGPoint(x: 100, y: 500)]
+        )!
+        require(number(rectangle["x"]) == 100, "rectangle x was not normalized")
+        require(number(rectangle["width"]) == 200, "rectangle width drifted")
+        require(number(rectangle["height"]) == 300, "rectangle height drifted")
+
+        let freehand = aosAnnotationGeometry(mode: .freehand, screenPoints: source)!
+        require((freehand["points"] as? [[String: Any]])?.count == 256, "freehand geometry exceeded point cap")
+        require(freehand["bounds"] as? [String: Any] != nil, "freehand bounds are missing")
+        require(aosAnnotationGeometry(mode: .point, screenPoints: [CGPoint(x: CGFloat.nan, y: 1)]) == nil, "non-finite geometry was accepted")
+
+        let currentPID = getpid()
+        let windowList: [[String: Any]] = [
+            [
+                kCGWindowOwnerPID as String: NSNumber(value: currentPID),
+                kCGWindowLayer as String: NSNumber(value: 0),
+                kCGWindowNumber as String: NSNumber(value: 8),
+                kCGWindowBounds as String: ["X": 0, "Y": 0, "Width": 500, "Height": 500],
+            ],
+            [
+                kCGWindowOwnerPID as String: NSNumber(value: 4242),
+                kCGWindowLayer as String: NSNumber(value: 0),
+                kCGWindowNumber as String: NSNumber(value: 17),
+                kCGWindowOwnerName as String: "Fixture App",
+                kCGWindowName as String: "Fixture Window",
+                kCGWindowBounds as String: ["X": 10, "Y": 20, "Width": 300, "Height": 200],
+            ],
+        ]
+        let facts = aosAnnotationWindowFacts(at: CGPoint(x: 20, y: 30), windowList: windowList, excludingPID: currentPID)!
+        require(facts["window_id"] as? Int == 17, "window selection did not skip daemon-owned window")
+        require(facts["title"] as? String == "Fixture Window", "window title drifted")
+        let application = facts["application"] as? [String: Any]
+        require(application?["pid"] as? Int == 4242, "application PID drifted")
+        require(application?["name"] as? String == "Fixture App", "application name drifted")
+
+        print("annotation selection native contracts passed")
+    }
+}
+SWIFT
+
+swiftc -parse-as-library \
+    "$ROOT/src/daemon/annotation-selection.swift" \
+    "$TMP/main.swift" \
+    -o "$TMP/annotation-selection-native"
+"$TMP/annotation-selection-native"

--- a/tests/schemas/aos-pending-annotation-v0.test.mjs
+++ b/tests/schemas/aos-pending-annotation-v0.test.mjs
@@ -79,3 +79,42 @@ test('pending annotation schema rejects terminal lifecycle records without trans
   await fs.writeFile(deletedPath, `${JSON.stringify(deletedWithoutEvidence, null, 2)}\n`, 'utf8');
   rejectJSONFile(deletedPath);
 });
+
+test('pending annotation schema enforces desktop selection identity and mode geometry', async () => {
+  const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aos-pending-annotation-desktop-schema-'));
+  const env = { AOS_STATE_ROOT: stateRoot, AOS_RUNTIME_MODE: 'repo' };
+  const inputPath = path.join(stateRoot, 'input.json');
+  await fs.writeFile(inputPath, `${JSON.stringify({
+    id: 'ann-desktop-schema',
+    target_kind: 'region',
+    target_summary: 'Desktop schema fixture',
+    desktop_selection: {
+      selection_id: 'sel-123e4567-e89b-12d3-a456-426614174000',
+      mode: 'rectangle',
+      geometry: {
+        kind: 'rectangle',
+        coordinate_space: 'desktop_points_top_left',
+        x: 1,
+        y: 2,
+        width: 3,
+        height: 4,
+      },
+      application: { pid: 42, name: null, bundle_id: null },
+      window: null,
+    },
+  }, null, 2)}\n`, 'utf8');
+  const created = parseJSON(run(['create', '--from-json', inputPath, '--json'], env));
+  const record = JSON.parse(await fs.readFile(created.annotation.path, 'utf8'));
+  validateJSONFile(created.annotation.path);
+
+  record.desktop_selection.mode = 'freehand';
+  const mismatchPath = path.join(stateRoot, 'mismatched-desktop-selection.json');
+  await fs.writeFile(mismatchPath, `${JSON.stringify(record, null, 2)}\n`, 'utf8');
+  rejectJSONFile(mismatchPath);
+
+  record.desktop_selection.mode = 'rectangle';
+  record.desktop_selection.selection_id = 'sel-not-a-uuid';
+  const invalidIDPath = path.join(stateRoot, 'invalid-desktop-selection-id.json');
+  await fs.writeFile(invalidIDPath, `${JSON.stringify(record, null, 2)}\n`, 'utf8');
+  rejectJSONFile(invalidIDPath);
+});

--- a/tests/schemas/daemon-event.test.mjs
+++ b/tests/schemas/daemon-event.test.mjs
@@ -85,9 +85,24 @@ test('voice event vocabulary is strict across dictation, capture, and speech', a
     'capture_segmented_canceled',
     'capture_segmented_failed',
     'audio_frame',
+    'playback_started',
+    'playback_finished',
+    'playback_canceled',
+    'playback_failed',
     'speech_started',
     'speech_finished',
     'speech_canceled',
     'speech_failed',
+  ]);
+});
+
+test('annotation event vocabulary is strict across desktop selection lifecycle', async () => {
+  const schema = JSON.parse(await fs.readFile(schemaPath, 'utf8'));
+  const rule = schema.allOf.find((item) => item.if?.properties?.service?.const === 'annotation' && !item.if?.properties?.event);
+  assert.deepEqual(rule.then.properties.event.enum, [
+    'selection_started',
+    'selection_completed',
+    'selection_canceled',
+    'selection_failed',
   ]);
 });

--- a/tests/shortcut-command.test.mjs
+++ b/tests/shortcut-command.test.mjs
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  parseShortcutRunArgs,
+  runAppleShortcut,
+} from '../scripts/lib/aos-shortcut-run.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+async function executableFixture(body) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'aos-shortcut-command-'));
+  const executable = path.join(root, 'fixture');
+  await fs.writeFile(executable, `#!/bin/sh\n${body}\n`, { mode: 0o700 });
+  return { executable, root };
+}
+
+test('shortcut parser accepts one exact name and bounded timeout', () => {
+  assert.deepEqual(parseShortcutRunArgs(['run', 'Prepare Focus Mode', '--timeout', '30s', '--json']), {
+    name: 'Prepare Focus Mode',
+    timeoutMs: 30_000,
+  });
+  assert.throws(() => parseShortcutRunArgs(['run']), { code: 'MISSING_ARG' });
+  assert.throws(() => parseShortcutRunArgs(['run', 'one', 'two']), { code: 'UNKNOWN_ARG' });
+  assert.throws(() => parseShortcutRunArgs(['run', 'name', '--timeout', '121s']), { code: 'INVALID_TIMEOUT' });
+});
+
+test('shortcut runner passes the name as one argv item and never returns output content', async () => {
+  const fixture = await executableFixture('printf "%s" "$2"; printf "private error" >&2; exit 0');
+  try {
+    const result = await runAppleShortcut({
+      name: 'Name With Shell Characters; $(false)',
+      timeoutMs: 5_000,
+      executable: fixture.executable,
+    });
+    assert.equal(result.status, 'ok');
+    assert(result.output.stdout_bytes > 0);
+    assert(result.output.stderr_bytes > 0);
+    assert(!JSON.stringify(result).includes('private error'));
+    assert(!JSON.stringify(result).includes('Shell Characters'));
+  } finally {
+    await fs.rm(fixture.root, { force: true, recursive: true });
+  }
+});
+
+test('shortcut runner bounds output, time, and cancellation', async () => {
+  const noisy = await executableFixture('dd if=/dev/zero bs=1024 count=80 2>/dev/null');
+  const slow = await executableFixture('sleep 5');
+  try {
+    await assert.rejects(
+      runAppleShortcut({ name: 'Noisy', timeoutMs: 5_000, executable: noisy.executable }),
+      { code: 'SHORTCUT_OUTPUT_LIMIT' },
+    );
+    await assert.rejects(
+      runAppleShortcut({ name: 'Slow', timeoutMs: 1_000, executable: slow.executable }),
+      { code: 'SHORTCUT_TIMEOUT' },
+    );
+    const controller = new AbortController();
+    const canceled = runAppleShortcut({
+      name: 'Canceled',
+      timeoutMs: 5_000,
+      executable: slow.executable,
+      signal: controller.signal,
+    });
+    controller.abort();
+    await assert.rejects(canceled, { code: 'SHORTCUT_CANCELED' });
+  } finally {
+    await fs.rm(noisy.root, { force: true, recursive: true });
+    await fs.rm(slow.root, { force: true, recursive: true });
+  }
+});
+
+test('shortcut runner escalates a process group that ignores termination', async () => {
+  const fixture = await executableFixture("trap '' TERM; while :; do sleep 1; done");
+  try {
+    const started = Date.now();
+    await assert.rejects(
+      runAppleShortcut({ name: 'Ignore Term', timeoutMs: 1_000, executable: fixture.executable }),
+      { code: 'SHORTCUT_TIMEOUT' },
+    );
+    assert(Date.now() - started < 3_000, 'Shortcut process group exceeded escalation bound');
+  } finally {
+    await fs.rm(fixture.root, { force: true, recursive: true });
+  }
+});
+
+test('shortcut CLI help is passive and errors never echo a Shortcut name', () => {
+  const script = path.join(repoRoot, 'scripts/aos-shortcut.mjs');
+  const help = spawnSync(process.execPath, [script, '--help'], { encoding: 'utf8' });
+  assert.equal(help.status, 0, help.stderr);
+  assert.match(help.stdout, /^Usage: aos shortcut run/);
+
+  const rejected = spawnSync(process.execPath, [script, 'Private Shortcut Name'], { encoding: 'utf8' });
+  assert.equal(rejected.status, 1);
+  assert.match(rejected.stderr, /"code":"UNKNOWN_SUBCOMMAND"/);
+  assert.equal(rejected.stderr.includes('Private Shortcut Name'), false);
+});

--- a/tests/toolkit/pending-annotation-model.test.mjs
+++ b/tests/toolkit/pending-annotation-model.test.mjs
@@ -206,3 +206,99 @@ test('pending annotation selected target does not manufacture fallback evidence'
   assert.equal(read.annotation.capability.fallback_used, false);
   validateJSONFile(created.annotation.path);
 });
+
+test('pending annotation records normalize bounded desktop selection evidence', async () => {
+  const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aos-pending-annotation-desktop-selection-'));
+  const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aos-pending-annotation-desktop-selection-fixtures-'));
+  const env = { AOS_STATE_ROOT: stateRoot, AOS_RUNTIME_MODE: 'repo' };
+  const inputPath = await writeJSON(fixtureRoot, 'desktop-selection.json', {
+    id: 'ann-desktop-selection',
+    target_kind: 'region',
+    target_summary: 'Selected desktop region',
+    desktop_selection: {
+      kind: 'desktop_annotation_selection',
+      selection_id: 'sel-123e4567-e89b-12d3-a456-426614174000',
+      mode: 'rectangle',
+      geometry: {
+        kind: 'rectangle',
+        coordinate_space: 'desktop_points_top_left',
+        x: 12,
+        y: 34,
+        width: 56,
+        height: 78,
+        ignored: true,
+      },
+      application: { pid: 42, name: 'Fixture', bundle_id: null, ignored: true },
+      window: {
+        window_id: 17,
+        title: 'Window',
+        bounds: { x: 0, y: 0, width: 800, height: 600, ignored: true },
+        ignored: true,
+      },
+      ignored: true,
+    },
+  });
+  const created = parseJSON(run(['create', '--from-json', inputPath, '--json'], env));
+  const record = JSON.parse(await fs.readFile(created.annotation.path, 'utf8'));
+
+  assert.deepEqual(record.desktop_selection, {
+    kind: 'desktop_annotation_selection',
+    selection_id: 'sel-123e4567-e89b-12d3-a456-426614174000',
+    mode: 'rectangle',
+    geometry: {
+      kind: 'rectangle',
+      coordinate_space: 'desktop_points_top_left',
+      x: 12,
+      y: 34,
+      width: 56,
+      height: 78,
+    },
+    application: { pid: 42, name: 'Fixture', bundle_id: null },
+    window: {
+      window_id: 17,
+      title: 'Window',
+      bounds: { x: 0, y: 0, width: 800, height: 600 },
+    },
+  });
+  validateJSONFile(created.annotation.path);
+  await validateAllPendingRecordFiles(env);
+});
+
+test('pending annotation records reject mismatched and oversized desktop selection evidence', async () => {
+  const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aos-pending-annotation-invalid-desktop-selection-'));
+  const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aos-pending-annotation-invalid-desktop-selection-fixtures-'));
+  const env = { AOS_STATE_ROOT: stateRoot, AOS_RUNTIME_MODE: 'repo' };
+  const base = {
+    target_kind: 'region',
+    target_summary: 'Invalid desktop selection',
+    desktop_selection: {
+      selection_id: 'sel-123e4567-e89b-12d3-a456-426614174000',
+      mode: 'freehand',
+      geometry: {
+        kind: 'point',
+        coordinate_space: 'desktop_points_top_left',
+        x: 1,
+        y: 2,
+      },
+      application: { pid: 42, name: null, bundle_id: null },
+      window: null,
+    },
+  };
+  const mismatchPath = await writeJSON(fixtureRoot, 'mismatch.json', base);
+  assert.equal(parseError(run(['create', '--from-json', mismatchPath, '--json'], env)).code, 'INVALID_ARG');
+
+  const oversizedPath = await writeJSON(fixtureRoot, 'oversized.json', {
+    ...base,
+    desktop_selection: {
+      ...base.desktop_selection,
+      geometry: {
+        kind: 'freehand',
+        coordinate_space: 'desktop_points_top_left',
+        points: Array.from({ length: 257 }, (_, index) => ({ x: index, y: index })),
+        bounds: { x: 0, y: 0, width: 256, height: 256 },
+      },
+    },
+  });
+  assert.equal(parseError(run(['create', '--from-json', oversizedPath, '--json'], env)).code, 'INVALID_ARG');
+  await validateAllPendingRecordFiles(env);
+});

--- a/tests/voice-follow-cli.test.mjs
+++ b/tests/voice-follow-cli.test.mjs
@@ -6,6 +6,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, test } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { voiceCLIErrorEnvelope } from '../scripts/lib/aos-voice-follow.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const cleanups = [];
@@ -154,7 +155,9 @@ const keepalive = setInterval(() => {}, 1000);
 function finish() {
   clearInterval(keepalive);
   try { fs.rmSync(socketPath, { force: true }); } catch {}
-  try { fs.rmSync(lockPath, { force: true }); } catch {}
+  if (process.env.AOS_FAKE_PRESERVE_LOCK_ON_SHUTDOWN !== '1') {
+    try { fs.rmSync(lockPath, { force: true }); } catch {}
+  }
   process.exit(0);
 }
 function shutdown() {
@@ -227,7 +230,12 @@ async function runStartupCancellation({ command, signal = null, parentLoss = fal
     AOS_DISABLE_DAEMON_AUTOSTART: '0',
     AOS_FAKE_START_DELAY_MS: '5000',
     AOS_FAKE_IGNORE_SIGTERM: ignoreSigterm ? '1' : '0',
-    ...(parentLoss ? { AOS_EXTERNAL_DISPATCH_PARENT_PID: '2147483647' } : {}),
+    AOS_FAKE_PRESERVE_LOCK_ON_SHUTDOWN: parentLoss ? '1' : '0',
+    ...(parentLoss ? {
+      NODE_ENV: 'test',
+      AOS_EXTERNAL_DISPATCH_PARENT_PID: '2147483647',
+      AOS_TEST_PARENT_MONITOR_DELAY_MS: '1000',
+    } : {}),
   });
   if (command === 'say') run.child.stdin.end('startup cancellation speech');
 
@@ -412,6 +420,61 @@ test('segmented microphone follow publishes path-free checkpoints and finalizes 
   ]);
 });
 
+test('audio playback follow keeps its input path private while streaming exact meters', async () => {
+  let requestSeen;
+  const stateRoot = await fakeDaemon((request, socket) => {
+    requestSeen = request;
+    socket.write(success(request.ref));
+    socket.write(event('playback_started', {
+      duration_ms: 1000,
+      bytes: 32044,
+      sample_rate: 16000,
+      channels: 1,
+    }, request.ref));
+    socket.write(event('audio_frame', {
+      stream: 'playback',
+      rms: 0.1,
+      peak: 0.2,
+      sequence: 1,
+    }, request.ref));
+    socket.write(event('playback_finished', { reason: 'completed' }, request.ref));
+  });
+  const privatePath = path.join(stateRoot, 'private.wav');
+  const run = launch('scripts/aos-play.mjs', ['--audio', privatePath, '--follow'], stateRoot);
+  const result = await run.completed;
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(requestSeen.service, 'voice');
+  assert.equal(requestSeen.action, 'playback');
+  assert.deepEqual(requestSeen.data, { audio_path: privatePath });
+  assert.ok(!result.stdout.includes(privatePath));
+  assert.ok(!result.stderr.includes(privatePath));
+  assert.deepEqual(result.stdout.trim().split('\n').map(JSON.parse).map((item) => item.event), [
+    'playback_started',
+    'audio_frame',
+    'playback_finished',
+  ]);
+});
+
+test('audio playback rejects a relative path before daemon startup', async () => {
+  const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aos-playback-relative-'));
+  cleanups.push(async () => { await fs.rm(stateRoot, { recursive: true, force: true }); });
+  const run = launch('scripts/aos-play.mjs', ['--audio', 'private.wav', '--follow'], stateRoot);
+  const result = await run.completed;
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /"code":"INVALID_AUDIO_PATH"/);
+  assert.ok(!result.stderr.includes('private.wav'));
+});
+
+test('audio playback help is passive', async () => {
+  const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aos-playback-help-'));
+  cleanups.push(async () => { await fs.rm(stateRoot, { recursive: true, force: true }); });
+  const run = launch('scripts/aos-play.mjs', ['--help'], stateRoot);
+  const result = await run.completed;
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /^Usage: aos play/);
+});
+
 test('say follow keeps stdin text out of output while streaming same-run meters', async () => {
   const secret = 'private spoken response';
   let receivedText;
@@ -455,6 +518,18 @@ test('daemon errors are code-projected without echoing request text or paths', a
   assert.ok(!result.stderr.includes(secret));
   assert.ok(!result.stderr.includes(leakedPath));
   assert.match(result.stderr, /"code":"VOICE_TRANSPORT_FAILED"/);
+});
+
+test('unexpected voice CLI exceptions are projected without raw messages or codes', () => {
+  const secret = '/private/tmp/voice-secret.wav';
+  const envelope = voiceCLIErrorEnvelope(Object.assign(new Error(`failed at ${secret}`), {
+    code: `LEAK_${secret}`,
+  }));
+  assert.deepEqual(envelope, {
+    code: 'VOICE_TRANSPORT_FAILED',
+    error: 'voice transport failed',
+  });
+  assert.ok(!JSON.stringify(envelope).includes(secret));
 });
 
 test('terminal native failure events produce a nonzero process exit', async () => {

--- a/tests/voice-transport-native.sh
+++ b/tests/voice-transport-native.sh
@@ -247,6 +247,31 @@ struct VoiceTransportNativeTest {
         } catch let failure as AOSVoiceTransportFailure {
             require(failure.code == "UNSAFE_OUTPUT_PARENT", "wrong parent-mode error")
         }
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: tempRoot.path)
+        let playbackInput = tempRoot.appendingPathComponent("playback.wav")
+        try writeOneSecondPCMFixture(to: playbackInput)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: playbackInput.path)
+        let playbackSource = try aosValidateAudioPlaybackSource(playbackInput.path)
+        require(playbackSource.durationMilliseconds == 1000, "playback duration drifted")
+        require(playbackSource.sampleRate == aosVoiceCaptureSampleRate, "playback sample rate drifted")
+        require(playbackSource.channels == aosVoiceCaptureChannels, "playback channels drifted")
+        require(playbackSource.bytes > 44, "playback byte count drifted")
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: playbackInput.path)
+        do {
+            _ = try aosValidateAudioPlaybackSource(playbackInput.path)
+            require(false, "non-owner-only playback input was accepted")
+        } catch let failure as AOSVoiceTransportFailure {
+            require(failure.code == "UNSAFE_AUDIO_INPUT", "wrong playback input mode error")
+        }
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: playbackInput.path)
+        let playbackSymlink = tempRoot.appendingPathComponent("playback-link.wav")
+        try FileManager.default.createSymbolicLink(at: playbackSymlink, withDestinationURL: playbackInput)
+        do {
+            _ = try aosValidateAudioPlaybackSource(playbackSymlink.path)
+            require(false, "symlinked playback input was accepted")
+        } catch let failure as AOSVoiceTransportFailure {
+            require(failure.code == "INVALID_AUDIO_PATH", "wrong playback symlink error")
+        }
 
         let segmentRoot = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("aos-voice-segments-\(UUID().uuidString)")
@@ -393,6 +418,7 @@ SWIFT
 swiftc -parse-as-library \
     "$ROOT/src/daemon/microphone-authorization.swift" \
     "$ROOT/src/daemon/segmented-microphone-capture.swift" \
+    "$ROOT/src/daemon/audio-playback.swift" \
     "$ROOT/src/daemon/voice-transport.swift" \
     "$TMP/main.swift" \
     -o "$TMP/voice-transport-native"


### PR DESCRIPTION
## Summary

- add bounded daemon-owned WAV playback with exact meter events and shared voice-output lease semantics
- add connection-scoped native desktop annotation selection with strict persisted evidence and path/text-redacted follow events
- add bounded shell-free execution of one explicitly named Apple Shortcut
- publish schemas, command manifests, ADRs, API docs, and proof-registry ownership

## Local validation

- command manifest generation and capability inventory: passed
- external command manifest schema/routing: 40/40
- focused voice follow: 16/16
- annotation and Shortcut CLI: 10/10
- native voice transport and annotation-selection Swift harnesses: passed
- pending annotation / daemon event / model contracts: 16/16
- proof registry: 20/20; all 15 changed proof assets routed
- full schema lane: 166/167 in restricted sandbox; sole failure was EPERM creating a test temp file, and the exact input-event suite passed 4/4 with write permission
- full non-linking Swift typecheck: passed with two unrelated existing warnings
- authority/docs workflow contracts, drift lint, changed-file threshold, and git diff --check: passed

## Deliberately deferred

No AOS binary build, raw ./aos invocation, help/dispatch suite through the raw binary, daemon operation, TCC change, native desktop interaction, audio hardware use, or live Apple Shortcut execution was performed. Those remain the separate managed-Mac acceptance lane.