### PR TITLE
Fix native companion startup contracts

### DIFF
--- a/docs/dev/test-proof-registry.d/desktop-world-scene-engine.json
+++ b/docs/dev/test-proof-registry.d/desktop-world-scene-engine.json
@@ -43,6 +43,22 @@
       "status": "active"
     },
     {
+      "id": "desktop-world-stage-lifecycle-contract",
+      "path_patterns": [
+        "tests/toolkit/desktop-world-stage-lifecycle.test.mjs"
+      ],
+      "fixture_patterns": [],
+      "owner": "toolkit-scene",
+      "harness_level": "model_unit",
+      "proof_kind": "desktop_world_stage_lifecycle_contract",
+      "contract": "The persistent DesktopWorld stage acknowledges supported suspend and resume requests through the canonical lifecycle completion handshake.",
+      "worth": "This prevents every stage resume from waiting for the daemon timeout before windows become visible, without requiring a live canvas or daemon.",
+      "command": "node --test tests/toolkit/desktop-world-stage-lifecycle.test.mjs",
+      "replaces": [],
+      "guard": "pure lifecycle message dispatch only; no AOS binary, daemon socket, GUI, TCC, WebGL, or live DesktopWorld",
+      "status": "active"
+    },
+    {
       "id": "desktop-world-scene-event-contract",
       "path_patterns": [
         "tests/daemon-scene-lease-registry.sh",

--- a/manifests/commands/aos-external-commands.json
+++ b/manifests/commands/aos-external-commands.json
@@ -2954,6 +2954,7 @@
       "executable": "/usr/bin/env",
       "argv_prefix": ["node", "scripts/aos-status-item.mjs", "register"],
       "cwd": "repo",
+      "stdio": "inherit",
       "env": {
         "AOS_RUNTIME_MODE": "$AOS_RUNTIME_MODE",
         "AOS_STATE_ROOT": "$AOS_STATE_ROOT",

--- a/manifests/commands/source/external/48-status-item.json
+++ b/manifests/commands/source/external/48-status-item.json
@@ -32,6 +32,7 @@
       "executable": "/usr/bin/env",
       "argv_prefix": ["node", "scripts/aos-status-item.mjs", "register"],
       "cwd": "repo",
+      "stdio": "inherit",
       "env": {
         "AOS_RUNTIME_MODE": "$AOS_RUNTIME_MODE",
         "AOS_STATE_ROOT": "$AOS_STATE_ROOT",

--- a/packages/toolkit/components/desktop-world-stage/index.js
+++ b/packages/toolkit/components/desktop-world-stage/index.js
@@ -1,7 +1,8 @@
 import { emit, wireBridge } from '../../runtime/bridge.js'
 import { DesktopWorldSurface2D } from '../../runtime/desktop-world-surface-2d.js'
-import { declareManifest, emitReady } from '../../runtime/manifest.js'
+import { declareManifest, emitLifecycleComplete, emitReady } from '../../runtime/manifest.js'
 import { createVisualObjectDescriptor } from '../../workbench/visual-object-contract.js'
+import { handleDesktopWorldStageLifecycle } from './lifecycle.js'
 import { createDesktopWorldSceneOutlet } from './scene-outlet.js'
 import { createDesktopWorldSceneInteractionRuntime } from './scene-interaction-runtime.js'
 import { createDesktopWorldSceneOperationCoordinator } from './scene-operation-coordinator.js'
@@ -225,6 +226,7 @@ declareManifest({
     'desktop_world_stage.devtools.configure',
     'desktop_world_stage.devtools.request',
     'input_region.event',
+    'lifecycle',
   ],
   emits: [
     'ready',
@@ -235,6 +237,7 @@ declareManifest({
     'input_region.register',
     'input_region.update',
     'input_region.remove',
+    'lifecycle.complete',
   ],
   surface: 'desktop-world',
 })
@@ -280,6 +283,7 @@ function enqueueSceneWork(work) {
 }
 
 wireBridge((message) => {
+  if (handleDesktopWorldStageLifecycle(message, emitLifecycleComplete)) return
   if (message?.type === 'desktop_world_stage.devtools.configure') {
     devtoolsProbe.configure(message.payload)
     if (message.payload?.enabled === true) devtoolsProbe.emitSnapshot('configured')

--- a/packages/toolkit/components/desktop-world-stage/lifecycle.js
+++ b/packages/toolkit/components/desktop-world-stage/lifecycle.js
@@ -1,0 +1,12 @@
+const LIFECYCLE_ACTIONS = new Set(['resume', 'suspend'])
+
+export function handleDesktopWorldStageLifecycle(message, complete) {
+  if (message?.type !== 'lifecycle' || !LIFECYCLE_ACTIONS.has(message.action)) {
+    return false
+  }
+  if (typeof complete !== 'function') {
+    throw new TypeError('desktop world lifecycle completion requires a callback')
+  }
+  complete(message.action)
+  return true
+}

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -51,6 +51,9 @@ commands, runtime helpers, wiki tools, and command adapters.
   registration result must be emitted before buffered initial events. Validate
   the complete daemon `status_item` event envelope, then expose only canonical
   `{event, data}` NDJSON to public consumers.
+  The long-lived `status-item register --follow` external route must inherit
+  stdio so registration and events stream before lease termination and signals
+  reach the owner process; captured external dispatch is invalid for this form.
   `lib/status-item-output-writer.mjs` owns bounded stdout backpressure for that
   follow stream and pauses its source socket until buffered output drains.
 - `lib/pending-annotations-model.mjs` owns the pending annotation durable

--- a/tests/external-command-dispatch.sh
+++ b/tests/external-command-dispatch.sh
@@ -330,6 +330,11 @@ assert command["executable"] == "/usr/bin/env", command
 assert command["argv_prefix"] == ["node", "scripts/aos-say.mjs"], command
 assert command["stdio"] == "inherit", command
 assert command["env"]["AOS_PATH"] == "$AOS_PATH", command
+command = commands[("status-item", "register")]
+assert command["executable"] == "/usr/bin/env", command
+assert command["argv_prefix"] == ["node", "scripts/aos-status-item.mjs", "register"], command
+assert command["stdio"] == "inherit", command
+assert command["env"]["AOS_PATH"] == "$AOS_PATH", command
 command = commands[("show", "render")]
 assert command["executable"] == "/usr/bin/env", command
 assert command["argv_prefix"] == ["node", "scripts/aos-show-render.mjs"], command

--- a/tests/schemas/aos-external-command-manifest-v0.test.mjs
+++ b/tests/schemas/aos-external-command-manifest-v0.test.mjs
@@ -172,6 +172,13 @@ test('listen routes through inherited stdio so follow forms stream and retain si
   assert.equal(listen.stdio, 'inherit');
 });
 
+test('status item registration inherits stdio for its connection-scoped follow lease', async () => {
+  const manifest = await loadJson(manifestPath);
+  const register = manifest.commands.find((command) => command.path.join(' ') === 'status-item register');
+  assert.ok(register, 'status-item register external route is missing');
+  assert.equal(register.stdio, 'inherit');
+});
+
 test('external command manifest only routes bootstrap families to Swift', async () => {
   const manifest = await loadJson(manifestPath);
   const allowedSwiftRoutes = new Map([

--- a/tests/toolkit/desktop-world-stage-lifecycle.test.mjs
+++ b/tests/toolkit/desktop-world-stage-lifecycle.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  handleDesktopWorldStageLifecycle,
+} from '../../packages/toolkit/components/desktop-world-stage/lifecycle.js'
+
+test('DesktopWorld stage acknowledges renderer suspend and resume lifecycle messages', () => {
+  const completed = []
+  const complete = (action) => completed.push(action)
+
+  assert.equal(handleDesktopWorldStageLifecycle({ type: 'lifecycle', action: 'suspend' }, complete), true)
+  assert.equal(handleDesktopWorldStageLifecycle({ type: 'lifecycle', action: 'resume' }, complete), true)
+  assert.deepEqual(completed, ['suspend', 'resume'])
+})
+
+test('DesktopWorld stage ignores unrelated and unsupported lifecycle messages', () => {
+  const completed = []
+  const complete = (action) => completed.push(action)
+
+  assert.equal(handleDesktopWorldStageLifecycle({ type: 'canvas_lifecycle', action: 'resume' }, complete), false)
+  assert.equal(handleDesktopWorldStageLifecycle({ type: 'lifecycle', action: 'reload' }, complete), false)
+  assert.equal(handleDesktopWorldStageLifecycle(null, complete), false)
+  assert.deepEqual(completed, [])
+})
+
+test('DesktopWorld stage fails closed when an accepted lifecycle message has no completion sink', () => {
+  assert.throws(
+    () => handleDesktopWorldStageLifecycle({ type: 'lifecycle', action: 'resume' }),
+    /requires a callback/,
+  )
+})


### PR DESCRIPTION
## Summary

- stream the connection-scoped `status-item register --follow` lease through inherited stdio so registration and events arrive before lease termination
- preserve dispatcher parent identity and signal forwarding for the long-lived owner
- acknowledge DesktopWorld suspend/resume through the canonical `lifecycle.complete` handshake
- register focused proof ownership for the new lifecycle regression

## Local validation

- DesktopWorld lifecycle and adjacent atomicity tests: 14/14
- focused status-item follow/output tests: 3/3
- focused external-manifest assertion: 1/1
- command manifest generation and inventory: passed
- proof routing and `git diff --check`: passed
- read-only publication review: no findings; publishable

The full Python `jsonschema` lanes are environmentally unavailable on this Mac because the installed dependency set hangs or fails during import. The broad external-dispatch shell was not run because it invokes the live repo binary. Both gaps remain for the later reviewed native lane; no AOS build, daemon, or TCC operation occurred.