### PR TITLE
Observe status item anchor rehosting

### DIFF
--- a/docs/dev/test-proof-registry.d/runtime-readiness.json
+++ b/docs/dev/test-proof-registry.d/runtime-readiness.json
@@ -29,12 +29,13 @@
         "tests/status-item-contract.test.mjs"
       ],
       "fixture_patterns": [
-        "tests/fixtures/status-item-host-controller-harness.swift"
+        "tests/fixtures/status-item-host-controller-harness.swift",
+        "tests/fixtures/status-item-anchor-observation-harness.swift"
       ],
       "owner": "runtime-readiness",
       "harness_level": "model_unit",
       "proof_kind": "status_item_host_contract",
-      "contract": "The product-neutral status-item descriptor, canonical Unicode text limits, committed installation anchor, observed anchor/event, pre-listen host admission, registration-before-ready ordering, canonical daemon-to-public event projection, bounded follow-stream backpressure, exact-revision compare-and-swap update, toolkit type surface, multi-connection fake transport, and file-size ownership ratchet stay schema-backed.",
+      "contract": "The product-neutral status-item descriptor, canonical Unicode text limits, committed installation anchor, rebindable and deduplicated anchor observation, pre-listen host admission, registration-before-ready ordering, canonical daemon-to-public event projection, bounded follow-stream backpressure, exact-revision compare-and-swap update, toolkit type surface, multi-connection fake transport, and file-size ownership ratchet stay schema-backed.",
       "worth": "This protects the owner-scoped native host contract without requiring a live menu-bar item, TCC, or embedded product fixture.",
       "command": "node --test tests/status-item-contract.test.mjs",
       "replaces": [

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -19,8 +19,9 @@ needs, but public command policy and product UI policy belong above it:
   AppKit-derived anchor facts, and native activation/menu bridge live in
   `display/status-item*.swift`; the successful installation anchor is also the
   committed registration/readiness anchor, so initial readiness may not depend
-  on a second best-effort AppKit lookup; consumer visuals and product actions
-  do not;
+  on a second best-effort AppKit lookup; anchor updates track the current button
+  and status-bar window across frame changes and AppKit rehosting; consumer
+  visuals and product actions do not;
 - permission status and request primitives belong to the process that owns the
   privileged capability; daemon-owned microphone capture therefore uses
   daemon-owned authorization rather than foreground CLI authorization;

--- a/src/display/status-item-anchor-observation.swift
+++ b/src/display/status-item-anchor-observation.swift
@@ -1,0 +1,125 @@
+// status-item-anchor-observation.swift — Rebindable AppKit anchor observation.
+
+import AppKit
+import Foundation
+
+struct AOSStatusItemAnchorObservationHost {
+    let button: NSView
+    let window: NSObject
+}
+
+final class AOSStatusItemAnchorObservation {
+    private let center: NotificationCenter
+    private let reacquisitionInterval: TimeInterval
+    private let resolveHost: () -> AOSStatusItemAnchorObservationHost?
+    private let readSignature: () -> String?
+    private let onBoundsChanged: () -> Void
+    private let onTopologyChanged: () -> Void
+    private var hostTokens: [NSObjectProtocol] = []
+    private var topologyToken: NSObjectProtocol?
+    private var reacquisitionTimer: Timer?
+    private weak var observedButton: NSView?
+    private weak var observedWindow: NSObject?
+    private var previousPostsFrameChangedNotifications: Bool?
+    private var lastSignature: String?
+    private var active = false
+
+    init(
+        center: NotificationCenter = .default,
+        reacquisitionInterval: TimeInterval = 0.25,
+        resolveHost: @escaping () -> AOSStatusItemAnchorObservationHost?,
+        readSignature: @escaping () -> String?,
+        onBoundsChanged: @escaping () -> Void,
+        onTopologyChanged: @escaping () -> Void
+    ) {
+        self.center = center
+        self.reacquisitionInterval = reacquisitionInterval
+        self.resolveHost = resolveHost
+        self.readSignature = readSignature
+        self.onBoundsChanged = onBoundsChanged
+        self.onTopologyChanged = onTopologyChanged
+    }
+
+    func start() {
+        stop()
+        active = true
+        _ = rebindIfNeeded()
+        lastSignature = readSignature()
+        topologyToken = center.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.handleTopologyChange()
+        }
+        let timer = Timer(timeInterval: reacquisitionInterval, repeats: true) { [weak self] _ in
+            self?.handlePotentialBoundsChange()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        reacquisitionTimer = timer
+    }
+
+    func stop() {
+        active = false
+        if let topologyToken { center.removeObserver(topologyToken) }
+        topologyToken = nil
+        reacquisitionTimer?.invalidate()
+        reacquisitionTimer = nil
+        unbindHost()
+        lastSignature = nil
+    }
+
+    @discardableResult
+    private func rebindIfNeeded() -> Bool {
+        guard active else { return false }
+        guard let host = resolveHost() else {
+            unbindHost()
+            return false
+        }
+        if observedButton === host.button, observedWindow === host.window { return false }
+        unbindHost()
+        observedButton = host.button
+        observedWindow = host.window
+        previousPostsFrameChangedNotifications = host.button.postsFrameChangedNotifications
+        host.button.postsFrameChangedNotifications = true
+        hostTokens.append(center.addObserver(
+            forName: NSView.frameDidChangeNotification,
+            object: host.button,
+            queue: .main
+        ) { [weak self] _ in
+            self?.handlePotentialBoundsChange()
+        })
+        for name in [NSWindow.didMoveNotification, NSWindow.didResizeNotification] {
+            hostTokens.append(center.addObserver(forName: name, object: host.window, queue: .main) { [weak self] _ in
+                self?.handlePotentialBoundsChange()
+            })
+        }
+        return true
+    }
+
+    private func unbindHost() {
+        hostTokens.forEach(center.removeObserver)
+        hostTokens.removeAll()
+        if let previousPostsFrameChangedNotifications {
+            observedButton?.postsFrameChangedNotifications = previousPostsFrameChangedNotifications
+        }
+        observedButton = nil
+        observedWindow = nil
+        previousPostsFrameChangedNotifications = nil
+    }
+
+    private func handlePotentialBoundsChange() {
+        guard active else { return }
+        _ = rebindIfNeeded()
+        guard let signature = readSignature(), signature != lastSignature else { return }
+        lastSignature = signature
+        onBoundsChanged()
+    }
+
+    private func handleTopologyChange() {
+        guard active else { return }
+        _ = rebindIfNeeded()
+        lastSignature = readSignature()
+        onTopologyChanged()
+    }
+}

--- a/src/display/status-item.swift
+++ b/src/display/status-item.swift
@@ -53,8 +53,16 @@ final class StatusItemManager {
     var hostedEventSink: (([String: Any]) -> Bool)?
 
     private var fallbackIcon: NSImage?
-    private var anchorObservationTokens: [NSObjectProtocol] = []
-    private var lastAnchorSignature: String?
+    private lazy var anchorObservation = AOSStatusItemAnchorObservation(
+        resolveHost: { [weak self] in
+            guard let button = self?.statusItem?.button,
+                  let window = button.window else { return nil }
+            return AOSStatusItemAnchorObservationHost(button: button, window: window)
+        },
+        readSignature: { [weak self] in self?.currentHostedAnchorSignature() },
+        onBoundsChanged: { [weak self] in self?.emitHostedAnchorEvent(type: "bounds_changed") },
+        onTopologyChanged: { [weak self] in self?.emitHostedAnchorEvent(type: "topology_changed") }
+    )
 
     func setup() {
         guard statusItem == nil else { return }
@@ -75,7 +83,6 @@ final class StatusItemManager {
         hostedDescriptor = nil
         hostedGeneration = 0
         statusMenuItems = []
-        lastAnchorSignature = nil
     }
 
     @objc func handleClick(_ sender: Any?) {
@@ -167,45 +174,24 @@ final class StatusItemManager {
     }
 
     func startHostedAnchorObservation() {
-        stopHostedAnchorObservation()
-        guard let window = statusItem?.button?.window else { return }
-        let center = NotificationCenter.default
-        for name in [NSWindow.didMoveNotification, NSWindow.didResizeNotification] {
-            anchorObservationTokens.append(center.addObserver(forName: name, object: window, queue: .main) { [weak self] _ in
-                self?.emitHostedAnchorEvent(type: "bounds_changed", onlyWhenChanged: true)
-            })
-        }
-        anchorObservationTokens.append(center.addObserver(
-            forName: NSApplication.didChangeScreenParametersNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            self?.emitHostedAnchorEvent(type: "topology_changed", onlyWhenChanged: false)
-        })
-        primeHostedAnchorObservation()
+        anchorObservation.start()
     }
 
     private func stopHostedAnchorObservation() {
-        let center = NotificationCenter.default
-        anchorObservationTokens.forEach(center.removeObserver)
-        anchorObservationTokens.removeAll()
+        anchorObservation.stop()
     }
 
-    private func primeHostedAnchorObservation() {
+    private func currentHostedAnchorSignature() -> String? {
         guard let hosted = hostedDescriptor,
               let anchor = statusItemAnchorPayload(owner: hosted.owner, itemID: hosted.itemID) else {
-            lastAnchorSignature = nil
-            return
+            return nil
         }
-        lastAnchorSignature = anchorSignature(anchor)
+        return anchorSignature(anchor)
     }
 
-    private func emitHostedAnchorEvent(type: String, onlyWhenChanged: Bool) {
+    private func emitHostedAnchorEvent(type: String) {
         guard let hosted = hostedDescriptor,
               let anchor = statusItemAnchorPayload(owner: hosted.owner, itemID: hosted.itemID) else { return }
-        let signature = anchorSignature(anchor)
-        if onlyWhenChanged, signature == lastAnchorSignature { return }
-        lastAnchorSignature = signature
         _ = hostedEventSink?([
             "type": type,
             "owner": hosted.owner,

--- a/tests/fixtures/status-item-anchor-observation-harness.swift
+++ b/tests/fixtures/status-item-anchor-observation-harness.swift
@@ -1,0 +1,91 @@
+import AppKit
+import Foundation
+
+private func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if !condition() {
+        FileHandle.standardError.write(Data("FAIL: \(message)\n".utf8))
+        exit(1)
+    }
+}
+
+private func waitForObservation() {
+    RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+}
+
+@main
+struct StatusItemAnchorObservationHarness {
+    static func main() {
+        let center = NotificationCenter()
+        let firstButton = NSView()
+        let firstWindow = NSObject()
+        firstButton.postsFrameChangedNotifications = false
+        var host: AOSStatusItemAnchorObservationHost? = AOSStatusItemAnchorObservationHost(
+            button: firstButton,
+            window: firstWindow
+        )
+        var signature = "initial"
+        var boundsEvents = 0
+        var topologyEvents = 0
+        let observation = AOSStatusItemAnchorObservation(
+            center: center,
+            reacquisitionInterval: 0.01,
+            resolveHost: { host },
+            readSignature: { host == nil ? nil : signature },
+            onBoundsChanged: { boundsEvents += 1 },
+            onTopologyChanged: { topologyEvents += 1 }
+        )
+
+        observation.start()
+        expect(firstButton.postsFrameChangedNotifications, "frame notifications were not enabled")
+        center.post(name: NSView.frameDidChangeNotification, object: firstButton)
+        expect(boundsEvents == 0, "unchanged frame emitted a duplicate event")
+        signature = "first-move"
+        center.post(name: NSView.frameDidChangeNotification, object: firstButton)
+        center.post(name: NSView.frameDidChangeNotification, object: firstButton)
+        expect(boundsEvents == 1, "changed frame was not emitted exactly once")
+
+        host = nil
+        center.post(name: NSView.frameDidChangeNotification, object: firstButton)
+        expect(!firstButton.postsFrameChangedNotifications, "first button notification state was not restored")
+
+        let secondButton = NSView()
+        let secondWindow = NSObject()
+        secondButton.postsFrameChangedNotifications = true
+        host = AOSStatusItemAnchorObservationHost(button: secondButton, window: secondWindow)
+        signature = "reacquired"
+        waitForObservation()
+        expect(boundsEvents == 2, "detached host was not reacquired")
+        expect(secondButton.postsFrameChangedNotifications, "rehosted button notifications were not enabled")
+
+        let thirdButton = NSView()
+        let thirdWindow = NSObject()
+        thirdButton.postsFrameChangedNotifications = false
+        host = AOSStatusItemAnchorObservationHost(button: thirdButton, window: thirdWindow)
+        signature = "silent-rehost"
+        waitForObservation()
+        expect(boundsEvents == 3, "silent host replacement was not discovered")
+        expect(secondButton.postsFrameChangedNotifications, "second button prior notification state was not restored")
+        expect(thirdButton.postsFrameChangedNotifications, "third button notifications were not enabled")
+
+        signature = "third-move"
+        center.post(name: NSView.frameDidChangeNotification, object: firstButton)
+        center.post(name: NSView.frameDidChangeNotification, object: secondButton)
+        expect(boundsEvents == 3, "retired button still emitted events")
+        center.post(name: NSView.frameDidChangeNotification, object: thirdButton)
+        expect(boundsEvents == 4, "current button did not emit a changed frame")
+
+        signature = "topology-change"
+        center.post(name: NSApplication.didChangeScreenParametersNotification, object: nil)
+        expect(topologyEvents == 1, "topology change was not emitted")
+
+        observation.stop()
+        expect(!thirdButton.postsFrameChangedNotifications, "stop did not restore the observed button")
+        signature = "after-stop"
+        center.post(name: NSView.frameDidChangeNotification, object: thirdButton)
+        center.post(name: NSWindow.didMoveNotification, object: thirdWindow)
+        center.post(name: NSApplication.didChangeScreenParametersNotification, object: nil)
+        waitForObservation()
+        expect(boundsEvents == 4 && topologyEvents == 1, "stopped observation emitted events")
+        print("status item anchor observation lifecycle harness passed")
+    }
+}

--- a/tests/status-item-contract.test.mjs
+++ b/tests/status-item-contract.test.mjs
@@ -25,6 +25,8 @@ const anchorSchemaPath = path.join(repoRoot, 'shared/schemas/aos-status-item-anc
 const hostContractPath = path.join(repoRoot, 'src/display/status-item-host-contract.swift')
 const hostControllerPath = path.join(repoRoot, 'src/display/status-item-host-controller.swift')
 const hostControllerHarnessPath = path.join(repoRoot, 'tests/fixtures/status-item-host-controller-harness.swift')
+const anchorObservationPath = path.join(repoRoot, 'src/display/status-item-anchor-observation.swift')
+const anchorObservationHarnessPath = path.join(repoRoot, 'tests/fixtures/status-item-anchor-observation-harness.swift')
 
 const descriptor = {
   schema_version: STATUS_ITEM_DESCRIPTOR_SCHEMA_VERSION,
@@ -785,16 +787,48 @@ test('native host controller enforces lease, CAS, failed-delivery, and disconnec
   }
 })
 
+test('native anchor observation rebinds, deduplicates, restores, and stops', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-status-item-anchor-observation-'))
+  const executable = path.join(tempRoot, 'status-item-anchor-observation-harness')
+  const moduleCache = path.join(tempRoot, 'module-cache')
+  fs.mkdirSync(moduleCache)
+  try {
+    execFileSync('swiftc', [
+      '-parse-as-library',
+      '-module-cache-path', moduleCache,
+      anchorObservationPath,
+      anchorObservationHarnessPath,
+      '-o', executable,
+    ], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CLANG_MODULE_CACHE_PATH: moduleCache,
+        SWIFT_MODULECACHE_PATH: moduleCache,
+        TMPDIR: tempRoot,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    const output = execFileSync(executable, [], { cwd: repoRoot, encoding: 'utf8' })
+    assert.equal(output, 'status item anchor observation lifecycle harness passed\n')
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
 test('native ownership is focused and excludes superseded visual and lifecycle routes', () => {
   const manager = fs.readFileSync(path.join(repoRoot, 'src/display/status-item.swift'), 'utf8')
+  const observation = fs.readFileSync(anchorObservationPath, 'utf8')
   const hosted = fs.readFileSync(path.join(repoRoot, 'src/display/status-item-hosted.swift'), 'utf8')
   const controller = fs.readFileSync(path.join(repoRoot, 'src/display/status-item-host-controller.swift'), 'utf8')
   const daemon = fs.readFileSync(path.join(repoRoot, 'src/daemon/unified.swift'), 'utf8')
-  const combined = `${manager}\n${hosted}\n${controller}`
+  const combined = `${manager}\n${observation}\n${hosted}\n${controller}`
   assert(!combined.includes('CryptoKit'))
   assert(!combined.includes('descriptor.icon'))
-  assert.match(manager, /didChangeScreenParametersNotification/)
-  assert.match(manager, /didMoveNotification/)
+  assert.match(observation, /didChangeScreenParametersNotification/)
+  assert.match(observation, /didMoveNotification/)
+  assert.match(observation, /NSView\.frameDidChangeNotification/)
   assert.match(controller, /runOnMainSync/)
   assert.match(controller, /STATUS_ITEM_REVISION_NOT_ADVANCED/)
   assert.match(controller, /owner: current\.owner/)
@@ -838,11 +872,13 @@ test('daemon admits status-item requests only after host installation and orders
 test('status item ownership files stay under the focused-size ratchet', () => {
   const counts = Object.fromEntries([
     'src/display/status-item.swift',
+    'src/display/status-item-anchor-observation.swift',
     'src/display/status-item-hosted.swift',
     'src/display/status-item-host-contract.swift',
     'src/display/status-item-host-controller.swift',
   ].map((file) => [file, fs.readFileSync(path.join(repoRoot, file), 'utf8').split('\n').length]))
   assert.ok(counts['src/display/status-item.swift'] < 400, JSON.stringify(counts))
+  assert.ok(counts['src/display/status-item-anchor-observation.swift'] < 200, JSON.stringify(counts))
   assert.ok(counts['src/display/status-item-hosted.swift'] < 300, JSON.stringify(counts))
   assert.ok(counts['src/display/status-item-host-contract.swift'] < 150, JSON.stringify(counts))
   assert.ok(counts['src/display/status-item-host-controller.swift'] < 500, JSON.stringify(counts))


### PR DESCRIPTION
## Summary

- track the current AppKit status-item button and host window across frame changes, topology changes, transient detach, and silent rehosting
- use a lease-scoped 250 ms reacquisition timer while retaining immediate native notifications
- restore exact prior notification state and stop every observer/timer on teardown
- add a compiled AppKit lifecycle harness and proof-registry ownership

This fixes stale status-item anchor events observed by Sigil native acceptance.

## Validation

- `node --test tests/status-item-contract.test.mjs`: 21/21
- `bash tests/daemon-ipc-schema.sh`: passed
- daemon event schemas: 7/7
- proof registry: 20/20
- workflow schemas: 10/10
- workflow router, audit, situation, and drift lint: passed
- full Swift source-only typecheck: passed with two unrelated existing warnings
- `git diff --check`: passed
- focused read-only correction review: no findings

No `./aos` binary, daemon, build, TCC, or native runtime operation was performed. GitHub Actions remain disabled.