### PR TITLE
Use the DesktopWorld render clock for interaction routes

### DIFF
--- a/packages/toolkit/components/desktop-world-stage/scene-outlet.js
+++ b/packages/toolkit/components/desktop-world-stage/scene-outlet.js
@@ -375,11 +375,17 @@ export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = win
   }
 
   const suspendPlaybackClocks = (at = performance.now()) => {
-    for (const mounted of resources.values()) mounted.playClock.suspend(at)
+    for (const mounted of resources.values()) {
+      mounted.playClock.suspend(at)
+      mounted.interactionVisuals?.suspend(at)
+    }
   }
   const resumePlaybackClocks = (at = performance.now()) => {
     for (const mounted of resources.values()) {
-      if (!mounted.suspended) mounted.playClock.resume(at)
+      if (!mounted.suspended) {
+        mounted.playClock.resume(at)
+        mounted.interactionVisuals?.resume(at)
+      }
     }
   }
   const onVisibility = () => {

--- a/packages/toolkit/components/desktop-world-stage/scene-outlet.js
+++ b/packages/toolkit/components/desktop-world-stage/scene-outlet.js
@@ -17,6 +17,10 @@ import { createScenePlaybackClock } from './scene-playback-clock.js'
 const MAX_RESOURCES = 32
 const MAX_SIGNALS_PER_SECOND = 30
 
+export function sceneResourceCanRun(resourceSuspended, stageHidden, contextLost) {
+  return !resourceSuspended && !stageHidden && !contextLost
+}
+
 export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = window } = {}) {
   if (!canvas) throw new TypeError('DesktopWorld scene outlet requires a canvas.')
   const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true, canvas, powerPreference: 'low-power' })
@@ -215,7 +219,9 @@ export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = win
         mounted.interactionState.takeDirty()
         mounted.playGeneration = ++nextPlayGeneration
         mounted.playClock.restart(now)
-        if (mounted.suspended || hidden || contextLost) mounted.playClock.suspend(now)
+        if (!sceneResourceCanRun(mounted.suspended, hidden, contextLost)) {
+          mounted.playClock.suspend(now)
+        }
       }
     } else if (operation.op === 'suspend' || operation.op === 'resume') {
       const mounted = resources.get(key)
@@ -224,9 +230,16 @@ export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = win
         const wasSuspended = mounted.suspended
         mounted.suspended = operation.op === 'suspend'
         if (!wasSuspended && mounted.suspended) mounted.playClock.suspend(now)
-        if (wasSuspended && !mounted.suspended && !hidden && !contextLost) mounted.playClock.resume(now)
+        if (wasSuspended && sceneResourceCanRun(mounted.suspended, hidden, contextLost)) {
+          mounted.playClock.resume(now)
+        }
         mounted.projection[operation.op]()
-        mounted.interactionVisuals?.[operation.op]()
+        if (
+          operation.op === 'suspend'
+          || sceneResourceCanRun(mounted.suspended, hidden, contextLost)
+        ) {
+          mounted.interactionVisuals?.[operation.op](now)
+        }
       }
     } else if (operation.op === 'remove' || operation.op === 'close') {
       release(key)
@@ -382,7 +395,7 @@ export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = win
   }
   const resumePlaybackClocks = (at = performance.now()) => {
     for (const mounted of resources.values()) {
-      if (!mounted.suspended) {
+      if (sceneResourceCanRun(mounted.suspended, hidden, contextLost)) {
         mounted.playClock.resume(at)
         mounted.interactionVisuals?.resume(at)
       }

--- a/packages/toolkit/scene/scene-interaction-visual.js
+++ b/packages/toolkit/scene/scene-interaction-visual.js
@@ -348,6 +348,7 @@ export function createSceneInteractionVisualController({ now = () => performance
 
   function apply(event = {}) {
     if (disposed || suspended || !event.frame || !event.response) return REJECTED_VISUAL_RESULT
+    const at = now()
     const recognizer = event.interaction?.recognizer
     if (recognizer?.implementation === 'aos.scene.gesture.radial') {
       if (event.frame.phase === 'start' || !radialStyle) radialStyle = resolveSceneRadialVisualStyle(recognizer.parameters)
@@ -360,19 +361,19 @@ export function createSceneInteractionVisualController({ now = () => performance
         finishRoute()
       }
       updateArrow(event, style)
-      if (event.frame.phase === 'end') beginRoute(event, style, event.frame.timing?.t ?? now())
+      if (event.frame.phase === 'end') beginRoute(event, style, at)
       if (event.frame.phase === 'cancel' && model.route.active) finishRoute()
-      publish(event.frame.timing?.t)
+      publish(at)
       if (event.frame.phase === 'end' || event.frame.phase === 'cancel') aimStyle = null
       return event.frame.phase === 'end' ? STARTED_ROUTE_RESULT : ACCEPTED_VISUAL_RESULT
     }
     if (event.response.kind === 'radial_menu') {
       updatePersistentRadial(event)
-      publish(event.frame.timing?.t)
+      publish(at)
       return ACCEPTED_VISUAL_RESULT
     }
     if (recognizer?.implementation === 'aos.scene.gesture.radial') {
-      publish(event.frame.timing?.t)
+      publish(at)
       if (event.frame.phase === 'end' || event.frame.phase === 'cancel') radialStyle = null
       return ACCEPTED_VISUAL_RESULT
     }

--- a/tests/toolkit/desktop-world-scene-interaction-three.test.mjs
+++ b/tests/toolkit/desktop-world-scene-interaction-three.test.mjs
@@ -53,13 +53,16 @@ test('Three interaction adapter uses the stage clock and keeps aim preview stati
 
 test('route projection spans both axes and restores object scale at completion', () => {
   const { body, projection, scene } = harness()
-  const visuals = createDesktopWorldSceneInteractionThree({ THREE, scene, projection })
+  let renderAt = 100
+  const visuals = createDesktopWorldSceneInteractionThree({ THREE, scene, projection, now: () => renderAt })
   visuals.apply(aim('end', 100, [300, 400, 0], 'wormhole'))
-  visuals.tick(550)
+  renderAt = 550
+  visuals.tick(renderAt)
   assert.ok(body.position.x > 100 && body.position.x < 300)
   assert.ok(body.position.y > 200 && body.position.y < 400)
   assert.ok(body.scale.x < 1)
-  visuals.tick(1000)
+  renderAt = 1000
+  visuals.tick(renderAt)
   assert.deepEqual(body.position.toArray(), [300, 400, 0])
   assert.deepEqual(body.scale.toArray(), [1, 1, 1])
   assert.equal(visuals.snapshot().route.active, false)
@@ -69,25 +72,30 @@ test('nested objects animate in parent space while route visuals remain in world
   const { body, projection, scene } = harness()
   projection.object.position.set(100, 200, 0)
   body.position.set(10, 20, 0)
-  const visuals = createDesktopWorldSceneInteractionThree({ THREE, scene, projection })
+  let renderAt = 0
+  const visuals = createDesktopWorldSceneInteractionThree({ THREE, scene, projection, now: () => renderAt })
   const event = aim('end', 0, [200, 200, 0])
   event.response.origin = { x: 110, y: 220 }
   event.response.pointer = { x: 300, y: 400 }
   event.response.angle = Math.atan2(180, 190)
   event.response.distance = Math.hypot(190, 180)
   visuals.apply(event)
-  visuals.tick(110)
+  renderAt = 110
+  visuals.tick(renderAt)
   assert.deepEqual(body.position.toArray(), [105, 110, 0])
   assert.deepEqual(visuals.snapshot().route.position, [205, 310, 0])
-  visuals.tick(220)
+  renderAt = 220
+  visuals.tick(renderAt)
   assert.deepEqual(body.position.toArray(), [200, 200, 0])
 })
 
 test('canceling an active route restores the committed destination and object scale', () => {
   const { body, projection, scene } = harness()
-  const visuals = createDesktopWorldSceneInteractionThree({ THREE, scene, projection })
+  let renderAt = 0
+  const visuals = createDesktopWorldSceneInteractionThree({ THREE, scene, projection, now: () => renderAt })
   visuals.apply(aim('end', 0, [300, 400, 0], 'wormhole'))
-  visuals.tick(450)
+  renderAt = 450
+  visuals.tick(renderAt)
   assert.ok(body.scale.x < 1)
   assert.equal(visuals.cancel(), true)
   assert.deepEqual(body.position.toArray(), [300, 400, 0])
@@ -96,9 +104,11 @@ test('canceling an active route restores the committed destination and object sc
 
 test('a completed route cannot overwrite a later unrelated object move', () => {
   const { body, projection, scene } = harness()
-  const visuals = createDesktopWorldSceneInteractionThree({ THREE, scene, projection })
+  let renderAt = 0
+  const visuals = createDesktopWorldSceneInteractionThree({ THREE, scene, projection, now: () => renderAt })
   visuals.apply(aim('end', 0, [300, 400, 0]))
-  visuals.tick(220)
+  renderAt = 220
+  visuals.tick(renderAt)
   body.position.set(40, 50, 0)
   visuals.apply(aim('start', 300, [500, 500, 0]))
   assert.deepEqual(body.position.toArray(), [40, 50, 0])

--- a/tests/toolkit/desktop-world-scene-interaction-three.test.mjs
+++ b/tests/toolkit/desktop-world-scene-interaction-three.test.mjs
@@ -165,13 +165,23 @@ test('historical aim rendering uses the route vector for glow, dashes, head, and
 
 test('100 preview and route cycles do not allocate additional GPU resources', () => {
   const { projection, scene } = harness()
-  const visuals = createDesktopWorldSceneInteractionThree({ THREE, scene, projection })
+  let renderAt = 0
+  const visuals = createDesktopWorldSceneInteractionThree({
+    THREE,
+    scene,
+    projection,
+    now: () => renderAt,
+  })
   const allocations = visuals.snapshot().allocations
   for (let index = 0; index < 100; index += 1) {
+    renderAt = index * 300
     visuals.apply(aim('start', index * 300))
+    renderAt += 10
     visuals.apply(aim('update', index * 300 + 10, [200, 300, 0]))
+    renderAt += 10
     visuals.apply(aim('end', index * 300 + 20, [200, 300, 0]))
-    visuals.tick(index * 300 + 240)
+    renderAt = index * 300 + 240
+    visuals.tick(renderAt)
   }
   assert.deepEqual(visuals.snapshot().allocations, allocations)
   assert.equal(visuals.snapshot().route.active, false)
@@ -188,4 +198,27 @@ test('suspension hides the shared group and disposal is idempotent', () => {
   assert.equal(visuals.dispose(), true)
   assert.equal(scene.getObjectByName('aos.scene.interaction.visuals'), undefined)
   assert.equal(visuals.dispose(), false)
+})
+
+test('suspension excludes hidden time from an active route', () => {
+  const { projection, scene } = harness()
+  let renderAt = 0
+  const visuals = createDesktopWorldSceneInteractionThree({
+    THREE,
+    scene,
+    projection,
+    now: () => renderAt,
+  })
+  visuals.apply(aim('end', 0, [300, 400, 0]))
+  renderAt = 10
+  visuals.tick(renderAt)
+  const before = visuals.snapshot().route.progress
+
+  visuals.suspend(renderAt)
+  renderAt = 5_010
+  visuals.resume(renderAt)
+  visuals.tick(renderAt)
+
+  assert.equal(visuals.snapshot().route.progress, before)
+  assert.equal(visuals.snapshot().route.active, true)
 })

--- a/tests/toolkit/desktop-world-scene-outlet.test.mjs
+++ b/tests/toolkit/desktop-world-scene-outlet.test.mjs
@@ -153,6 +153,8 @@ test('DesktopWorld scene outlet is local, bounded, and shares one renderer loop'
   assert.match(outlet, /mounted\.playGeneration = \+\+nextPlayGeneration/u)
   assert.match(outlet, /resources\.has\(key\) \? nextPlayGeneration \+ 1 : null/u)
   assert.match(outlet, /mounted\.interactionVisuals\?\.tick\(at\)/u)
+  assert.match(outlet, /mounted\.interactionVisuals\?\.suspend\(at\)/u)
+  assert.match(outlet, /mounted\.interactionVisuals\?\.resume\(at\)/u)
   assert.match(outlet, /createDesktopWorldSceneInteractionThree/u)
   assert.match(outlet, /ensureInteractionVisuals/u)
   assert.match(outlet, /interactionVisuals: null/u)

--- a/tests/toolkit/desktop-world-scene-outlet.test.mjs
+++ b/tests/toolkit/desktop-world-scene-outlet.test.mjs
@@ -3,8 +3,15 @@ import { readFile, stat } from 'node:fs/promises'
 import test from 'node:test'
 
 import { createSceneAnimationInteractionState } from '../../packages/toolkit/components/desktop-world-stage/scene-animation-interaction-state.js'
+import {
+  sceneResourceCanRun,
+} from '../../packages/toolkit/components/desktop-world-stage/scene-outlet.js'
 import { createScenePlaybackClock } from '../../packages/toolkit/components/desktop-world-stage/scene-playback-clock.js'
-import { compileSceneAnimationBindings, resolveSceneAffordanceFrame } from '../../packages/toolkit/scene/index.js'
+import {
+  compileSceneAnimationBindings,
+  createSceneInteractionVisualController,
+  resolveSceneAffordanceFrame,
+} from '../../packages/toolkit/scene/index.js'
 
 const outletURL = new URL('../../packages/toolkit/components/desktop-world-stage/scene-outlet.js', import.meta.url)
 const stageURL = new URL('../../packages/toolkit/components/desktop-world-stage/index.js', import.meta.url)
@@ -128,6 +135,55 @@ test('scene playback clock excludes operation, visibility, and context suspensio
   assert.equal(clock.elapsed(5_100), 100)
 })
 
+test('resource resume cannot reactivate a route while the stage remains suspended', () => {
+  let at = 0
+  const visuals = createSceneInteractionVisualController({ now: () => at })
+  const event = {
+    frame: {
+      phase: 'end',
+      origin: { x: 100, y: 200 },
+      current: { x: 300, y: 200 },
+      timing: { t: 9_000_000 },
+    },
+    interaction: {
+      recognizer: { implementation: 'aos.scene.gesture.drag', parameters: { threshold: 4 } },
+      response: { implementation: 'aos.scene.response.aim-commit', parameters: { route: 'line' } },
+    },
+    response: {
+      kind: 'aim_commit',
+      objectId: 'body',
+      origin: { x: 100, y: 200 },
+      pointer: { x: 300, y: 200 },
+      position: [300, 200, 0],
+      angle: 0,
+      distance: 200,
+      route: 'line',
+    },
+  }
+  visuals.apply(event)
+  at = 10
+  visuals.tick(at)
+  const before = visuals.snapshot().route.progress
+
+  assert.equal(sceneResourceCanRun(true, false, false), false)
+  at = 20
+  visuals.tick(at)
+  const suspended = visuals.snapshot().route.progress
+  visuals.suspend(at)
+  assert.equal(sceneResourceCanRun(false, true, false), false)
+  at = 1_000
+  visuals.tick(at)
+  assert.ok(suspended > before)
+  assert.equal(visuals.snapshot().route.progress, suspended)
+
+  assert.equal(sceneResourceCanRun(false, false, false), true)
+  at = 5_010
+  visuals.resume(at)
+  visuals.tick(at)
+  assert.equal(visuals.snapshot().route.progress, suspended)
+  assert.equal(visuals.snapshot().route.active, true)
+})
+
 test('DesktopWorld scene outlet is local, bounded, and shares one renderer loop', async () => {
   const [outlet, stage, three, threeCore] = await Promise.all([
     readFile(outletURL, 'utf8'),
@@ -155,6 +211,7 @@ test('DesktopWorld scene outlet is local, bounded, and shares one renderer loop'
   assert.match(outlet, /mounted\.interactionVisuals\?\.tick\(at\)/u)
   assert.match(outlet, /mounted\.interactionVisuals\?\.suspend\(at\)/u)
   assert.match(outlet, /mounted\.interactionVisuals\?\.resume\(at\)/u)
+  assert.match(outlet, /sceneResourceCanRun\(mounted\.suspended, hidden, contextLost\)/u)
   assert.match(outlet, /createDesktopWorldSceneInteractionThree/u)
   assert.match(outlet, /ensureInteractionVisuals/u)
   assert.match(outlet, /interactionVisuals: null/u)

--- a/tests/toolkit/scene-interaction-visual.test.mjs
+++ b/tests/toolkit/scene-interaction-visual.test.mjs
@@ -154,45 +154,54 @@ test('gesture updates reuse resolved visual styles instead of allocating per fra
 
 test('fixed-clock line routes preserve horizontal, vertical, and diagonal vectors', () => {
   for (const destination of [[300, 200, 0], [100, 400, 0], [300, 400, 0]]) {
-    const controller = createSceneInteractionVisualController()
+    let renderAt = 100
+    const controller = createSceneInteractionVisualController({ now: () => renderAt })
     const pointer = { x: destination[0], y: destination[1] }
-    assert.equal(controller.apply(aimEvent('end', { at: 100, pointer, position: destination })).routeStarted, true)
-    controller.tick(210)
+    assert.equal(controller.apply(aimEvent('end', { at: 9_000_000, pointer, position: destination })).routeStarted, true)
+    renderAt = 210
+    controller.tick(renderAt)
     assert.deepEqual(controller.snapshot().route.position.map(Math.round), [
       Math.round((100 + destination[0]) / 2),
       Math.round((200 + destination[1]) / 2),
       0,
     ])
-    controller.tick(320)
+    renderAt = 320
+    controller.tick(renderAt)
     assert.equal(controller.snapshot().route.active, false)
     assert.deepEqual(controller.snapshot().route.position, destination)
   }
 })
 
 test('route visuals retain world coordinates separately from parent-local commits', () => {
-  const controller = createSceneInteractionVisualController()
+  let renderAt = 0
+  const controller = createSceneInteractionVisualController({ now: () => renderAt })
   controller.apply(aimEvent('end', {
     at: 0,
     origin: { x: 110, y: 220 },
     pointer: { x: 300, y: 400 },
     position: [200, 200, 0],
   }))
-  controller.tick(110)
+  renderAt = 110
+  controller.tick(renderAt)
   assert.deepEqual(controller.snapshot().route.position, [205, 310, 0])
 })
 
 test('wormhole route exposes bounded entry, travel, flash, and rebound phases', () => {
   let model
-  const controller = createSceneInteractionVisualController({ onFrame(value) { model = value } })
+  let renderAt = 0
+  const controller = createSceneInteractionVisualController({ now: () => renderAt, onFrame(value) { model = value } })
   controller.apply(aimEvent('end', { at: 0, route: 'wormhole' }))
-  controller.tick(198)
+  renderAt = 198
+  controller.tick(renderAt)
   assert.ok(model.route.scale <= 0.09)
   assert.ok(model.route.opacity <= 0.13)
   assert.ok(model.route.originRing > 0)
-  controller.tick(702)
+  renderAt = 702
+  controller.tick(renderAt)
   assert.ok(model.route.flash > 0)
   assert.ok(model.route.destinationRing > 0)
-  controller.tick(900)
+  renderAt = 900
+  controller.tick(renderAt)
   assert.equal(model.route.active, false)
   assert.equal(model.route.scale, 1)
   assert.deepEqual([...model.route.position], [300, 200, 0])
@@ -226,9 +235,11 @@ test('tap-open radial menus remain visible across pointer sessions and close aft
 test('radial style resolution caps descriptors and suspend pauses route time', () => {
   const style = resolveSceneRadialVisualStyle({ items: 99 })
   assert.equal(style.items.length, 32)
-  const controller = createSceneInteractionVisualController()
+  let renderAt = 0
+  const controller = createSceneInteractionVisualController({ now: () => renderAt })
   controller.apply(aimEvent('end', { at: 0 }))
-  controller.tick(50)
+  renderAt = 50
+  controller.tick(renderAt)
   const before = controller.snapshot().route.progress
   controller.suspend(50)
   assert.equal(controller.tick(1000), false)
@@ -239,4 +250,19 @@ test('radial style resolution caps descriptors and suspend pauses route time', (
   assert.ok(controller.snapshot().route.progress > before)
   assert.equal(controller.dispose(), true)
   assert.equal(controller.dispose(), false)
+})
+
+test('route progress uses the render clock rather than the unrelated gesture clock', () => {
+  let renderAt = 100
+  const controller = createSceneInteractionVisualController({ now: () => renderAt })
+  controller.apply(aimEvent('end', { at: 9_000_000 }))
+
+  renderAt = 210
+  controller.tick(renderAt)
+  assert.ok(controller.snapshot().route.progress > 0)
+
+  renderAt = 320
+  controller.tick(renderAt)
+  assert.equal(controller.snapshot().route.active, false)
+  assert.equal(controller.snapshot().route.progress, 1)
 })


### PR DESCRIPTION
## Summary

- start and publish interaction visuals on the injected DesktopWorld render clock
- keep gesture timestamps as event metadata instead of animation-clock authority
- add a regression with intentionally unrelated gesture and render clock origins
- make fixed-clock visual and Three adapter tests explicit

## Root cause

Native input timestamps use the daemon monotonic uptime clock while requestAnimationFrame uses the browser performance clock. Route startup used the former and frame advancement used the latter, leaving aim-and-commit progress pinned at zero in live DesktopWorld acceptance.

## Validation

- focused scene visual: 11/11
- Three interaction adapter: 9/9
- interaction runtime: 23/23
- complete static scene contract lane: 131/131
- git diff --check

No ./aos invocation, binary build, daemon operation, TCC action, or live native retry was performed.