### PR TITLE
Expose DesktopWorld DevTools host control

### DIFF
--- a/docs/api/aos.md
+++ b/docs/api/aos.md
@@ -863,12 +863,15 @@ Open, inspect, and close the AOS-owned detachable inspector:
 ```bash
 aos scene devtools open --resource companion/main --json
 aos scene devtools status --json
+aos scene devtools update --session <session-id> --expected-revision <n> --tab performance --recording on --json
+aos scene devtools transfer --session <session-id> --expected-revision <n> --host-kind external --host-id <canvas-id> --json
 aos scene devtools close --session <session-id> --json
 ```
 
 The panel is an AOS surface and does not require an AOS status item. A consumer
-may transfer the same revisioned session into its own approved host through the
-typed SDK; exactly one interactive host owns a session at a time.
+may transfer the same revisioned session into an existing approved AOS canvas
+through the CLI or typed SDK. The daemon suspends the previous host before
+activating the next; exactly one interactive host owns a session at a time.
 
 Replay a deterministic fixture without a daemon or live input:
 

--- a/docs/api/toolkit/scene.md
+++ b/docs/api/toolkit/scene.md
@@ -237,8 +237,16 @@ aos scene perf --resource companion/main --json
 aos scene replay --events packages/toolkit/scene/fixtures/aim-commit.ndjson --json
 aos scene devtools open --resource companion/main --json
 aos scene devtools status --json
+aos scene devtools update --session <session-id> --expected-revision <n> --tab performance --recording on --json
+aos scene devtools transfer --session <session-id> --expected-revision <n> --host-kind external --host-id <canvas-id> --json
 aos scene devtools close --session <session-id> --json
 ```
+
+`update` and `transfer` use optimistic session revisions. A transfer target is
+an existing AOS canvas host; the daemon suspends the previous host before
+activating the target, so detached and consumer-aligned views never become two
+interactive inspectors. Filters and recording remain daemon-owned session
+state, and recording is opt-in.
 
 The deterministic replay helper enforces monotonic owner/resource sequences,
 complete start/update/end-or-cancel gesture lifecycles, and fixed event/resource

--- a/docs/dev/reports/aos-command-capability-inventory-v0.md
+++ b/docs/dev/reports/aos-command-capability-inventory-v0.md
@@ -18,13 +18,13 @@ current command tree before public CLI and self-hosting boundary changes.
 
 ## Summary
 
-- Command paths: 53
-- Concrete forms: 216
-- Consumer-discoverable forms: 207
+- Command paths: 55
+- Concrete forms: 218
+- Consumer-discoverable forms: 209
 - Internal/transitional command paths: 1
-- Mutating or conditionally mutating forms: 119
+- Mutating or conditionally mutating forms: 121
 - Forms with unspecified mutability metadata: 0
-- Forms with JSON output path: 211
+- Forms with JSON output path: 213
 - Forms with dry-run support: 37
 
 ## Capability Group Counts
@@ -43,7 +43,7 @@ current command tree before public CLI and self-hosting boundary changes.
 | Diagnostics/debug | 6 |
 | Operator input | 7 |
 | Operator messaging | 10 |
-| Overlay/display | 25 |
+| Overlay/display | 27 |
 | Pointer and keyboard | 9 |
 | Runtime/service | 16 |
 | Saved workspace | 6 |
@@ -108,6 +108,8 @@ current command tree before public CLI and self-hosting boundary changes.
 | `scene replay` | 1 | Overlay/display | yes | read-only | --json | `manifests/commands/source/aos/39-scene.json` | `node scripts/aos-scene.mjs replay` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `scene devtools open` | 1 | Overlay/display | yes | mutates | --json | `manifests/commands/source/aos/39-scene.json` | `node scripts/aos-scene.mjs devtools open` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `scene devtools status` | 1 | Overlay/display | yes | read-only | --json | `manifests/commands/source/aos/39-scene.json` | `node scripts/aos-scene.mjs devtools status` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
+| `scene devtools update` | 1 | Overlay/display | yes | mutates | --json | `manifests/commands/source/aos/39-scene.json` | `node scripts/aos-scene.mjs devtools update` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
+| `scene devtools transfer` | 1 | Overlay/display | yes | mutates | --json | `manifests/commands/source/aos/39-scene.json` | `node scripts/aos-scene.mjs devtools transfer` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `scene devtools close` | 1 | Overlay/display | yes | mutates | --json | `manifests/commands/source/aos/39-scene.json` | `node scripts/aos-scene.mjs devtools close` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 
 ## Concrete Forms
@@ -329,4 +331,6 @@ current command tree before public CLI and self-hosting boundary changes.
 | `scene replay` | `scene-replay` | Overlay/display | yes | read-only | --json | no | `manifests/commands/source/aos/39-scene.json` | `node scripts/aos-scene.mjs replay` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `scene devtools open` | `scene-devtools-open` | Overlay/display | yes | mutates | --json | no | `manifests/commands/source/aos/39-scene.json` | `node scripts/aos-scene.mjs devtools open` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `scene devtools status` | `scene-devtools-status` | Overlay/display | yes | read-only | --json | no | `manifests/commands/source/aos/39-scene.json` | `node scripts/aos-scene.mjs devtools status` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
+| `scene devtools update` | `scene-devtools-update` | Overlay/display | yes | mutates | --json | no | `manifests/commands/source/aos/39-scene.json` | `node scripts/aos-scene.mjs devtools update` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
+| `scene devtools transfer` | `scene-devtools-transfer` | Overlay/display | yes | mutates | --json | no | `manifests/commands/source/aos/39-scene.json` | `node scripts/aos-scene.mjs devtools transfer` | `docs/api/aos.md, docs/api/aos-capabilities.md` |
 | `scene devtools close` | `scene-devtools-close` | Overlay/display | yes | mutates | --json | no | `manifests/commands/source/aos/39-scene.json` | `node scripts/aos-scene.mjs devtools close` | `docs/api/aos.md, docs/api/aos-capabilities.md` |

--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -12804,6 +12804,204 @@
       "path" : [
         "scene",
         "devtools",
+        "update"
+      ],
+      "summary" : "Update one revisioned DesktopWorld inspector session",
+      "forms" : [
+        {
+          "id" : "scene-devtools-update",
+          "usage" : "aos scene devtools update --session <id> --expected-revision <n> [view options] --json",
+          "args" : [
+            {
+              "id" : "session",
+              "kind" : "flag",
+              "token" : "--session",
+              "value_type" : "string",
+              "required" : true,
+              "summary" : "DevTools session identifier"
+            },
+            {
+              "id" : "expected-revision",
+              "kind" : "flag",
+              "token" : "--expected-revision",
+              "value_type" : "int",
+              "required" : true,
+              "summary" : "Current session revision"
+            },
+            {
+              "id" : "resource",
+              "kind" : "flag",
+              "token" : "--resource",
+              "value_type" : "string",
+              "required" : false,
+              "summary" : "Selected scene resource"
+            },
+            {
+              "id" : "clear-resource",
+              "kind" : "flag",
+              "token" : "--clear-resource",
+              "value_type" : "bool",
+              "required" : false,
+              "summary" : "Clear the selected scene resource"
+            },
+            {
+              "id" : "tab",
+              "kind" : "flag",
+              "token" : "--tab",
+              "value_type" : "string",
+              "required" : false,
+              "summary" : "World, resources, interactions, performance, or events"
+            },
+            {
+              "id" : "query",
+              "kind" : "flag",
+              "token" : "--query",
+              "value_type" : "string",
+              "required" : false,
+              "summary" : "Bounded inspector query"
+            },
+            {
+              "id" : "event-kinds",
+              "kind" : "flag",
+              "token" : "--event-kinds",
+              "value_type" : "string",
+              "required" : false,
+              "summary" : "Comma-separated event-kind filter"
+            },
+            {
+              "id" : "errors-only",
+              "kind" : "flag",
+              "token" : "--errors-only",
+              "value_type" : "string",
+              "required" : false,
+              "summary" : "Set the error-only filter to on or off"
+            },
+            {
+              "id" : "recording",
+              "kind" : "flag",
+              "token" : "--recording",
+              "value_type" : "string",
+              "required" : false,
+              "summary" : "Set opt-in telemetry recording to on or off"
+            },
+            {
+              "id" : "json",
+              "kind" : "flag",
+              "token" : "--json",
+              "value_type" : "bool",
+              "required" : true,
+              "summary" : "Emit the updated session snapshot"
+            }
+          ],
+          "stdin" : {
+            "supported" : false,
+            "content_type" : null,
+            "used_when" : "never"
+          },
+          "output" : {
+            "default_mode" : "json",
+            "error_mode" : "json_stderr",
+            "streaming" : false,
+            "supports_json_flag" : true
+          },
+          "execution" : {
+            "auto_starts_daemon" : true,
+            "interactive" : false,
+            "mutates_state" : true,
+            "read_only" : false,
+            "requires_permissions" : false,
+            "streaming" : false,
+            "supports_dry_run" : false
+          },
+          "examples" : [
+            "aos scene devtools update --session devtools-example --expected-revision 2 --tab performance --recording on --json"
+          ]
+        }
+      ]
+    },
+    {
+      "path" : [
+        "scene",
+        "devtools",
+        "transfer"
+      ],
+      "summary" : "Transfer the sole interactive host for a DesktopWorld inspector",
+      "forms" : [
+        {
+          "id" : "scene-devtools-transfer",
+          "usage" : "aos scene devtools transfer --session <id> --expected-revision <n> --host-kind <kind> --host-id <id> --json",
+          "args" : [
+            {
+              "id" : "session",
+              "kind" : "flag",
+              "token" : "--session",
+              "value_type" : "string",
+              "required" : true,
+              "summary" : "DevTools session identifier"
+            },
+            {
+              "id" : "expected-revision",
+              "kind" : "flag",
+              "token" : "--expected-revision",
+              "value_type" : "int",
+              "required" : true,
+              "summary" : "Current session revision"
+            },
+            {
+              "id" : "host-kind",
+              "kind" : "flag",
+              "token" : "--host-kind",
+              "value_type" : "string",
+              "required" : true,
+              "summary" : "Panel, external, or compatibility host kind"
+            },
+            {
+              "id" : "host-id",
+              "kind" : "flag",
+              "token" : "--host-id",
+              "value_type" : "string",
+              "required" : true,
+              "summary" : "Canonical AOS canvas host identifier"
+            },
+            {
+              "id" : "json",
+              "kind" : "flag",
+              "token" : "--json",
+              "value_type" : "bool",
+              "required" : true,
+              "summary" : "Emit the transferred session snapshot"
+            }
+          ],
+          "stdin" : {
+            "supported" : false,
+            "content_type" : null,
+            "used_when" : "never"
+          },
+          "output" : {
+            "default_mode" : "json",
+            "error_mode" : "json_stderr",
+            "streaming" : false,
+            "supports_json_flag" : true
+          },
+          "execution" : {
+            "auto_starts_daemon" : true,
+            "interactive" : false,
+            "mutates_state" : true,
+            "read_only" : false,
+            "requires_permissions" : false,
+            "streaming" : false,
+            "supports_dry_run" : false
+          },
+          "examples" : [
+            "aos scene devtools transfer --session devtools-example --expected-revision 2 --host-kind external --host-id sigil/companion-studio --json"
+          ]
+        }
+      ]
+    },
+    {
+      "path" : [
+        "scene",
+        "devtools",
         "close"
       ],
       "summary" : "Close one AOS-owned DesktopWorld inspector session",

--- a/manifests/commands/aos-external-commands.json
+++ b/manifests/commands/aos-external-commands.json
@@ -2913,6 +2913,22 @@
       "stdio": "inherit"
     },
     {
+      "path": ["scene", "devtools", "update"],
+      "summary": "Update a revisioned DesktopWorld inspector session",
+      "executable": "/usr/bin/env",
+      "argv_prefix": ["node", "scripts/aos-scene.mjs", "devtools", "update"],
+      "cwd": "repo",
+      "stdio": "inherit"
+    },
+    {
+      "path": ["scene", "devtools", "transfer"],
+      "summary": "Transfer a DesktopWorld inspector host lease",
+      "executable": "/usr/bin/env",
+      "argv_prefix": ["node", "scripts/aos-scene.mjs", "devtools", "transfer"],
+      "cwd": "repo",
+      "stdio": "inherit"
+    },
+    {
       "path": ["scene", "devtools", "close"],
       "summary": "Close a DesktopWorld inspector session",
       "executable": "/usr/bin/env",

--- a/manifests/commands/source/aos/39-scene.json
+++ b/manifests/commands/source/aos/39-scene.json
@@ -138,6 +138,47 @@
       "examples":["aos scene devtools status --json"]
     }]
   }, {
+    "path": ["scene", "devtools", "update"],
+    "summary": "Update one revisioned DesktopWorld inspector session",
+    "forms": [{
+      "id": "scene-devtools-update",
+      "usage": "aos scene devtools update --session <id> --expected-revision <n> [view options] --json",
+      "args": [
+        {"id":"session","kind":"flag","token":"--session","value_type":"string","required":true,"summary":"DevTools session identifier"},
+        {"id":"expected-revision","kind":"flag","token":"--expected-revision","value_type":"int","required":true,"summary":"Current session revision"},
+        {"id":"resource","kind":"flag","token":"--resource","value_type":"string","required":false,"summary":"Selected scene resource"},
+        {"id":"clear-resource","kind":"flag","token":"--clear-resource","value_type":"bool","required":false,"summary":"Clear the selected scene resource"},
+        {"id":"tab","kind":"flag","token":"--tab","value_type":"string","required":false,"summary":"World, resources, interactions, performance, or events"},
+        {"id":"query","kind":"flag","token":"--query","value_type":"string","required":false,"summary":"Bounded inspector query"},
+        {"id":"event-kinds","kind":"flag","token":"--event-kinds","value_type":"string","required":false,"summary":"Comma-separated event-kind filter"},
+        {"id":"errors-only","kind":"flag","token":"--errors-only","value_type":"string","required":false,"summary":"Set the error-only filter to on or off"},
+        {"id":"recording","kind":"flag","token":"--recording","value_type":"string","required":false,"summary":"Set opt-in telemetry recording to on or off"},
+        {"id":"json","kind":"flag","token":"--json","value_type":"bool","required":true,"summary":"Emit the updated session snapshot"}
+      ],
+      "stdin":{"supported":false,"content_type":null,"used_when":"never"},
+      "output":{"default_mode":"json","error_mode":"json_stderr","streaming":false,"supports_json_flag":true},
+      "execution":{"auto_starts_daemon":true,"interactive":false,"mutates_state":true,"read_only":false,"requires_permissions":false,"streaming":false,"supports_dry_run":false},
+      "examples":["aos scene devtools update --session devtools-example --expected-revision 2 --tab performance --recording on --json"]
+    }]
+  }, {
+    "path": ["scene", "devtools", "transfer"],
+    "summary": "Transfer the sole interactive host for a DesktopWorld inspector",
+    "forms": [{
+      "id": "scene-devtools-transfer",
+      "usage": "aos scene devtools transfer --session <id> --expected-revision <n> --host-kind <kind> --host-id <id> --json",
+      "args": [
+        {"id":"session","kind":"flag","token":"--session","value_type":"string","required":true,"summary":"DevTools session identifier"},
+        {"id":"expected-revision","kind":"flag","token":"--expected-revision","value_type":"int","required":true,"summary":"Current session revision"},
+        {"id":"host-kind","kind":"flag","token":"--host-kind","value_type":"string","required":true,"summary":"Panel, external, or compatibility host kind"},
+        {"id":"host-id","kind":"flag","token":"--host-id","value_type":"string","required":true,"summary":"Canonical AOS canvas host identifier"},
+        {"id":"json","kind":"flag","token":"--json","value_type":"bool","required":true,"summary":"Emit the transferred session snapshot"}
+      ],
+      "stdin":{"supported":false,"content_type":null,"used_when":"never"},
+      "output":{"default_mode":"json","error_mode":"json_stderr","streaming":false,"supports_json_flag":true},
+      "execution":{"auto_starts_daemon":true,"interactive":false,"mutates_state":true,"read_only":false,"requires_permissions":false,"streaming":false,"supports_dry_run":false},
+      "examples":["aos scene devtools transfer --session devtools-example --expected-revision 2 --host-kind external --host-id sigil/companion-studio --json"]
+    }]
+  }, {
     "path": ["scene", "devtools", "close"],
     "summary": "Close one AOS-owned DesktopWorld inspector session",
     "forms": [{

--- a/manifests/commands/source/external/47-scene.json
+++ b/manifests/commands/source/external/47-scene.json
@@ -63,6 +63,18 @@
     "argv_prefix": ["node", "scripts/aos-scene.mjs", "devtools", "status"],
     "cwd": "repo", "stdio": "inherit"
   }, {
+    "path": ["scene", "devtools", "update"],
+    "summary": "Update a revisioned DesktopWorld inspector session",
+    "executable": "/usr/bin/env",
+    "argv_prefix": ["node", "scripts/aos-scene.mjs", "devtools", "update"],
+    "cwd": "repo", "stdio": "inherit"
+  }, {
+    "path": ["scene", "devtools", "transfer"],
+    "summary": "Transfer a DesktopWorld inspector host lease",
+    "executable": "/usr/bin/env",
+    "argv_prefix": ["node", "scripts/aos-scene.mjs", "devtools", "transfer"],
+    "cwd": "repo", "stdio": "inherit"
+  }, {
     "path": ["scene", "devtools", "close"],
     "summary": "Close a DesktopWorld inspector session",
     "executable": "/usr/bin/env",

--- a/scripts/aos-scene.mjs
+++ b/scripts/aos-scene.mjs
@@ -18,6 +18,8 @@ const MAX_STDERR_BYTES = 32 * 1024
 const MAX_REPLAY_BYTES = 16 * 1024 * 1024
 const ALLOWED_OPERATIONS = new Set(['mount', 'transact', 'signal', 'play', 'suspend', 'resume', 'inspect', 'remove', 'close', 'subscribe', 'unsubscribe'])
 const ALLOWED_SCENE_EVENTS = new Set(['gesture'])
+const DEVTOOLS_TABS = new Set(['world', 'resources', 'interactions', 'performance', 'events'])
+const DEVTOOLS_HOST_KINDS = new Set(['compatibility', 'external', 'panel'])
 
 function fail(code, message) {
   const error = new Error(message)
@@ -69,6 +71,101 @@ function validateResource(value) {
   return value
 }
 
+function validateDevToolsIdentifier(value, label) {
+  if (!/^[a-z0-9][a-z0-9._/-]{0,127}$/u.test(value ?? '') || value.split('/').some((part) => part === '' || part === '.' || part === '..')) {
+    fail(`INVALID_DEVTOOLS_${label.toUpperCase()}`, `DesktopWorld DevTools ${label} identifier is invalid`)
+  }
+  return value
+}
+
+function parseRevision(value) {
+  if (!/^(?:0|[1-9][0-9]*)$/u.test(value ?? '')) fail('INVALID_DEVTOOLS_REVISION', 'DesktopWorld DevTools revision must be a non-negative integer')
+  const revision = Number(value)
+  if (!Number.isSafeInteger(revision)) fail('INVALID_DEVTOOLS_REVISION', 'DesktopWorld DevTools revision exceeds the supported range')
+  return revision
+}
+
+function parseToggle(value, token) {
+  if (value === 'on') return true
+  if (value === 'off') return false
+  fail('INVALID_DEVTOOLS_TOGGLE', `${token} requires on or off`)
+}
+
+function parseEventKinds(value) {
+  const values = value === '' ? [] : value.split(',')
+  if (values.length > 16 || values.some((entry) => !/^[a-z0-9][a-z0-9._-]{0,63}$/u.test(entry))) {
+    fail('INVALID_DEVTOOLS_FILTER', '--event-kinds must contain at most 16 comma-separated event identifiers')
+  }
+  return [...new Set(values)]
+}
+
+function parseDevToolsArgs(action, args) {
+  if (!['open', 'status', 'update', 'transfer', 'close'].includes(action)) {
+    fail('UNKNOWN_SUBCOMMAND', 'scene devtools requires open, status, update, transfer, or close')
+  }
+  const allowed = {
+    open: new Set(['--resource']),
+    status: new Set(['--session']),
+    update: new Set(['--session', '--expected-revision', '--resource', '--clear-resource', '--tab', '--query', '--event-kinds', '--errors-only', '--recording']),
+    transfer: new Set(['--session', '--expected-revision', '--host-kind', '--host-id']),
+    close: new Set(['--session']),
+  }[action]
+  const valueLess = new Set(['--clear-resource'])
+  const values = new Map()
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index]
+    if (!allowed.has(token)) fail('UNKNOWN_FLAG', `Unknown scene devtools flag: ${token}`)
+    if (values.has(token)) fail('DUPLICATE_FLAG', `${token} may be supplied once`)
+    if (valueLess.has(token)) {
+      values.set(token, true)
+      continue
+    }
+    if (args[index + 1] == null || args[index + 1].startsWith('--')) fail('MISSING_ARG', `${token} requires a value`)
+    values.set(token, args[index + 1])
+    index += 1
+  }
+
+  const session = values.has('--session') ? validateDevToolsIdentifier(values.get('--session'), 'session') : null
+  if (['update', 'transfer', 'close'].includes(action) && session == null) fail('MISSING_ARG', `scene devtools ${action} requires --session`)
+  const expectedRevision = values.has('--expected-revision') ? parseRevision(values.get('--expected-revision')) : null
+  if (['update', 'transfer'].includes(action) && expectedRevision == null) fail('MISSING_ARG', `scene devtools ${action} requires --expected-revision`)
+
+  const resource = values.has('--resource') ? validateResource(values.get('--resource')) : null
+  if (values.has('--clear-resource') && values.has('--resource')) fail('CONFLICTING_FLAGS', '--resource and --clear-resource cannot be combined')
+
+  if (action === 'update') {
+    const changes = {}
+    if (values.has('--resource')) changes.selected_resource = resource
+    if (values.has('--clear-resource')) changes.selected_resource = null
+    if (values.has('--tab')) {
+      const tab = values.get('--tab')
+      if (!DEVTOOLS_TABS.has(tab)) fail('INVALID_DEVTOOLS_TAB', 'DesktopWorld DevTools tab is invalid')
+      changes.active_tab = tab
+    }
+    const filters = {}
+    if (values.has('--query')) {
+      const query = values.get('--query')
+      if (Buffer.byteLength(query) > 128) fail('INVALID_DEVTOOLS_FILTER', '--query exceeds the 128-byte limit')
+      filters.query = query
+    }
+    if (values.has('--event-kinds')) filters.event_kinds = parseEventKinds(values.get('--event-kinds'))
+    if (values.has('--errors-only')) filters.errors_only = parseToggle(values.get('--errors-only'), '--errors-only')
+    if (Object.keys(filters).length > 0) changes.filters = filters
+    if (values.has('--recording')) changes.recording = parseToggle(values.get('--recording'), '--recording')
+    if (Object.keys(changes).length === 0) fail('MISSING_ARG', 'scene devtools update requires at least one update flag')
+    return { action, session, expectedRevision, changes }
+  }
+
+  if (action === 'transfer') {
+    if (!values.has('--host-kind') || !values.has('--host-id')) fail('MISSING_ARG', 'scene devtools transfer requires --host-kind and --host-id')
+    const kind = values.get('--host-kind')
+    if (!DEVTOOLS_HOST_KINDS.has(kind)) fail('INVALID_DEVTOOLS_HOST_KIND', 'DesktopWorld DevTools host kind is invalid')
+    return { action, session, expectedRevision, host: { kind, id: validateDevToolsIdentifier(values.get('--host-id'), 'host') } }
+  }
+
+  return { action, session, resource }
+}
+
 function parseToolArgs(args) {
   const command = args[0]
   const tail = args.slice(1)
@@ -106,20 +203,7 @@ function parseToolArgs(args) {
   }
   if (command === 'devtools') {
     const action = withoutJson[0]
-    const rest = withoutJson.slice(1)
-    if (!['open', 'status', 'close'].includes(action)) fail('UNKNOWN_SUBCOMMAND', 'scene devtools requires open, status, or close')
-    const allowed = action === 'open' ? new Set(['--resource']) : action === 'status' ? new Set(['--session']) : new Set(['--session'])
-    for (let index = 0; index < rest.length; index += 2) {
-      if (!allowed.has(rest[index])) fail('UNKNOWN_FLAG', `Unknown scene devtools flag: ${rest[index]}`)
-    }
-    if (rest.filter((value) => value === '--resource').length > 1 || rest.filter((value) => value === '--session').length > 1) {
-      fail('DUPLICATE_FLAG', 'scene devtools flags may be supplied once')
-    }
-    const resource = action === 'open' && rest.includes('--resource') ? validateResource(valueAfter(rest, '--resource')) : null
-    const session = rest.includes('--session') ? valueAfter(rest, '--session') : null
-    if (session != null && !/^[a-z0-9][a-z0-9._-]{0,127}$/u.test(session)) fail('INVALID_DEVTOOLS_SESSION', 'DesktopWorld DevTools session identifier is invalid')
-    if (action === 'close' && session == null) fail('MISSING_ARG', 'scene devtools close requires --session')
-    return { command, action, json, resource, session }
+    return { command, json, ...parseDevToolsArgs(action, withoutJson.slice(1)) }
   }
   return null
 }
@@ -223,6 +307,8 @@ async function runToolCommand(options) {
     else if (options.command === 'perf') result = await client.perf(options.resource)
     else if (options.command === 'devtools' && options.action === 'open') result = await client.devtools.open({ resource: options.resource })
     else if (options.command === 'devtools' && options.action === 'status') result = await client.devtools.status(options.session)
+    else if (options.command === 'devtools' && options.action === 'update') result = await client.devtools.update(options.session, options.expectedRevision, options.changes)
+    else if (options.command === 'devtools' && options.action === 'transfer') result = await client.devtools.transfer(options.session, options.expectedRevision, options.host)
     else if (options.command === 'devtools' && options.action === 'close') result = await client.devtools.close(options.session)
     else fail('UNKNOWN_SUBCOMMAND', 'Unknown scene command')
     writeToolResult(result, options.json, options.action ?? options.command)

--- a/skills/aos-desktop-world-authoring/SKILL.md
+++ b/skills/aos-desktop-world-authoring/SKILL.md
@@ -76,11 +76,17 @@ Open the AOS-owned inspector anywhere on the desktop:
 ```bash
 ./aos scene devtools open --resource companion/main --json
 ./aos scene devtools status --json
+./aos scene devtools update --session <session-id> --expected-revision <n> \
+  --tab performance --recording on --json
+./aos scene devtools transfer --session <session-id> --expected-revision <n> \
+  --host-kind external --host-id <canvas-id> --json
 ./aos scene devtools close --session <session-id> --json
 ```
 
-A consumer may host the same session through the typed toolkit SDK, but must
-not fork the telemetry model or create a second interactive host.
+A consumer may transfer the same session into an existing AOS canvas through
+the CLI or typed toolkit SDK. The daemon suspends the old host before activating
+the new one; consumers must not fork the telemetry model or create a second
+interactive host.
 
 ## Replay
 

--- a/tests/aos-skills-registry.test.mjs
+++ b/tests/aos-skills-registry.test.mjs
@@ -81,6 +81,8 @@ test('installable browser and saved-workspace skills preserve split contracts', 
   const scene = await readFile(path.join(repoRoot, 'skills', 'aos-desktop-world-authoring', 'SKILL.md'), 'utf8');
   assert.match(scene, /Aim-and-commit/);
   assert.match(scene, /scene devtools open/);
+  assert.match(scene, /scene devtools update/);
+  assert.match(scene, /scene devtools transfer/);
   assert.match(scene, /scene replay/);
 
   const verification = await readFile(path.join(repoRoot, 'skills', 'aos-verification', 'SKILL.md'), 'utf8');

--- a/tests/scene-agent-tooling-cli.test.mjs
+++ b/tests/scene-agent-tooling-cli.test.mjs
@@ -65,6 +65,7 @@ test('scene agent tooling uses headless snapshots and a bounded monitor stream',
         const reply = (value) => socket.write(`${JSON.stringify({ v: 1, ref: request.ref, ...value })}\n`)
         if (request.action === 'devtools_open') reply({ status: 'ok', session: snapshot() })
         else if (request.action === 'devtools_status') reply(request.data.session ? { status: 'ok', session: snapshot() } : { status: 'ok', sessions: [snapshot()] })
+        else if (request.action === 'devtools_update' || request.action === 'devtools_transfer') reply({ status: 'ok', session: snapshot() })
         else if (request.action === 'devtools_close') reply({ status: 'ok', session: request.data.session, closed: true })
         else if (request.action === 'devtools_monitor') {
           socket.write(`${JSON.stringify({
@@ -85,6 +86,8 @@ test('scene agent tooling uses headless snapshots and a bounded monitor stream',
       [['perf', '--resource', 'companion/main', '--json'], (value) => assert.equal(value.performance.currentFps, 60)],
       [['devtools', 'open', '--resource', 'companion/main', '--json'], (value) => assert.equal(value.session.session.id, 'devtools-test')],
       [['devtools', 'status', '--json'], (value) => assert.equal(value.sessions.length, 1)],
+      [['devtools', 'update', '--session', 'devtools-test', '--expected-revision', '1', '--tab', 'performance', '--query', 'companion', '--event-kinds', 'gesture,error', '--errors-only', 'on', '--recording', 'on', '--json'], (value) => assert.equal(value.session.session.id, 'devtools-test')],
+      [['devtools', 'transfer', '--session', 'devtools-test', '--expected-revision', '1', '--host-kind', 'external', '--host-id', 'sigil/companion-studio', '--json'], (value) => assert.equal(value.session.session.id, 'devtools-test')],
       [['devtools', 'close', '--session', 'devtools-test', '--json'], (value) => assert.equal(value.closed, true)],
     ]) {
       const result = await run(args, env)
@@ -95,6 +98,13 @@ test('scene agent tooling uses headless snapshots and a bounded monitor stream',
     assert.equal(monitor.code, 0, monitor.stderr)
     assert.equal(JSON.parse(monitor.stdout).data.snapshot.resources[0].id, 'companion/main')
     assert.ok(received.filter((entry) => entry.action === 'devtools_open' && entry.data.headless === true).length >= 3)
+    assert.deepEqual(received.find((entry) => entry.action === 'devtools_update')?.data, {
+      session: 'devtools-test', expected_revision: 1, active_tab: 'performance',
+      filters: { query: 'companion', event_kinds: ['gesture', 'error'], errors_only: true }, recording: true,
+    })
+    assert.deepEqual(received.find((entry) => entry.action === 'devtools_transfer')?.data, {
+      session: 'devtools-test', expected_revision: 1, host: { kind: 'external', id: 'sigil/companion-studio' },
+    })
   } finally {
     await new Promise((resolve) => server.close(resolve))
     await rm(root, { recursive: true, force: true })
@@ -153,6 +163,11 @@ test('scene tooling rejects missing machine mode and duplicate identity flags be
     [['list'], 'MISSING_ARG'],
     [['inspect', '--resource', 'one', '--resource', 'two', '--json'], 'DUPLICATE_FLAG'],
     [['devtools', 'close', '--json'], 'MISSING_ARG'],
+    [['devtools', 'update', '--session', 'one', '--expected-revision', '1', '--json'], 'MISSING_ARG'],
+    [['devtools', 'update', '--session', 'one', '--expected-revision', '1', '--recording', 'yes', '--json'], 'INVALID_DEVTOOLS_TOGGLE'],
+    [['devtools', 'update', '--session', 'one', '--expected-revision', '1', '--query', 'x'.repeat(129), '--json'], 'INVALID_DEVTOOLS_FILTER'],
+    [['devtools', 'transfer', '--session', 'one', '--expected-revision', '1', '--host-kind', 'browser', '--host-id', 'host', '--json'], 'INVALID_DEVTOOLS_HOST_KIND'],
+    [['devtools', 'transfer', '--session', 'one', '--expected-revision', '1', '--host-kind', 'external', '--host-id', 'host/', '--json'], 'INVALID_DEVTOOLS_HOST'],
   ]) {
     const result = await run(args, { AOS_STATE_ROOT: path.join(os.tmpdir(), 'must-not-connect') })
     assert.equal(result.code, 1)


### PR DESCRIPTION
## Summary
- expose revisioned DesktopWorld DevTools update and host-transfer forms through the public CLI
- keep one daemon-owned interactive host lease across detached and consumer-aligned AOS canvases
- generate manifests, inventory, docs, skill recipes, and strict parser coverage from the public contract

## Validation
- `node --test tests/scene-agent-tooling-cli.test.mjs` (5/5)
- `node --test tests/toolkit/desktop-world-client.test.mjs tests/schemas/desktop-world-scene-tooling.test.mjs tests/scene-agent-tooling-cli.test.mjs` (10/10)
- `bash tests/daemon-desktop-world-devtools-session.sh`
- command manifest generation and inventory checks
- command/external schema suite (49/49)
- DevTools contract and skill registry suites
- skill validator: 23 skills, 0 errors, 0 warnings
- `git diff --check`

## Deferred
The repository has no live `./aos` binary by design at this static checkpoint. Live wrapper/help gates, daemon operation, build, TCC, and signing remain deferred to the single managed-Mac rebuild lane.