### PR TITLE
Expose native DesktopWorld display geometry

### DIFF
--- a/docs/api/toolkit/scene.md
+++ b/docs/api/toolkit/scene.md
@@ -214,6 +214,13 @@ performance, event, counter, and last-error facts. Unknown fields are removed
 at the daemon boundary; text, prompts, audio, scene parameters, and desktop
 content are not part of the snapshot.
 
+Each display reports DesktopWorld-local `bounds` and, when the surface host
+provides it, native global `nativeBounds`. Consumers that translate scene
+geometry to native input coordinates must require `nativeBounds`; treating
+DesktopWorld-local bounds as native geometry is invalid on offset or stacked
+display topologies. Older snapshots without `nativeBounds` remain readable,
+but compatibility projections do not fabricate native display geometry.
+
 The probe owns no scheduler. When disabled, `sampleFrame()` and event recording
 perform no stage read and retain no samples. When enabled but not recording,
 frame samples are throttled to 500 ms and snapshots to 2 Hz. Recording samples

--- a/packages/toolkit/components/desktop-world-devtools/compat.js
+++ b/packages/toolkit/components/desktop-world-devtools/compat.js
@@ -33,19 +33,21 @@ export function projectDesktopWorldDevToolsPerformance(input, { now = Date.now()
 export function projectDesktopWorldDevToolsSpatial(input) {
   const snapshot = normalizeDesktopWorldDevToolsSnapshot(input);
   const { stage } = snapshot;
-  const displays = stage.world.displays.map((display) => {
+  const displays = stage.world.displays.flatMap((display) => {
     const bounds = rectObject(display.bounds);
-    return Object.freeze({
+    if (!display.nativeBounds) return [];
+    const nativeBounds = rectObject(display.nativeBounds);
+    return [Object.freeze({
       id: display.id,
       is_main: display.index === 0,
       scale_factor: 1,
-      bounds,
-      visible_bounds: bounds,
-      native_bounds: bounds,
-      native_visible_bounds: bounds,
+      bounds: nativeBounds,
+      visible_bounds: nativeBounds,
+      native_bounds: nativeBounds,
+      native_visible_bounds: nativeBounds,
       desktop_world_bounds: bounds,
       visible_desktop_world_bounds: bounds,
-    });
+    })];
   });
   const canvases = stage.world.hitRegions.map((region) => Object.freeze({
     id: `scene-hit:${region.resourceId}:${region.id}`,

--- a/packages/toolkit/components/desktop-world-stage/index.js
+++ b/packages/toolkit/components/desktop-world-stage/index.js
@@ -6,6 +6,10 @@ import { handleDesktopWorldStageLifecycle } from './lifecycle.js'
 import { createDesktopWorldSceneOutlet } from './scene-outlet.js'
 import { createDesktopWorldSceneInteractionRuntime } from './scene-interaction-runtime.js'
 import { createDesktopWorldSceneOperationCoordinator } from './scene-operation-coordinator.js'
+import {
+  projectDesktopWorldDevToolsTopology,
+  projectSceneEventTopology,
+} from './topology.js'
 import { createDesktopWorldDevToolsStageProbe } from '../../scene/desktop-world-devtools.js'
 import { registerInputRegion, removeInputRegion, updateInputRegion } from '../../runtime/input-region.js'
 import { applyVisualObjectControllerUpdate } from '../../workbench/visual-object-controller.js'
@@ -31,13 +35,11 @@ let sceneInteractions = null
 let lastSceneError = null
 
 function sceneTopologySnapshot() {
-  return {
-    displays: surface.topology.slice(0, 16).map((segment) => ({
-      displayId: segment.display_id ?? null,
-      index: segment.index ?? null,
-      bounds: Array.isArray(segment.dw_bounds) ? segment.dw_bounds.slice(0, 4) : null,
-    })),
-  }
+  return projectSceneEventTopology(surface.topology)
+}
+
+function devtoolsTopologySnapshot() {
+  return projectDesktopWorldDevToolsTopology(surface.topology)
 }
 
 const devtoolsProbe = createDesktopWorldDevToolsStageProbe({
@@ -66,7 +68,7 @@ const devtoolsProbe = createDesktopWorldDevToolsStageProbe({
       status: 'available',
       world: {
         affordances: interaction.affordances,
-        displays: sceneTopologySnapshot().displays,
+        displays: devtoolsTopologySnapshot().displays,
         gestures: interaction.gestures,
         hitRegions: interaction.hitRegions,
         nodes: outlet.nodes,

--- a/packages/toolkit/components/desktop-world-stage/topology.js
+++ b/packages/toolkit/components/desktop-world-stage/topology.js
@@ -1,0 +1,26 @@
+function boundedSegments(segments) {
+  return Array.isArray(segments) ? segments.slice(0, 16) : []
+}
+
+function sceneDisplay(segment) {
+  return {
+    displayId: segment?.display_id ?? null,
+    index: segment?.index ?? null,
+    bounds: Array.isArray(segment?.dw_bounds) ? segment.dw_bounds.slice(0, 4) : null,
+  }
+}
+
+export function projectSceneEventTopology(segments) {
+  return {
+    displays: boundedSegments(segments).map(sceneDisplay),
+  }
+}
+
+export function projectDesktopWorldDevToolsTopology(segments) {
+  return {
+    displays: boundedSegments(segments).map((segment) => ({
+      ...sceneDisplay(segment),
+      nativeBounds: Array.isArray(segment?.native_bounds) ? segment.native_bounds.slice(0, 4) : null,
+    })),
+  }
+}

--- a/packages/toolkit/scene/AGENTS.md
+++ b/packages/toolkit/scene/AGENTS.md
@@ -71,6 +71,10 @@ stage internals.
   instrumentation creates no timer, RAF, stage read, or per-frame allocation.
   The daemon owns revisioned session and host-lease state; consumers may host
   the public view but never own or fork its telemetry.
+- DevTools display facts use `bounds` for DesktopWorld-local geometry and
+  optional `nativeBounds` for native global geometry. A consumer translating
+  scene coordinates into native input must require the latter rather than
+  infer an origin from DesktopWorld-local bounds.
 - Focused compatibility panels consume the canonical DevTools snapshot through
   `components/desktop-world-devtools/compat.js`. They must not introduce a
   second DesktopWorld sampler or competing session model.

--- a/packages/toolkit/scene/desktop-world-devtools.d.ts
+++ b/packages/toolkit/scene/desktop-world-devtools.d.ts
@@ -15,7 +15,12 @@ export interface DesktopWorldDevToolsStageSnapshot {
   sequence: number;
   status: 'available' | 'unavailable' | 'unknown';
   world: {
-    displays: ReadonlyArray<Readonly<{ id: string; index: number; bounds: readonly [number, number, number, number] }>>;
+    displays: ReadonlyArray<Readonly<{
+      id: string;
+      index: number;
+      bounds: readonly [number, number, number, number];
+      nativeBounds?: readonly [number, number, number, number];
+    }>>;
     nodes: ReadonlyArray<Readonly<{ id: string; resourceId: string; parentId: string | null; kind: string; implementation: string | null; position: readonly [number, number, number]; visible: boolean }>>;
     hitRegions: ReadonlyArray<Readonly<{ id: string; resourceId: string; affordanceId: string; frame: readonly [number, number, number, number]; registered: boolean }>>;
     affordances: ReadonlyArray<Readonly<{ id: string; resourceId: string; objectId: string; enabled: boolean; priority: number }>>;
@@ -116,7 +121,13 @@ export function buildDesktopWorldMinimapLayout(
 ): Readonly<{
   bounds: readonly [number, number, number, number] | null;
   scale: number;
-  displays: ReadonlyArray<Readonly<{ id: string; index: number; bounds: readonly [number, number, number, number]; frame: readonly number[] }>>;
+  displays: ReadonlyArray<Readonly<{
+    id: string;
+    index: number;
+    bounds: readonly [number, number, number, number];
+    nativeBounds?: readonly [number, number, number, number];
+    frame: readonly number[];
+  }>>;
   nodes: ReadonlyArray<Readonly<Record<string, unknown>>>;
   hitRegions: ReadonlyArray<Readonly<Record<string, unknown>>>;
 }>;

--- a/packages/toolkit/scene/desktop-world-devtools.js
+++ b/packages/toolkit/scene/desktop-world-devtools.js
@@ -55,11 +55,15 @@ function uniqueStrings(values, limit = 32) {
 
 function normalizeDisplay(value = {}, index = 0) {
   const bounds = point(value.bounds, 4)
+  const nativeBounds = point(value.nativeBounds ?? value.native_bounds, 4)
   if (!bounds || bounds[2] <= 0 || bounds[3] <= 0) return null
   return Object.freeze({
     id: boundedString(value.id ?? value.displayId, `display-${index}`),
     index: boundedInteger(value.index, index, 0, 31),
     bounds: Object.freeze(bounds),
+    ...(nativeBounds && nativeBounds[2] > 0 && nativeBounds[3] > 0
+      ? { nativeBounds: Object.freeze(nativeBounds) }
+      : {}),
   })
 }
 

--- a/shared/schemas/desktop-world-devtools-stage-v1.schema.json
+++ b/shared/schemas/desktop-world-devtools-stage-v1.schema.json
@@ -38,7 +38,12 @@
     "Rect": { "type": "array", "minItems": 4, "maxItems": 4, "prefixItems": [{ "type": "number" }, { "type": "number" }, { "type": "number", "exclusiveMinimum": 0 }, { "type": "number", "exclusiveMinimum": 0 }], "items": false },
     "Display": {
       "type": "object", "required": ["id", "index", "bounds"], "additionalProperties": false,
-      "properties": { "id": { "$ref": "#/$defs/Identifier" }, "index": { "type": "integer", "minimum": 0, "maximum": 31 }, "bounds": { "$ref": "#/$defs/Rect" } }
+      "properties": {
+        "id": { "$ref": "#/$defs/Identifier" },
+        "index": { "type": "integer", "minimum": 0, "maximum": 31 },
+        "bounds": { "$ref": "#/$defs/Rect" },
+        "nativeBounds": { "$ref": "#/$defs/Rect" }
+      }
     },
     "Node": {
       "type": "object", "required": ["id", "resourceId", "parentId", "kind", "implementation", "position", "visible"], "additionalProperties": false,

--- a/src/daemon/desktop-world-devtools-session.swift
+++ b/src/daemon/desktop-world-devtools-session.swift
@@ -136,6 +136,7 @@ private struct AOSDesktopWorldDevToolsStageSnapshot: Codable {
         let id: String
         let index: Int
         let bounds: [Double]
+        let nativeBounds: [Double]?
     }
 
     struct Node: Codable {
@@ -305,6 +306,10 @@ private struct AOSDesktopWorldDevToolsStageSnapshot: Codable {
         guard world.displays.allSatisfy({
             Self.validString($0.id) && $0.bounds.count == 4 && $0.bounds.allSatisfy({ $0.isFinite })
                 && $0.bounds[2] > 0 && $0.bounds[3] > 0 && $0.index >= 0 && $0.index <= 31
+                && ($0.nativeBounds.map({ bounds in
+                    bounds.count == 4 && bounds.allSatisfy({ $0.isFinite })
+                        && bounds[2] > 0 && bounds[3] > 0
+                }) ?? true)
         }), world.nodes.allSatisfy({
             Self.validString($0.id) && Self.validString($0.resourceId)
                 && $0.position.count == 3 && $0.position.allSatisfy({ $0.isFinite })

--- a/tests/daemon-desktop-world-devtools-contract.test.mjs
+++ b/tests/daemon-desktop-world-devtools-contract.test.mjs
@@ -4,6 +4,11 @@ import path from 'node:path'
 import test from 'node:test'
 import { fileURLToPath } from 'node:url'
 
+import {
+  projectDesktopWorldDevToolsTopology,
+  projectSceneEventTopology,
+} from '../packages/toolkit/components/desktop-world-stage/topology.js'
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), 'utf8')
 
@@ -48,7 +53,27 @@ test('stage probe is configured inside the existing DesktopWorld render lifecycl
   const probe = read('packages/toolkit/scene/desktop-world-devtools.js')
 
   assert.match(stage, /sceneOutlet\.setDevToolsProbe\(devtoolsProbe\)/)
+  assert.match(stage, /displays: devtoolsTopologySnapshot\(\)\.displays/)
   assert.match(outlet, /devtoolsProbe\.sampleFrame/)
   assert.match(stage, /desktop_world_stage\.devtools\.configure/)
   assert.doesNotMatch(probe, /requestAnimationFrame|setInterval|setTimeout/)
+})
+
+test('stage topology keeps native geometry in DevTools and out of strict scene events', () => {
+  const segments = [
+    { display_id: 1, index: 0, dw_bounds: [0, 200, 1440, 900], native_bounds: [-1440, 0, 1440, 900] },
+    { display_id: 2, index: 1, dw_bounds: [1440, 0, 1920, 1080], native_bounds: [0, -200, 1920, 1080] },
+  ]
+  const scene = projectSceneEventTopology(segments)
+  const devtools = projectDesktopWorldDevToolsTopology(segments)
+
+  assert.deepEqual(scene.displays, [
+    { displayId: 1, index: 0, bounds: [0, 200, 1440, 900] },
+    { displayId: 2, index: 1, bounds: [1440, 0, 1920, 1080] },
+  ])
+  assert.deepEqual(devtools.displays, [
+    { displayId: 1, index: 0, bounds: [0, 200, 1440, 900], nativeBounds: [-1440, 0, 1440, 900] },
+    { displayId: 2, index: 1, bounds: [1440, 0, 1920, 1080], nativeBounds: [0, -200, 1920, 1080] },
+  ])
+  assert.equal(scene.displays.some((display) => Object.hasOwn(display, 'nativeBounds')), false)
 })

--- a/tests/daemon-desktop-world-devtools-session.sh
+++ b/tests/daemon-desktop-world-devtools-session.sh
@@ -26,7 +26,11 @@ func stageSnapshot() -> [String: Any] {
         "sequence": 1,
         "status": "available",
         "world": [
-            "displays": [["id": "main", "index": 0, "bounds": [0.0, 0.0, 1440.0, 900.0]]],
+            "displays": [[
+                "id": "main", "index": 0,
+                "bounds": [200.0, 0.0, 1440.0, 900.0],
+                "nativeBounds": [0.0, 0.0, 1440.0, 900.0],
+            ]],
             "nodes": [["id": "body", "resourceId": "companion/main", "parentId": NSNull(), "kind": "mesh", "implementation": "aos.scene.geometry.primitive", "position": [100.0, 200.0, 0.0], "visible": true]],
             "hitRegions": [], "affordances": [], "gestures": [], "routes": [],
         ],
@@ -154,6 +158,10 @@ require(registry.recordStageSnapshot(leaked), "valid stage snapshot with unknown
 let canonical = registry.snapshot(sessionID: first.id)!
 let stage = canonical["stage"] as! [String: Any]
 require(stage["transcript"] == nil, "unknown renderer content crossed the daemon boundary")
+let canonicalWorld = stage["world"] as! [String: Any]
+let canonicalDisplay = (canonicalWorld["displays"] as! [[String: Any]])[0]
+require(canonicalDisplay["bounds"] as? [Double] == [200.0, 0.0, 1440.0, 900.0], "DesktopWorld display bounds drifted")
+require(canonicalDisplay["nativeBounds"] as? [Double] == [0.0, 0.0, 1440.0, 900.0], "native display bounds were lost")
 require((canonical["contract"] as? String) == aosDesktopWorldDevToolsSnapshotContract, "session snapshot contract mismatch")
 let selectedStage = registry.stageSnapshot(resourceID: "companion/main")!
 let selectedResources = selectedStage["resources"] as! [[String: Any]]

--- a/tests/schemas/desktop-world-scene-tooling.test.mjs
+++ b/tests/schemas/desktop-world-scene-tooling.test.mjs
@@ -30,7 +30,7 @@ function stage() {
   return {
     contract: 'aos.desktop-world.devtools.stage.v1', sequence: 1, status: 'available',
     world: {
-      displays: [{ id: 'main', index: 0, bounds: [0, 0, 1440, 900] }],
+      displays: [{ id: 'main', index: 0, bounds: [200, 0, 1440, 900], nativeBounds: [0, 0, 1440, 900] }],
       nodes: [{ id: 'body', resourceId: 'companion/main', parentId: null, kind: 'mesh', implementation: 'aos.scene.geometry.primitive', position: [100, 200, 0], visible: true }],
       hitRegions: [], affordances: [], gestures: [], routes: [],
     },
@@ -62,6 +62,9 @@ test('DesktopWorld tooling schemas accept canonical content-free facts', () => {
 
 test('DesktopWorld tooling schemas reject product content and unknown fields', () => {
   assert.notEqual(validate('desktop-world-devtools-stage-v1.schema.json', { ...stage(), transcript: 'secret' }).status, 0)
+  const malformedNativeBounds = stage()
+  malformedNativeBounds.world.displays[0].nativeBounds = [0, 0, -1, 900]
+  assert.notEqual(validate('desktop-world-devtools-stage-v1.schema.json', malformedNativeBounds).status, 0)
   assert.notEqual(validate('scene-replay-v1.schema.json', {
     status: 'ok', contract: 'aos.scene.replay.v1', eventCount: 0, resourceCount: 0,
     resources: [], completedGestures: 0, canceledGestures: 0, finalPositions: {}, prompt: 'secret',

--- a/tests/toolkit/desktop-world-devtools-compat.test.mjs
+++ b/tests/toolkit/desktop-world-devtools-compat.test.mjs
@@ -28,8 +28,8 @@ function snapshot() {
       status: 'available',
       world: {
         displays: [
-          { id: 'main', index: 0, bounds: [0, 0, 1440, 900] },
-          { id: 'lower', index: 1, bounds: [0, 900, 1920, 1080] },
+          { id: 'main', index: 0, bounds: [200, 0, 1440, 900], nativeBounds: [0, 0, 1440, 900] },
+          { id: 'lower', index: 1, bounds: [0, 900, 1920, 1080], nativeBounds: [-200, 900, 1920, 1080] },
         ],
         nodes: [{
           id: 'body', resourceId: 'companion/main', parentId: null, kind: 'mesh',
@@ -69,6 +69,8 @@ test('focused compatibility projections consume the canonical DesktopWorld snaps
 
   const spatial = projectDesktopWorldDevToolsSpatial(snapshot())
   assert.equal(spatial.displays.length, 2)
+  assert.deepEqual(spatial.displays[0].native_bounds, { x: 0, y: 0, w: 1440, h: 900 })
+  assert.deepEqual(spatial.displays[0].desktop_world_bounds, { x: 200, y: 0, w: 1440, h: 900 })
   assert.deepEqual(spatial.canvases[0].atResolved, [280, 200, 80, 80])
   assert.deepEqual(spatial.marksByCanvas.get('scene-resource:companion/main').marks[0], {
     id: 'body', name: 'aos.scene.geometry.primitive', x: 320, y: 240,
@@ -78,6 +80,16 @@ test('focused compatibility projections consume the canonical DesktopWorld snaps
   assert.equal(resources.stageLayers[0].affordanceId, 'body-drag')
   assert.equal(resources.inputRegions[0].affordanceId, 'body-drag')
   assert.deepEqual(resources.inputRegions[0].frame, [280, 200, 80, 80])
+})
+
+test('compatibility projection does not fabricate native geometry for legacy snapshots', () => {
+  const legacy = snapshot()
+  legacy.stage.world.displays = [{ id: 'main', index: 0, bounds: [200, 0, 1440, 900] }]
+
+  const spatial = projectDesktopWorldDevToolsSpatial(legacy)
+
+  assert.deepEqual(spatial.displays, [])
+  assert.equal(spatial.canvases.length, 1)
 })
 
 test('Surface Inspector compatibility state activates and clears atomically', () => {

--- a/tests/toolkit/desktop-world-devtools-model.test.mjs
+++ b/tests/toolkit/desktop-world-devtools-model.test.mjs
@@ -18,8 +18,8 @@ function stageSnapshot(overrides = {}) {
     status: 'available',
     world: {
       displays: [
-        { id: 'left', index: 0, bounds: [-1920, 0, 1920, 1080] },
-        { id: 'main', index: 1, bounds: [0, 0, 2560, 1440] },
+        { id: 'left', index: 0, bounds: [0, 0, 1920, 1080], nativeBounds: [-1920, 0, 1920, 1080] },
+        { id: 'main', index: 1, bounds: [1920, 0, 2560, 1440], nativeBounds: [0, 0, 2560, 1440] },
       ],
       nodes: [{ id: 'node', resourceId: 'resource', position: [1280, 720, 0] }],
       hitRegions: [{ id: 'hit', resourceId: 'resource', affordanceId: 'drag', frame: [1200, 640, 160, 160], registered: true }],
@@ -62,6 +62,20 @@ test('DesktopWorld DevTools stage normalization is strict, bounded, and content-
   assert.equal('transcript' in normalized.interactions[0], false);
   assert.equal(normalized.counters.activeGestures, 1);
   assert.equal(normalized.counters.activeRoutes, 1);
+  assert.deepEqual(normalized.world.displays[0].nativeBounds, [-1920, 0, 1920, 1080]);
+});
+
+test('DesktopWorld DevTools keeps older display facts readable without inventing native geometry', () => {
+  const legacy = stageSnapshot();
+  legacy.world.displays = [{ id: 'main', index: 0, bounds: [0, 0, 1440, 900] }];
+  const normalized = normalizeDesktopWorldDevToolsStageSnapshot(legacy);
+
+  assert.deepEqual(normalized.world.displays[0], {
+    id: 'main',
+    index: 0,
+    bounds: [0, 0, 1440, 900],
+  });
+  assert.equal('nativeBounds' in normalized.world.displays[0], false);
 });
 
 test('DesktopWorld DevTools session normalization validates host and filters', () => {
@@ -135,7 +149,7 @@ test('DesktopWorld minimap projects multi-display world geometry consistently', 
   const stage = normalizeDesktopWorldDevToolsStageSnapshot(stageSnapshot());
   const minimap = buildDesktopWorldMinimapLayout(stage, { width: 480, height: 240, padding: 12 });
 
-  assert.deepEqual(minimap.bounds, [-1920, 0, 4480, 1440]);
+  assert.deepEqual(minimap.bounds, [0, 0, 4480, 1440]);
   assert.equal(minimap.displays.length, 2);
   assert.equal(minimap.nodes.length, 1);
   assert.ok(minimap.displays.every((display) => display.frame.every(Number.isFinite)));


### PR DESCRIPTION
## Summary

- expose optional native global display bounds beside DesktopWorld-local bounds in the canonical DevTools snapshot
- preserve strict scene-event topology and legacy snapshot readability without fabricating native geometry
- validate and document the additive contract across toolkit, daemon, schema, and compatibility views

## Validation

- focused DevTools and schema tests: 18/18
- disposable Swift daemon-session proof: passed
- scene agent tooling CLI: 6/6
- scene public API and docs: 9/9
- full toolkit: 1369 passed, 3 skipped
- full schemas: 173 passed after rerunning one sandbox-blocked fixture
- independent correction-delta review: approved, no P0-P2 findings
- git diff --check: passed

No AOS binary, daemon, TCC, build, or signing operation was performed. The live help contract was intentionally deferred because this changes no command form and the native runtime is externally owned during acceptance.