### PR TITLE
Fix DesktopWorld scene event routing and diagnostics

### DIFF
--- a/docs/api/aos-capabilities.md
+++ b/docs/api/aos-capabilities.md
@@ -173,9 +173,11 @@ compatibility policy.
 
 For DesktopWorld gesture delivery, `daemon-snapshot` includes the bounded
 `runtime_resources.desktop_world_scene_event_routing` readback. It reports
-counts for delivered, rejected, unsubscribed, stale-topology, and outbound
-delivery outcomes plus only the most recent failure code and timestamp. It
-never includes scene documents, gesture coordinates, labels, or product data.
+counts for outbound-queue admission, invalid events, identity mismatches,
+missing subscriptions, stale topology, unavailable stages, and queue-admission
+failure, plus only the most recent failure code and timestamp. Queue admission
+does not claim that the asynchronous client write completed. The readback never
+includes scene documents, gesture coordinates, labels, or product data.
 Capture a troubleshooting snapshot without changing AOS state by using the
 standard Unix `tee` utility:
 

--- a/docs/api/aos-capabilities.md
+++ b/docs/api/aos-capabilities.md
@@ -171,6 +171,23 @@ deliberately a recipe-sized composition over existing surfaces, not a new
 with source manifests, routes, docs, tests, generated artifacts, and a clear
 compatibility policy.
 
+For DesktopWorld gesture delivery, `daemon-snapshot` includes the bounded
+`runtime_resources.desktop_world_scene_event_routing` readback. It reports
+counts for delivered, rejected, unsubscribed, stale-topology, and outbound
+delivery outcomes plus only the most recent failure code and timestamp. It
+never includes scene documents, gesture coordinates, labels, or product data.
+Capture a troubleshooting snapshot without changing AOS state by using the
+standard Unix `tee` utility:
+
+```bash
+./aos daemon-snapshot | tee /tmp/aos-daemon-snapshot.json
+```
+
+Use `service logs --tail N` for the bounded daemon log and the scene
+`inspect`, `monitor`, `perf`, `replay`, and DevTools surfaces for scene-specific
+state. Keep `log` for the operator-visible DesktopWorld log panel; it is not a
+passive daemon logging command.
+
 ## Dashboard And Readback Boundary
 
 The current AOS dashboard answer is a composed readback flow, not a visual

--- a/docs/dev/test-proof-registry.d/desktop-world-scene-engine.json
+++ b/docs/dev/test-proof-registry.d/desktop-world-scene-engine.json
@@ -61,6 +61,7 @@
     {
       "id": "desktop-world-scene-event-contract",
       "path_patterns": [
+        "tests/desktop-world-scene-event-routing.test.mjs",
         "tests/daemon-scene-lease-registry.sh",
         "tests/daemon-scene-event.sh",
         "tests/schemas/scene-event-v1.test.mjs"
@@ -74,7 +75,7 @@
       "proof_kind": "scene_event_subscription_contract",
       "contract": "Scene leases atomically own subscriptions and route strict bounded gesture events only to the current owner connection.",
       "worth": "This prevents cross-owner event leakage, stale subscription delivery, and product payloads in the public scene stream.",
-      "command": "bash tests/daemon-scene-lease-registry.sh && bash tests/daemon-scene-event.sh && node --test tests/schemas/scene-event-v1.test.mjs tests/schemas/daemon-event.test.mjs",
+      "command": "bash tests/daemon-scene-lease-registry.sh && bash tests/daemon-scene-event.sh && node --test tests/desktop-world-scene-event-routing.test.mjs tests/schemas/scene-event-v1.test.mjs tests/schemas/daemon-event.test.mjs",
       "replaces": [],
       "guard": "disposable Swift model plus JSON-schema fixtures only; no AOS binary, daemon socket, GUI, TCC, or GPU",
       "status": "active"

--- a/docs/dev/workflow-rules.json
+++ b/docs/dev/workflow-rules.json
@@ -184,6 +184,7 @@
         "packages/toolkit/scene/**",
         "packages/toolkit/components/desktop-world-stage/**",
         "src/daemon/desktop-world-scene-*.swift",
+        "src/daemon/scene-event.swift",
         "src/daemon/scene-lease-registry.swift",
         "src/daemon/unified.swift",
         "src/display/desktop-world-surface.swift",
@@ -193,6 +194,7 @@
         "manifests/commands/source/external/47-scene.json",
         "docs/api/toolkit/scene*.md",
         "tests/scene-*.test.mjs",
+        "tests/desktop-world-scene-event-routing.test.mjs",
         "tests/desktop-world-scene-result-coordinator.test.mjs",
         "tests/daemon-desktop-world-devtools-contract.test.mjs",
         "tests/toolkit/desktop-world-scene-*.test.mjs",
@@ -213,8 +215,8 @@
       "commands": [
         {
           "id": "scene-daemon-contract",
-          "command": "node --test tests/desktop-world-scene-result-coordinator.test.mjs tests/daemon-desktop-world-devtools-contract.test.mjs tests/scene-follow-cli.test.mjs",
-          "reason": "Verify the daemon scene lifecycle aggregate, all-segment barrier ownership, DevTools delegation, and bounded follow transport."
+          "command": "node --test tests/desktop-world-scene-event-routing.test.mjs tests/desktop-world-scene-result-coordinator.test.mjs tests/daemon-desktop-world-devtools-contract.test.mjs tests/scene-follow-cli.test.mjs",
+          "reason": "Verify canonical event routing diagnostics, the daemon scene lifecycle aggregate, all-segment barrier ownership, DevTools delegation, and bounded follow transport."
         },
         {
           "id": "scene-core-contract",

--- a/src/daemon/AGENTS.md
+++ b/src/daemon/AGENTS.md
@@ -18,6 +18,9 @@ canvas I/O, extension admission, barrier timing, and bounded stage readiness
 wait around that state aggregate. `UnifiedDaemon` only delegates transport
 events and emits response envelopes. Do not recreate parallel scene ownership,
 subscription maps, or transport orchestration in the connection handler.
+DesktopWorld event-routing failures remain reason-coded and observable through
+bounded daemon diagnostics; never log scene payloads, gesture coordinates,
+labels, or product data to diagnose delivery.
 The singleton full-display stage must be created hidden and resume only after
 every physical display segment in the exact current canvas and topology
 generation reports ready following transparent renderer initialization.

--- a/src/daemon/desktop-world-scene-controller.swift
+++ b/src/daemon/desktop-world-scene-controller.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 enum AOSDesktopWorldSceneEventRouteOutcome: String, CaseIterable {
-    case delivered
-    case deliveryFailed = "delivery_failed"
+    case enqueued
+    case enqueueFailed = "enqueue_failed"
     case identityMismatch = "identity_mismatch"
     case invalidEvent = "invalid_event"
     case stageUnavailable = "stage_unavailable"
@@ -316,13 +316,13 @@ final class AOSDesktopWorldSceneController {
         identity: AOSDesktopWorldSceneStageIdentity,
         key: String,
         event: String,
-        deliver: (AOSSceneLeaseRoute) -> Bool
+        enqueue: (AOSSceneLeaseRoute) -> Bool
     ) -> AOSDesktopWorldSceneEventRouteOutcome {
         withLock {
             guard retirement == nil,
                   readiness.isReady(for: identity) else { return .stageUnavailable }
             guard let route = leases.routeEvent(key: key, event: event) else { return .unsubscribed }
-            return deliver(route) ? .delivered : .deliveryFailed
+            return enqueue(route) ? .enqueued : .enqueueFailed
         }
     }
 

--- a/src/daemon/desktop-world-scene-controller.swift
+++ b/src/daemon/desktop-world-scene-controller.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+enum AOSDesktopWorldSceneEventRouteOutcome: String, CaseIterable {
+    case delivered
+    case deliveryFailed = "delivery_failed"
+    case identityMismatch = "identity_mismatch"
+    case invalidEvent = "invalid_event"
+    case stageUnavailable = "stage_unavailable"
+    case staleTopology = "stale_topology"
+    case unsubscribed
+}
+
 struct AOSDesktopWorldSceneTopologyDescriptor {
     let identity: AOSDesktopWorldSceneStageIdentity
     let segments: [AOSDesktopWorldSceneStageSegment]
@@ -306,13 +316,13 @@ final class AOSDesktopWorldSceneController {
         identity: AOSDesktopWorldSceneStageIdentity,
         key: String,
         event: String,
-        deliver: (AOSSceneLeaseRoute) -> Void
-    ) {
+        deliver: (AOSSceneLeaseRoute) -> Bool
+    ) -> AOSDesktopWorldSceneEventRouteOutcome {
         withLock {
             guard retirement == nil,
-                  readiness.isReady(for: identity),
-                  let route = leases.routeEvent(key: key, event: event) else { return }
-            deliver(route)
+                  readiness.isReady(for: identity) else { return .stageUnavailable }
+            guard let route = leases.routeEvent(key: key, event: event) else { return .unsubscribed }
+            return deliver(route) ? .delivered : .deliveryFailed
         }
     }
 

--- a/src/daemon/desktop-world-scene-event-router.swift
+++ b/src/daemon/desktop-world-scene-event-router.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+final class AOSDesktopWorldSceneEventRouteDiagnostics {
+    private static let maximumCount = 1_000_000_000
+    private let lock = NSLock()
+    private let now: () -> Double
+    private var counts: [AOSDesktopWorldSceneEventRouteOutcome: Int] = [:]
+    private var lastFailure: (outcome: AOSDesktopWorldSceneEventRouteOutcome, at: Double)?
+
+    init(now: @escaping () -> Double = { Date().timeIntervalSince1970 * 1_000 }) {
+        self.now = now
+    }
+
+    func record(_ outcome: AOSDesktopWorldSceneEventRouteOutcome) {
+        let failureAt = outcome == .delivered ? nil : now()
+        lock.lock()
+        counts[outcome] = min(
+            counts[outcome, default: 0] + 1,
+            Self.maximumCount
+        )
+        if let failureAt {
+            lastFailure = (outcome: outcome, at: failureAt)
+        }
+        lock.unlock()
+    }
+
+    func snapshot() -> [String: Any] {
+        lock.lock()
+        let currentCounts = counts
+        let currentLastFailure = lastFailure
+        lock.unlock()
+
+        var byOutcome: [String: Int] = [:]
+        for outcome in AOSDesktopWorldSceneEventRouteOutcome.allCases {
+            byOutcome[outcome.rawValue] = currentCounts[outcome] ?? 0
+        }
+        let total = byOutcome.values.reduce(0, +)
+        let delivered = byOutcome[AOSDesktopWorldSceneEventRouteOutcome.delivered.rawValue] ?? 0
+        let lastFailureValue: Any = currentLastFailure.map {
+            ["at": $0.at, "code": $0.outcome.rawValue] as [String: Any]
+        } ?? NSNull()
+        return [
+            "contract": "aos.desktop-world.scene-event-routing.v1",
+            "total": total,
+            "failures": total - delivered,
+            "by_outcome": byOutcome,
+            "last_failure": lastFailureValue,
+        ]
+    }
+}
+
+final class AOSDesktopWorldSceneEventRouter {
+    private let scene: AOSDesktopWorldSceneController
+    private let emit: (AOSSceneLeaseRoute, String, [String: Any]) -> Bool
+    private let diagnostics: AOSDesktopWorldSceneEventRouteDiagnostics
+
+    init(
+        scene: AOSDesktopWorldSceneController,
+        diagnostics: AOSDesktopWorldSceneEventRouteDiagnostics = AOSDesktopWorldSceneEventRouteDiagnostics(),
+        emit: @escaping (AOSSceneLeaseRoute, String, [String: Any]) -> Bool
+    ) {
+        self.scene = scene
+        self.diagnostics = diagnostics
+        self.emit = emit
+    }
+
+    func record(_ outcome: AOSDesktopWorldSceneEventRouteOutcome) {
+        diagnostics.record(outcome)
+    }
+
+    func handle(
+        identity: AOSDesktopWorldSceneStageIdentity,
+        payload: [String: Any]
+    ) {
+        guard let key = payload["lease_key"] as? String,
+              let eventType = payload["event_type"] as? String,
+              let event = payload["event"] as? [String: Any],
+              let canonicalEvent = aosCanonicalSceneEvent(event),
+              eventType == "gesture",
+              canonicalEvent["type"] as? String == eventType else {
+            diagnostics.record(.invalidEvent)
+            return
+        }
+        guard let ownerID = canonicalEvent["ownerId"] as? String,
+              let resourceID = canonicalEvent["resourceId"] as? String,
+              scene.key(owner: ownerID, resource: resourceID) == key else {
+            diagnostics.record(.identityMismatch)
+            return
+        }
+        diagnostics.record(scene.withEventRoute(identity: identity, key: key, event: eventType) { route in
+            emit(route, eventType, canonicalEvent)
+        })
+    }
+
+    func snapshot() -> [String: Any] {
+        diagnostics.snapshot()
+    }
+}

--- a/src/daemon/desktop-world-scene-event-router.swift
+++ b/src/daemon/desktop-world-scene-event-router.swift
@@ -12,8 +12,8 @@ final class AOSDesktopWorldSceneEventRouteDiagnostics {
     }
 
     func record(_ outcome: AOSDesktopWorldSceneEventRouteOutcome) {
-        let failureAt = outcome == .delivered ? nil : now()
         lock.lock()
+        let failureAt = outcome == .enqueued ? nil : now()
         counts[outcome] = min(
             counts[outcome, default: 0] + 1,
             Self.maximumCount
@@ -35,14 +35,14 @@ final class AOSDesktopWorldSceneEventRouteDiagnostics {
             byOutcome[outcome.rawValue] = currentCounts[outcome] ?? 0
         }
         let total = byOutcome.values.reduce(0, +)
-        let delivered = byOutcome[AOSDesktopWorldSceneEventRouteOutcome.delivered.rawValue] ?? 0
+        let enqueued = byOutcome[AOSDesktopWorldSceneEventRouteOutcome.enqueued.rawValue] ?? 0
         let lastFailureValue: Any = currentLastFailure.map {
             ["at": $0.at, "code": $0.outcome.rawValue] as [String: Any]
         } ?? NSNull()
         return [
             "contract": "aos.desktop-world.scene-event-routing.v1",
             "total": total,
-            "failures": total - delivered,
+            "failures": total - enqueued,
             "by_outcome": byOutcome,
             "last_failure": lastFailureValue,
         ]

--- a/src/daemon/desktop-world-scene-transport-controller.swift
+++ b/src/daemon/desktop-world-scene-transport-controller.swift
@@ -16,11 +16,13 @@ final class AOSDesktopWorldSceneTransportController {
     private let resolveContentURL: (String) -> String
     private let clearReadyManifest: () -> Void
     private let emit: (AOSSceneLeaseRoute, String, [String: Any]) -> Bool
+    private let eventRouter: AOSDesktopWorldSceneEventRouter
 
     init(
         canvasManager: CanvasManager,
         scene: AOSDesktopWorldSceneController = AOSDesktopWorldSceneController(),
         extensionStore: AOSSceneExtensionStore,
+        eventDiagnostics: AOSDesktopWorldSceneEventRouteDiagnostics = AOSDesktopWorldSceneEventRouteDiagnostics(),
         resolveContentURL: @escaping (String) -> String,
         clearReadyManifest: @escaping () -> Void,
         emit: @escaping (AOSSceneLeaseRoute, String, [String: Any]) -> Bool
@@ -31,6 +33,11 @@ final class AOSDesktopWorldSceneTransportController {
         self.resolveContentURL = resolveContentURL
         self.clearReadyManifest = clearReadyManifest
         self.emit = emit
+        self.eventRouter = AOSDesktopWorldSceneEventRouter(
+            scene: scene,
+            diagnostics: eventDiagnostics,
+            emit: emit
+        )
     }
 
     func recordReady(
@@ -119,19 +126,11 @@ final class AOSDesktopWorldSceneTransportController {
     }
 
     func handleEvent(target: CanvasLifecycleGeneration, payload: [String: Any]) {
-        guard let topology = authenticatedTopology(target: target, payload: payload),
-              let key = payload["lease_key"] as? String,
-              let eventType = payload["event_type"] as? String,
-              let event = payload["event"] as? [String: Any],
-              let canonicalEvent = aosCanonicalSceneEvent(event),
-              eventType == "gesture",
-              canonicalEvent["type"] as? String == eventType,
-              let ownerID = canonicalEvent["ownerId"] as? String,
-              let resourceID = canonicalEvent["resourceId"] as? String,
-              scene.key(owner: ownerID, resource: resourceID) == key else { return }
-        scene.withEventRoute(identity: stageIdentity(topology), key: key, event: eventType) { route in
-            _ = emit(route, eventType, canonicalEvent)
+        guard let topology = authenticatedTopology(target: target, payload: payload) else {
+            eventRouter.record(.staleTopology)
+            return
         }
+        eventRouter.handle(identity: stageIdentity(topology), payload: payload)
     }
 
     func ensureStage() -> DesktopWorldSceneBarrierTopology? {

--- a/src/daemon/scene-event.swift
+++ b/src/daemon/scene-event.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreFoundation
 
 private let aosSceneCancellationReasons = Set([
     "escape",
@@ -16,7 +17,8 @@ private func aosSceneExactKeys(_ value: [String: Any], _ keys: Set<String>) -> B
 }
 
 private func aosSceneFiniteNumber(_ value: Any?) -> Double? {
-    guard !(value is Bool), let number = value as? NSNumber else { return nil }
+    guard let number = value as? NSNumber,
+          CFGetTypeID(number) != CFBooleanGetTypeID() else { return nil }
     let result = number.doubleValue
     return result.isFinite ? result : nil
 }

--- a/src/daemon/unified.swift
+++ b/src/daemon/unified.swift
@@ -129,6 +129,7 @@ class UnifiedDaemon {
     private var contentServer: ContentServer?
     private lazy var sceneExtensionStore = AOSSceneExtensionStore()
     private lazy var sceneExtensionSchemeHandler = AOSSceneExtensionSchemeHandler(store: sceneExtensionStore)
+    private let desktopWorldSceneEventRouting = AOSDesktopWorldSceneEventRouteDiagnostics()
     let coordination = CoordinationBus()
 
     // Socket server
@@ -140,6 +141,7 @@ class UnifiedDaemon {
     private lazy var desktopWorldSceneTransport = AOSDesktopWorldSceneTransportController(
         canvasManager: canvasManager,
         extensionStore: sceneExtensionStore,
+        eventDiagnostics: desktopWorldSceneEventRouting,
         resolveContentURL: { [weak self] value in self?.resolveContentURL(value) ?? value },
         clearReadyManifest: { [weak self] in
             guard let self else { return }
@@ -3614,6 +3616,7 @@ class UnifiedDaemon {
                         "count": inputRegionSnapshot.count,
                         "active_capture": activeInputCapture,
                     ],
+                    "desktop_world_scene_event_routing": desktopWorldSceneEventRouting.snapshot(),
                     "surface_transport_probe": surfaceTransportProbeSnapshot(
                         inputEventSubscriberCount: inputEventSubscriberCount
                     ),

--- a/tests/daemon-scene-event.sh
+++ b/tests/daemon-scene-event.sh
@@ -40,6 +40,16 @@ let valid: [String: Any] = [
 ]
 
 require(aosCanonicalSceneEvent(valid) != nil, "valid scene event was rejected")
+let encodedValid = try JSONSerialization.data(withJSONObject: valid)
+let decodedValid = try JSONSerialization.jsonObject(with: encodedValid) as! [String: Any]
+require(aosCanonicalSceneEvent(decodedValid) != nil, "JSON numeric zero and one were misclassified as booleans")
+var booleanCoordinate = valid
+booleanCoordinate["coordinates"] = [
+    "origin": ["x": true, "y": 200.0], "previous": ["x": 110.0, "y": 210.0],
+    "current": ["x": 120.0, "y": 220.0], "desktopWorld": ["x": 120.0, "y": 220.0],
+    "native": NSNull(), "delta": ["x": 10.0, "y": 10.0], "totalDelta": ["x": 20.0, "y": 20.0],
+]
+require(aosCanonicalSceneEvent(booleanCoordinate) == nil, "boolean coordinate was accepted as numeric")
 var radial = valid
 radial["gesture"] = ["id": "gesture-menu", "kind": "tap", "phase": "end", "pointerSessionId": "capture-menu", "cancellationReason": NSNull()]
 radial["response"] = [

--- a/tests/desktop-world-scene-event-routing.test.mjs
+++ b/tests/desktop-world-scene-event-routing.test.mjs
@@ -1,0 +1,219 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import { createSceneEventEnvelope } from '../packages/toolkit/scene/scene-response-runtime.js'
+
+const repoRoot = path.resolve(import.meta.dirname, '..')
+
+function aimCommitEvent() {
+  return createSceneEventEnvelope({
+    identity: {
+      ownerId: 'example.consumer',
+      resourceId: 'companion/main',
+      stageId: 'desktop-world/main',
+    },
+    frame: {
+      affordanceId: 'body-hit',
+      cancelReason: null,
+      coordinates: {
+        desktop_world: { x: 900, y: 600 },
+        native: { x: 900, y: 480 },
+      },
+      current: { x: 900, y: 600 },
+      delta: { x: 20, y: 15 },
+      gesture_id: 'gesture-1',
+      gesture_type: 'drag',
+      interactionId: 'aim-body',
+      origin: { x: 400, y: 300 },
+      phase: 'end',
+      pointer: { capture_id: 'pointer-1' },
+      previous: { x: 880, y: 585 },
+      total_delta: { x: 500, y: 300 },
+    },
+    response: {
+      angle: 0.5404195002705842,
+      applied: true,
+      distance: 583.09518948453,
+      kind: 'aim_commit',
+      objectId: 'body',
+      origin: { x: 400, y: 300 },
+      pointer: { x: 900, y: 600 },
+      position: [900, 600, 0],
+      revision: 2,
+      route: 'line',
+    },
+    sequence: 7,
+    topology: {
+      displays: [{ bounds: [0, 0, 1920, 1080], displayId: 7, index: 0 }],
+    },
+    at: 1_721_000_000_000,
+  })
+}
+
+test('toolkit aim-and-commit events cross canonical routing with bounded rejection diagnostics', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'aos-scene-event-routing-'))
+  const eventPath = path.join(root, 'event.json')
+  const main = path.join(root, 'main.swift')
+  const executable = path.join(root, 'scene-event-routing-proof')
+  try {
+    await writeFile(eventPath, `${JSON.stringify(aimCommitEvent())}\n`)
+    await writeFile(main, `
+import Foundation
+
+func readyController() -> (AOSDesktopWorldSceneController, AOSDesktopWorldSceneStageIdentity) {
+    let controller = AOSDesktopWorldSceneController()
+    let identity = AOSDesktopWorldSceneStageIdentity(canvasGeneration: 3, topologyGeneration: 4)
+    let topology = AOSDesktopWorldSceneTopologyDescriptor(
+        identity: identity,
+        segments: [AOSDesktopWorldSceneStageSegment(displayID: 7, index: 0)]
+    )
+    precondition(controller.configureInitial(topology))
+    precondition(controller.recordReady(
+        topology: topology,
+        displayID: 7,
+        index: 0,
+        manifest: ["name": "desktop-world-stage"]
+    ))
+    return (controller, identity)
+}
+
+let bytes = try Data(contentsOf: URL(fileURLWithPath: CommandLine.arguments[1]))
+guard let event = try JSONSerialization.jsonObject(with: bytes) as? [String: Any] else {
+    preconditionFailure("event fixture did not decode")
+}
+precondition(aosCanonicalSceneEvent(event) != nil)
+
+let (controller, identity) = readyController()
+let connection = UUID()
+let key = controller.key(owner: "example.consumer", resource: "companion/main")
+guard case .accepted = controller.updateSubscriptions(
+    key: key,
+    connectionID: connection,
+    ref: "follow-ref",
+    adding: Set(["gesture"]),
+    removing: [],
+    removeAll: false
+) else { preconditionFailure("subscription rejected") }
+
+let diagnostics = AOSDesktopWorldSceneEventRouteDiagnostics(now: { 1234 })
+var delivered: [String: Any]?
+let router = AOSDesktopWorldSceneEventRouter(
+    scene: controller,
+    diagnostics: diagnostics
+) { route, eventType, value in
+    precondition(route.connectionID == connection)
+    precondition(route.ref == "follow-ref")
+    precondition(eventType == "gesture")
+    delivered = value
+    return true
+}
+router.handle(identity: identity, payload: [
+    "lease_key": key,
+    "event_type": "gesture",
+    "event": event,
+])
+precondition((delivered?["response"] as? [String: Any])?["kind"] as? String == "aim_commit")
+
+var wrongIdentity = event
+wrongIdentity["ownerId"] = "different.consumer"
+router.handle(identity: identity, payload: [
+    "lease_key": key,
+    "event_type": "gesture",
+    "event": wrongIdentity,
+])
+router.handle(identity: identity, payload: [
+    "lease_key": key,
+    "event_type": "gesture",
+    "event": ["contract": "invalid"],
+])
+router.record(.staleTopology)
+
+let failingDiagnostics = AOSDesktopWorldSceneEventRouteDiagnostics(now: { 2345 })
+let failingRouter = AOSDesktopWorldSceneEventRouter(
+    scene: controller,
+    diagnostics: failingDiagnostics
+) { _, _, _ in false }
+failingRouter.handle(identity: identity, payload: [
+    "lease_key": key,
+    "event_type": "gesture",
+    "event": event,
+])
+
+let stageDiagnostics = AOSDesktopWorldSceneEventRouteDiagnostics(now: { 3000 })
+let stageRouter = AOSDesktopWorldSceneEventRouter(
+    scene: controller,
+    diagnostics: stageDiagnostics
+) { _, _, _ in true }
+_ = controller.stageRemoved(code: "SCENE_STAGE_REMOVED")
+stageRouter.handle(identity: identity, payload: [
+    "lease_key": key,
+    "event_type": "gesture",
+    "event": event,
+])
+
+let (unsubscribedController, unsubscribedIdentity) = readyController()
+let unsubscribedDiagnostics = AOSDesktopWorldSceneEventRouteDiagnostics(now: { 3456 })
+let unsubscribedRouter = AOSDesktopWorldSceneEventRouter(
+    scene: unsubscribedController,
+    diagnostics: unsubscribedDiagnostics
+) { _, _, _ in true }
+unsubscribedRouter.handle(identity: unsubscribedIdentity, payload: [
+    "lease_key": unsubscribedController.key(owner: "example.consumer", resource: "companion/main"),
+    "event_type": "gesture",
+    "event": event,
+])
+
+let snapshot = diagnostics.snapshot()
+let counts = snapshot["by_outcome"] as? [String: Int]
+precondition(Set(snapshot.keys) == Set(["contract", "total", "failures", "by_outcome", "last_failure"]))
+precondition(snapshot["contract"] as? String == "aos.desktop-world.scene-event-routing.v1")
+precondition(snapshot["total"] as? Int == 4)
+precondition(snapshot["failures"] as? Int == 3)
+precondition(counts?["delivered"] == 1)
+precondition(counts?["identity_mismatch"] == 1)
+precondition(counts?["invalid_event"] == 1)
+precondition(counts?["stale_topology"] == 1)
+let lastFailure = snapshot["last_failure"] as? [String: Any]
+precondition(Set(lastFailure?.keys.map { $0 } ?? []) == Set(["at", "code"]))
+precondition(lastFailure?["code"] as? String == "stale_topology")
+precondition(lastFailure?["at"] as? Double == 1234)
+precondition((failingDiagnostics.snapshot()["by_outcome"] as? [String: Int])?["delivery_failed"] == 1)
+precondition((stageDiagnostics.snapshot()["by_outcome"] as? [String: Int])?["stage_unavailable"] == 1)
+precondition((unsubscribedDiagnostics.snapshot()["by_outcome"] as? [String: Int])?["unsubscribed"] == 1)
+print("PASS desktop world scene event routing")
+`)
+    execFileSync('swiftc', [
+      '-module-cache-path', path.join(root, 'module-cache'),
+      path.join(repoRoot, 'src/daemon/scene-lease-registry.swift'),
+      path.join(repoRoot, 'src/daemon/desktop-world-scene-result-coordinator.swift'),
+      path.join(repoRoot, 'src/daemon/desktop-world-scene-stage-readiness.swift'),
+      path.join(repoRoot, 'src/daemon/desktop-world-scene-controller.swift'),
+      path.join(repoRoot, 'src/daemon/scene-event.swift'),
+      path.join(repoRoot, 'src/daemon/desktop-world-scene-event-router.swift'),
+      main,
+      '-o', executable,
+    ], { cwd: repoRoot, stdio: 'pipe' })
+    const output = execFileSync(executable, [eventPath], { cwd: repoRoot, encoding: 'utf8' })
+    assert.match(output, /PASS desktop world scene event routing/u)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+test('daemon snapshot exposes scene route outcomes without scene payloads', async () => {
+  const [router, transport, daemon] = await Promise.all([
+    readFile(path.join(repoRoot, 'src/daemon/desktop-world-scene-event-router.swift'), 'utf8'),
+    readFile(path.join(repoRoot, 'src/daemon/desktop-world-scene-transport-controller.swift'), 'utf8'),
+    readFile(path.join(repoRoot, 'src/daemon/unified.swift'), 'utf8'),
+  ])
+  assert.match(transport, /eventRouter\.record\(\.staleTopology\)/u)
+  assert.match(transport, /eventRouter\.handle\(identity: stageIdentity\(topology\), payload: payload\)/u)
+  assert.match(daemon, /"desktop_world_scene_event_routing": desktopWorldSceneEventRouting\.snapshot\(\)/u)
+  assert.match(router, /"by_outcome": byOutcome/u)
+  assert.doesNotMatch(router, /"event": event/u)
+  assert.doesNotMatch(router, /"payload": payload/u)
+})

--- a/tests/desktop-world-scene-event-routing.test.mjs
+++ b/tests/desktop-world-scene-event-routing.test.mjs
@@ -188,6 +188,7 @@ precondition((unsubscribedDiagnostics.snapshot()["by_outcome"] as? [String: Int]
 let firstClockEntered = DispatchSemaphore(value: 0)
 let releaseFirstClock = DispatchSemaphore(value: 0)
 let firstRecordFinished = DispatchSemaphore(value: 0)
+let secondRecordStarted = DispatchSemaphore(value: 0)
 let secondRecordFinished = DispatchSemaphore(value: 0)
 let clockLock = NSLock()
 var clockCalls = 0
@@ -208,9 +209,11 @@ DispatchQueue.global().async {
 }
 precondition(firstClockEntered.wait(timeout: .now() + 1) == .success)
 DispatchQueue.global().async {
+    secondRecordStarted.signal()
     orderedDiagnostics.record(.invalidEvent)
     secondRecordFinished.signal()
 }
+precondition(secondRecordStarted.wait(timeout: .now() + 1) == .success)
 precondition(secondRecordFinished.wait(timeout: .now() + 0.05) == .timedOut)
 releaseFirstClock.signal()
 precondition(firstRecordFinished.wait(timeout: .now() + 1) == .success)

--- a/tests/desktop-world-scene-event-routing.test.mjs
+++ b/tests/desktop-world-scene-event-routing.test.mjs
@@ -173,7 +173,7 @@ precondition(Set(snapshot.keys) == Set(["contract", "total", "failures", "by_out
 precondition(snapshot["contract"] as? String == "aos.desktop-world.scene-event-routing.v1")
 precondition(snapshot["total"] as? Int == 4)
 precondition(snapshot["failures"] as? Int == 3)
-precondition(counts?["delivered"] == 1)
+precondition(counts?["enqueued"] == 1)
 precondition(counts?["identity_mismatch"] == 1)
 precondition(counts?["invalid_event"] == 1)
 precondition(counts?["stale_topology"] == 1)
@@ -181,9 +181,43 @@ let lastFailure = snapshot["last_failure"] as? [String: Any]
 precondition(Set(lastFailure?.keys.map { $0 } ?? []) == Set(["at", "code"]))
 precondition(lastFailure?["code"] as? String == "stale_topology")
 precondition(lastFailure?["at"] as? Double == 1234)
-precondition((failingDiagnostics.snapshot()["by_outcome"] as? [String: Int])?["delivery_failed"] == 1)
+precondition((failingDiagnostics.snapshot()["by_outcome"] as? [String: Int])?["enqueue_failed"] == 1)
 precondition((stageDiagnostics.snapshot()["by_outcome"] as? [String: Int])?["stage_unavailable"] == 1)
 precondition((unsubscribedDiagnostics.snapshot()["by_outcome"] as? [String: Int])?["unsubscribed"] == 1)
+
+let firstClockEntered = DispatchSemaphore(value: 0)
+let releaseFirstClock = DispatchSemaphore(value: 0)
+let firstRecordFinished = DispatchSemaphore(value: 0)
+let secondRecordFinished = DispatchSemaphore(value: 0)
+let clockLock = NSLock()
+var clockCalls = 0
+let orderedDiagnostics = AOSDesktopWorldSceneEventRouteDiagnostics(now: {
+    clockLock.lock()
+    clockCalls += 1
+    let call = clockCalls
+    clockLock.unlock()
+    if call == 1 {
+        firstClockEntered.signal()
+        releaseFirstClock.wait()
+    }
+    return Double(call)
+})
+DispatchQueue.global().async {
+    orderedDiagnostics.record(.identityMismatch)
+    firstRecordFinished.signal()
+}
+precondition(firstClockEntered.wait(timeout: .now() + 1) == .success)
+DispatchQueue.global().async {
+    orderedDiagnostics.record(.invalidEvent)
+    secondRecordFinished.signal()
+}
+precondition(secondRecordFinished.wait(timeout: .now() + 0.05) == .timedOut)
+releaseFirstClock.signal()
+precondition(firstRecordFinished.wait(timeout: .now() + 1) == .success)
+precondition(secondRecordFinished.wait(timeout: .now() + 1) == .success)
+let orderedFailure = orderedDiagnostics.snapshot()["last_failure"] as? [String: Any]
+precondition(orderedFailure?["code"] as? String == "invalid_event")
+precondition(orderedFailure?["at"] as? Double == 2)
 print("PASS desktop world scene event routing")
 `)
     execFileSync('swiftc', [

--- a/tests/desktop-world-scene-result-coordinator.test.mjs
+++ b/tests/desktop-world-scene-result-coordinator.test.mjs
@@ -410,6 +410,7 @@ guard case .accepted = eventAtomic.updateSubscriptions(
 let eventEnteredEnqueue = DispatchSemaphore(value: 0)
 let releaseEventEnqueue = DispatchSemaphore(value: 0)
 let eventRouteFinished = DispatchSemaphore(value: 0)
+let eventInvalidationStarted = DispatchSemaphore(value: 0)
 let eventInvalidationFinished = DispatchSemaphore(value: 0)
 let eventStateLock = NSLock()
 var eventRouteOutcome: AOSDesktopWorldSceneEventRouteOutcome?
@@ -431,6 +432,7 @@ DispatchQueue.global().async {
 }
 precondition(eventEnteredEnqueue.wait(timeout: .now() + 1) == .success)
 DispatchQueue.global().async {
+    eventInvalidationStarted.signal()
     let plan = eventAtomic.invalidateStage(
         identity: eventAtomicTopology.identity,
         code: "SCENE_STAGE_REMOVED"
@@ -440,6 +442,7 @@ DispatchQueue.global().async {
     eventStateLock.unlock()
     eventInvalidationFinished.signal()
 }
+precondition(eventInvalidationStarted.wait(timeout: .now() + 1) == .success)
 precondition(eventInvalidationFinished.wait(timeout: .now() + 0.05) == .timedOut)
 releaseEventEnqueue.signal()
 precondition(eventRouteFinished.wait(timeout: .now() + 1) == .success)

--- a/tests/desktop-world-scene-result-coordinator.test.mjs
+++ b/tests/desktop-world-scene-result-coordinator.test.mjs
@@ -341,7 +341,7 @@ let routedOutcome = controller.withEventRoute(identity: identity, key: key, even
     return true
 }
 precondition(routed)
-precondition(routedOutcome == .delivered)
+precondition(routedOutcome == .enqueued)
 
 let operation: [String: Any] = ["op": "mount", "document": ["revision": 1]]
 guard case .accepted(let initial) = controller.admitOperation(
@@ -394,6 +394,68 @@ guard case .accepted = atomic.updateSubscriptions(
     removing: [],
     removeAll: false
 ) else { preconditionFailure("atomic subscription rejected") }
+
+let eventAtomic = AOSDesktopWorldSceneController()
+let eventAtomicTopology = readyController(eventAtomic)
+let eventAtomicConnection = UUID()
+let eventAtomicKey = eventAtomic.key(owner: "event-atomic", resource: "main")
+guard case .accepted = eventAtomic.updateSubscriptions(
+    key: eventAtomicKey,
+    connectionID: eventAtomicConnection,
+    ref: "event-atomic-ref",
+    adding: Set(["gesture"]),
+    removing: [],
+    removeAll: false
+) else { preconditionFailure("event atomic subscription rejected") }
+let eventEnteredEnqueue = DispatchSemaphore(value: 0)
+let releaseEventEnqueue = DispatchSemaphore(value: 0)
+let eventRouteFinished = DispatchSemaphore(value: 0)
+let eventInvalidationFinished = DispatchSemaphore(value: 0)
+let eventStateLock = NSLock()
+var eventRouteOutcome: AOSDesktopWorldSceneEventRouteOutcome?
+var eventInvalidationPlan: AOSDesktopWorldSceneInvalidationPlan?
+DispatchQueue.global().async {
+    let outcome = eventAtomic.withEventRoute(
+        identity: eventAtomicTopology.identity,
+        key: eventAtomicKey,
+        event: "gesture"
+    ) { _ in
+        eventEnteredEnqueue.signal()
+        releaseEventEnqueue.wait()
+        return true
+    }
+    eventStateLock.lock()
+    eventRouteOutcome = outcome
+    eventStateLock.unlock()
+    eventRouteFinished.signal()
+}
+precondition(eventEnteredEnqueue.wait(timeout: .now() + 1) == .success)
+DispatchQueue.global().async {
+    let plan = eventAtomic.invalidateStage(
+        identity: eventAtomicTopology.identity,
+        code: "SCENE_STAGE_REMOVED"
+    )
+    eventStateLock.lock()
+    eventInvalidationPlan = plan
+    eventStateLock.unlock()
+    eventInvalidationFinished.signal()
+}
+precondition(eventInvalidationFinished.wait(timeout: .now() + 0.05) == .timedOut)
+releaseEventEnqueue.signal()
+precondition(eventRouteFinished.wait(timeout: .now() + 1) == .success)
+precondition(eventInvalidationFinished.wait(timeout: .now() + 1) == .success)
+eventStateLock.lock()
+let eventOutcomeBeforeInvalidation = eventRouteOutcome
+let eventRetirement = eventInvalidationPlan
+eventStateLock.unlock()
+precondition(eventOutcomeBeforeInvalidation == .enqueued)
+guard case .retire(let eventAtomicRetirement)? = eventRetirement else {
+    preconditionFailure("event atomic retirement request missing")
+}
+guard case .recoverable = eventAtomic.settleRetirement(
+    eventAtomicRetirement,
+    outcome: .retired
+) else { preconditionFailure("event atomic retirement did not settle") }
 guard case .accepted(let atomicAction) = atomic.admitOperation(
     topology: atomicTopology,
     key: atomicKey,

--- a/tests/desktop-world-scene-result-coordinator.test.mjs
+++ b/tests/desktop-world-scene-result-coordinator.test.mjs
@@ -262,11 +262,7 @@ test('DesktopWorld native orchestration pins lease refs and serializes topology 
     /if canvasInfo\.id == self\.sceneStageCanvasID \{[\s\S]{0,180}desktopWorldSceneTransport\.stageRemoved\(\)/u,
     'removing the native stage must retire the exact scene generation and its leases',
   )
-  assert.match(
-    transport,
-    /func handleEvent\([\s\S]{0,1300}scene\.withEventRoute\([\s\S]{0,300}emit\(route, eventType, canonicalEvent\)/u,
-    'gesture routing and outbound admission must remain linearized with stage invalidation',
-  )
+  assert.match(transport, /eventRouter\.handle\(identity: stageIdentity\(topology\), payload: payload\)/u)
 })
 
 test('DesktopWorld scene controller owns readiness, leases, barriers, subscriptions, and retirement', async () => {
@@ -340,10 +336,12 @@ guard case .accepted(let events) = controller.updateSubscriptions(
 ) else { preconditionFailure("subscription rejected") }
 precondition(events == Set(["gesture"]))
 var routed = false
-controller.withEventRoute(identity: identity, key: key, event: "gesture") { route in
+let routedOutcome = controller.withEventRoute(identity: identity, key: key, event: "gesture") { route in
     routed = route.connectionID == connection && route.ref == "ref-1"
+    return true
 }
 precondition(routed)
+precondition(routedOutcome == .delivered)
 
 let operation: [String: Any] = ["op": "mount", "document": ["revision": 1]]
 guard case .accepted(let initial) = controller.admitOperation(
@@ -447,10 +445,12 @@ guard case .retire(let atomicRetirement)? = retired else {
     preconditionFailure("atomic retirement request missing")
 }
 var postInvalidationEvent = false
-atomic.withEventRoute(identity: atomicTopology.identity, key: atomicKey, event: "gesture") { _ in
+let postInvalidationOutcome = atomic.withEventRoute(identity: atomicTopology.identity, key: atomicKey, event: "gesture") { _ in
     postInvalidationEvent = true
+    return true
 }
 precondition(postInvalidationEvent == false)
+precondition(postInvalidationOutcome == .stageUnavailable)
 precondition(atomic.acceptResult(
     identity: atomicTopology.identity,
     payload: result(atomicBroadcast.operationID, "apply", 7, 0, nil)
@@ -623,12 +623,13 @@ guard let closeCompletion = completion(closeActions),
 precondition(closeDelivery.route.ref == "disconnect-ref")
 precondition(closeDelivery.payload["status"] as? String == "ok")
 var disconnectedEvent = false
-disconnected.withEventRoute(
+let disconnectedEventOutcome = disconnected.withEventRoute(
     identity: disconnectedTopology.identity,
     key: disconnectedKey,
     event: "gesture"
-) { _ in disconnectedEvent = true }
+) { _ in disconnectedEvent = true; return true }
 precondition(disconnectedEvent == false)
+precondition(disconnectedEventOutcome == .unsubscribed)
 let duplicateDisconnect = disconnected.beginDisconnect(
     connectionID: disconnectedConnection,
     topology: disconnectedTopology


### PR DESCRIPTION
## Summary

- distinguish JSON numbers from booleans in the strict Swift scene-event canonicalizer
- route scene events through one reason-coded controller boundary with bounded redacted diagnostics
- expose passive event-routing counts through `daemon-snapshot`
- prove toolkit-generated aim-and-commit events cross JSON, Swift canonicalization, subscription routing, and writer admission

## Validation

- routed DesktopWorld scene suite: 17/17
- focused scene/controller/event suite: 76/76
- daemon scene event and lease-registry Swift proofs: passed
- full Swift static typecheck: passed with two unrelated existing warnings
- full schema suite: 174/174
- command manifest generation: passed
- proof/workflow routing: 24/24
- `git diff --check`: passed

No AOS binary build, daemon operation, TCC action, signing change, or native runtime test was performed.