### PR TITLE
Settle DesktopWorld affordances after animation

### DIFF
--- a/docs/api/toolkit/scene.md
+++ b/docs/api/toolkit/scene.md
@@ -333,6 +333,34 @@ allocates no event object per binding per tick; the host or consumer owns the
 clock. This is a numeric binding primitive, not a general timeline or
 consumer-code evaluator.
 
+`restart()` explicitly starts a new completion generation for the controller.
+The optional `onComplete` callback fires at most once for each successfully
+applied one-shot binding in that generation; callback failures are counted and
+are not retried on every frame. A completed one-shot stops applying until the
+next explicit `restart()`, so a later interaction can own the resulting
+property without the animation overwriting it on every render tick.
+
+When a DesktopWorld resource combines native affordances with one-shot bindings
+that affect 2D hit geometry (`position.x/y`, `rotation.z`, or `scale.x/y`),
+`play` quiesces its active regions before visual motion starts. The outlet
+retains a separate terminal interaction projection while leaving the authored
+scene document and revision unchanged. After every relevant one-shot binding
+reaches its terminal value, the stage operation queue prepares a fresh
+generation of inactive native regions, commits the interaction aggregate, and
+activates the complete generation as one settlement barrier. A stale play
+generation cannot settle a newer scene; failed activation releases the
+interaction lease rather than exposing partial input. This path performs no
+per-frame native IPC and emits no additional public scene event.
+
+Operation suspension, document visibility, and WebGL context loss pause the
+playback clock. Resumption continues from the prior elapsed time rather than
+jumping to wall-clock progress.
+
+Looping and ping-pong spatial bindings continue to animate visually, but V1
+does not move native hit regions per frame. Interactive moving loops must use a
+stable nonanimated collider ancestor or wait for a future daemon-side atomic
+batch transport.
+
 `createLocalSceneViewportHost()` and `createDesktopWorldSceneHost()` own the
 same document, lease, registry, transaction, animation, signal, inspection,
 suspension, context-recovery, and disposal policy. Consumers provide a trusted

--- a/docs/dev/test-proof-registry.d/substrate-reclassification.json
+++ b/docs/dev/test-proof-registry.d/substrate-reclassification.json
@@ -209,7 +209,9 @@
       "path_patterns": [
         "tests/toolkit/desktop-world-surface-three.test.mjs",
         "tests/toolkit/desktop-world-scene-outlet.test.mjs",
+        "tests/toolkit/scene-document.test.mjs",
         "tests/toolkit/scene-generic-three.test.mjs",
+        "tests/toolkit/scene-host.test.mjs",
         "tests/toolkit/scene-public-contract.test.mjs",
         "tests/toolkit/three-render-lifecycle.test.mjs",
         "tests/toolkit/toolkit-api-docs-contract.test.mjs"
@@ -220,7 +222,7 @@
       "proof_kind": "scene_toolkit_contract",
       "contract": "The external scene facade exposes only product-neutral DesktopWorld, bounded Three lifecycle, canvas projection, and visual-object primitives.",
       "worth": "This lets external first-party consumers reuse renderer mechanics and editing contracts without copying toolkit source or restoring product authority to AOS.",
-      "command": "node --test tests/toolkit/desktop-world-surface-three.test.mjs tests/toolkit/desktop-world-scene-outlet.test.mjs tests/toolkit/scene-generic-three.test.mjs tests/toolkit/scene-public-contract.test.mjs tests/toolkit/three-render-lifecycle.test.mjs tests/toolkit/toolkit-api-docs-contract.test.mjs",
+      "command": "node --test tests/toolkit/desktop-world-surface-three.test.mjs tests/toolkit/desktop-world-scene-outlet.test.mjs tests/toolkit/scene-document.test.mjs tests/toolkit/scene-generic-three.test.mjs tests/toolkit/scene-host.test.mjs tests/toolkit/scene-public-contract.test.mjs tests/toolkit/three-render-lifecycle.test.mjs tests/toolkit/toolkit-api-docs-contract.test.mjs",
       "replaces": [
         "embedded product avatar renderer lifecycle tests"
       ],

--- a/docs/dev/workflow-rules.json
+++ b/docs/dev/workflow-rules.json
@@ -136,18 +136,7 @@
       "hot_swappable": true,
       "tcc_identity_sensitive": false,
       "commands": [],
-      "verification": [
-        {
-          "id": "toolkit-test",
-          "command": "node --test tests/toolkit/*.test.mjs",
-          "reason": "Use focused toolkit/runtime tests for pure browser-surface changes."
-        },
-        {
-          "id": "show-wait",
-          "command": "./aos show wait --id <canvas-id> --json --timeout 15s",
-          "reason": "When manually verifying a canvas-backed component, use diagnostic JSON waits so timeout failures include runtime verdict detail."
-        }
-      ]
+      "verification": []
     },
     {
       "id": "status-item-contract",

--- a/packages/toolkit/AGENTS.md
+++ b/packages/toolkit/AGENTS.md
@@ -43,6 +43,10 @@ daemon-backed singleton transport is exposed only through owner/resource-scoped
 `scene-follow` leases. Pair visual objects with
 explicit interaction surfaces or input regions; do not make the full visual
 stage interactive by default. ADR 0024 owns the 3D outlet boundary.
+One-shot spatial animation temporarily quiesces affected native interaction
+regions and settles the terminal pose through a fresh staged generation. Keep
+the authored scene revision stable and do not synchronize native hit geometry
+per frame.
 
 DesktopWorld DevTools are AOS-owned toolkit views over a daemon-owned session.
 Consumers may host the public inspector view, but one revisioned AOS host lease

--- a/packages/toolkit/components/desktop-world-stage/index.js
+++ b/packages/toolkit/components/desktop-world-stage/index.js
@@ -97,6 +97,27 @@ sceneInteractions = createDesktopWorldSceneInteractionRuntime({
     })
   },
 })
+sceneOutlet.setInteractionGeometryObserver((key, generation) => {
+  void enqueueSceneWork(async () => {
+    try {
+      const settled = await sceneInteractions.settleAnimationGeometry(key, generation)
+      if (settled) {
+        devtoolsProbe.recordEvent({
+          kind: 'interaction.animation_geometry.settled',
+          resourceId: sceneInteractions.configuration(key)?.resource ?? null,
+        })
+      }
+    } catch {
+      const code = 'INPUT_REGION_SYNC_FAILED'
+      lastSceneError = { at: Date.now(), code }
+      devtoolsProbe.recordEvent({
+        code,
+        kind: 'interaction.animation_geometry.failed',
+        resourceId: sceneInteractions.configuration(key)?.resource ?? null,
+      })
+    }
+  })
+})
 const sceneOperations = createDesktopWorldSceneOperationCoordinator({
   outlet: sceneOutlet,
   interactions: sceneInteractions,

--- a/packages/toolkit/components/desktop-world-stage/scene-animation-interaction-state.js
+++ b/packages/toolkit/components/desktop-world-stage/scene-animation-interaction-state.js
@@ -1,0 +1,70 @@
+import {
+  canonicalizeSceneDocument,
+  compileSceneAnimationBindings,
+} from '../../scene/index.js'
+
+const SPATIAL_TARGETS = Object.freeze({
+  'position.x': ['position', 0],
+  'position.y': ['position', 1],
+  'rotation.z': ['rotation', 2],
+  'scale.x': ['scale', 0],
+  'scale.y': ['scale', 1],
+})
+
+export function createSceneAnimationInteractionState(documentInput) {
+  let document = canonicalizeSceneDocument(documentInput)
+  const spatialBindingIds = new Set(compileSceneAnimationBindings(document).bindings
+    .filter((binding) => binding.playback === 'once' && SPATIAL_TARGETS[binding.target])
+    .map((binding) => binding.id))
+  const completedBindingIds = new Set()
+  let dirty = false
+
+  function object(objectId) {
+    return document.objects.find((entry) => entry.id === objectId) ?? null
+  }
+
+  return Object.freeze({
+    complete(binding, value) {
+      const target = SPATIAL_TARGETS[binding?.target]
+      const descriptor = object(binding?.objectId)
+      if (
+        !target
+        || !descriptor
+        || !Number.isFinite(value)
+        || binding?.playback !== 'once'
+        || !spatialBindingIds.has(binding.id)
+      ) return false
+      const [property, index] = target
+      descriptor.transform[property][index] = value
+      completedBindingIds.add(binding.id)
+      dirty = completedBindingIds.size === spatialBindingIds.size
+      return true
+    },
+    document() {
+      return document
+    },
+    reset(nextDocument) {
+      document = canonicalizeSceneDocument(nextDocument)
+      completedBindingIds.clear()
+      dirty = false
+      return document
+    },
+    hasSpatialAnimation() {
+      return spatialBindingIds.size > 0
+    },
+    setObjectPosition(objectId, position) {
+      const descriptor = object(objectId)
+      if (!descriptor || !Array.isArray(position) || position.length !== 3 || !position.every(Number.isFinite)) {
+        return false
+      }
+      descriptor.transform.position = [...position]
+      dirty = true
+      return true
+    },
+    takeDirty() {
+      const value = dirty
+      dirty = false
+      return value
+    },
+  })
+}

--- a/packages/toolkit/components/desktop-world-stage/scene-animation-region-transition.js
+++ b/packages/toolkit/components/desktop-world-stage/scene-animation-region-transition.js
@@ -1,0 +1,121 @@
+export function createSceneAnimationRegionTransitionRuntime({
+  entryFor,
+  outlet,
+  closeRadialMenu,
+  settleRadialMenu,
+  retireRegisteredRegions,
+  retireIndexedRegions,
+  syncRegions,
+  prepareReplacement,
+  releaseEntry,
+} = {}) {
+  for (const [name, value] of Object.entries({
+    entryFor,
+    closeRadialMenu,
+    settleRadialMenu,
+    retireRegisteredRegions,
+    retireIndexedRegions,
+    syncRegions,
+    prepareReplacement,
+    releaseEntry,
+  })) {
+    if (typeof value !== 'function') {
+      throw new TypeError(`DesktopWorld animation-region transitions require ${name}.`)
+    }
+  }
+  if (!outlet) throw new TypeError('DesktopWorld animation-region transitions require a scene outlet.')
+
+  async function quiesce(key, generation) {
+    const entry = entryFor(key)
+    if (!entry || entry.disposed || !Number.isInteger(generation) || generation < 1) {
+      return false
+    }
+    entry.animationGeneration = generation
+    entry.animationQuiesced = true
+    entry.animationReady = false
+    entry.generation += 1
+    entry.controller.cancel('resource_changed')
+    closeRadialMenu(key, 'resource_changed')
+    await entry.regionSync
+    await settleRadialMenu(key)
+    try {
+      await retireRegisteredRegions(entry)
+    } catch (error) {
+      entry.regionSyncErrorCode = 'INPUT_REGION_CLEANUP_FAILED'
+      throw error
+    }
+    return true
+  }
+
+  async function restore(key, generation) {
+    const entry = entryFor(key)
+    if (!entry || entry.disposed || entry.animationGeneration !== generation) return false
+    entry.animationReady = false
+    if (!entry.suspended) {
+      try {
+        await syncRegions(entry)
+      } catch (error) {
+        entry.regionSyncErrorCode = 'INPUT_REGION_SYNC_FAILED'
+        try {
+          await retireIndexedRegions(entry)
+        } catch (cleanupError) {
+          throw new AggregateError(
+            [error, cleanupError],
+            'DesktopWorld animation-region restoration and cleanup both failed.',
+          )
+        }
+        throw error
+      }
+    }
+    entry.animationGeneration = null
+    entry.animationQuiesced = false
+    return true
+  }
+
+  async function settle(key, generation) {
+    const previous = entryFor(key)
+    if (
+      !previous
+      || previous.disposed
+      || !previous.animationQuiesced
+      || previous.animationGeneration !== generation
+      || outlet.animationGeneration?.(key) !== generation
+    ) return false
+    previous.animationReady = true
+    if (previous.suspended) return false
+    const document = outlet.interactionDocument?.(key)
+    if (!document) return false
+
+    let replacement = null
+    let committed = false
+    try {
+      replacement = await prepareReplacement({
+        key,
+        owner: previous.owner,
+        resource: previous.resource,
+        document,
+        interactions: previous.interactions,
+        animationGeneration: generation,
+      })
+      replacement.commit(() => {})
+      committed = true
+      const settled = await replacement.settle()
+      if (!settled) throw new Error('DesktopWorld animated input-region settlement failed.')
+      return true
+    } catch (error) {
+      try {
+        if (committed) await replacement?.failClosed()
+        else if (replacement) await replacement.rollback()
+        else await releaseEntry(key, 'resource_removed')
+      } catch (cleanupError) {
+        throw new AggregateError(
+          [error, cleanupError],
+          'DesktopWorld animated input-region settlement and cleanup both failed.',
+        )
+      }
+      throw error
+    }
+  }
+
+  return Object.freeze({ quiesce, restore, settle })
+}

--- a/packages/toolkit/components/desktop-world-stage/scene-interaction-runtime.js
+++ b/packages/toolkit/components/desktop-world-stage/scene-interaction-runtime.js
@@ -3,6 +3,7 @@ import {
   validateSceneInteractionDocument,
 } from '../../scene/index.js'
 import { normalizeCanvasInputMessage } from '../../runtime/input-events.js'
+import { createSceneAnimationRegionTransitionRuntime } from './scene-animation-region-transition.js'
 import { createDesktopWorldSceneRadialMenuRuntime } from './scene-radial-menu-runtime.js'
 
 const MAX_LEASES = 32
@@ -103,7 +104,9 @@ export function createDesktopWorldSceneInteractionRuntime({
         ownerId: entry.owner,
         resourceId: entry.resource,
       },
-      document: () => leases.get(entry.key) === entry ? outlet.document(entry.key) : entry.document,
+      document: () => leases.get(entry.key) === entry
+        ? outlet.interactionDocument?.(entry.key) ?? outlet.document(entry.key)
+        : entry.document,
       interactions: entry.interactions,
       topology,
       now,
@@ -144,7 +147,17 @@ export function createDesktopWorldSceneInteractionRuntime({
     return indexed
   }
 
-  function createEntry({ key, owner, resource, document, interactions, regionGeneration = null }) {
+  function createEntry({
+    key,
+    owner,
+    resource,
+    document,
+    interactions,
+    regionGeneration = null,
+    animationGeneration = null,
+    animationQuiesced = false,
+    animationReady = false,
+  }) {
     const entry = {
       key,
       owner,
@@ -161,6 +174,9 @@ export function createDesktopWorldSceneInteractionRuntime({
       generation: 0,
       regionSync: Promise.resolve(),
       regionSyncErrorCode: null,
+      animationGeneration,
+      animationQuiesced,
+      animationReady,
       sequence: leases.get(key)?.sequence ?? 0,
     }
     entry.controller = createController(entry)
@@ -198,6 +214,46 @@ export function createDesktopWorldSceneInteractionRuntime({
     await Promise.allSettled([...unique.values()].map((payload) => updateRegion(inactiveRegionPayload(payload))))
     return cleanupRetiredRegions([...unique.keys()])
   }
+
+  function retiredRegionIdsForEntry(entry) {
+    return [...retiredRegions].flatMap(([id, payload]) => (
+      payload?.metadata?.scene_owner === entry.owner
+      && payload?.metadata?.scene_resource === entry.resource
+        ? [id]
+        : []
+    ))
+  }
+
+  async function requireRetiredRegionsClean(entry) {
+    const ids = retiredRegionIdsForEntry(entry)
+    if (ids.length === 0) return true
+    const clean = await cleanupRetiredRegions(ids)
+    if (!clean || retiredRegionIdsForEntry(entry).length > 0) {
+      throw new Error('DesktopWorld animated input-region cleanup is still pending.')
+    }
+    return true
+  }
+
+  async function retireEntryRegions(entry, includeIndexed = false) {
+    await requireRetiredRegionsClean(entry)
+    const regions = new Map()
+    const ids = includeIndexed
+      ? new Set([...entry.regionIds.keys(), ...entry.registeredIds])
+      : entry.registeredIds
+    for (const id of ids) {
+      const payload = entry.regionIds.get(id)?.payload
+      if (payload) regions.set(id, payload)
+    }
+    const clean = await retireAndRemoveRegions(regions)
+    entry.registeredIds.clear()
+    if (!clean || retiredRegionIdsForEntry(entry).length > 0) {
+      throw new Error('DesktopWorld animated input-region cleanup failed.')
+    }
+    return true
+  }
+
+  const retireRegisteredRegions = (entry) => retireEntryRegions(entry)
+  const retireIndexedRegions = (entry) => retireEntryRegions(entry, true)
 
   async function removeRegions(entry) {
     entry.generation += 1
@@ -290,7 +346,14 @@ export function createDesktopWorldSceneInteractionRuntime({
     return true
   }
 
-  async function prepareReplacement({ key, owner, resource, document, interactions = undefined }) {
+  async function prepareReplacement({
+    key,
+    owner,
+    resource,
+    document,
+    interactions = undefined,
+    animationGeneration = null,
+  }) {
     if (preparations.has(key)) throw new TypeError('DesktopWorld scene interaction replacement is already pending.')
     const previous = leases.get(key) ?? null
     const resolved = interactions === undefined ? previous?.interactions ?? null : interactions
@@ -308,6 +371,7 @@ export function createDesktopWorldSceneInteractionRuntime({
       document,
       interactions: validated,
       regionGeneration: `r${++nextRegionGeneration}`,
+      animationGeneration,
     }) : null
     const preparation = {
       key,
@@ -498,6 +562,18 @@ export function createDesktopWorldSceneInteractionRuntime({
     return radialMenus.close(key, reason) || gesture
   }
 
+  const animationRegions = createSceneAnimationRegionTransitionRuntime({
+    entryFor: (key) => leases.get(key) ?? null,
+    outlet,
+    closeRadialMenu: (key, reason) => radialMenus.close(key, reason),
+    settleRadialMenu: (key) => radialMenus.settle(key, { requireClean: true }),
+    retireRegisteredRegions,
+    retireIndexedRegions,
+    syncRegions,
+    prepareReplacement,
+    releaseEntry: release,
+  })
+
   async function suspend(key) {
     const entry = leases.get(key)
     if (!entry) return false
@@ -509,7 +585,7 @@ export function createDesktopWorldSceneInteractionRuntime({
     }
     await entry.regionSync
     await radialMenus.settle(key, { requireClean: true })
-    await removeRegions(entry)
+    if (!entry.animationQuiesced) await removeRegions(entry)
     return true
   }
 
@@ -518,6 +594,10 @@ export function createDesktopWorldSceneInteractionRuntime({
     if (!entry || !entry.suspended) return false
     await entry.regionSync
     entry.suspended = false
+    if (entry.animationQuiesced) {
+      if (entry.animationReady) return animationRegions.settle(key, entry.animationGeneration)
+      return true
+    }
     await syncRegions(entry)
     return true
   }
@@ -528,7 +608,7 @@ export function createDesktopWorldSceneInteractionRuntime({
       radialMenus.close(entry.key, 'topology_changed')
       await entry.regionSync
       await radialMenus.settle(entry.key, { requireClean: true })
-      await syncRegions(entry, true)
+      if (!entry.animationQuiesced) await syncRegions(entry, true)
     }
   }
 
@@ -541,7 +621,7 @@ export function createDesktopWorldSceneInteractionRuntime({
     radialMenus.close(key, reason)
     await entry.regionSync
     await radialMenus.settle(key, { requireClean: true })
-    await removeRegions(entry)
+    if (!entry.animationQuiesced) await removeRegions(entry)
     leases.delete(key)
     return true
   }
@@ -554,7 +634,9 @@ export function createDesktopWorldSceneInteractionRuntime({
     if (stagedRegionIds.has(regionId) || retiredRegions.has(regionId)) return true
     for (const entry of leases.values()) {
       const affordanceId = entry.regionIds.get(regionId)?.affordanceId
-      if (affordanceId && !entry.suspended) return entry.controller.handle(affordanceId, message)
+      if (affordanceId && !entry.suspended && !entry.animationQuiesced) {
+        return entry.controller.handle(affordanceId, message)
+      }
     }
     return false
   }
@@ -572,6 +654,9 @@ export function createDesktopWorldSceneInteractionRuntime({
         resource: entry.resource,
         regions: [...entry.regionIds.keys()],
         registered: entry.registeredIds.size,
+        animationGeneration: entry.animationGeneration,
+        animationQuiesced: entry.animationQuiesced,
+        animationReady: entry.animationReady,
         regionSyncErrorCode: entry.regionSyncErrorCode,
         suspended: entry.suspended,
         controller: entry.controller.snapshot(),
@@ -695,6 +780,9 @@ export function createDesktopWorldSceneInteractionRuntime({
     reconcile,
     refresh,
     cancel,
+    quiesceAnimation: animationRegions.quiesce,
+    restoreAnimation: animationRegions.restore,
+    settleAnimationGeometry: animationRegions.settle,
     suspend,
     resume,
     topologyChanged,

--- a/packages/toolkit/components/desktop-world-stage/scene-operation-coordinator.js
+++ b/packages/toolkit/components/desktop-world-stage/scene-operation-coordinator.js
@@ -96,11 +96,46 @@ export function createDesktopWorldSceneOperationCoordinator({ outlet, interactio
     }
   }
 
+  async function play(message, key) {
+    const generation = outlet.hasInteractionAnimation?.(key)
+      ? outlet.nextAnimationGeneration?.(key) ?? null
+      : null
+    let quiesced = false
+    if (Number.isInteger(generation)) {
+      quiesced = await interactions.quiesceAnimation(key, generation)
+    }
+
+    let applied
+    try {
+      applied = outlet.apply(message)
+    } catch (error) {
+      if (!quiesced) throw error
+      try {
+        await interactions.restoreAnimation(key, generation)
+      } catch (restoreError) {
+        throw new AggregateError([error, restoreError], 'DesktopWorld scene play and interaction restoration both failed.')
+      }
+      throw error
+    }
+    if (!applied && quiesced) {
+      try {
+        await interactions.restoreAnimation(key, generation)
+      } catch (restoreError) {
+        throw new AggregateError(
+          [new Error('DesktopWorld scene play was not applied.'), restoreError],
+          'DesktopWorld scene play rejection and interaction restoration both failed.',
+        )
+      }
+    }
+    return { applied, op: 'play' }
+  }
+
   async function apply(message) {
     const payload = message?.payload ?? {}
     const key = payload.lease_key
     const op = operationName(message)
     if (op === 'mount' || op === 'transact') return replace(message, op)
+    if (op === 'play') return play(message, key)
 
     const previousOutlet = outlet.configuration(key)
     const previous = {

--- a/packages/toolkit/components/desktop-world-stage/scene-outlet.js
+++ b/packages/toolkit/components/desktop-world-stage/scene-outlet.js
@@ -10,7 +10,9 @@ import {
   deriveOrthoCamera,
   resolveThreeRenderMetrics,
 } from '../../scene/index.js'
+import { createSceneAnimationInteractionState } from './scene-animation-interaction-state.js'
 import { createDesktopWorldSceneInteractionThree } from './scene-interaction-three.js'
+import { createScenePlaybackClock } from './scene-playback-clock.js'
 
 const MAX_RESOURCES = 32
 const MAX_SIGNALS_PER_SECOND = 30
@@ -36,6 +38,16 @@ export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = win
   let devtoolsProbe = null
   let gpuTimer = null
   let lastRenderAt = null
+  let interactionGeometryObserver = null
+  let nextPlayGeneration = 0
+
+  const notifyInteractionGeometry = (key, generation) => {
+    try {
+      interactionGeometryObserver?.(key, generation)
+    } catch {
+      devtoolsProbe?.recordEvent({ kind: 'interaction.geometry.failed', code: 'INPUT_REGION_SYNC_FAILED' })
+    }
+  }
 
   const updateSegment = (nextSegment) => {
     const projection = deriveOrthoCamera(nextSegment)
@@ -88,11 +100,13 @@ export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = win
     const validation = registry.validateDocument(document)
     if (!validation.ok) throw new TypeError('Scene document requires an unavailable or invalid implementation.')
     const projection = createGenericThreeSceneProjection({ THREE, document })
+    const interactionState = createSceneAnimationInteractionState(document)
     let animations
     let signals
     try {
       animations = createSceneAnimationController(document, {
         apply: (binding, value, elapsedMs, progress) => projection.applyAnimation(binding, value, elapsedMs, progress),
+        onComplete: (binding, value) => interactionState.complete(binding, value),
       })
       signals = createSceneSignalController(document, {
         apply: (binding, value, input, at) => projection.applySignal(binding, value, input, at),
@@ -112,7 +126,10 @@ export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = win
       projection,
       signals,
       animations,
+      interactionState,
       interactionVisuals: null,
+      playGeneration: null,
+      playClock: createScenePlaybackClock(),
       suspended: false,
       signalWindowAt: 0,
       signalWindowCount: 0,
@@ -191,11 +208,23 @@ export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = win
       mounted.signals.publish(operation.signalId, operation.value, Number(operation.at) || Date.now())
     } else if (operation.op === 'play') {
       const mounted = resources.get(key)
-      if (mounted) mounted.playStartedAt = performance.now()
+      if (mounted) {
+        const now = performance.now()
+        mounted.animations.restart()
+        mounted.interactionState.reset(mounted.document)
+        mounted.interactionState.takeDirty()
+        mounted.playGeneration = ++nextPlayGeneration
+        mounted.playClock.restart(now)
+        if (mounted.suspended || hidden || contextLost) mounted.playClock.suspend(now)
+      }
     } else if (operation.op === 'suspend' || operation.op === 'resume') {
       const mounted = resources.get(key)
       if (mounted) {
+        const now = performance.now()
+        const wasSuspended = mounted.suspended
         mounted.suspended = operation.op === 'suspend'
+        if (!wasSuspended && mounted.suspended) mounted.playClock.suspend(now)
+        if (wasSuspended && !mounted.suspended && !hidden && !contextLost) mounted.playClock.resume(now)
         mounted.projection[operation.op]()
         mounted.interactionVisuals?.[operation.op]()
       }
@@ -222,6 +251,8 @@ export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = win
       revision: mounted.document.revision + 1,
       objects,
     })
+    mounted.interactionState.setObjectPosition(objectId, position)
+    mounted.interactionState.takeDirty()
     return mounted.document.revision
   }
 
@@ -298,8 +329,11 @@ export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = win
     if (!hidden && !contextLost) {
       for (const mounted of resources.values()) {
         if (mounted.suspended) continue
-        const elapsed = at - (mounted.playStartedAt ?? at)
+        const elapsed = mounted.playClock.elapsed(at)
         mounted.animations.tick(elapsed)
+        if (mounted.interactionState.takeDirty()) {
+          notifyInteractionGeometry(mounted.key, mounted.playGeneration)
+        }
         mounted.interactionVisuals?.tick(at)
       }
       const renderStartedAt = trackPerformance ? performance.now() : 0
@@ -340,9 +374,23 @@ export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = win
     frame = hostWindow.requestAnimationFrame(render)
   }
 
-  const onVisibility = () => { hidden = document.hidden }
+  const suspendPlaybackClocks = (at = performance.now()) => {
+    for (const mounted of resources.values()) mounted.playClock.suspend(at)
+  }
+  const resumePlaybackClocks = (at = performance.now()) => {
+    for (const mounted of resources.values()) {
+      if (!mounted.suspended) mounted.playClock.resume(at)
+    }
+  }
+  const onVisibility = () => {
+    const nextHidden = document.hidden
+    if (nextHidden && !hidden) suspendPlaybackClocks()
+    if (!nextHidden && hidden && !contextLost) resumePlaybackClocks()
+    hidden = nextHidden
+  }
   const onContextLost = (event) => {
     event.preventDefault()
+    if (!contextLost) suspendPlaybackClocks()
     contextLost = true
     gpuTimer?.dispose()
     gpuTimer = null
@@ -350,6 +398,7 @@ export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = win
   }
   const onContextRestored = () => {
     contextLost = false
+    if (!hidden) resumePlaybackClocks()
     resize()
     devtoolsProbe?.recordEvent({ kind: 'context.restored' })
   }
@@ -369,6 +418,14 @@ export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = win
       return mounted ? Object.freeze({ document: mounted.document, suspended: mounted.suspended }) : null
     },
     document(key) { return resources.get(key)?.document ?? null },
+    animationGeneration(key) { return resources.get(key)?.playGeneration ?? null },
+    hasInteractionAnimation(key) {
+      return resources.get(key)?.interactionState.hasSpatialAnimation() === true
+    },
+    interactionDocument(key) { return resources.get(key)?.interactionState.document() ?? null },
+    nextAnimationGeneration(key) {
+      return resources.has(key) ? nextPlayGeneration + 1 : null
+    },
     devtoolsSnapshot() {
       const mountedResources = []
       const nodes = []
@@ -431,6 +488,10 @@ export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = win
       lastRenderAt = null
       return true
     },
+    setInteractionGeometryObserver(observer) {
+      interactionGeometryObserver = typeof observer === 'function' ? observer : null
+      return true
+    },
     updateSegment,
     snapshot() {
       return {
@@ -456,6 +517,7 @@ export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = win
       for (const key of [...resources.keys()]) release(key)
       gpuTimer?.dispose()
       gpuTimer = null
+      interactionGeometryObserver = null
       renderer.dispose()
       renderer.forceContextLoss()
       return true

--- a/packages/toolkit/components/desktop-world-stage/scene-playback-clock.js
+++ b/packages/toolkit/components/desktop-world-stage/scene-playback-clock.js
@@ -1,0 +1,39 @@
+function validTime(value) {
+  return Number.isFinite(value) ? value : null
+}
+
+export function createScenePlaybackClock() {
+  let startedAt = null
+  let pausedAt = null
+
+  return Object.freeze({
+    elapsed(at) {
+      const now = validTime(at)
+      if (startedAt === null || now === null) return 0
+      return Math.max(0, (pausedAt ?? now) - startedAt)
+    },
+    restart(at) {
+      const now = validTime(at)
+      if (now === null) return false
+      startedAt = now
+      pausedAt = null
+      return true
+    },
+    suspend(at) {
+      const now = validTime(at)
+      if (startedAt === null || pausedAt !== null || now === null) return false
+      pausedAt = now
+      return true
+    },
+    resume(at) {
+      const now = validTime(at)
+      if (startedAt === null || pausedAt === null || now === null) return false
+      startedAt += Math.max(0, now - pausedAt)
+      pausedAt = null
+      return true
+    },
+    snapshot() {
+      return Object.freeze({ paused: pausedAt !== null, pausedAt, startedAt })
+    },
+  })
+}

--- a/packages/toolkit/scene/AGENTS.md
+++ b/packages/toolkit/scene/AGENTS.md
@@ -53,6 +53,16 @@ stage internals.
 - Signal and animation bindings carry finite numeric values only. Text, audio,
   prompts, product state vocabularies, and arbitrary timelines stay outside
   this contract.
+- A DesktopWorld `play` with one-shot 2D-affordance transform bindings
+  (`position.x/y`, `rotation.z`, or `scale.x/y`) quiesces native affordances
+  before movement and atomically activates a fresh region generation at the
+  terminal pose. The terminal interaction projection stays separate from the
+  authored scene document and revision. Do not add per-frame native region
+  updates; moving affordances for loop or ping-pong playback need a future
+  atomic batch transport or a stable nonanimated collider ancestor.
+- Completed one-shot bindings stop applying until the next explicit play
+  generation. Operation suspension, page visibility, and context loss pause
+  elapsed animation time.
 - Generic implementation parameter validators fail before projection. The
   stock browser outlet uses the pinned local Three module and performs no
   runtime network fetch; the package facade remains dependency-injected.

--- a/packages/toolkit/scene/index.d.ts
+++ b/packages/toolkit/scene/index.d.ts
@@ -672,10 +672,12 @@ export interface SceneAnimationController {
   tick(elapsedMs: number): number;
   snapshot(): {
     bindings: Array<Pick<SceneAnimationBinding, 'id' | 'objectId' | 'componentId' | 'target' | 'playback'>>;
+    completed: number;
     disposed: boolean;
     failures: number;
     frames: number;
   };
+  restart(): boolean;
   dispose(): boolean;
 }
 
@@ -692,6 +694,11 @@ export function createSceneAnimationController(
       value: number,
       elapsedMs: number,
       progress: number,
+    ) => unknown;
+    onComplete?: (
+      binding: Readonly<SceneAnimationBinding>,
+      value: number,
+      elapsedMs: number,
     ) => unknown;
     maxBindings?: number;
   },

--- a/packages/toolkit/scene/scene-animation.js
+++ b/packages/toolkit/scene/scene-animation.js
@@ -122,16 +122,25 @@ export function createSceneAnimationController(documentInput, options = {}) {
   let disposed = false
   let frames = 0
   let failures = 0
+  const completedOnceBindings = new Set()
   return Object.freeze({
     tick(elapsedMs) {
       if (disposed || !Number.isFinite(elapsedMs) || elapsedMs < 0) return 0
       let applied = 0
       for (const binding of compiled.bindings) {
+        if (binding.playback === 'once' && completedOnceBindings.has(binding.id)) continue
         const progress = ease(binding.easing, playbackProgress(binding, elapsedMs))
         const value = binding.from + (binding.to - binding.from) * progress
         try {
-          options.apply(binding, value, elapsedMs, progress)
+          if (options.apply(binding, value, elapsedMs, progress) === false) {
+            failures += 1
+            continue
+          }
           applied += 1
+          if (binding.playback === 'once' && progress >= 1 && !completedOnceBindings.has(binding.id)) {
+            completedOnceBindings.add(binding.id)
+            options.onComplete?.(binding, value, elapsedMs)
+          }
         } catch {
           failures += 1
         }
@@ -149,9 +158,15 @@ export function createSceneAnimationController(documentInput, options = {}) {
           playback,
         })),
         disposed,
+        completed: completedOnceBindings.size,
         failures,
         frames,
       }
+    },
+    restart() {
+      if (disposed) return false
+      completedOnceBindings.clear()
+      return true
     },
     dispose() {
       if (disposed) return false

--- a/packages/toolkit/scene/scene-host.js
+++ b/packages/toolkit/scene/scene-host.js
@@ -361,7 +361,7 @@ function createSceneHost(options = {}, hooks = {}) {
           bindings: [], disposed: false, failures: 0, publications: 0,
         },
         animations: animationController?.snapshot() ?? {
-          bindings: [], disposed: false, failures: 0, frames: 0,
+          bindings: [], completed: 0, disposed: false, failures: 0, frames: 0,
         },
         lifecycle: projection?.lifecycle?.snapshot?.() ?? null,
       }

--- a/tests/README.md
+++ b/tests/README.md
@@ -176,18 +176,23 @@ Examples:
 - `./aos runtime status --json`
 - `./aos show create ...`
 
-## No `./aos` Rebuild Needed
+## Static Package Loops
 
-Stay in the local package or Node loop when the work does not depend on a fresh
-`./aos` binary.
+Stay in a focused local package or Node loop when work must not execute the repo
+binary. Choose the nearest family below or the proof-registry command returned
+by `node scripts/aos-dev-workflow.mjs recommend`.
 
 Examples:
 
 - `node --test tests/renderer/*.test.mjs`
-- `node --test tests/toolkit/*.test.mjs`
 - `node --test tests/bundled-whisper-stt.test.mjs`
 - `cd packages/gateway && npm test`
 - `cd packages/host && npm test`
+
+Do not treat `node --test tests/toolkit/*.test.mjs` as static proof. That broad
+glob includes Work Record public-CLI cases that execute the existing `./aos`
+artifact. It is therefore incompatible with static-only scene work and with
+ADR 0023's post-build or exit-`137` stop boundaries.
 
 ## DesktopWorld Scene Engine And DevTools
 

--- a/tests/schemas/dev-workflow-rules.test.mjs
+++ b/tests/schemas/dev-workflow-rules.test.mjs
@@ -196,6 +196,13 @@ test('canonical rules preserve the expected V0 routing contracts', async () => {
   assert.ok(rules.get('dev-gh-helper')?.patterns?.includes('tests/aos-dev-gh-contract.test.mjs'));
   assert.equal(rules.has('aos-agent-runner'), false);
   assert.equal(rules.get('toolkit-components')?.hot_swappable, true);
+  assert.deepEqual(rules.get('toolkit-components')?.verification, []);
+  assert.equal(
+    manifest.rules
+      .flatMap((rule) => [...(rule.commands ?? []), ...(rule.verification ?? [])])
+      .some((step) => step.command === 'node --test tests/toolkit/*.test.mjs'),
+    false,
+  );
   assert.equal(rules.get('schemas')?.commands?.[0]?.command, 'node --test tests/schemas/*.test.mjs');
   assert.deepEqual(
     rules.get('dev-workflow-manifest')?.commands?.map((step) => step.command),

--- a/tests/toolkit/desktop-world-scene-interaction-runtime.test.mjs
+++ b/tests/toolkit/desktop-world-scene-interaction-runtime.test.mjs
@@ -52,8 +52,13 @@ function harness({
   const calls = []
   const responses = []
   const events = []
+  const regionUpdates = []
+  let interactionDocument = document
+  let animationGeneration = 1
   const outlet = {
     document: () => document,
+    interactionDocument: () => interactionDocument,
+    animationGeneration: () => animationGeneration,
     applyInteractionResponse(_key, event) {
       responses.push(event)
       return applyResponse(event)
@@ -64,13 +69,26 @@ function harness({
     isPrimary: () => primary,
     topology: () => ({ displays: [{ displayId: 1, index: 0, bounds: [0, 0, 1000, 800] }] }),
     registerRegion: async (payload) => { calls.push(['register', payload.id]); await register(payload) },
-    updateRegion: async (payload) => { calls.push(['update', payload.id]); await update(payload) },
+    updateRegion: async (payload) => {
+      calls.push(['update', payload.id])
+      regionUpdates.push(structuredClone(payload))
+      await update(payload)
+    },
     removeRegion: async (id) => { calls.push(['remove', id]); await remove(id) },
     scheduleFrame(callback) { callback() },
     scheduleTimer,
     emitEvent(event) { events.push(event) },
   })
-  return { calls, events, outlet, responses, runtime }
+  return {
+    calls,
+    events,
+    outlet,
+    regionUpdates,
+    responses,
+    runtime,
+    setAnimationGeneration(value) { animationGeneration = value },
+    setInteractionDocument(value) { interactionDocument = value },
+  }
 }
 
 function routed(regionId, type, x, y, sequenceValue) {
@@ -240,6 +258,209 @@ test('translated hit-region refresh retries once without duplicating the gesture
     ['update', regionId],
     ['update', regionId],
   ])
+})
+
+test('completed spatial animation settles a fresh native-region generation at the terminal pose', async () => {
+  const fixture = harness()
+  const key = 'example.consumer::companion/main'
+  const oldRegionId = sceneAffordanceRegionId('example.consumer', 'companion/main', 'body-hit')
+  const moved = structuredClone(document)
+  moved.objects[1].transform.position = [500, 400, 0]
+  moved.objects[1].transform.scale = [2, 2, 2]
+  await fixture.runtime.mount({ key, owner: 'example.consumer', resource: 'companion/main', document, interactions })
+
+  assert.equal(await fixture.runtime.quiesceAnimation(key, 1), true)
+  fixture.setInteractionDocument(moved)
+  assert.equal(await fixture.runtime.settleAnimationGeometry(key, 1), true)
+
+  const terminalRegionId = fixture.runtime.snapshot(key).leases[0].regions[0]
+  assert.notEqual(terminalRegionId, oldRegionId)
+  assert.match(terminalRegionId, /:generation:r\d+$/u)
+  assert.deepEqual(fixture.regionUpdates.at(-1).frame, [420, 340, 160, 120])
+  assert.deepEqual(fixture.runtime.devtoolsSnapshot().hitRegions[0].frame, [420, 340, 160, 120])
+  fixture.runtime.handleInput(routed(terminalRegionId, 'left_mouse_down', 500, 400, 1))
+  fixture.runtime.handleInput(routed(terminalRegionId, 'left_mouse_dragged', 520, 420, 2))
+  assert.deepEqual(fixture.responses.map(({ frame }) => frame.phase), ['start', 'update'])
+})
+
+test('terminal animation regions remain staged together when one activation fails', async () => {
+  let releaseActivation
+  let markActivationStarted
+  let candidateUpdates = 0
+  const activationStarted = new Promise((resolve) => { markActivationStarted = resolve })
+  const activationGate = new Promise((resolve) => { releaseActivation = resolve })
+  const fixture = harness({
+    update: async (payload) => {
+      if (!payload.id.includes(':generation:') || payload.enabled !== true) return
+      candidateUpdates += 1
+      if (candidateUpdates === 1) {
+        markActivationStarted()
+        await activationGate
+      }
+      if (candidateUpdates === 2) throw new Error('fixture second activation failure')
+    },
+  })
+  const key = 'example.consumer::companion/main'
+  const twoObjectDocument = structuredClone(document)
+  twoObjectDocument.objects.push({
+    id: 'badge',
+    parentId: 'root',
+    kind: 'mesh',
+    transform: { position: [200, 260, 0], rotation: [0, 0, 0], scale: [1, 1, 1] },
+    visible: true,
+    geometryId: null,
+    materialId: null,
+    components: [],
+  })
+  const twoObjectInteractions = structuredClone(interactions)
+  twoObjectInteractions.affordances.push({
+    ...twoObjectInteractions.affordances[0],
+    id: 'badge-hit',
+    objectId: 'badge',
+  })
+  twoObjectInteractions.interactions.push({
+    ...twoObjectInteractions.interactions[0],
+    id: 'drag-badge',
+    affordanceId: 'badge-hit',
+  })
+  const moved = structuredClone(twoObjectDocument)
+  moved.objects[1].transform.position = [500, 400, 0]
+  moved.objects[2].transform.position = [620, 440, 0]
+  fixture.setInteractionDocument(twoObjectDocument)
+  await fixture.runtime.mount({
+    key,
+    owner: 'example.consumer',
+    resource: 'companion/main',
+    document: twoObjectDocument,
+    interactions: twoObjectInteractions,
+  })
+  await fixture.runtime.quiesceAnimation(key, 1)
+  fixture.setInteractionDocument(moved)
+  const settling = fixture.runtime.settleAnimationGeometry(key, 1)
+  await activationStarted
+  const candidateRegionId = fixture.runtime.snapshot(key).leases[0].regions[0]
+
+  fixture.runtime.handleInput(routed(candidateRegionId, 'left_mouse_down', 500, 400, 1))
+  assert.deepEqual(fixture.responses, [])
+  releaseActivation()
+
+  await assert.rejects(settling, /animated input-region settlement failed/u)
+  assert.equal(candidateUpdates, 2)
+  assert.deepEqual(fixture.runtime.snapshot(key).leases, [])
+  assert.deepEqual(fixture.responses, [])
+})
+
+test('terminal preparation failure releases the quiesced interaction lease', async () => {
+  const fixture = harness({
+    register: async (payload) => {
+      if (payload.id.includes(':generation:')) throw new Error('fixture candidate registration failure')
+    },
+  })
+  const key = 'example.consumer::companion/main'
+  const moved = structuredClone(document)
+  moved.objects[1].transform.position = [500, 400, 0]
+  await fixture.runtime.mount({ key, owner: 'example.consumer', resource: 'companion/main', document, interactions })
+  await fixture.runtime.quiesceAnimation(key, 1)
+  fixture.setInteractionDocument(moved)
+
+  await assert.rejects(
+    fixture.runtime.settleAnimationGeometry(key, 1),
+    /fixture candidate registration failure/u,
+  )
+
+  assert.deepEqual(fixture.runtime.snapshot(key).leases, [])
+  assert.deepEqual(fixture.runtime.devtoolsSnapshot().hitRegions, [])
+})
+
+test('retired-region cleanup blocks new animation generations without allocation growth', async () => {
+  let allowCleanup = false
+  const fixture = harness({
+    remove: async () => {
+      if (!allowCleanup) throw new Error('fixture cleanup failure')
+    },
+    scheduleTimer: () => ({ unref() {} }),
+  })
+  const key = 'example.consumer::companion/main'
+  await fixture.runtime.mount({ key, owner: 'example.consumer', resource: 'companion/main', document, interactions })
+
+  await assert.rejects(fixture.runtime.quiesceAnimation(key, 1), /cleanup failed/u)
+  await assert.rejects(fixture.runtime.quiesceAnimation(key, 2), /cleanup is still pending/u)
+  await assert.rejects(fixture.runtime.quiesceAnimation(key, 3), /cleanup is still pending/u)
+  assert.equal(fixture.calls.filter(([kind]) => kind === 'register').length, 1)
+  assert.equal(fixture.runtime.snapshot(key).leases[0].registered, 0)
+  assert.equal(fixture.runtime.snapshot(key).leases[0].animationQuiesced, true)
+
+  allowCleanup = true
+  fixture.setAnimationGeneration(4)
+  const moved = structuredClone(document)
+  moved.objects[1].transform.position = [500, 400, 0]
+  fixture.setInteractionDocument(moved)
+  assert.equal(await fixture.runtime.quiesceAnimation(key, 4), true)
+  assert.equal(await fixture.runtime.settleAnimationGeometry(key, 4), true)
+  assert.equal(fixture.calls.filter(([kind]) => kind === 'register').length, 2)
+  assert.equal(fixture.runtime.snapshot(key).leases[0].registered, 1)
+})
+
+test('stale animation generations cannot settle input regions for a newer play', async () => {
+  const fixture = harness()
+  const key = 'example.consumer::companion/main'
+  const moved = structuredClone(document)
+  moved.objects[1].transform.position = [500, 400, 0]
+  await fixture.runtime.mount({ key, owner: 'example.consumer', resource: 'companion/main', document, interactions })
+  await fixture.runtime.quiesceAnimation(key, 1)
+  fixture.setInteractionDocument(moved)
+  fixture.setAnimationGeneration(2)
+
+  assert.equal(await fixture.runtime.settleAnimationGeometry(key, 1), false)
+  assert.equal(fixture.runtime.snapshot(key).leases[0].registered, 0)
+  assert.equal(fixture.runtime.snapshot(key).leases[0].animationReady, false)
+
+  await fixture.runtime.quiesceAnimation(key, 2)
+  assert.equal(await fixture.runtime.settleAnimationGeometry(key, 2), true)
+  assert.deepEqual(fixture.runtime.devtoolsSnapshot().hitRegions[0].frame, [460, 370, 80, 60])
+})
+
+test('terminal animation geometry settles after a suspended resource resumes', async () => {
+  const fixture = harness()
+  const key = 'example.consumer::companion/main'
+  const moved = structuredClone(document)
+  moved.objects[1].transform.position = [500, 400, 0]
+  await fixture.runtime.mount({ key, owner: 'example.consumer', resource: 'companion/main', document, interactions })
+  await fixture.runtime.quiesceAnimation(key, 1)
+  fixture.setInteractionDocument(moved)
+  await fixture.runtime.suspend(key)
+
+  assert.equal(await fixture.runtime.settleAnimationGeometry(key, 1), false)
+  assert.equal(fixture.runtime.snapshot(key).leases[0].animationReady, true)
+  assert.equal(fixture.runtime.snapshot(key).leases[0].registered, 0)
+
+  assert.equal(await fixture.runtime.resume(key), true)
+  assert.equal(fixture.runtime.snapshot(key).leases[0].suspended, false)
+  assert.equal(fixture.runtime.snapshot(key).leases[0].animationQuiesced, false)
+  assert.deepEqual(fixture.runtime.devtoolsSnapshot().hitRegions[0].frame, [460, 370, 80, 60])
+})
+
+test('repeated animation settlement retains exactly one interaction generation', async () => {
+  const fixture = harness()
+  const key = 'example.consumer::companion/main'
+  await fixture.runtime.mount({ key, owner: 'example.consumer', resource: 'companion/main', document, interactions })
+
+  for (let generation = 1; generation <= 100; generation += 1) {
+    const moved = structuredClone(document)
+    moved.objects[1].transform.position = [100 + generation, 200 + generation, 0]
+    fixture.setAnimationGeneration(generation)
+    fixture.setInteractionDocument(moved)
+    assert.equal(await fixture.runtime.quiesceAnimation(key, generation), true)
+    assert.equal(await fixture.runtime.settleAnimationGeometry(key, generation), true)
+  }
+
+  const snapshot = fixture.runtime.snapshot(key)
+  assert.equal(snapshot.leases.length, 1)
+  assert.equal(snapshot.leases[0].registered, 1)
+  assert.equal(snapshot.leases[0].animationQuiesced, false)
+  assert.equal(fixture.runtime.devtoolsSnapshot().hitRegions.length, 1)
+  assert.equal(fixture.calls.filter(([kind]) => kind === 'register').length, 101)
+  assert.equal(fixture.calls.filter(([kind]) => kind === 'remove').length, 100)
 })
 
 test('accepted aim-and-commit release refreshes the destination hit region', async () => {

--- a/tests/toolkit/desktop-world-scene-operation-coordinator.test.mjs
+++ b/tests/toolkit/desktop-world-scene-operation-coordinator.test.mjs
@@ -69,8 +69,10 @@ function harness({
   deferAffordance = null,
   deferRegistrationNumber = null,
   failAffordance = null,
+  rejectPlay = false,
   remove = async () => {},
   scheduleTimer = undefined,
+  spatialAnimation = false,
 } = {}) {
   const resources = new Map()
   const regions = new Map()
@@ -90,8 +92,18 @@ function harness({
     apply(message) {
       const key = message.payload.lease_key
       const op = message.payload.operation?.op ?? 'release'
+      calls.push(['outlet', op])
       if (op === 'release' || op === 'remove' || op === 'close') resources.delete(key)
-      else if (op === 'mount') resources.set(key, { document: message.payload.operation.document, suspended: false })
+      else if (op === 'mount') resources.set(key, {
+        document: message.payload.operation.document,
+        playGeneration: 0,
+        suspended: false,
+      })
+      else if (op === 'play') {
+        if (rejectPlay) throw new Error('fixture play failure')
+        const mounted = resources.get(key)
+        if (mounted) mounted.playGeneration += 1
+      }
       else if (op === 'suspend' || op === 'resume') resources.get(key).suspended = op === 'suspend'
       return true
     },
@@ -101,6 +113,13 @@ function harness({
     },
     configuration(key) { return resources.get(key) ?? null },
     document(key) { return resources.get(key)?.document ?? null },
+    animationGeneration(key) { return resources.get(key)?.playGeneration ?? null },
+    hasInteractionAnimation() { return spatialAnimation },
+    interactionDocument(key) { return resources.get(key)?.document ?? null },
+    nextAnimationGeneration(key) {
+      const mounted = resources.get(key)
+      return mounted ? mounted.playGeneration + 1 : null
+    },
     prepareReplacement(message) {
       const key = message.payload.lease_key
       const previous = resources.get(key) ?? null
@@ -115,7 +134,11 @@ function harness({
         },
         commit() {
           this.assertCurrent()
-          resources.set(key, { document, suspended: false })
+          resources.set(key, {
+            document,
+            playGeneration: previous?.playGeneration ?? 0,
+            suspended: false,
+          })
           pending = false
           return true
         },
@@ -221,6 +244,59 @@ function mount(key, document, interactions) {
     },
   }
 }
+
+function play(key) {
+  return {
+    type: 'desktop_world_stage.scene.operation',
+    payload: {
+      lease_key: key,
+      operation: { op: 'play', animationId: 'entrance' },
+    },
+  }
+}
+
+test('spatial play quiesces native input before visual animation starts', async () => {
+  const key = 'example.consumer::companion/main'
+  const fixture = harness({ spatialAnimation: true })
+  await fixture.coordinator.apply(mount(key, scene('animated-scene', 'body'), interaction('body')))
+  const regionId = regionIdFor(fixture.regions, 'body-hit')
+
+  assert.deepEqual(await fixture.coordinator.apply(play(key)), { applied: true, op: 'play' })
+
+  const removalIndex = fixture.calls.findIndex(([kind, id]) => kind === 'remove' && id === regionId)
+  const playIndex = fixture.calls.findIndex(([kind, op]) => kind === 'outlet' && op === 'play')
+  assert.ok(removalIndex >= 0 && removalIndex < playIndex)
+  assert.equal(fixture.regions.has(regionId), false)
+  assert.equal(fixture.interactions.snapshot(key).leases[0].animationGeneration, 1)
+  assert.equal(fixture.interactions.snapshot(key).leases[0].animationQuiesced, true)
+})
+
+test('nonspatial play leaves native input active', async () => {
+  const key = 'example.consumer::companion/main'
+  const fixture = harness()
+  await fixture.coordinator.apply(mount(key, scene('material-scene', 'body'), interaction('body')))
+  const regionId = regionIdFor(fixture.regions, 'body-hit')
+
+  assert.deepEqual(await fixture.coordinator.apply(play(key)), { applied: true, op: 'play' })
+
+  assert.equal(fixture.calls.some(([kind, id]) => kind === 'remove' && id === regionId), false)
+  assert.equal(fixture.regions.has(regionId), true)
+  assert.equal(fixture.interactions.handleInput(pointerDown(regionId)), true)
+})
+
+test('failed spatial play restores the authored native input region', async () => {
+  const key = 'example.consumer::companion/main'
+  const fixture = harness({ rejectPlay: true, spatialAnimation: true })
+  await fixture.coordinator.apply(mount(key, scene('animated-scene', 'body'), interaction('body')))
+  const regionId = regionIdFor(fixture.regions, 'body-hit')
+
+  await assert.rejects(fixture.coordinator.apply(play(key)), /fixture play failure/u)
+
+  assert.equal(fixture.regions.has(regionId), true)
+  assert.equal(fixture.interactions.snapshot(key).leases[0].animationGeneration, null)
+  assert.equal(fixture.interactions.snapshot(key).leases[0].animationQuiesced, false)
+  assert.equal(fixture.interactions.handleInput(pointerDown(regionId)), true)
+})
 
 test('failed interaction registration restores the prior scene document and regions', async () => {
   const key = 'example.consumer::companion/main'

--- a/tests/toolkit/desktop-world-scene-outlet.test.mjs
+++ b/tests/toolkit/desktop-world-scene-outlet.test.mjs
@@ -2,10 +2,131 @@ import assert from 'node:assert/strict'
 import { readFile, stat } from 'node:fs/promises'
 import test from 'node:test'
 
+import { createSceneAnimationInteractionState } from '../../packages/toolkit/components/desktop-world-stage/scene-animation-interaction-state.js'
+import { createScenePlaybackClock } from '../../packages/toolkit/components/desktop-world-stage/scene-playback-clock.js'
+import { compileSceneAnimationBindings, resolveSceneAffordanceFrame } from '../../packages/toolkit/scene/index.js'
+
 const outletURL = new URL('../../packages/toolkit/components/desktop-world-stage/scene-outlet.js', import.meta.url)
 const stageURL = new URL('../../packages/toolkit/components/desktop-world-stage/index.js', import.meta.url)
 const threeURL = new URL('../../packages/toolkit/vendor/three/three.module.min.js', import.meta.url)
 const threeCoreURL = new URL('../../packages/toolkit/vendor/three/three.core.min.js', import.meta.url)
+
+function interactionScene() {
+  const animation = (id, target, from, to) => ({
+    id,
+    implementation: 'aos.scene.animation.bind',
+    parameters: { delayMs: 0, durationMs: 400, easing: 'linear', from, playback: 'once', target, to },
+    enabled: true,
+  })
+  return {
+    contract: 'aos.scene.document.v1',
+    schemaVersion: 1,
+    id: 'companion/main',
+    revision: 1,
+    rootObjectId: 'root',
+    objects: [{
+      id: 'root',
+      parentId: null,
+      kind: 'group',
+      transform: { position: [20, 30, 0], rotation: [0, 0, 0], scale: [0.1, 0.1, 0.1] },
+      visible: true,
+      geometryId: null,
+      materialId: null,
+      components: [
+        animation('animation/position-x', 'position.x', 20, 300),
+        animation('animation/position-y', 'position.y', 30, 240),
+        animation('animation/scale-x', 'scale.x', 0.1, 1),
+        animation('animation/scale-y', 'scale.y', 0.1, 1),
+      ],
+    }],
+    resources: [],
+    metadata: {},
+  }
+}
+
+test('completed spatial animations update one coalesced interaction document without rewriting source', () => {
+  const source = interactionScene()
+  const state = createSceneAnimationInteractionState(source)
+  const bindings = new Map(compileSceneAnimationBindings(source).bindings.map((binding) => [binding.target, binding]))
+
+  assert.equal(state.complete({ objectId: 'root', target: 'material.opacity' }, 0.5), false)
+  assert.equal(state.complete(bindings.get('position.x'), 300), true)
+  assert.equal(state.complete(bindings.get('position.y'), 240), true)
+  assert.equal(state.complete(bindings.get('scale.x'), 1), true)
+  assert.equal(state.complete(bindings.get('scale.y'), 1), true)
+  assert.equal(state.takeDirty(), true)
+  assert.equal(state.takeDirty(), false)
+  assert.deepEqual(source.objects[0].transform.position, [20, 30, 0])
+  assert.deepEqual(resolveSceneAffordanceFrame(state.document(), {
+    objectId: 'root',
+    geometry: { kind: 'rect', width: 80, height: 60, offset: [0, 0] },
+  }), [260, 210, 80, 60])
+
+  assert.equal(state.setObjectPosition('root', [500, 400, 0]), true)
+  assert.deepEqual(state.document().objects[0].transform.scale, [1, 1, 0.1])
+  assert.deepEqual(state.document().objects[0].transform.position, [500, 400, 0])
+  state.reset(source)
+  assert.equal(state.takeDirty(), false)
+  assert.deepEqual(state.document().objects[0].transform.position, [20, 30, 0])
+})
+
+test('3D-only and continuous animation bindings do not claim native hit-geometry settlement', () => {
+  const source = interactionScene()
+  source.objects[0].components = [
+    {
+      id: 'animation/depth',
+      implementation: 'aos.scene.animation.bind',
+      parameters: {
+        delayMs: 0,
+        durationMs: 400,
+        easing: 'linear',
+        from: 0,
+        playback: 'once',
+        target: 'position.z',
+        to: 100,
+      },
+      enabled: true,
+    },
+    {
+      id: 'animation/orbit',
+      implementation: 'aos.scene.animation.bind',
+      parameters: {
+        delayMs: 0,
+        durationMs: 400,
+        easing: 'linear',
+        from: 0,
+        playback: 'loop',
+        target: 'rotation.z',
+        to: Math.PI * 2,
+      },
+      enabled: true,
+    },
+  ]
+  const state = createSceneAnimationInteractionState(source)
+  const depth = compileSceneAnimationBindings(source).bindings.find((binding) => binding.target === 'position.z')
+
+  assert.equal(state.hasSpatialAnimation(), false)
+  assert.equal(state.complete(depth, 100), false)
+  assert.equal(state.takeDirty(), false)
+})
+
+test('scene playback clock excludes operation, visibility, and context suspension time', () => {
+  const clock = createScenePlaybackClock()
+
+  assert.equal(clock.elapsed(100), 0)
+  assert.equal(clock.restart(100), true)
+  assert.equal(clock.elapsed(250), 150)
+  assert.equal(clock.suspend(250), true)
+  assert.equal(clock.elapsed(1_000), 150)
+  assert.equal(clock.resume(1_000), true)
+  assert.equal(clock.elapsed(1_100), 250)
+  assert.deepEqual(clock.snapshot(), { paused: false, pausedAt: null, startedAt: 850 })
+
+  assert.equal(clock.restart(2_000), true)
+  assert.equal(clock.suspend(2_000), true)
+  assert.equal(clock.resume(5_000), true)
+  assert.equal(clock.elapsed(5_100), 100)
+})
 
 test('DesktopWorld scene outlet is local, bounded, and shares one renderer loop', async () => {
   const [outlet, stage, three, threeCore] = await Promise.all([
@@ -25,6 +146,12 @@ test('DesktopWorld scene outlet is local, bounded, and shares one renderer loop'
   assert.match(outlet, /createSceneAnimationController\(document/u)
   assert.match(outlet, /createSceneSignalController\(document/u)
   assert.match(outlet, /mounted\.animations\.tick\(elapsed\)/u)
+  assert.match(outlet, /mounted\.playClock\.elapsed\(at\)/u)
+  assert.doesNotMatch(outlet, /playStartedAt/u)
+  assert.match(outlet, /onComplete: \(binding, value\) => interactionState\.complete\(binding, value\)/u)
+  assert.match(outlet, /notifyInteractionGeometry\(mounted\.key, mounted\.playGeneration\)/u)
+  assert.match(outlet, /mounted\.playGeneration = \+\+nextPlayGeneration/u)
+  assert.match(outlet, /resources\.has\(key\) \? nextPlayGeneration \+ 1 : null/u)
   assert.match(outlet, /mounted\.interactionVisuals\?\.tick\(at\)/u)
   assert.match(outlet, /createDesktopWorldSceneInteractionThree/u)
   assert.match(outlet, /ensureInteractionVisuals/u)
@@ -53,6 +180,8 @@ test('DesktopWorld scene outlet is local, bounded, and shares one renderer loop'
   assert.match(stage, /if \(surface\.isPrimary\)/u)
   assert.equal((stage.match(/emit\('desktop_world_stage\.scene\.result'/gu) ?? []).length, 2)
   assert.match(stage, /sceneOutlet\.updateSegment\(segment\)/u)
+  assert.match(stage, /enqueueSceneWork\(async \(\) => \{[\s\S]*settleAnimationGeometry\(key, generation\)/u)
+  assert.doesNotMatch(stage, /animationGeometryChanged/u)
   assert.match(stage, /\.then\(\(\) => \{[\s\S]*emitReady\(\)/u)
   assert.doesNotMatch(stage, /\ninstallVisualObjectLiveProof\(\)\nemitReady\(\)\s*$/u)
   assert.ok(three.size > 100_000 && three.size < 1_000_000)

--- a/tests/toolkit/scene-document.test.mjs
+++ b/tests/toolkit/scene-document.test.mjs
@@ -312,6 +312,80 @@ test('scene animation bindings use an explicit deterministic elapsed clock', () 
   assert.equal(compileSceneAnimationBindings(document).ok, false)
 })
 
+test('one-shot animation bindings complete once and restart explicitly', () => {
+  const document = sceneDocument()
+  document.objects[1].components.push({
+    id: 'animation/entrance',
+    implementation: SCENE_ANIMATION_BINDING_IMPLEMENTATION_ID,
+    parameters: {
+      target: 'position.x',
+      from: 10,
+      to: 90,
+      durationMs: 400,
+      delayMs: 0,
+      playback: 'once',
+      easing: 'linear',
+    },
+    enabled: true,
+  })
+  const values = []
+  const completed = []
+  let renderedValue = null
+  const controller = createSceneAnimationController(document, {
+    apply: (_binding, value) => {
+      values.push(value)
+      renderedValue = value
+    },
+    onComplete: (binding, value, elapsedMs) => completed.push([binding.id, value, elapsedMs]),
+  })
+
+  assert.equal(controller.tick(200), 1)
+  assert.equal(controller.tick(400), 1)
+  renderedValue = 160
+  assert.equal(controller.tick(800), 0)
+  assert.equal(renderedValue, 160)
+  assert.deepEqual(values, [50, 90])
+  assert.deepEqual(completed, [['body/alpha/animation/entrance', 90, 400]])
+  assert.equal(controller.snapshot().completed, 1)
+
+  assert.equal(controller.restart(), true)
+  assert.equal(controller.snapshot().completed, 0)
+  assert.equal(controller.tick(400), 1)
+  assert.equal(completed.length, 2)
+})
+
+test('one-shot completion callback failures are counted without repeating the callback', () => {
+  const document = sceneDocument()
+  document.objects[1].components.push({
+    id: 'animation/entrance',
+    implementation: SCENE_ANIMATION_BINDING_IMPLEMENTATION_ID,
+    parameters: {
+      target: 'position.x',
+      from: 10,
+      to: 90,
+      durationMs: 400,
+      delayMs: 0,
+      playback: 'once',
+      easing: 'linear',
+    },
+    enabled: true,
+  })
+  let completions = 0
+  const controller = createSceneAnimationController(document, {
+    apply: () => true,
+    onComplete: () => {
+      completions += 1
+      throw new Error('fixture completion failure')
+    },
+  })
+
+  assert.equal(controller.tick(400), 1)
+  assert.equal(controller.tick(800), 0)
+  assert.equal(completions, 1)
+  assert.equal(controller.snapshot().completed, 1)
+  assert.equal(controller.snapshot().failures, 1)
+})
+
 test('scene leases preserve stage, owner, resource, and scope identity', () => {
   assert.deepEqual(createSceneLease({
     stageId: 'desktop-world/main',


### PR DESCRIPTION
## Summary

- settle native DesktopWorld affordance geometry after successful one-shot spatial animation without rewriting the authored scene document or revision
- pause animation elapsed time across operation suspension, document visibility, and WebGL context loss, and stop completed one-shots from overwriting later interaction changes
- fail closed on candidate preparation/activation failure, gate new generations behind per-resource retired cleanup, and isolate the lifecycle in a focused transition aggregate
- remove the unsafe broad toolkit glob from static workflow routing because Work Record tests in that glob execute the repo `./aos` binary

## Local validation

- scene interaction and operation contract: 46/46
- scene facade, host, renderer lifecycle, and API docs: 38/38
- focused corrected lifecycle set: 50/50
- workflow/proof schemas: 30/30
- `AOS_SKIP_LIVE_CLI_CHECKS=1 bash tests/dev-workflow-router.sh`: passed
- `bash tests/dev-drift-lint.sh`: passed
- workflow recommendation and proof-worth routing: passed; no broad toolkit verification remains
- changed JavaScript syntax, `git diff --check`, and changed-file line review: passed; largest changed source is 878 lines

The original broad `node --test tests/toolkit/*.test.mjs` attempt was stopped as invalid evidence after its Work Record cases invoked the repo AOS binary. Twenty-four public-CLI cases failed with killed child status; the active workflow rule and test guidance now prevent that static/runtime category error.

No AOS rebuild, daemon/runtime operation, TCC action, signing change, or native acceptance was performed. Native proof remains the dependent Sigil lane after review, merge, and pin update.
