### PR TITLE
Stabilize status item readiness events

### DIFF
--- a/docs/dev/test-proof-registry.d/runtime-readiness.json
+++ b/docs/dev/test-proof-registry.d/runtime-readiness.json
@@ -28,11 +28,13 @@
       "path_patterns": [
         "tests/status-item-contract.test.mjs"
       ],
-      "fixture_patterns": [],
+      "fixture_patterns": [
+        "tests/fixtures/status-item-host-controller-harness.swift"
+      ],
       "owner": "runtime-readiness",
       "harness_level": "model_unit",
       "proof_kind": "status_item_host_contract",
-      "contract": "The product-neutral status-item descriptor, canonical Unicode text limits, observed anchor/event, pre-listen host admission, registration-before-ready ordering, canonical response-envelope status, bounded follow-stream backpressure, exact-revision compare-and-swap update, toolkit type surface, multi-connection fake transport, and file-size ownership ratchet stay schema-backed.",
+      "contract": "The product-neutral status-item descriptor, canonical Unicode text limits, committed installation anchor, observed anchor/event, pre-listen host admission, registration-before-ready ordering, canonical daemon-to-public event projection, bounded follow-stream backpressure, exact-revision compare-and-swap update, toolkit type surface, multi-connection fake transport, and file-size ownership ratchet stay schema-backed.",
       "worth": "This protects the owner-scoped native host contract without requiring a live menu-bar item, TCC, or embedded product fixture.",
       "command": "node --test tests/status-item-contract.test.mjs",
       "replaces": [

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -48,7 +48,9 @@ commands, runtime helpers, wiki tools, and command adapters.
   is not silently reused for the status-item-free output.
 - `aos-status-item.mjs` owns the public descriptor CLI. Register-follow retains
   lease/event ownership; update is exact-revision compare-and-swap, and the
-  registration result must be emitted before buffered initial events.
+  registration result must be emitted before buffered initial events. Validate
+  the complete daemon `status_item` event envelope, then expose only canonical
+  `{event, data}` NDJSON to public consumers.
   `lib/status-item-output-writer.mjs` owns bounded stdout backpressure for that
   follow stream and pauses its source socket until buffered output drains.
 - `lib/pending-annotations-model.mjs` owns the pending annotation durable

--- a/scripts/aos-status-item.mjs
+++ b/scripts/aos-status-item.mjs
@@ -206,8 +206,25 @@ async function withDaemon(callback, onEvent = () => {}, { allowStart = true, sig
   signal?.addEventListener('abort', onAbort, { once: true })
   const reader = new LineReader((payload) => {
     if (payload.event) {
-      if (!payload.data) throw makeError('STATUS_ITEM_DAEMON_PROTOCOL_ERROR', 'status item daemon event is malformed')
-      onEvent({ ...payload, data: normalizeStatusItemEvent(payload.data) }, socket)
+      const keys = Object.keys(payload).sort()
+      const expectedKeys = payload.ref === undefined
+        ? 'data,event,service,ts,v'
+        : 'data,event,ref,service,ts,v'
+      if (payload.v !== 1
+          || payload.service !== 'status_item'
+          || typeof payload.event !== 'string'
+          || typeof payload.ts !== 'number'
+          || !Number.isFinite(payload.ts)
+          || !payload.data
+          || (payload.ref !== undefined && typeof payload.ref !== 'string')
+          || keys.join(',') !== expectedKeys) {
+        throw makeError('STATUS_ITEM_DAEMON_PROTOCOL_ERROR', 'status item daemon event is malformed')
+      }
+      const data = normalizeStatusItemEvent(payload.data)
+      if (payload.event !== data.type) {
+        throw makeError('STATUS_ITEM_DAEMON_PROTOCOL_ERROR', 'status item daemon event type is inconsistent')
+      }
+      onEvent({ event: payload.event, data }, socket)
       return
     }
     const pendingRequest = typeof payload.ref === 'string' ? pending.get(payload.ref) : null

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -17,7 +17,10 @@ needs, but public command policy and product UI policy belong above it:
   streams, and lifecycle routing belong here;
 - the owner-scoped native status-item lease, exact-revision compare-and-swap,
   AppKit-derived anchor facts, and native activation/menu bridge live in
-  `display/status-item*.swift`; consumer visuals and product actions do not;
+  `display/status-item*.swift`; the successful installation anchor is also the
+  committed registration/readiness anchor, so initial readiness may not depend
+  on a second best-effort AppKit lookup; consumer visuals and product actions
+  do not;
 - permission status and request primitives belong to the process that owns the
   privileged capability; daemon-owned microphone capture therefore uses
   daemon-owned authorization rather than foreground CLI authorization;

--- a/src/display/status-item-host-controller.swift
+++ b/src/display/status-item-host-controller.swift
@@ -116,7 +116,10 @@ final class AOSStatusItemHostController {
                 guard descriptor.signature == current.signature else {
                     return AOSStatusItemHostCommandResult(failure("STATUS_ITEM_REVISION_CONFLICT", "status item descriptor revision already names different content"))
                 }
-                return AOSStatusItemHostCommandResult(registrationResponse(current, updated: false))
+                guard let anchor = manager.statusItemAnchorPayload(owner: current.ownerID, itemID: current.itemID) else {
+                    return AOSStatusItemHostCommandResult(failure("STATUS_ITEM_ANCHOR_UNAVAILABLE", "native status item anchor is unavailable"))
+                }
+                return AOSStatusItemHostCommandResult(registrationResponse(current, updated: false, anchor: anchor))
             }
             return AOSStatusItemHostCommandResult(failure("STATUS_ITEM_UPDATE_REQUIRED", "advance a live lease with status-item update"))
         }
@@ -124,7 +127,7 @@ final class AOSStatusItemHostController {
         let previousDescriptor = manager.hostedDescriptor
         let previousGeneration = manager.hostedGeneration
         let generation = lease?.generation ?? nextGeneration
-        guard manager.installHostedDescriptor(descriptor, generation: generation) != nil else {
+        guard let installedAnchor = manager.installHostedDescriptor(descriptor, generation: generation) else {
             if let previousDescriptor {
                 _ = manager.installHostedDescriptor(previousDescriptor, generation: previousGeneration)
             } else {
@@ -145,9 +148,11 @@ final class AOSStatusItemHostController {
             sequence: lease?.sequence ?? 0
         )
         lease = current
-        let afterResponse: (() -> Void)? = isNewLease ? { [weak self] in self?.emitReady(current) } : nil
+        let afterResponse: (() -> Void)? = isNewLease ? { [weak self] in
+            self?.emitReady(current, anchor: installedAnchor)
+        } : nil
         return AOSStatusItemHostCommandResult(
-            registrationResponse(current, updated: true),
+            registrationResponse(current, updated: true, anchor: installedAnchor),
             afterResponse: afterResponse
         )
     }
@@ -223,7 +228,7 @@ final class AOSStatusItemHostController {
         ])
     }
 
-    private func registrationResponse(_ current: AOSStatusItemLease, updated: Bool) -> [String: Any] {
+    private func registrationResponse(_ current: AOSStatusItemLease, updated: Bool, anchor: [String: Any]) -> [String: Any] {
         [
             "status": "ok",
             "schema_version": aosStatusItemDescriptorSchema,
@@ -232,7 +237,7 @@ final class AOSStatusItemHostController {
             "generation": current.generation,
             "descriptor_revision": current.revision,
             "updated": updated,
-            "anchor": manager.statusItemAnchorPayload(owner: current.ownerID, itemID: current.itemID) ?? NSNull(),
+            "anchor": anchor,
             "lease": ["status": "active", "cleanup": "connection_scoped"],
         ]
     }
@@ -304,9 +309,8 @@ final class AOSStatusItemHostController {
         }
     }
 
-    private func emitReady(_ current: AOSStatusItemLease) {
+    private func emitReady(_ current: AOSStatusItemLease, anchor: [String: Any]) {
         runOnMainSync {
-            guard let anchor = self.manager.statusItemAnchorPayload(owner: current.ownerID, itemID: current.itemID) else { return }
             _ = self.receiveHostedEvent([
                 "type": "ready",
                 "owner": current.ownerID,

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -35,8 +35,9 @@ tests.
   scene contract work must not execute the repo AOS binary or require TCC.
 - Status-item host contract tests must use disposable fake sockets and schema
   fixtures, model startup admission ordering, and prove registration output
-  precedes initial events; native menu-bar acceptance remains a separate
-  build/runtime gate.
+  precedes initial events. Fake sockets must emit the complete daemon envelope
+  so tests also prove the CLI's canonical public event projection; native
+  menu-bar acceptance remains a separate build/runtime gate.
 - `tests/dev-workflow-router.sh` runs its public `./aos` rejection checks by
   default. Use `AOS_SKIP_LIVE_CLI_CHECKS=1` only for explicit static-only
   validation while the repo artifact is absent or waiting at ADR 0023's human

--- a/tests/fixtures/status-item-host-controller-harness.swift
+++ b/tests/fixtures/status-item-host-controller-harness.swift
@@ -56,6 +56,8 @@ private final class FakeStatusItemHost: AOSStatusItemHosting {
     var hostedEventSink: (([String: Any]) -> Bool)?
 
     var installOutcomes: [Bool] = []
+    var invalidateAnchorAfterInstall = false
+    private var anchorAvailable = true
     private(set) var installCalls: [(revision: Int, generation: Int)] = []
     private(set) var clearCalls: [(owner: String, itemID: String, generation: Int)] = []
     private(set) var teardownCount = 0
@@ -68,7 +70,10 @@ private final class FakeStatusItemHost: AOSStatusItemHosting {
         hostedDescriptor = descriptor
         hostedGeneration = generation
         let succeeds = installOutcomes.isEmpty ? true : installOutcomes.removeFirst()
-        return succeeds ? anchor(owner: descriptor.owner, itemID: descriptor.itemID) : nil
+        guard succeeds else { return nil }
+        let installedAnchor = anchor(owner: descriptor.owner, itemID: descriptor.itemID)
+        if invalidateAnchorAfterInstall { anchorAvailable = false }
+        return installedAnchor
     }
 
     func clearHostedDescriptor(owner: String, itemID: String, generation: Int) -> Bool {
@@ -140,7 +145,8 @@ private final class FakeStatusItemHost: AOSStatusItemHosting {
     }
 
     func statusItemAnchorPayload(owner: String, itemID: String) -> [String: Any]? {
-        guard let descriptor = hostedDescriptor,
+        guard anchorAvailable,
+              let descriptor = hostedDescriptor,
               descriptor.owner == owner,
               descriptor.itemID == itemID else { return nil }
         return anchor(owner: owner, itemID: itemID)
@@ -248,6 +254,18 @@ private func testLeaseBusyRegistration() {
     expect(responseCode(busy) == "STATUS_ITEM_LEASE_BUSY", "contending registration did not fail busy")
     expect(manager.installCalls.count == 1, "busy registration touched the native host")
     expect(recorder.terminations.isEmpty, "busy registration terminated the active owner")
+}
+
+private func testReadyUsesCommittedInstallationAnchor() {
+    let (manager, recorder, controller) = makeController()
+    let owner = UUID(uuidString: "88888888-8888-8888-8888-888888888888")!
+    manager.invalidateAnchorAfterInstall = true
+
+    let registered = register(controller, owner: owner)
+    expect(responseCode(registered) == nil, "committed-anchor registration failed")
+    expect(registered.response["anchor"] is [String: Any], "registration discarded its committed anchor")
+    expect(recorder.emittedEvents.count == 1, "registration did not emit readiness")
+    expect(recorder.emittedEvents.first?.event == "ready", "registration emitted the wrong initial event")
 }
 
 private func testExactRevisionCAS() {
@@ -366,6 +384,7 @@ private func testConnectionCloseClearsOnlyExactOwner() {
 private struct StatusItemHostControllerHarness {
     static func main() {
         testLeaseBusyRegistration()
+        testReadyUsesCommittedInstallationAnchor()
         testExactRevisionCAS()
         testFailedInstallAndRestoreTerminatesOwner()
         testRejectedInvokeEventFailsAndCleansLease()

--- a/tests/status-item-contract.test.mjs
+++ b/tests/status-item-contract.test.mjs
@@ -423,7 +423,7 @@ test('documented register-follow, update, inspect, dry-run, and invoke use truth
     if (request.action === 'register') {
       leaseSocket = socket
       socket.write(`${JSON.stringify({ v: 1, ref: request.ref, status: 'success', data: { owner: descriptor.owner, item_id: descriptor.item_id, generation: 7, descriptor_revision: 3, anchor } })}\n`)
-      socket.write(`${JSON.stringify({ event: 'ready', data: { ...event, type: 'ready', sequence: 1, action_id: undefined, menu_item_id: undefined, origin_x: undefined, origin_y: undefined, modifiers: undefined } })}\n`)
+      socket.write(`${JSON.stringify({ v: 1, service: 'status_item', event: 'ready', ts: 1, ref: request.ref, data: { ...event, type: 'ready', sequence: 1, action_id: undefined, menu_item_id: undefined, origin_x: undefined, origin_y: undefined, modifiers: undefined } })}\n`)
     } else if (request.action === 'update') {
       updateSocket = socket
       assert.notEqual(socket, leaseSocket)
@@ -437,7 +437,7 @@ test('documented register-follow, update, inspect, dry-run, and invoke use truth
       activeRevision = updatedDescriptor.revision
       socket.write(`${JSON.stringify({ v: 1, ref: request.ref, status: 'success', data: { owner: descriptor.owner, item_id: descriptor.item_id, generation: 7, previous_descriptor_revision: 3, descriptor_revision: activeRevision, updated: true, anchor } })}\n`)
       socket.end()
-      leaseSocket.write(`${JSON.stringify({ event: 'menu_selection', data: { ...event, descriptor_revision: activeRevision, sequence: 2 } })}\n`)
+      leaseSocket.write(`${JSON.stringify({ v: 1, service: 'status_item', event: 'menu_selection', ts: 2, data: { ...event, descriptor_revision: activeRevision, sequence: 2 } })}\n`)
     } else if (request.action === 'inspect') {
       socket.write(`${JSON.stringify({ v: 1, ref: request.ref, status: 'success', data: { state: { owner: descriptor.owner, item_id: descriptor.item_id, generation: 7, descriptor_revision: activeRevision, anchor } } })}\n`)
       socket.end()
@@ -470,6 +470,7 @@ test('documented register-follow, update, inspect, dry-run, and invoke use truth
     assert.equal(registrationLines[0].registered.descriptor_revision, 3)
     assert.equal(registrationLines[1].event, 'ready')
     assert.equal(registrationLines[1].data.sequence, 1)
+    assert.deepEqual(Object.keys(registrationLines[1]).sort(), ['data', 'event'])
 
     const updatedLeaseEvent = waitForOutput(register, (value) => value.includes('"descriptor_revision":4'))
     const update = await runCLI([
@@ -511,7 +512,10 @@ test('register bounds events that arrive before the registration result', async 
   const server = await listenFake(stateRoot, (socket, request) => {
     for (let sequence = 1; sequence <= 33; sequence += 1) {
       socket.write(`${JSON.stringify({
+        v: 1,
+        service: 'status_item',
         event: 'ready',
+        ts: sequence,
         data: { ...event, type: 'ready', sequence, action_id: undefined, menu_item_id: undefined, origin_x: undefined, origin_y: undefined, modifiers: undefined },
       })}\n`)
     }


### PR DESCRIPTION
## Summary

- reuse the committed native installation anchor for status-item registration and initial readiness
- fail closed when a same-revision lease no longer has a native anchor
- validate the real daemon status-item event envelope and expose only canonical `{event,data}` NDJSON
- accept the schema-valid optional correlation `ref` without exposing it publicly
- register the native Swift fixture in proof ownership

## Validation

- `node --test tests/status-item-contract.test.mjs`: 20/20
- `bash tests/daemon-ipc-schema.sh`: passed
- daemon-event and proof-registry suites: 27/27
- workflow schema/router focused suite: 33/33
- `AOS_SKIP_LIVE_CLI_CHECKS=1 bash tests/dev-workflow-router.sh`: passed
- `bash tests/dev-drift-lint.sh`: passed
- full static Swift typecheck: passed with existing unrelated warnings
- `node --check scripts/aos-status-item.mjs`: passed
- `git diff --check`: passed
- independent findings-first review and correction-delta re-review: no remaining findings

## Deferred runtime gates

No repo binary was built or executed. External dispatch, parser, help-contract, daemon, TCC, and native status-item acceptance remain deferred to the post-merge managed-Mac lane. `dev-situation` passed its hermetic checks; its single live `./aos help` assertion could not run because the repo binary is intentionally absent.