### PR TITLE
Unwrap canonical scene daemon responses

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -120,8 +120,9 @@ commands, runtime helpers, wiki tools, and command adapters.
   without starting the daemon or exposing absolute paths.
   `lib/aos-scene-daemon.mjs` owns the agent-tooling request transport: bounded
   incremental NDJSON reads, request/ref correlation, timeouts, signal and
-  parent-loss handling, and cleanup of only a daemon it started. It must not
-  replace the canonical stage snapshot or carry product content.
+  parent-loss handling, canonical daemon-response envelope validation and data
+  unwrapping, and cleanup of only a daemon it started. It must not replace the
+  canonical stage snapshot or carry product content.
 - `aos-shortcut.mjs` owns explicit Apple Shortcut execution through
   `/usr/bin/shortcuts`. It passes one exact shortcut name as an argv item,
   never invokes a shell, bounds time and output, and never returns captured

--- a/scripts/lib/aos-scene-daemon.mjs
+++ b/scripts/lib/aos-scene-daemon.mjs
@@ -12,6 +12,14 @@ function fail(code, message) {
   return error
 }
 
+function responseData(payload) {
+  if (payload.v !== 1 || payload.status !== 'success'
+      || !payload.data || typeof payload.data !== 'object' || Array.isArray(payload.data)) {
+    throw fail('INVALID_SCENE_DAEMON_RESPONSE', 'DesktopWorld daemon returned an invalid success response.')
+  }
+  return payload.data
+}
+
 class BoundedLineReader {
   #buffer = Buffer.alloc(0)
   #onLine
@@ -84,7 +92,10 @@ export async function connectSceneDaemon({ signal = null, onEvent = () => {} } =
       pending.delete(payload.ref)
       clearTimeout(request.timer)
       if (typeof payload.code === 'string' && typeof payload.error === 'string') request.reject(fail(payload.code, payload.error))
-      else request.resolve(payload)
+      else {
+        try { request.resolve(responseData(payload)) }
+        catch (error) { request.reject(error) }
+      }
       return
     }
     if (typeof payload.ref === 'string') return

--- a/tests/scene-agent-tooling-cli.test.mjs
+++ b/tests/scene-agent-tooling-cli.test.mjs
@@ -62,7 +62,7 @@ test('scene agent tooling uses headless snapshots and a bounded monitor stream',
         const request = JSON.parse(buffer.slice(0, newline))
         buffer = buffer.slice(newline + 1)
         received.push(request)
-        const reply = (value) => socket.write(`${JSON.stringify({ v: 1, ref: request.ref, ...value })}\n`)
+        const reply = (data) => socket.write(`${JSON.stringify({ v: 1, ref: request.ref, status: 'success', data })}\n`)
         if (request.action === 'devtools_open') reply({ status: 'ok', session: snapshot() })
         else if (request.action === 'devtools_status') reply(request.data.session ? { status: 'ok', session: snapshot() } : { status: 'ok', sessions: [snapshot()] })
         else if (request.action === 'devtools_update' || request.action === 'devtools_transfer') reply({ status: 'ok', session: snapshot() })
@@ -121,7 +121,10 @@ test('scene monitor preserves unsolicited events that arrive before the correlat
       v: 1, service: 'scene', event: 'monitor', ref: request.ref, ts: 1,
       data: { resource: request.data.resource, snapshot: stage() },
     })}\n`)
-    socket.write(`${JSON.stringify({ v: 1, ref: request.ref, status: 'ok', resource: request.data.resource, following: true })}\n`)
+    socket.write(`${JSON.stringify({
+      v: 1, ref: request.ref, status: 'success',
+      data: { status: 'ok', resource: request.data.resource, following: true },
+    })}\n`)
   }))
   await new Promise((resolve, reject) => server.listen(path.join(state, 'sock'), resolve).once('error', reject))
   try {
@@ -186,6 +189,26 @@ test('scene tooling bounds daemon output before JSON parsing', async () => {
     assert.equal(result.code, 1)
     assert.equal(result.stdout, '')
     assert.match(result.stderr, /SCENE_DAEMON_LINE_TOO_LARGE/u)
+  } finally {
+    await new Promise((resolve) => server.close(resolve))
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('scene tooling rejects a correlated success response without canonical data', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'aos-scene-tools-invalid-envelope-'))
+  const state = path.join(root, 'repo')
+  await mkdir(state, { recursive: true })
+  const server = net.createServer((socket) => socket.once('data', (chunk) => {
+    const request = JSON.parse(chunk.toString('utf8').trim())
+    socket.write(`${JSON.stringify({ v: 1, ref: request.ref, status: 'success' })}\n`)
+  }))
+  await new Promise((resolve, reject) => server.listen(path.join(state, 'sock'), resolve).once('error', reject))
+  try {
+    const result = await run(['list', '--json'], { AOS_STATE_ROOT: root, AOS_RUNTIME_MODE: 'repo' })
+    assert.equal(result.code, 1)
+    assert.equal(result.stdout, '')
+    assert.match(result.stderr, /INVALID_SCENE_DAEMON_RESPONSE/u)
   } finally {
     await new Promise((resolve) => server.close(resolve))
     await rm(root, { recursive: true, force: true })

--- a/tests/scene-agent-tooling-cli.test.mjs
+++ b/tests/scene-agent-tooling-cli.test.mjs
@@ -97,7 +97,10 @@ test('scene agent tooling uses headless snapshots and a bounded monitor stream',
     const monitor = await run(['monitor', '--resource', 'companion/main', '--follow', '--json'], env, { stopAfter: '"event":"monitor"' })
     assert.equal(monitor.code, 0, monitor.stderr)
     assert.equal(JSON.parse(monitor.stdout).data.snapshot.resources[0].id, 'companion/main')
-    assert.ok(received.filter((entry) => entry.action === 'devtools_open' && entry.data.headless === true).length >= 3)
+    const opened = received.filter((entry) => entry.action === 'devtools_open')
+    const closed = received.filter((entry) => entry.action === 'devtools_close')
+    assert.ok(opened.filter((entry) => entry.data.headless === true).length >= 3)
+    assert.equal(closed.length, opened.length, 'every DevTools session must be closed')
     assert.deepEqual(received.find((entry) => entry.action === 'devtools_update')?.data, {
       session: 'devtools-test', expected_revision: 1, active_tab: 'performance',
       filters: { query: 'companion', event_kinds: ['gesture', 'error'], errors_only: true }, recording: true,


### PR DESCRIPTION
## Summary

- validate and unwrap canonical daemon response envelopes in the public scene tooling transport
- align the scene CLI fake daemon with the documented `{ status: "success", data: ... }` wire contract
- fail closed when a correlated success response omits canonical data

## Native defect reproduced

Against the isolated live repo runtime, both documented read-only forms failed before this correction:

```text
aos scene list --json
aos scene inspect --resource companion/main --json
```

Both returned `INVALID_DEVTOOLS_SESSION` because the daemon response was still wrapped under `data` when it reached the transport-injected toolkit client. The failed reads also left headless DevTools sessions behind; those exact sessions were closed before validation continued.

The corrected adapter was then run directly against the same daemon without rebuilding AOS. `list` returned the suspended `companion/main` resource, `inspect` returned its bounded DesktopWorld snapshot, and `scene devtools status` confirmed no residual sessions.

## Validation

- proof-registry route: 12/12
- adjacent scene client, CLI, and daemon contracts: 13/13
- daemon DevTools Swift session proof: passed
- command-manifest generation and inventory: passed
- malformed-envelope regression: passed
- `git diff --check`: passed

No AOS binary build, daemon lifecycle operation, TCC change, native input action, or Sigil source change occurred.
