### PR TITLE
Hide DesktopWorld stage until ready

### DIFF
--- a/packages/toolkit/components/desktop-world-stage/scene-outlet.js
+++ b/packages/toolkit/components/desktop-world-stage/scene-outlet.js
@@ -15,6 +15,7 @@ const MAX_SIGNALS_PER_SECOND = 30
 export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = window } = {}) {
   if (!canvas) throw new TypeError('DesktopWorld scene outlet requires a canvas.')
   const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true, canvas, powerPreference: 'low-power' })
+  renderer.setClearColor(0x000000, 0)
   const scene = new THREE.Scene()
   const camera = new THREE.OrthographicCamera(0, 1, 0, 1, -1000, 1000)
   camera.position.set(0, 0, 7)
@@ -50,6 +51,7 @@ export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = win
     const dpr = Math.min(2, Math.max(1, hostWindow.devicePixelRatio || 1))
     renderer.setPixelRatio(dpr)
     renderer.setSize(width, height, false)
+    renderer.clear(true, true, true)
     camera.aspect = width / height
     camera.updateProjectionMatrix()
   }

--- a/src/daemon/AGENTS.md
+++ b/src/daemon/AGENTS.md
@@ -11,6 +11,9 @@ delivery, voice/communication routing, and cleanup.
 Scene transport owns only connection-scoped owner/resource leases and delivery
 to the singleton toolkit DesktopWorld stage. Declarative validation and render
 policy remain in the scene toolkit; disconnect always releases owned scenes.
+The singleton full-display stage must be created hidden and resume only after
+its ready manifest follows transparent renderer initialization. Readiness
+failure leaves the stage hidden.
 
 Use generic nouns in daemon contracts. Prefer `canvas`, `surface`,
 `input_region`, `binding`, `channel`, and `lifecycle` over product names such as

--- a/src/daemon/unified.swift
+++ b/src/daemon/unified.swift
@@ -2668,10 +2668,13 @@ class UnifiedDaemon {
             }
             var request = CanvasRequest(action: "create", id: self.sceneStageCanvasID)
             request.url = self.resolveContentURL("aos://toolkit/components/desktop-world-stage/index.html")
-            request.track = "union"
+            request.surface = "desktop-world"
             request.interactive = false
             request.scope = "global"
             request.cascade = false
+            // DesktopWorld windows span every display. Keep them hidden until
+            // the toolkit manifest follows transparent renderer initialization.
+            request.suspended = true
             available = self.canvasManager.handle(request).status == "success"
             semaphore.signal()
         }
@@ -2681,7 +2684,18 @@ class UnifiedDaemon {
         while Date() < deadline {
             if let manifest = readyManifest(for: sceneStageCanvasID),
                manifest["name"] as? String == "desktop-world-stage" {
-                return true
+                let resumeSemaphore = DispatchSemaphore(value: 0)
+                var resumed = false
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { resumeSemaphore.signal(); return }
+                    resumed = self.canvasManager.handle(CanvasRequest(
+                        action: "resume",
+                        id: self.sceneStageCanvasID
+                    )).status == "success"
+                    resumeSemaphore.signal()
+                }
+                resumeSemaphore.wait()
+                return resumed
             }
             usleep(20_000)
         }

--- a/tests/scene-follow-cli.test.mjs
+++ b/tests/scene-follow-cli.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
-import { mkdtemp, mkdir, rm } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, rm } from 'node:fs/promises'
 import net from 'node:net'
 import os from 'node:os'
 import path from 'node:path'
@@ -59,4 +59,25 @@ test('scene follow rejects invalid stage before opening a socket', async () => {
   const result = await output.exit
   assert.equal(result.code, 1)
   assert.match(output.stderr(), /INVALID_STAGE/u)
+})
+
+test('scene-follow keeps the full-display stage hidden until its manifest is ready', async () => {
+  const source = await readFile(new URL('../src/daemon/unified.swift', import.meta.url), 'utf8')
+  const start = source.indexOf('private func ensureSceneStage() -> Bool')
+  const end = source.indexOf('\n    private func handleSceneFollow(', start)
+  assert.notEqual(start, -1, 'ensureSceneStage is missing')
+  assert.notEqual(end, -1, 'handleSceneFollow boundary is missing')
+  const body = source.slice(start, end)
+  const create = body.indexOf('CanvasRequest(action: "create"')
+  const hidden = body.indexOf('request.suspended = true')
+  const manifest = body.indexOf('manifest["name"] as? String == "desktop-world-stage"')
+  const resume = body.indexOf('CanvasRequest(\n                        action: "resume"')
+
+  assert.ok(create >= 0, 'scene stage create request is missing')
+  assert.ok(hidden > create, 'scene stage must be born hidden')
+  assert.ok(manifest > hidden, 'scene stage readiness must follow hidden creation')
+  assert.ok(resume > manifest, 'scene stage must resume only after manifest readiness')
+  assert.match(body, /request\.surface = "desktop-world"/u)
+  assert.doesNotMatch(body, /request\.track = "union"/u)
+  assert.match(body, /return resumed/u)
 })

--- a/tests/toolkit/desktop-world-scene-outlet.test.mjs
+++ b/tests/toolkit/desktop-world-scene-outlet.test.mjs
@@ -14,6 +14,8 @@ test('DesktopWorld scene outlet is local, bounded, and shares one renderer loop'
   ])
   assert.match(outlet, /new THREE\.WebGLRenderer/u)
   assert.equal((outlet.match(/new THREE\.WebGLRenderer/gu) ?? []).length, 1)
+  assert.match(outlet, /renderer\.setClearColor\(0x000000, 0\)/u)
+  assert.match(outlet, /renderer\.setSize\(width, height, false\)[\s\S]*renderer\.clear\(true, true, true\)/u)
   assert.match(outlet, /new THREE\.OrthographicCamera/u)
   assert.doesNotMatch(outlet, /new THREE\.PerspectiveCamera/u)
   assert.match(outlet, /deriveOrthoCamera\(nextSegment\)/u)


### PR DESCRIPTION
## Summary

- create the singleton full-display DesktopWorld stage suspended
- resume it only after the toolkit ready manifest follows transparent renderer initialization
- explicitly clear the WebGL backing buffer to transparent after every resize

## Incident

Summoning Sigil projected stale application imagery across both displays before the DesktopWorld stage was ready. The AOS emergency chord terminated the runtime and released the surfaces. This change closes the create-visible-before-ready window and leaves the stage hidden when readiness fails.

## Validation

- `node --test tests/scene-follow-cli.test.mjs` (3/3)
- focused DesktopWorld/scene toolkit contracts (20/20)
- `node --test tests/toolkit/*.test.mjs` (1296 passed, 3 skipped)
- full Swift static typecheck (passed; existing unrelated warnings only)
- workflow proof routing (passed)
- `git diff --check` (passed)

No AOS binary build, daemon operation, TCC change, or live DesktopWorld acceptance was performed. Native proof remains a post-merge external-operator checkpoint under ADR 0023.
