### PR TITLE
Target declared DesktopWorld scene objects directly

### DIFF
--- a/packages/toolkit/scene/scene-generic-three.js
+++ b/packages/toolkit/scene/scene-generic-three.js
@@ -127,9 +127,9 @@ function applyTransform(object, transform = {}) {
   object.visible = transform.visible !== false
 }
 
-function setTarget(root, objectId, target, value) {
+function setTarget(objects, objectId, target, value) {
   const path = String(target).split('.')
-  const object = root.getObjectByName?.(objectId)
+  const object = objects.get(objectId)
   if (!object || path.length === 0) return false
   let cursor = object
   for (let index = 0; index < path.length - 1; index += 1) {
@@ -189,8 +189,8 @@ export function createGenericThreeSceneProjection({ THREE, document }) {
       )
       return true
     },
-    applyAnimation(binding, value) { return setTarget(root, binding.objectId, binding.target, value) },
-    applySignal(binding, value) { return setTarget(root, binding.objectId, binding.target, value) },
+    applyAnimation(binding, value) { return setTarget(objects, binding.objectId, binding.target, value) },
+    applySignal(binding, value) { return setTarget(objects, binding.objectId, binding.target, value) },
     suspend() { root.visible = false },
     resume() { root.visible = true },
     dispose() {

--- a/tests/toolkit/scene-generic-three.test.mjs
+++ b/tests/toolkit/scene-generic-three.test.mjs
@@ -80,3 +80,20 @@ test('generic Three projection builds and disposes a bounded object tree', () =>
   assert.equal(mesh.geometry.disposed, true)
   assert.equal(mesh.material.disposed, true)
 })
+
+test('animation and signals target the declared object when its id matches the scene document id', () => {
+  const input = document()
+  input.id = 'main'
+  const projection = createGenericThreeSceneProjection({ THREE, document: input })
+  const wrapper = projection.object
+  const mesh = wrapper.children[0]
+
+  assert.equal(projection.applyAnimation({ objectId: 'main', target: 'position.x' }, 42), true)
+  assert.equal(projection.applySignal({ objectId: 'main', target: 'scale.x' }, 1.5), true)
+  assert.equal(wrapper.position.x, 0)
+  assert.equal(wrapper.scale.x, 0)
+  assert.equal(mesh.position.x, 42)
+  assert.equal(mesh.scale.x, 1.5)
+
+  projection.dispose()
+})


### PR DESCRIPTION
## Summary

- resolve animation and signal bindings through the declared scene-object map
- prevent document/root ID collisions from animating the projection wrapper
- add a regression for matching scene and root object IDs

## Evidence

- Focused scene and interaction suites: 57/57
- Public scene contract route: 39/39
- Real WebGL repro before: root remained at [1287,17], drawCalls=0
- Real WebGL repro after: root reached [1287,181], drawCalls=3
- git diff --check passed

No AOS binary build, daemon operation, TCC action, or native execution was performed.