### PR TITLE
Add bounded DesktopWorld visual primitives

### DIFF
--- a/docs/api/toolkit/scene.md
+++ b/docs/api/toolkit/scene.md
@@ -136,6 +136,35 @@ transaction never mutates the supplied document.
 stage, owner, resource, and ResourceScope IDs. The contract does not create a
 daemon lease or shared renderer by itself.
 
+### Stock Generic Three Implementations
+
+`createGenericSceneImplementationRegistry()` exposes bounded, product-neutral
+implementations for the daemon outlet and dependency-injected local hosts.
+Alongside primitive geometry and surface, line, and point materials, the stock
+registry includes:
+
+- `aos.scene.geometry.edges`, which derives clean feature edges from a declared
+  primitive and accepts a threshold angle from 0 through 180 degrees;
+- `aos.scene.geometry.segments`, which renders at most 64 explicit finite line
+  segments with coordinates clamped to the validated scene-space range; and
+- `aos.scene.effect.radial-aura`, which renders two local radial sprites and at
+  most 24 deterministic wobble elements with bounded colors, reach, intensity,
+  pulse, radius, scale, speed, amplitude, and opacity.
+
+The radial effect advances through the mounted scene projection's `tick()`
+method on the existing stage playback clock. It creates no renderer or frame
+loop, allocates no per-frame GPU resources, pauses with stage/resource
+suspension and context loss, and disposes shared geometry, materials, and
+textures with the projection. A direct projection rejects more than 1,024
+objects, 256 resources, or 32 aggregate effect descriptors before allocating
+Three resources, and retains per-implementation count and coordinate caps even
+when registry validation is bypassed.
+
+These are rendering mechanics, not product vocabulary. A consumer may compile
+a nested shape, connector set, core, or ambient field into these descriptors;
+the corresponding product concepts and persisted definitions remain outside
+AOS.
+
 ### Affordances And Gestures
 
 `aos.scene.cartridge.interactions.v1` declares object-relative rectangular

--- a/packages/toolkit/components/desktop-world-stage/scene-outlet.js
+++ b/packages/toolkit/components/desktop-world-stage/scene-outlet.js
@@ -21,6 +21,22 @@ export function sceneResourceCanRun(resourceSuspended, stageHidden, contextLost)
   return !resourceSuspended && !stageHidden && !contextLost
 }
 
+export function reconcileSceneStageRunState(resources, previous, next, at = performance.now()) {
+  const wasRunnable = !previous.hidden && !previous.contextLost
+  const isRunnable = !next.hidden && !next.contextLost
+  if (wasRunnable === isRunnable) return false
+  for (const mounted of resources.values()) {
+    if (!isRunnable) {
+      mounted.playClock.suspend(at)
+      mounted.interactionVisuals?.suspend(at)
+    } else if (sceneResourceCanRun(mounted.suspended, next.hidden, next.contextLost)) {
+      mounted.playClock.resume(at)
+      mounted.interactionVisuals?.resume(at)
+    }
+  }
+  return true
+}
+
 export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = window } = {}) {
   if (!canvas) throw new TypeError('DesktopWorld scene outlet requires a canvas.')
   const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true, canvas, powerPreference: 'low-power' })
@@ -344,6 +360,7 @@ export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = win
         if (mounted.suspended) continue
         const elapsed = mounted.playClock.elapsed(at)
         mounted.animations.tick(elapsed)
+        mounted.projection.tick?.(elapsed)
         if (mounted.interactionState.takeDirty()) {
           notifyInteractionGeometry(mounted.key, mounted.playGeneration)
         }
@@ -387,37 +404,34 @@ export function createDesktopWorldSceneOutlet({ canvas, window: hostWindow = win
     frame = hostWindow.requestAnimationFrame(render)
   }
 
-  const suspendPlaybackClocks = (at = performance.now()) => {
-    for (const mounted of resources.values()) {
-      mounted.playClock.suspend(at)
-      mounted.interactionVisuals?.suspend(at)
-    }
-  }
-  const resumePlaybackClocks = (at = performance.now()) => {
-    for (const mounted of resources.values()) {
-      if (sceneResourceCanRun(mounted.suspended, hidden, contextLost)) {
-        mounted.playClock.resume(at)
-        mounted.interactionVisuals?.resume(at)
-      }
-    }
-  }
   const onVisibility = () => {
     const nextHidden = document.hidden
-    if (nextHidden && !hidden) suspendPlaybackClocks()
-    if (!nextHidden && hidden && !contextLost) resumePlaybackClocks()
+    reconcileSceneStageRunState(
+      resources,
+      { hidden, contextLost },
+      { hidden: nextHidden, contextLost },
+    )
     hidden = nextHidden
   }
   const onContextLost = (event) => {
     event.preventDefault()
-    if (!contextLost) suspendPlaybackClocks()
+    reconcileSceneStageRunState(
+      resources,
+      { hidden, contextLost },
+      { hidden, contextLost: true },
+    )
     contextLost = true
     gpuTimer?.dispose()
     gpuTimer = null
     devtoolsProbe?.recordEvent({ kind: 'context.lost', code: 'WEBGL_CONTEXT_LOST' })
   }
   const onContextRestored = () => {
+    reconcileSceneStageRunState(
+      resources,
+      { hidden, contextLost },
+      { hidden, contextLost: false },
+    )
     contextLost = false
-    if (!hidden) resumePlaybackClocks()
     resize()
     devtoolsProbe?.recordEvent({ kind: 'context.restored' })
   }

--- a/packages/toolkit/scene/index.d.ts
+++ b/packages/toolkit/scene/index.d.ts
@@ -39,6 +39,7 @@ export function createGenericThreeSceneProjection(input: {
   activate(): void;
   applyAnimation(binding: { target: string }, value: number): boolean;
   applySignal(binding: { target: string }, value: number): boolean;
+  tick(elapsedMs: number): number;
   suspend(): void;
   resume(): void;
   dispose(): void;

--- a/packages/toolkit/scene/scene-generic-three.js
+++ b/packages/toolkit/scene/scene-generic-three.js
@@ -1,7 +1,13 @@
 import { createSceneImplementationRegistry } from './scene-registry.js'
+import {
+  createRadialAuraThreeEffect,
+  validateRadialAuraParameters,
+} from './scene-radial-aura-three.js'
 
 export const GENERIC_SCENE_IMPLEMENTATIONS = Object.freeze({
   primitiveGeometry: 'aos.scene.geometry.primitive',
+  edgesGeometry: 'aos.scene.geometry.edges',
+  segmentGeometry: 'aos.scene.geometry.segments',
   nestedShellGeometry: 'aos.scene.geometry.nested-shell',
   surfaceMaterial: 'aos.scene.material.surface',
   lineMaterial: 'aos.scene.material.line',
@@ -18,10 +24,15 @@ export const GENERIC_SCENE_IMPLEMENTATIONS = Object.freeze({
   lineTravel: 'aos.scene.effect.line-travel',
   tunnel: 'aos.scene.effect.tunnel',
   radialBurst: 'aos.scene.effect.radial-burst',
+  radialAura: 'aos.scene.effect.radial-aura',
 })
 
 const EFFECT_IDS = new Set(Object.values(GENERIC_SCENE_IMPLEMENTATIONS).filter((id) => id.includes('.effect.')))
 const PRIMITIVES = new Set(['box', 'sphere', 'tetrahedron', 'octahedron', 'icosahedron', 'torus', 'torus-knot'])
+const MAX_SEGMENTS = 64
+const MAX_PROJECTION_OBJECTS = 1024
+const MAX_PROJECTION_RESOURCES = 256
+const MAX_PROJECTION_EFFECTS = 32
 
 function finite(value, fallback = 0, min = -1e6, max = 1e6) {
   return Number.isFinite(value) ? Math.min(max, Math.max(min, value)) : fallback
@@ -41,23 +52,51 @@ function validateBoundedCount(parameters) {
     : 'count_out_of_bounds'
 }
 
+function validateEdges(parameters) {
+  const primitive = validatePrimitive(parameters)
+  if (primitive !== true) return primitive
+  return parameters.thresholdAngle === undefined
+    || (Number.isFinite(parameters.thresholdAngle) && parameters.thresholdAngle >= 0 && parameters.thresholdAngle <= 180)
+    ? true
+    : 'threshold_angle_out_of_bounds'
+}
+
+function validateSegments(parameters) {
+  if (!Array.isArray(parameters?.segments) || parameters.segments.length < 1 || parameters.segments.length > MAX_SEGMENTS) {
+    return 'segment_count_out_of_bounds'
+  }
+  return parameters.segments.every((segment) => (
+    Array.isArray(segment)
+    && segment.length === 6
+    && segment.every((value) => Number.isFinite(value) && Math.abs(value) <= 1e4)
+  )) ? true : 'segment_coordinates_invalid'
+}
+
 export function createGenericSceneImplementationRegistry() {
   const registry = createSceneImplementationRegistry()
   registry.register({ id: GENERIC_SCENE_IMPLEMENTATIONS.primitiveGeometry, kind: 'geometry', create: () => null, validateParameters: validatePrimitive })
+  registry.register({ id: GENERIC_SCENE_IMPLEMENTATIONS.edgesGeometry, kind: 'geometry', create: () => null, validateParameters: validateEdges })
+  registry.register({ id: GENERIC_SCENE_IMPLEMENTATIONS.segmentGeometry, kind: 'geometry', create: () => null, validateParameters: validateSegments })
   registry.register({ id: GENERIC_SCENE_IMPLEMENTATIONS.nestedShellGeometry, kind: 'geometry', create: () => null, validateParameters: (parameters) => Number.isInteger(parameters?.shells) && parameters.shells >= 1 && parameters.shells <= 16 ? true : 'shell_count_out_of_bounds' })
   for (const id of [GENERIC_SCENE_IMPLEMENTATIONS.surfaceMaterial, GENERIC_SCENE_IMPLEMENTATIONS.lineMaterial, GENERIC_SCENE_IMPLEMENTATIONS.pointMaterial]) {
     registry.register({ id, kind: 'material', create: () => null })
   }
   registry.register({ id: GENERIC_SCENE_IMPLEMENTATIONS.transform, kind: 'component', create: () => null })
-  for (const id of EFFECT_IDS) registry.register({ id, kind: 'effect', create: () => null, validateParameters: validateBoundedCount })
+  for (const id of EFFECT_IDS) {
+    registry.register({
+      id,
+      kind: 'effect',
+      create: () => null,
+      validateParameters: id === GENERIC_SCENE_IMPLEMENTATIONS.radialAura
+        ? validateRadialAuraParameters
+        : validateBoundedCount,
+    })
+  }
   return registry
 }
 
-function geometryFor(THREE, descriptor) {
-  const p = descriptor.parameters ?? {}
-  if (descriptor.implementation === GENERIC_SCENE_IMPLEMENTATIONS.nestedShellGeometry) {
-    return new THREE.BoxGeometry(finite(p.size, 1, 0.01, 100), finite(p.size, 1, 0.01, 100), finite(p.size, 1, 0.01, 100), 1, 1, 1)
-  }
+function primitiveGeometryFor(THREE, parameters = {}) {
+  const p = parameters
   const radius = finite(p.radius, 1, 0.01, 100)
   const detail = Math.round(finite(p.detail, 1, 0, 5))
   switch (p.primitive) {
@@ -72,6 +111,33 @@ function geometryFor(THREE, descriptor) {
       return new THREE.BoxGeometry(size, size, size)
     }
   }
+}
+
+function geometryFor(THREE, descriptor) {
+  const p = descriptor.parameters ?? {}
+  if (descriptor.implementation === GENERIC_SCENE_IMPLEMENTATIONS.nestedShellGeometry) {
+    return new THREE.BoxGeometry(finite(p.size, 1, 0.01, 100), finite(p.size, 1, 0.01, 100), finite(p.size, 1, 0.01, 100), 1, 1, 1)
+  }
+  if (descriptor.implementation === GENERIC_SCENE_IMPLEMENTATIONS.edgesGeometry) {
+    const source = primitiveGeometryFor(THREE, p)
+    const edges = new THREE.EdgesGeometry(source, finite(p.thresholdAngle, 1, 0, 180))
+    source.dispose()
+    return edges
+  }
+  if (descriptor.implementation === GENERIC_SCENE_IMPLEMENTATIONS.segmentGeometry) {
+    const segments = Array.isArray(p.segments) ? p.segments.slice(0, MAX_SEGMENTS) : []
+    const positions = new Float32Array(segments.length * 6)
+    for (let index = 0; index < segments.length; index += 1) {
+      const segment = Array.isArray(segments[index]) ? segments[index] : []
+      for (let coordinate = 0; coordinate < 6; coordinate += 1) {
+        positions[index * 6 + coordinate] = finite(segment[coordinate], 0, -1e4, 1e4)
+      }
+    }
+    const geometry = new THREE.BufferGeometry()
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3))
+    return geometry
+  }
+  return primitiveGeometryFor(THREE, p)
 }
 
 function materialFor(THREE, descriptor) {
@@ -142,12 +208,48 @@ function setTarget(objects, objectId, target, value) {
   return true
 }
 
+function assertProjectionBudgets(document) {
+  if (!Array.isArray(document.objects) || !Array.isArray(document.resources)) {
+    throw new TypeError('Generic Three projections require object and resource arrays.')
+  }
+  if (document.objects.length > MAX_PROJECTION_OBJECTS) {
+    throw new RangeError('Generic Three projection object budget exceeded.')
+  }
+  if (document.resources.length > MAX_PROJECTION_RESOURCES) {
+    throw new RangeError('Generic Three projection resource budget exceeded.')
+  }
+  let effects = 0
+  for (const resource of document.resources) {
+    if (resource?.kind === 'effect' && ++effects > MAX_PROJECTION_EFFECTS) {
+      throw new RangeError('Generic Three projection effect budget exceeded.')
+    }
+  }
+  for (const object of document.objects) {
+    for (const component of object?.components ?? []) {
+      if (EFFECT_IDS.has(component?.implementation) && component.enabled !== false && ++effects > MAX_PROJECTION_EFFECTS) {
+        throw new RangeError('Generic Three projection effect budget exceeded.')
+      }
+    }
+  }
+}
+
 export function createGenericThreeSceneProjection({ THREE, document }) {
   if (!THREE?.Group || !document) throw new TypeError('Generic Three projection requires Three.js and a scene document.')
+  assertProjectionBudgets(document)
   const root = new THREE.Group()
   root.name = document.id
   const resources = new Map(document.resources.map((resource) => [resource.id, resource]))
   const objects = new Map()
+  const effects = []
+  const attachEffect = (descriptor, target) => {
+    if (descriptor.implementation === GENERIC_SCENE_IMPLEMENTATIONS.radialAura) {
+      const effect = createRadialAuraThreeEffect({ THREE, descriptor })
+      target.add(effect.object)
+      effects.push(effect)
+      return
+    }
+    target.add(effectObject(THREE, descriptor))
+  }
   for (const descriptor of document.objects) {
     const geometry = descriptor.geometryId ? geometryFor(THREE, resources.get(descriptor.geometryId)) : null
     const material = descriptor.materialId ? materialFor(THREE, resources.get(descriptor.materialId)) : null
@@ -159,7 +261,7 @@ export function createGenericThreeSceneProjection({ THREE, document }) {
     object.name = descriptor.id
     applyTransform(object, { ...descriptor.transform, visible: descriptor.visible })
     for (const component of descriptor.components ?? []) {
-      if (EFFECT_IDS.has(component.implementation) && component.enabled !== false) object.add(effectObject(THREE, component))
+      if (EFFECT_IDS.has(component.implementation) && component.enabled !== false) attachEffect(component, object)
     }
     objects.set(descriptor.id, object)
   }
@@ -170,7 +272,7 @@ export function createGenericThreeSceneProjection({ THREE, document }) {
   }
   for (const descriptor of document.resources.filter((resource) => resource.kind === 'effect')) {
     const target = objects.get(descriptor.parameters?.targetObjectId) ?? root
-    target.add(effectObject(THREE, descriptor))
+    attachEffect(descriptor, target)
   }
   return {
     object: root,
@@ -191,14 +293,25 @@ export function createGenericThreeSceneProjection({ THREE, document }) {
     },
     applyAnimation(binding, value) { return setTarget(objects, binding.objectId, binding.target, value) },
     applySignal(binding, value) { return setTarget(objects, binding.objectId, binding.target, value) },
+    tick(elapsedMs) {
+      if (!Number.isFinite(elapsedMs) || elapsedMs < 0) return 0
+      let updated = 0
+      for (const effect of effects) if (effect.tick(elapsedMs)) updated += 1
+      return updated
+    },
     suspend() { root.visible = false },
     resume() { root.visible = true },
     dispose() {
+      for (const effect of effects) effect.dispose()
+      const geometries = new Set()
+      const materials = new Set()
       root.traverse?.((object) => {
-        object.geometry?.dispose?.()
-        const materials = Array.isArray(object.material) ? object.material : [object.material]
-        for (const material of materials) material?.dispose?.()
+        if (object.geometry?.dispose) geometries.add(object.geometry)
+        const objectMaterials = Array.isArray(object.material) ? object.material : [object.material]
+        for (const material of objectMaterials) if (material?.dispose) materials.add(material)
       })
+      for (const geometry of geometries) geometry.dispose()
+      for (const material of materials) material.dispose()
       root.clear?.()
     },
   }

--- a/packages/toolkit/scene/scene-radial-aura-three.js
+++ b/packages/toolkit/scene/scene-radial-aura-three.js
@@ -1,0 +1,204 @@
+const TEXTURE_SIZE = 32
+const MAX_WOBBLES = 24
+const HEX_COLOR = /^#[0-9a-f]{6}$/iu
+const PARAMETER_KEYS = new Set([
+  'intensity',
+  'primaryColor',
+  'pulseHz',
+  'reach',
+  'secondaryColor',
+  'targetObjectId',
+  'wobbleAmplitude',
+  'wobbleCount',
+  'wobbleOpacity',
+  'wobbleRadius',
+  'wobbleScaleX',
+  'wobbleScaleY',
+  'wobbleSpeed',
+])
+
+function finite(value, fallback, min, max) {
+  return Number.isFinite(value) ? Math.min(max, Math.max(min, value)) : fallback
+}
+
+function rgb(value, fallback) {
+  const source = HEX_COLOR.test(value) ? value : fallback
+  return [
+    Number.parseInt(source.slice(1, 3), 16),
+    Number.parseInt(source.slice(3, 5), 16),
+    Number.parseInt(source.slice(5, 7), 16),
+  ]
+}
+
+function radialTexture(THREE, primary, secondary, core) {
+  const first = rgb(primary, '#9b7cff')
+  const second = rgb(secondary, '#28154f')
+  const data = new Uint8Array(TEXTURE_SIZE * TEXTURE_SIZE * 4)
+  for (let y = 0; y < TEXTURE_SIZE; y += 1) {
+    for (let x = 0; x < TEXTURE_SIZE; x += 1) {
+      const dx = ((x + 0.5) / TEXTURE_SIZE) * 2 - 1
+      const dy = ((y + 0.5) / TEXTURE_SIZE) * 2 - 1
+      const distance = Math.min(1, Math.hypot(dx, dy))
+      const falloff = core
+        ? Math.max(0, 1 - distance ** 1.6)
+        : Math.max(0, (1 - distance) ** 2.4)
+      const mix = Math.min(1, distance * (core ? 1.1 : 0.72))
+      const offset = (y * TEXTURE_SIZE + x) * 4
+      data[offset] = Math.round(first[0] + (second[0] - first[0]) * mix)
+      data[offset + 1] = Math.round(first[1] + (second[1] - first[1]) * mix)
+      data[offset + 2] = Math.round(first[2] + (second[2] - first[2]) * mix)
+      data[offset + 3] = Math.round(falloff * 255)
+    }
+  }
+  const texture = new THREE.DataTexture(
+    data,
+    TEXTURE_SIZE,
+    TEXTURE_SIZE,
+    THREE.RGBAFormat,
+    THREE.UnsignedByteType,
+  )
+  texture.colorSpace = THREE.SRGBColorSpace
+  texture.minFilter = THREE.LinearFilter
+  texture.magFilter = THREE.LinearFilter
+  texture.needsUpdate = true
+  return texture
+}
+
+function directionAt(index, count) {
+  if (count <= 1) return [0, 1, 0]
+  const y = 1 - (index / (count - 1)) * 2
+  const radius = Math.sqrt(Math.max(0, 1 - y * y))
+  const angle = index * Math.PI * (3 - Math.sqrt(5))
+  return [Math.cos(angle) * radius, y, Math.sin(angle) * radius]
+}
+
+function boundedNumber(value, min, max) {
+  return Number.isFinite(value) && value >= min && value <= max
+}
+
+export function validateRadialAuraParameters(parameters) {
+  if (!parameters || typeof parameters !== 'object' || Array.isArray(parameters)) {
+    return 'radial_aura_parameters_invalid'
+  }
+  for (const key of Object.keys(parameters)) {
+    if (!PARAMETER_KEYS.has(key)) return 'radial_aura_parameter_unknown'
+  }
+  if (parameters.targetObjectId !== undefined && (
+    typeof parameters.targetObjectId !== 'string'
+    || parameters.targetObjectId.length === 0
+    || parameters.targetObjectId.length > 256
+  )) return 'radial_aura_target_invalid'
+  if (!HEX_COLOR.test(parameters.primaryColor) || !HEX_COLOR.test(parameters.secondaryColor)) {
+    return 'radial_aura_color_invalid'
+  }
+  if (!boundedNumber(parameters.reach, 0, 8)) return 'radial_aura_reach_out_of_bounds'
+  if (!boundedNumber(parameters.intensity, 0, 4)) return 'radial_aura_intensity_out_of_bounds'
+  if (!boundedNumber(parameters.pulseHz, 0, 8)) return 'radial_aura_pulse_out_of_bounds'
+  if (!Number.isInteger(parameters.wobbleCount) || parameters.wobbleCount < 0 || parameters.wobbleCount > MAX_WOBBLES) {
+    return 'radial_aura_wobble_count_out_of_bounds'
+  }
+  if (!boundedNumber(parameters.wobbleRadius, 0, 8)) return 'radial_aura_wobble_radius_out_of_bounds'
+  if (!boundedNumber(parameters.wobbleScaleX, 0.05, 3)) return 'radial_aura_wobble_scale_out_of_bounds'
+  if (!boundedNumber(parameters.wobbleScaleY, 0.05, 3)) return 'radial_aura_wobble_scale_out_of_bounds'
+  if (!boundedNumber(parameters.wobbleAmplitude, 0, 2)) return 'radial_aura_wobble_amplitude_out_of_bounds'
+  if (!boundedNumber(parameters.wobbleSpeed, 0, 16)) return 'radial_aura_wobble_speed_out_of_bounds'
+  if (!boundedNumber(parameters.wobbleOpacity, 0, 1)) return 'radial_aura_wobble_opacity_out_of_bounds'
+  return true
+}
+
+export function createRadialAuraThreeEffect({ THREE, descriptor }) {
+  const p = descriptor.parameters ?? {}
+  const group = new THREE.Group()
+  group.name = `${descriptor.id}/radial-aura`
+  const outerTexture = radialTexture(THREE, p.primaryColor, p.secondaryColor, false)
+  const coreTexture = radialTexture(THREE, p.primaryColor, p.secondaryColor, true)
+  const materialOptions = {
+    blending: THREE.AdditiveBlending,
+    depthTest: false,
+    depthWrite: false,
+    transparent: true,
+  }
+  const outer = new THREE.Sprite(new THREE.SpriteMaterial({
+    ...materialOptions,
+    map: outerTexture,
+    opacity: 0.62,
+  }))
+  outer.name = `${descriptor.id}/reach`
+  outer.renderOrder = 20
+  const core = new THREE.Sprite(new THREE.SpriteMaterial({
+    ...materialOptions,
+    map: coreTexture,
+    opacity: 0.86,
+  }))
+  core.name = `${descriptor.id}/core`
+  core.renderOrder = 21
+  const wobbleGroup = new THREE.Group()
+  wobbleGroup.name = `${descriptor.id}/wobbles`
+  const wobbleCount = Math.round(finite(p.wobbleCount, 0, 0, MAX_WOBBLES))
+  const wobbleGeometry = wobbleCount > 0 ? new THREE.IcosahedronGeometry(0.09, 1) : null
+  const wobbleMaterials = wobbleCount > 0
+    ? [p.primaryColor, p.secondaryColor].map((entry) => new THREE.MeshBasicMaterial({
+        ...materialOptions,
+        color: entry,
+        opacity: finite(p.wobbleOpacity, 0.32, 0, 1),
+      }))
+    : []
+  const wobbles = []
+  for (let index = 0; index < wobbleCount; index += 1) {
+    const direction = directionAt(index, wobbleCount)
+    const mesh = new THREE.Mesh(wobbleGeometry, wobbleMaterials[index % 2])
+    mesh.name = `${descriptor.id}/wobble/${index}`
+    wobbleGroup.add(mesh)
+    wobbles.push({ direction, index, mesh })
+  }
+  group.add(outer, core, wobbleGroup)
+
+  let disposed = false
+  return Object.freeze({
+    object: group,
+    tick(elapsedMs) {
+      if (disposed || !Number.isFinite(elapsedMs) || elapsedMs < 0) return false
+      const seconds = elapsedMs / 1_000
+      const reach = finite(p.reach, 0.75, 0, 8)
+      const intensity = finite(p.intensity, 1, 0, 4)
+      const pulse = Math.sin(seconds * Math.PI * 2 * finite(p.pulseHz, 0.5, 0, 8))
+      outer.scale.setScalar(1.6 + reach * 1.4 + pulse * 0.08)
+      core.scale.setScalar(0.34 + intensity * 0.28 + pulse * 0.04)
+      outer.material.opacity = Math.min(1, 0.24 + intensity * 0.24)
+      core.material.opacity = Math.min(1, 0.42 + intensity * 0.32)
+      const radius = finite(p.wobbleRadius, 0.62, 0, 8)
+      const scaleX = finite(p.wobbleScaleX, 0.66, 0.05, 3)
+      const scaleY = finite(p.wobbleScaleY, 0.66, 0.05, 3)
+      const amplitude = finite(p.wobbleAmplitude, 0.14, 0, 2)
+      const speed = finite(p.wobbleSpeed, 0.65, 0, 16)
+      for (const entry of wobbles) {
+        const phase = entry.index * 1.61803398875
+        const offset = radius + Math.sin(seconds * speed + phase) * amplitude
+        entry.mesh.position.set(
+          entry.direction[0] * offset,
+          entry.direction[1] * offset,
+          entry.direction[2] * offset,
+        )
+        entry.mesh.rotation.set(
+          seconds * speed * 0.21 + phase,
+          seconds * speed * 0.27 - phase,
+          Math.sin(seconds * speed + phase) * 0.22,
+        )
+        const pulseScale = 1 + Math.sin(seconds * speed * 1.3 + phase) * 0.18
+        entry.mesh.scale.set(
+          scaleX * pulseScale,
+          scaleY * (2 - pulseScale),
+          Math.min(scaleX, scaleY) * 0.92,
+        )
+      }
+      return true
+    },
+    dispose() {
+      if (disposed) return false
+      disposed = true
+      outerTexture.dispose()
+      coreTexture.dispose()
+      return true
+    },
+  })
+}

--- a/tests/toolkit/desktop-world-scene-outlet.test.mjs
+++ b/tests/toolkit/desktop-world-scene-outlet.test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test'
 
 import { createSceneAnimationInteractionState } from '../../packages/toolkit/components/desktop-world-stage/scene-animation-interaction-state.js'
 import {
+  reconcileSceneStageRunState,
   sceneResourceCanRun,
 } from '../../packages/toolkit/components/desktop-world-stage/scene-outlet.js'
 import { createScenePlaybackClock } from '../../packages/toolkit/components/desktop-world-stage/scene-playback-clock.js'
@@ -184,6 +185,86 @@ test('resource resume cannot reactivate a route while the stage remains suspende
   assert.equal(visuals.snapshot().route.active, true)
 })
 
+test('stage visibility and context transitions resume only runnable resources', () => {
+  const visibilityClock = createScenePlaybackClock()
+  visibilityClock.restart(0)
+  const visibilityResources = new Map([['visible', {
+    suspended: false,
+    playClock: visibilityClock,
+    interactionVisuals: null,
+  }]])
+  reconcileSceneStageRunState(
+    visibilityResources,
+    { hidden: false, contextLost: false },
+    { hidden: true, contextLost: false },
+    10,
+  )
+  reconcileSceneStageRunState(
+    visibilityResources,
+    { hidden: true, contextLost: false },
+    { hidden: false, contextLost: false },
+    100,
+  )
+  assert.equal(visibilityClock.elapsed(110), 20)
+
+  const activeClock = createScenePlaybackClock()
+  const resourceClock = createScenePlaybackClock()
+  activeClock.restart(0)
+  resourceClock.restart(0)
+  const calls = []
+  const resources = new Map([
+    ['active', {
+      suspended: false,
+      playClock: activeClock,
+      interactionVisuals: {
+        suspend: (at) => calls.push(`active:suspend:${at}`),
+        resume: (at) => calls.push(`active:resume:${at}`),
+      },
+    }],
+    ['resource-suspended', {
+      suspended: true,
+      playClock: resourceClock,
+      interactionVisuals: {
+        suspend: (at) => calls.push(`resource:suspend:${at}`),
+        resume: (at) => calls.push(`resource:resume:${at}`),
+      },
+    }],
+  ])
+
+  assert.equal(reconcileSceneStageRunState(
+    resources,
+    { hidden: false, contextLost: false },
+    { hidden: true, contextLost: false },
+    10,
+  ), true)
+  assert.equal(reconcileSceneStageRunState(
+    resources,
+    { hidden: true, contextLost: false },
+    { hidden: true, contextLost: true },
+    20,
+  ), false)
+  assert.equal(reconcileSceneStageRunState(
+    resources,
+    { hidden: true, contextLost: true },
+    { hidden: false, contextLost: true },
+    50,
+  ), false)
+  assert.equal(reconcileSceneStageRunState(
+    resources,
+    { hidden: false, contextLost: true },
+    { hidden: false, contextLost: false },
+    100,
+  ), true)
+
+  assert.deepEqual(calls, [
+    'active:suspend:10',
+    'resource:suspend:10',
+    'active:resume:100',
+  ])
+  assert.equal(activeClock.elapsed(110), 20)
+  assert.equal(resourceClock.snapshot().paused, true)
+})
+
 test('DesktopWorld scene outlet is local, bounded, and shares one renderer loop', async () => {
   const [outlet, stage, three, threeCore] = await Promise.all([
     readFile(outletURL, 'utf8'),
@@ -202,6 +283,7 @@ test('DesktopWorld scene outlet is local, bounded, and shares one renderer loop'
   assert.match(outlet, /createSceneAnimationController\(document/u)
   assert.match(outlet, /createSceneSignalController\(document/u)
   assert.match(outlet, /mounted\.animations\.tick\(elapsed\)/u)
+  assert.match(outlet, /mounted\.projection\.tick\?\.\(elapsed\)/u)
   assert.match(outlet, /mounted\.playClock\.elapsed\(at\)/u)
   assert.doesNotMatch(outlet, /playStartedAt/u)
   assert.match(outlet, /onComplete: \(binding, value\) => interactionState\.complete\(binding, value\)/u)
@@ -212,6 +294,7 @@ test('DesktopWorld scene outlet is local, bounded, and shares one renderer loop'
   assert.match(outlet, /mounted\.interactionVisuals\?\.suspend\(at\)/u)
   assert.match(outlet, /mounted\.interactionVisuals\?\.resume\(at\)/u)
   assert.match(outlet, /sceneResourceCanRun\(mounted\.suspended, hidden, contextLost\)/u)
+  assert.match(outlet, /reconcileSceneStageRunState/u)
   assert.match(outlet, /createDesktopWorldSceneInteractionThree/u)
   assert.match(outlet, /ensureInteractionVisuals/u)
   assert.match(outlet, /interactionVisuals: null/u)

--- a/tests/toolkit/scene-generic-three.test.mjs
+++ b/tests/toolkit/scene-generic-three.test.mjs
@@ -7,25 +7,42 @@ import {
   createGenericThreeSceneProjection,
 } from '../../packages/toolkit/scene/index.js'
 
+let allocations = 0
+
 class Vector {
   constructor() { this.x = 0; this.y = 0; this.z = 0 }
   set(x, y, z) { this.x = x; this.y = y; this.z = z }
+  setScalar(value) { this.set(value, value, value) }
 }
 class Node {
-  constructor() { this.children = []; this.position = new Vector(); this.rotation = new Vector(); this.scale = new Vector(); this.visible = true }
-  add(child) { this.children.push(child) }
+  constructor() { allocations += 1; this.children = []; this.position = new Vector(); this.rotation = new Vector(); this.scale = new Vector(); this.visible = true }
+  add(...children) { this.children.push(...children) }
   clear() { this.children = [] }
-  traverse(callback) { callback(this); for (const child of this.children) child.traverse?.(callback) ?? callback(child) }
+  traverse(callback) { callback(this); for (const child of this.children) { if (child.traverse) child.traverse(callback); else callback(child) } }
   getObjectByName(name) { if (this.name === name) return this; for (const child of this.children) { const found = child.getObjectByName?.(name); if (found) return found } return null }
 }
-class Disposable { dispose() { this.disposed = true } }
+class Disposable { constructor(options = {}) { allocations += 1; Object.assign(this, options); this.disposeCount = 0 } dispose() { this.disposed = true; this.disposeCount += 1 } }
 class Mesh extends Node { constructor(geometry, material) { super(); this.geometry = geometry; this.material = material } }
 class Points extends Mesh {}
+class Sprite extends Mesh { constructor(material) { super(null, material) } }
+class BufferGeometry extends Disposable {
+  constructor() { super(); this.attributes = {} }
+  setAttribute(name, attribute) { this.attributes[name] = attribute }
+}
+class BufferAttribute { constructor(array, itemSize) { allocations += 1; this.array = array; this.itemSize = itemSize } }
+class EdgesGeometry extends Disposable { constructor(source, thresholdAngle) { super(); this.source = source; this.thresholdAngle = thresholdAngle } }
+class DataTexture extends Disposable { constructor(data, width, height) { super(); this.data = data; this.width = width; this.height = height } }
 
 const THREE = {
+  AdditiveBlending: 2,
+  RGBAFormat: 1,
+  UnsignedByteType: 1,
+  SRGBColorSpace: 'srgb',
+  LinearFilter: 1,
   Group: Node,
   Mesh,
   Points,
+  Sprite,
   LineSegments: Mesh,
   BoxGeometry: Disposable,
   SphereGeometry: Disposable,
@@ -34,11 +51,15 @@ const THREE = {
   IcosahedronGeometry: Disposable,
   TorusGeometry: Disposable,
   TorusKnotGeometry: Disposable,
-  BufferGeometry: class extends Disposable { setAttribute() {} },
-  BufferAttribute: class {},
+  EdgesGeometry,
+  BufferGeometry,
+  BufferAttribute,
+  DataTexture,
   MeshStandardMaterial: Disposable,
+  MeshBasicMaterial: Disposable,
   LineBasicMaterial: Disposable,
   PointsMaterial: Disposable,
+  SpriteMaterial: Disposable,
 }
 
 function document() {
@@ -56,6 +77,38 @@ function document() {
   }
 }
 
+function richDocument() {
+  const input = document()
+  input.resources.push(
+    { id: 'edges', kind: 'geometry', implementation: GENERIC_SCENE_IMPLEMENTATIONS.edgesGeometry, parameters: { primitive: 'box', size: 1, thresholdAngle: 1 }, asset: null },
+    { id: 'segments', kind: 'geometry', implementation: GENERIC_SCENE_IMPLEMENTATIONS.segmentGeometry, parameters: { segments: [[-1, -1, -1, -0.5, -0.5, -0.5]] }, asset: null },
+    { id: 'line', kind: 'material', implementation: GENERIC_SCENE_IMPLEMENTATIONS.lineMaterial, parameters: { color: '#ffffff' }, asset: null },
+    {
+      id: 'aura', kind: 'effect', implementation: GENERIC_SCENE_IMPLEMENTATIONS.radialAura,
+      parameters: {
+        targetObjectId: 'main', primaryColor: '#9b7cff', secondaryColor: '#28154f',
+        reach: 0.75, intensity: 1, pulseHz: 1, wobbleCount: 4, wobbleRadius: 0.62,
+        wobbleScaleX: 0.66, wobbleScaleY: 0.48, wobbleAmplitude: 0.14,
+        wobbleSpeed: 0.65, wobbleOpacity: 0.32,
+      },
+      asset: null,
+    },
+  )
+  input.objects.push(
+    {
+      id: 'edge-object', parentId: 'main', kind: 'line', visible: true,
+      transform: { position: [0, 0, 0], rotation: [0, 0, 0], scale: [1, 1, 1] },
+      geometryId: 'edges', materialId: 'line', components: [],
+    },
+    {
+      id: 'segment-object', parentId: 'main', kind: 'line', visible: true,
+      transform: { position: [0, 0, 0], rotation: [0, 0, 0], scale: [1, 1, 1] },
+      geometryId: 'segments', materialId: 'line', components: [],
+    },
+  )
+  return input
+}
+
 test('generic registry validates implementation parameter bounds', () => {
   const registry = createGenericSceneImplementationRegistry()
   const valid = document()
@@ -64,6 +117,22 @@ test('generic registry validates implementation parameter bounds', () => {
   const invalid = registry.validateDocument({ ...valid, contract: 'aos.scene.document.v1', schemaVersion: 1, revision: 1, rootObjectId: 'main', metadata: {} })
   assert.equal(invalid.ok, false)
   assert.equal(invalid.mismatched[0].reason, 'unsupported_primitive')
+
+  const rich = richDocument()
+  const richInput = { ...rich, contract: 'aos.scene.document.v1', schemaVersion: 1, revision: 1, rootObjectId: 'main', metadata: {} }
+  assert.equal(registry.validateDocument(richInput).ok, true)
+  rich.resources.find((resource) => resource.id === 'segments').parameters.segments = Array.from({ length: 65 }, () => [0, 0, 0, 1, 1, 1])
+  assert.equal(registry.validateDocument(richInput).mismatched[0].reason, 'segment_count_out_of_bounds')
+  rich.resources.find((resource) => resource.id === 'segments').parameters.segments = [[0, 0, 0, 1, 1, 1]]
+  rich.resources.find((resource) => resource.id === 'aura').parameters.wobbleCount = 25
+  assert.equal(registry.validateDocument(richInput).mismatched[0].reason, 'radial_aura_wobble_count_out_of_bounds')
+
+  const narrow = richDocument()
+  narrow.resources.find((resource) => resource.id === 'aura').parameters.wobbleScaleX = 0.01
+  assert.equal(registry.validateDocument({ ...narrow, contract: 'aos.scene.document.v1', schemaVersion: 1, revision: 1, rootObjectId: 'main', metadata: {} }).mismatched[0].reason, 'radial_aura_wobble_scale_out_of_bounds')
+  const wide = richDocument()
+  wide.resources.find((resource) => resource.id === 'aura').parameters.wobbleScaleY = 4
+  assert.equal(registry.validateDocument({ ...wide, contract: 'aos.scene.document.v1', schemaVersion: 1, revision: 1, rootObjectId: 'main', metadata: {} }).mismatched[0].reason, 'radial_aura_wobble_scale_out_of_bounds')
 })
 
 test('generic Three projection builds and disposes a bounded object tree', () => {
@@ -96,4 +165,63 @@ test('animation and signals target the declared object when its id matches the s
   assert.equal(mesh.scale.x, 1.5)
 
   projection.dispose()
+})
+
+test('generic projection renders clean edges, explicit segments, and one bounded clock-driven radial field', () => {
+  const projection = createGenericThreeSceneProjection({ THREE, document: richDocument() })
+  const edge = projection.object.getObjectByName('edge-object')
+  const segment = projection.object.getObjectByName('segment-object')
+  const outer = projection.object.getObjectByName('aura/reach')
+  const core = projection.object.getObjectByName('aura/core')
+  const wobbles = projection.object.getObjectByName('aura/wobbles')
+
+  assert.ok(edge.geometry instanceof EdgesGeometry)
+  assert.equal(edge.geometry.source.disposed, true)
+  assert.deepEqual([...segment.geometry.attributes.position.array], [-1, -1, -1, -0.5, -0.5, -0.5])
+  assert.equal(wobbles.children.length, 4)
+  assert.equal(wobbles.children[0].geometry, wobbles.children[1].geometry)
+  assert.equal(wobbles.children[0].material, wobbles.children[2].material)
+  projection.tick(0)
+  const initialScale = outer.scale.x
+  const beforeTick = allocations
+  assert.equal(projection.tick(250), 1)
+  assert.equal(allocations, beforeTick)
+  assert.notEqual(outer.scale.x, initialScale)
+  assert.ok(core.scale.x > 0)
+
+  projection.dispose()
+  assert.equal(edge.geometry.disposed, true)
+  assert.equal(segment.geometry.disposed, true)
+  assert.equal(outer.material.map.disposed, true)
+  assert.equal(core.material.map.disposed, true)
+  assert.equal(wobbles.children[0].geometry.disposeCount, 1)
+  assert.equal(wobbles.children[0].material.disposeCount, 1)
+})
+
+test('direct generic projection caps explicit segments even when registry validation is bypassed', () => {
+  const input = richDocument()
+  input.resources.find((resource) => resource.id === 'segments').parameters.segments = Array.from(
+    { length: 1_000 },
+    () => [1e9, -1e9, 0, 1, 1, 1],
+  )
+  const projection = createGenericThreeSceneProjection({ THREE, document: input })
+  const segment = projection.object.getObjectByName('segment-object')
+  assert.equal(segment.geometry.attributes.position.array.length, 64 * 6)
+  assert.deepEqual([...segment.geometry.attributes.position.array.slice(0, 2)], [10_000, -10_000])
+  projection.dispose()
+})
+
+test('direct generic projection rejects aggregate effects before allocating Three resources', () => {
+  const input = richDocument()
+  const template = input.resources.find((resource) => resource.id === 'aura')
+  input.resources.push(...Array.from({ length: 32 }, (_, index) => ({
+    ...structuredClone(template),
+    id: `aura-${index}`,
+  })))
+  const before = allocations
+  assert.throws(
+    () => createGenericThreeSceneProjection({ THREE, document: input }),
+    /effect budget exceeded/u,
+  )
+  assert.equal(allocations, before)
 })


### PR DESCRIPTION
## Summary\n- add product-neutral clean-edge and explicit-segment geometry implementations\n- add a bounded clock-driven radial effect with shared GPU resources\n- advance effects on the existing DesktopWorld stage playback clock\n- reconcile visibility/context suspension through one aggregate run-state transition\n- document the public implementation IDs, aggregate budgets, and lifecycle contract\n\n## Validation\n- scene and DesktopWorld scene suites: 107/107\n- final focused review suite: 31/31\n- proof registry and public scene contract: 23/23\n- toolkit API documentation contracts: passed\n- syntax and git diff --check: passed\n- review delta b4f4c50c..b2dde472: approved with no findings\n\n## Scope\nStatic toolkit work only. No AOS binary build, daemon/runtime operation, TCC change, or Sigil product semantics.