### PR TITLE
Prioritize microphone readiness for segmented capture

### DIFF
--- a/docs/adr/0022-public-voice-transport-boundary.md
+++ b/docs/adr/0022-public-voice-transport-boundary.md
@@ -29,6 +29,8 @@ The broker owns the behavior that requires its stable permissioned identity:
 - 16 kHz mono PCM microphone capture;
 - create-new owner-only WAV handoff and cleanup;
 - continuous capture with atomically published, deterministic WAV checkpoints;
+- an optional bounded ready chime after microphone arming and before segmented
+  capture admission;
 - capture and playback meter calculation;
 - system speech buffers and playback;
 - bounded owner-only WAV validation and playback;
@@ -60,6 +62,19 @@ translation, and NDJSON presentation.
   non-symlinked, owner-owned `0700` parent. Input is at most 4 MiB and 120
   seconds, with mono or stereo PCM at 8 to 192 kHz.
 - Events never contain audio bytes, spoken text, or local paths.
+- When segmented capture requests the ready chime, AOS starts the input engine
+  with its capture gate closed, discards cue and settling audio, then opens the
+  gate and emits `capture_segmented_started`. Cue failure emits no start event
+  and leaves no capture output.
+- Segmented capture startup is asynchronous after its connection-scoped lease
+  is acknowledged. Only `capture_segmented_started` proves microphone
+  admission. Owner disconnect and cancellation remain observable while input
+  arming or cue playback is in progress, and terminal cleanup waits for any
+  in-flight engine arming to settle.
+- Cue exclusion uses the microphone callback's host clock when available and
+  its sample clock otherwise. A cue request fails with
+  `CAPTURE_CLOCK_UNAVAILABLE` rather than claiming readiness when neither clock
+  can establish the capture boundary.
 - There is no raw PCM socket stream and no AOS-owned transcription.
 
 ## Event Contract
@@ -75,7 +90,8 @@ stream.
 
 Existing channel/session `aos listen`, hotkey, one-shot microphone, and
 one-shot `aos say` behavior are unchanged. Segmented microphone capture is a
-separate form selected by `--segments`. `say --follow` remains a separate form
+separate form selected by `--segments`; `--ready-cue chime` is opt-in and
+defaults to no cue. `say --follow` remains a separate form
 using streamed system speech; provider-backed non-system speech remains behind
 its existing provider seam. `aos play --follow` shares the singleton output
 lease with streamed speech, so capture, barge-in, cancellation, owner loss, and

--- a/manifests/commands/aos-commands.json
+++ b/manifests/commands/aos-commands.json
@@ -6733,6 +6733,15 @@
               "value_type" : "duration"
             },
             {
+              "default_value" : "none",
+              "id" : "ready-cue",
+              "kind" : "flag",
+              "required" : false,
+              "summary" : "Audible cue after microphone arming and before capture admission: none or chime",
+              "token" : "--ready-cue",
+              "value_type" : "string"
+            },
+            {
               "default_value" : "120s",
               "id" : "max-duration",
               "kind" : "flag",
@@ -6751,7 +6760,7 @@
             }
           ],
           "examples" : [
-            "aos listen --source microphone --segments /private/tmp/aos-voice/segments --segment-duration 3s --follow --max-duration 120s"
+            "aos listen --source microphone --segments /private/tmp/aos-voice/segments --segment-duration 3s --ready-cue chime --follow --max-duration 120s"
           ],
           "execution" : {
             "auto_starts_daemon" : true,
@@ -6769,7 +6778,7 @@
             "streaming" : true,
             "supports_json_flag" : false
           },
-          "usage" : "aos listen --source microphone --segments <absolute-directory> --follow [--segment-duration 3s] [--max-duration 120s]"
+          "usage" : "aos listen --source microphone --segments <absolute-directory> --follow [--segment-duration 3s] [--ready-cue none|chime] [--max-duration 120s]"
         },
         {
           "args" : [

--- a/manifests/commands/source/aos/12-listen.json
+++ b/manifests/commands/source/aos/12-listen.json
@@ -295,6 +295,15 @@
               "value_type": "duration"
             },
             {
+              "default_value": "none",
+              "id": "ready-cue",
+              "kind": "flag",
+              "required": false,
+              "summary": "Audible cue after microphone arming and before capture admission: none or chime",
+              "token": "--ready-cue",
+              "value_type": "string"
+            },
+            {
               "default_value": "120s",
               "id": "max-duration",
               "kind": "flag",
@@ -313,7 +322,7 @@
             }
           ],
           "examples": [
-            "aos listen --source microphone --segments /private/tmp/aos-voice/segments --segment-duration 3s --follow --max-duration 120s"
+            "aos listen --source microphone --segments /private/tmp/aos-voice/segments --segment-duration 3s --ready-cue chime --follow --max-duration 120s"
           ],
           "execution": {
             "auto_starts_daemon": true,
@@ -331,7 +340,7 @@
             "streaming": true,
             "supports_json_flag": false
           },
-          "usage": "aos listen --source microphone --segments <absolute-directory> --follow [--segment-duration 3s] [--max-duration 120s]"
+          "usage": "aos listen --source microphone --segments <absolute-directory> --follow [--segment-duration 3s] [--ready-cue none|chime] [--max-duration 120s]"
         },
         {
           "args": [

--- a/scripts/lib/aos-voice-follow.mjs
+++ b/scripts/lib/aos-voice-follow.mjs
@@ -44,6 +44,9 @@ const SAFE_DAEMON_ERRORS = new Map([
   ['SEGMENT_DIRECTORY_NOT_EMPTY', 'voice segment directory must be empty'],
   ['INVALID_SEGMENT_DURATION', 'voice segment duration is invalid'],
   ['SEGMENT_CREATE_FAILED', 'voice segment could not be created'],
+  ['INVALID_READY_CUE', 'microphone ready cue is invalid'],
+  ['READY_CUE_UNAVAILABLE', 'microphone ready cue is unavailable'],
+  ['CAPTURE_CLOCK_UNAVAILABLE', 'microphone input timing is unavailable'],
   ['INVALID_SPEECH_TEXT', 'speech input is invalid'],
   ['INVALID_SPEECH_RATE', 'speech rate is invalid'],
   ['INVALID_VOICE_ID', 'voice identifier is malformed'],
@@ -116,6 +119,14 @@ function parseSegmentDuration(value) {
     fail('listen --segment-duration must be between 500ms and 5s', 'INVALID_ARG');
   }
   return seconds;
+}
+
+function parseReadyCue(value) {
+  if (value === undefined) return undefined;
+  if (value !== 'none' && value !== 'chime') {
+    fail('listen --ready-cue must be none or chime', 'INVALID_ARG');
+  }
+  return value;
 }
 
 function request(service, action, data, ref) {
@@ -294,7 +305,7 @@ function followVoice(options) {
 export async function listenVoice(args) {
   assertOnlyFlags(
     args,
-    new Set(['--source', '--shortcut', '--output', '--segments', '--segment-duration', '--max-duration']),
+    new Set(['--source', '--shortcut', '--output', '--segments', '--segment-duration', '--max-duration', '--ready-cue']),
     new Set(['--follow']),
   );
   if (!args.includes('--follow')) fail('voice listen sources require --follow', 'MISSING_ARG');
@@ -305,6 +316,7 @@ export async function listenVoice(args) {
       || args.includes('--segments')
       || args.includes('--segment-duration')
       || args.includes('--max-duration')
+      || args.includes('--ready-cue')
     ) fail('hotkey listen does not accept microphone flags', 'INVALID_ARG');
     const shortcut = valueAfter(args, '--shortcut') ?? 'Control+Option+Space';
     await followVoice({
@@ -328,6 +340,9 @@ export async function listenVoice(args) {
     if (output && args.includes('--segment-duration')) {
       fail('listen --segment-duration requires --segments', 'INVALID_ARG');
     }
+    if (output && args.includes('--ready-cue')) {
+      fail('listen --ready-cue requires --segments', 'INVALID_ARG');
+    }
     if (segmentsDirectory) {
       await followVoice({
         service: 'listen',
@@ -336,6 +351,7 @@ export async function listenVoice(args) {
           segments_directory: segmentsDirectory,
           segment_duration_seconds: parseSegmentDuration(valueAfter(args, '--segment-duration')),
           max_duration_seconds: parseDuration(valueAfter(args, '--max-duration')),
+          ready_cue: parseReadyCue(valueAfter(args, '--ready-cue')),
         },
         stopAction: { service: 'listen', action: 'stop' },
         cancelAction: { service: 'listen', action: 'cancel' },

--- a/src/daemon/capture-ready-cue.swift
+++ b/src/daemon/capture-ready-cue.swift
@@ -1,0 +1,195 @@
+import AVFoundation
+import Darwin
+import Foundation
+
+enum AOSCaptureReadyCue: String {
+    case none
+    case chime
+
+    static func parse(_ value: String?) throws -> AOSCaptureReadyCue {
+        guard let value else { return .none }
+        guard let cue = AOSCaptureReadyCue(rawValue: value) else {
+            throw AOSVoiceTransportFailure(
+                code: "INVALID_READY_CUE",
+                message: "microphone ready cue must be none or chime"
+            )
+        }
+        return cue
+    }
+}
+
+final class AOSCaptureInputGate {
+    private let lock = NSLock()
+    private var openState = false
+    private var latestSampleTime: AVAudioFramePosition?
+    private var observedTimingSource = false
+    private var minimumHostTime: UInt64?
+    private var minimumSampleTime: AVAudioFramePosition?
+
+    func observe(_ time: AVAudioTime) -> AOSCaptureInputTimestamp {
+        let timestamp = AOSCaptureInputTimestamp(time)
+        lock.lock()
+        if timestamp.hostTime != nil { observedTimingSource = true }
+        if let sampleTime = timestamp.sampleTime {
+            observedTimingSource = true
+            latestSampleTime = max(latestSampleTime ?? sampleTime, sampleTime)
+        }
+        lock.unlock()
+        return timestamp
+    }
+
+    func acceptsInput(at time: AVAudioTime) -> Bool {
+        acceptsInput(AOSCaptureInputTimestamp(time))
+    }
+
+    func acceptsInput(hostTime: UInt64) -> Bool {
+        acceptsInput(AOSCaptureInputTimestamp(hostTime: hostTime, sampleTime: nil))
+    }
+
+    func acceptsInput(_ timestamp: AOSCaptureInputTimestamp) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard openState else { return false }
+        if let hostTime = timestamp.hostTime, let minimumHostTime {
+            return hostTime >= minimumHostTime
+        }
+        if let sampleTime = timestamp.sampleTime, let minimumSampleTime {
+            return sampleTime >= minimumSampleTime
+        }
+        return minimumHostTime == nil && minimumSampleTime == nil
+    }
+
+    @discardableResult
+    func open(afterHostTime boundary: UInt64, requireCueExclusion: Bool = true) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if requireCueExclusion && !observedTimingSource { return false }
+        minimumHostTime = requireCueExclusion ? boundary : nil
+        if requireCueExclusion, let latestSampleTime {
+            minimumSampleTime = latestSampleTime == .max ? .max : latestSampleTime + 1
+        } else {
+            minimumSampleTime = nil
+        }
+        openState = true
+        return true
+    }
+
+    func close() {
+        lock.lock()
+        openState = false
+        lock.unlock()
+    }
+}
+
+struct AOSCaptureInputTimestamp: Equatable {
+    let hostTime: UInt64?
+    let sampleTime: AVAudioFramePosition?
+
+    init(hostTime: UInt64?, sampleTime: AVAudioFramePosition?) {
+        self.hostTime = hostTime
+        self.sampleTime = sampleTime
+    }
+
+    init(_ time: AVAudioTime) {
+        hostTime = time.isHostTimeValid ? time.hostTime : nil
+        sampleTime = time.isSampleTimeValid ? time.sampleTime : nil
+    }
+}
+
+private let aosCaptureReadyCueSampleRate = 48_000.0
+private let aosCaptureReadyCueDuration: TimeInterval = 0.14
+private let aosCaptureReadyCueSettleDuration: TimeInterval = 0.06
+private let aosCaptureReadyCueTimeout: TimeInterval = 1
+
+func aosMakeCaptureReadyCueBuffer() throws -> AVAudioPCMBuffer {
+    guard let format = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32,
+        sampleRate: aosCaptureReadyCueSampleRate,
+        channels: 1,
+        interleaved: false
+    ) else {
+        throw AOSVoiceTransportFailure(
+            code: "READY_CUE_UNAVAILABLE",
+            message: "microphone ready cue format is unavailable"
+        )
+    }
+    let frameCount = AVAudioFrameCount((aosCaptureReadyCueDuration * aosCaptureReadyCueSampleRate).rounded())
+    guard frameCount > 0,
+          let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount),
+          let samples = buffer.floatChannelData?[0] else {
+        throw AOSVoiceTransportFailure(
+            code: "READY_CUE_UNAVAILABLE",
+            message: "microphone ready cue buffer is unavailable"
+        )
+    }
+    buffer.frameLength = frameCount
+    var phase = 0.0
+    for index in 0..<Int(frameCount) {
+        let progress = Double(index) / Double(max(1, Int(frameCount) - 1))
+        let attack = min(1, progress / 0.08)
+        let release = min(1, (1 - progress) / 0.32)
+        let envelope = min(attack, release)
+        let frequency = 659.25 + 220.75 * progress
+        phase += 2 * Double.pi * frequency / aosCaptureReadyCueSampleRate
+        samples[index] = Float(sin(phase) * envelope * 0.18)
+    }
+    return buffer
+}
+
+func aosPlayCaptureReadyCue(
+    _ cue: AOSCaptureReadyCue,
+    isCanceled: @escaping () -> Bool = { false }
+) throws -> UInt64 {
+    guard cue == .chime else { return mach_absolute_time() }
+    let buffer = try aosMakeCaptureReadyCueBuffer()
+    let engine = AVAudioEngine()
+    let player = AVAudioPlayerNode()
+    let completed = DispatchSemaphore(value: 0)
+    engine.attach(player)
+    engine.connect(player, to: engine.mainMixerNode, format: buffer.format)
+    engine.prepare()
+    do {
+        try engine.start()
+    } catch {
+        throw AOSVoiceTransportFailure(
+            code: "READY_CUE_UNAVAILABLE",
+            message: "microphone ready cue output is unavailable"
+        )
+    }
+    defer {
+        player.stop()
+        engine.stop()
+    }
+    player.scheduleBuffer(
+        buffer,
+        at: nil,
+        options: [],
+        completionCallbackType: .dataPlayedBack
+    ) { _ in
+        completed.signal()
+    }
+    player.play()
+    let deadline = DispatchTime.now() + aosCaptureReadyCueTimeout
+    while completed.wait(timeout: .now() + .milliseconds(10)) != .success {
+        if isCanceled() {
+            throw AOSVoiceTransportFailure(
+                code: "CAPTURE_CANCELED",
+                message: "microphone capture was canceled before startup"
+            )
+        }
+        if DispatchTime.now() >= deadline {
+            throw AOSVoiceTransportFailure(
+                code: "READY_CUE_UNAVAILABLE",
+                message: "microphone ready cue did not complete"
+            )
+        }
+    }
+    Thread.sleep(forTimeInterval: aosCaptureReadyCueSettleDuration)
+    guard !isCanceled() else {
+        throw AOSVoiceTransportFailure(
+            code: "CAPTURE_CANCELED",
+            message: "microphone capture was canceled before startup"
+        )
+    }
+    return mach_absolute_time()
+}

--- a/src/daemon/segmented-microphone-capture.swift
+++ b/src/daemon/segmented-microphone-capture.swift
@@ -304,12 +304,28 @@ final class AOSAtomicVoiceSegmentWriter {
 }
 
 final class AOSSegmentedMicrophoneCaptureSession: AOSMicrophoneCaptureLease {
+    typealias InputHandler = (AVAudioPCMBuffer, AVAudioTime) -> Void
+
+    private struct FinishRequest {
+        let keepSegments: Bool
+        let event: String
+        let reason: String
+        let failureCode: String?
+    }
+
     let token = UUID()
     let owner: UUID
     let ref: String?
 
     private let maximumDuration: TimeInterval
     private let segmentDuration: TimeInterval
+    private let readyCue: AOSCaptureReadyCue
+    private let playReadyCue: (AOSCaptureReadyCue, @escaping () -> Bool) throws -> UInt64
+    private let startInputEngine: ((@escaping InputHandler) throws -> Void)?
+    private let inputEngineHealthy: (() -> Bool)?
+    private let stopInputEngine: (() -> Void)?
+    private let receiveInput: ((AVAudioPCMBuffer) -> Void)?
+    private let authorizeMicrophone: () -> AOSMicrophoneAuthorizationState
     private let authorizationState: () -> AOSMicrophoneAuthorizationState
     private let emit: (String, [String: Any]) -> Void
     private let terminal: (UUID) -> Void
@@ -317,8 +333,13 @@ final class AOSSegmentedMicrophoneCaptureSession: AOSMicrophoneCaptureLease {
     private let engine = AVAudioEngine()
     private let queue = DispatchQueue(label: "aos.voice.segmented-capture")
     private let finishLock = NSLock()
+    private let inputGate = AOSCaptureInputGate()
+    private var engineArming = false
+    private var engineOwned = false
+    private var captureAdmitted = false
     private var finishRequested = false
     private var finished = false
+    private var pendingFinish: FinishRequest?
     private var converter: AVAudioConverter?
     private var meterTimer: DispatchSourceTimer?
     private var startedAt: DispatchTime?
@@ -332,6 +353,18 @@ final class AOSSegmentedMicrophoneCaptureSession: AOSMicrophoneCaptureLease {
         directoryPath: String,
         segmentDuration: TimeInterval,
         maximumDuration: TimeInterval,
+        readyCue: AOSCaptureReadyCue = .none,
+        playReadyCue: @escaping (
+            AOSCaptureReadyCue,
+            @escaping () -> Bool
+        ) throws -> UInt64 = { cue, isCanceled in
+            try aosPlayCaptureReadyCue(cue, isCanceled: isCanceled)
+        },
+        startInputEngine: ((@escaping InputHandler) throws -> Void)? = nil,
+        inputEngineHealthy: (() -> Bool)? = nil,
+        stopInputEngine: (() -> Void)? = nil,
+        receiveInput: ((AVAudioPCMBuffer) -> Void)? = nil,
+        authorizeMicrophone: (() -> AOSMicrophoneAuthorizationState)? = nil,
         authorizationState: @escaping () -> AOSMicrophoneAuthorizationState,
         emit: @escaping (String, [String: Any]) -> Void,
         terminal: @escaping (UUID) -> Void
@@ -339,6 +372,13 @@ final class AOSSegmentedMicrophoneCaptureSession: AOSMicrophoneCaptureLease {
         self.owner = owner
         self.ref = ref
         self.segmentDuration = segmentDuration
+        self.readyCue = readyCue
+        self.playReadyCue = playReadyCue
+        self.startInputEngine = startInputEngine
+        self.inputEngineHealthy = inputEngineHealthy
+        self.stopInputEngine = stopInputEngine
+        self.receiveInput = receiveInput
+        self.authorizeMicrophone = authorizeMicrophone ?? authorizationState
         self.authorizationState = authorizationState
         self.emit = emit
         self.terminal = terminal
@@ -351,70 +391,131 @@ final class AOSSegmentedMicrophoneCaptureSession: AOSMicrophoneCaptureLease {
     }
 
     func start() throws {
-        finishLock.lock()
-        defer { finishLock.unlock() }
-        guard !finishRequested else {
-            writer.cancel()
+        guard !startupCanceled() else {
             throw AOSVoiceTransportFailure(
                 code: "CAPTURE_CANCELED",
                 message: "microphone capture was canceled before startup"
             )
         }
-        var startupError: Error?
-        aosRunOnMainSync {
-            let input = engine.inputNode
-            let inputFormat = input.outputFormat(forBus: 0)
-            guard inputFormat.channelCount > 0,
-                  inputFormat.sampleRate.isFinite,
-                  inputFormat.sampleRate > 0,
-                  let converter = AVAudioConverter(from: inputFormat, to: writer.outputFormat) else {
-                startupError = AOSVoiceTransportFailure(
-                    code: "MICROPHONE_UNAVAILABLE",
-                    message: "microphone input is unavailable"
-                )
-                return
-            }
-            self.converter = converter
-            input.installTap(onBus: 0, bufferSize: 1024, format: inputFormat) { [weak self] buffer, _ in
-                guard let self, let copy = aosCopyPCMBuffer(buffer) else { return }
-                self.queue.async { self.receive(copy) }
-            }
-            tapInstalled = true
-            engine.prepare()
-            do {
-                try engine.start()
-            } catch {
-                if tapInstalled {
-                    input.removeTap(onBus: 0)
-                    tapInstalled = false
-                }
-                startupError = AOSVoiceTransportFailure(
-                    code: "MICROPHONE_UNAVAILABLE",
-                    message: "microphone input is unavailable"
-                )
-            }
-        }
-        if let startupError {
-            writer.cancel()
-            throw startupError
+        let authorization = authorizeMicrophone()
+        if let failure = authorization.failure {
+            let error = AOSVoiceTransportFailure(code: failure.code, message: failure.message)
+            throw failStartup(error)
         }
 
-        emit("capture_segmented_started", [
-            "sample_rate": Int(aosVoiceCaptureSampleRate),
-            "channels": aosVoiceCaptureChannels,
-            "max_duration_ms": Int(maximumDuration * 1000),
-            "segment_duration_ms": Int(segmentDuration * 1000),
-        ])
-        startedAt = .now()
-        let timer = DispatchSource.makeTimerSource(queue: queue)
-        timer.schedule(deadline: .now(), repeating: .milliseconds(100))
-        timer.setEventHandler { [weak self] in self?.emitMeterOrStop() }
-        timer.resume()
-        meterTimer = timer
+        try beginEngineArming()
+        do {
+            try startCaptureEngine()
+        } catch {
+            let resolved = completeEngineArming(started: false, startupError: error)
+                ?? AOSVoiceTransportFailure(
+                    code: "MICROPHONE_UNAVAILABLE",
+                    message: "microphone input is unavailable"
+                )
+            throw failStartup(resolved)
+        }
+        if let cancellation = completeEngineArming(started: true, startupError: nil) {
+            throw failStartup(cancellation)
+        }
+
+        let admissionBoundary: UInt64
+        do {
+            admissionBoundary = try playReadyCue(readyCue) { [weak self] in
+                self?.startupCanceled() ?? true
+            }
+        } catch let failure as AOSVoiceTransportFailure {
+            throw failStartup(failure)
+        } catch {
+            let failure = AOSVoiceTransportFailure(
+                code: "READY_CUE_UNAVAILABLE",
+                message: "microphone ready cue failed"
+            )
+            throw failStartup(failure)
+        }
+
+        do {
+            try admitCapture(afterHostTime: admissionBoundary)
+        } catch let failure as AOSVoiceTransportFailure {
+            throw failStartup(failure)
+        } catch {
+            let failure = AOSVoiceTransportFailure(
+                code: "VOICE_TRANSPORT_FAILED",
+                message: "microphone capture admission failed"
+            )
+            throw failStartup(failure)
+        }
+    }
+
+    private func beginEngineArming() throws {
+        finishLock.lock()
+        guard !finishRequested, !finished else {
+            finishLock.unlock()
+            throw AOSVoiceTransportFailure(
+                code: "CAPTURE_CANCELED",
+                message: "microphone capture was canceled before startup"
+            )
+        }
+        engineArming = true
+        finishLock.unlock()
+    }
+
+    private func completeEngineArming(
+        started: Bool,
+        startupError: Error?
+    ) -> AOSVoiceTransportFailure? {
+        finishLock.lock()
+        engineArming = false
+        if started { engineOwned = true }
+        let cancellationWon = finishRequested
+        let shouldScheduleFinish = cancellationWon && !finished
+        finishLock.unlock()
+        if shouldScheduleFinish { schedulePendingFinish() }
+        if cancellationWon {
+            return AOSVoiceTransportFailure(
+                code: "CAPTURE_CANCELED",
+                message: "microphone capture was canceled before startup"
+            )
+        }
+        if let failure = startupError as? AOSVoiceTransportFailure { return failure }
+        if startupError != nil {
+            return AOSVoiceTransportFailure(
+                code: "MICROPHONE_UNAVAILABLE",
+                message: "microphone input is unavailable"
+            )
+        }
+        return nil
+    }
+
+    private func failStartup(_ failure: AOSVoiceTransportFailure) -> AOSVoiceTransportFailure {
+        finishLock.lock()
+        if finishRequested {
+            finishLock.unlock()
+            return AOSVoiceTransportFailure(
+                code: "CAPTURE_CANCELED",
+                message: "microphone capture was canceled before startup"
+            )
+        }
+        finishRequested = true
+        pendingFinish = FinishRequest(
+            keepSegments: false,
+            event: "capture_segmented_failed",
+            reason: "failure",
+            failureCode: failure.code
+        )
+        let shouldSchedule = !engineArming
+        finishLock.unlock()
+        if shouldSchedule { schedulePendingFinish() }
+        return failure
     }
 
     func finalize(reason: String) {
-        requestFinish(keepSegments: true, event: "capture_segmented_completed", reason: reason, failureCode: nil)
+        requestFinish(
+            keepSegments: true,
+            event: "capture_segmented_completed",
+            reason: reason,
+            failureCode: nil,
+            cancelBeforeAdmission: true
+        )
     }
 
     func cancel(reason: String) {
@@ -424,7 +525,7 @@ final class AOSSegmentedMicrophoneCaptureSession: AOSMicrophoneCaptureLease {
     private func receive(_ input: AVAudioPCMBuffer) {
         guard !finished else { return }
         guard authorizationState().isAuthorized else {
-            finishLocked(
+            requestFinish(
                 keepSegments: false,
                 event: "capture_segmented_failed",
                 reason: "failure",
@@ -434,7 +535,7 @@ final class AOSSegmentedMicrophoneCaptureSession: AOSMicrophoneCaptureLease {
         }
         if let metrics = aosAudioFrameMetrics(input) { lastMetrics = metrics }
         guard let converter else {
-            finishLocked(
+            requestFinish(
                 keepSegments: false,
                 event: "capture_segmented_failed",
                 reason: "failure",
@@ -445,7 +546,7 @@ final class AOSSegmentedMicrophoneCaptureSession: AOSMicrophoneCaptureLease {
         let ratio = writer.outputFormat.sampleRate / input.format.sampleRate
         let capacity = AVAudioFrameCount(max(1, ceil(Double(input.frameLength) * ratio) + 32))
         guard let output = AVAudioPCMBuffer(pcmFormat: writer.outputFormat, frameCapacity: capacity) else {
-            finishLocked(
+            requestFinish(
                 keepSegments: false,
                 event: "capture_segmented_failed",
                 reason: "failure",
@@ -465,7 +566,7 @@ final class AOSSegmentedMicrophoneCaptureSession: AOSMicrophoneCaptureLease {
             return input
         }
         guard conversionError == nil, status != .error else {
-            finishLocked(
+            requestFinish(
                 keepSegments: false,
                 event: "capture_segmented_failed",
                 reason: "failure",
@@ -477,7 +578,7 @@ final class AOSSegmentedMicrophoneCaptureSession: AOSMicrophoneCaptureLease {
         do {
             emitReady(try writer.append(output))
         } catch let failure as AOSVoiceTransportFailure {
-            finishLocked(
+            requestFinish(
                 keepSegments: false,
                 event: "capture_segmented_failed",
                 reason: "failure",
@@ -485,7 +586,7 @@ final class AOSSegmentedMicrophoneCaptureSession: AOSMicrophoneCaptureLease {
             )
             return
         } catch {
-            finishLocked(
+            requestFinish(
                 keepSegments: false,
                 event: "capture_segmented_failed",
                 reason: "failure",
@@ -494,7 +595,7 @@ final class AOSSegmentedMicrophoneCaptureSession: AOSMicrophoneCaptureLease {
             return
         }
         if writer.reachedMaximumDuration {
-            finishLocked(
+            requestFinish(
                 keepSegments: true,
                 event: "capture_segmented_completed",
                 reason: "max_duration",
@@ -507,7 +608,7 @@ final class AOSSegmentedMicrophoneCaptureSession: AOSMicrophoneCaptureLease {
         guard !finished else { return }
         if let startedAt,
            aosVoiceCaptureDeadlineReached(startedAt: startedAt, maximumDuration: maximumDuration) {
-            finishLocked(
+            requestFinish(
                 keepSegments: true,
                 event: "capture_segmented_completed",
                 reason: "max_duration",
@@ -516,7 +617,7 @@ final class AOSSegmentedMicrophoneCaptureSession: AOSMicrophoneCaptureLease {
             return
         }
         guard authorizationState().isAuthorized else {
-            finishLocked(
+            requestFinish(
                 keepSegments: false,
                 event: "capture_segmented_failed",
                 reason: "failure",
@@ -537,7 +638,8 @@ final class AOSSegmentedMicrophoneCaptureSession: AOSMicrophoneCaptureLease {
         keepSegments: Bool,
         event: String,
         reason: String,
-        failureCode: String?
+        failureCode: String?,
+        cancelBeforeAdmission: Bool = false
     ) {
         finishLock.lock()
         guard !finishRequested else {
@@ -545,36 +647,182 @@ final class AOSSegmentedMicrophoneCaptureSession: AOSMicrophoneCaptureLease {
             return
         }
         finishRequested = true
+        let canceledBeforeAdmission = cancelBeforeAdmission && !captureAdmitted
+        pendingFinish = FinishRequest(
+            keepSegments: canceledBeforeAdmission ? false : keepSegments,
+            event: canceledBeforeAdmission ? "capture_segmented_canceled" : event,
+            reason: reason,
+            failureCode: canceledBeforeAdmission ? nil : failureCode
+        )
+        let shouldSchedule = !engineArming
         finishLock.unlock()
-        queue.async { [weak self] in
-            self?.finishLocked(
-                keepSegments: keepSegments,
-                event: event,
-                reason: reason,
-                failureCode: failureCode
+        if shouldSchedule { schedulePendingFinish() }
+    }
+
+    private func schedulePendingFinish() {
+        queue.async { [weak self] in self?.finishPending() }
+    }
+
+    private func startupCanceled() -> Bool {
+        finishLock.lock()
+        defer { finishLock.unlock() }
+        return finishRequested || finished
+    }
+
+    private func admitCapture(afterHostTime boundary: UInt64) throws {
+        guard !startupCanceled() else {
+            throw AOSVoiceTransportFailure(
+                code: "CAPTURE_CANCELED",
+                message: "microphone capture was canceled before startup"
             )
+        }
+        guard authorizationState().isAuthorized else {
+            throw AOSVoiceTransportFailure(
+                code: "MICROPHONE_PERMISSION_LOST",
+                message: "microphone permission was lost before capture started"
+            )
+        }
+        guard captureEngineIsHealthy() else {
+            throw AOSVoiceTransportFailure(
+                code: "MICROPHONE_UNAVAILABLE",
+                message: "microphone input became unavailable before capture started"
+            )
+        }
+
+        finishLock.lock()
+        guard !finishRequested, !finished else {
+            finishLock.unlock()
+            throw AOSVoiceTransportFailure(
+                code: "CAPTURE_CANCELED",
+                message: "microphone capture was canceled before startup"
+            )
+        }
+        let admissionCompleted = DispatchSemaphore(value: 0)
+        var admissionFailure: AOSVoiceTransportFailure?
+        queue.async { [self] in
+            finishLock.lock()
+            if finishRequested || finished {
+                admissionFailure = AOSVoiceTransportFailure(
+                    code: "CAPTURE_CANCELED",
+                    message: "microphone capture was canceled before startup"
+                )
+                finishLock.unlock()
+            } else if !inputGate.open(
+                afterHostTime: boundary,
+                requireCueExclusion: readyCue == .chime
+            ) {
+                admissionFailure = AOSVoiceTransportFailure(
+                    code: "CAPTURE_CLOCK_UNAVAILABLE",
+                    message: "microphone input timing is unavailable"
+                )
+                finishLock.unlock()
+            } else {
+                captureAdmitted = true
+                finishLock.unlock()
+                emitStartedAndBeginMetering()
+            }
+            admissionCompleted.signal()
+        }
+        finishLock.unlock()
+        admissionCompleted.wait()
+        if let admissionFailure { throw admissionFailure }
+    }
+
+    private func emitStartedAndBeginMetering() {
+        startedAt = .now()
+        emit("capture_segmented_started", [
+            "sample_rate": Int(aosVoiceCaptureSampleRate),
+            "channels": aosVoiceCaptureChannels,
+            "max_duration_ms": Int(maximumDuration * 1000),
+            "segment_duration_ms": Int(segmentDuration * 1000),
+        ])
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now(), repeating: .milliseconds(100))
+        timer.setEventHandler { [weak self] in self?.emitMeterOrStop() }
+        timer.resume()
+        meterTimer = timer
+    }
+
+    private func startCaptureEngine() throws {
+        let handler: InputHandler = { [weak self] buffer, time in
+            self?.enqueueInput(buffer, at: time)
+        }
+        if let startInputEngine {
+            try startInputEngine(handler)
+            return
+        }
+        var startupError: Error?
+        aosRunOnMainSync {
+            let input = engine.inputNode
+            let inputFormat = input.outputFormat(forBus: 0)
+            guard inputFormat.channelCount > 0,
+                  inputFormat.sampleRate.isFinite,
+                  inputFormat.sampleRate > 0,
+                  let converter = AVAudioConverter(from: inputFormat, to: writer.outputFormat) else {
+                startupError = AOSVoiceTransportFailure(
+                    code: "MICROPHONE_UNAVAILABLE",
+                    message: "microphone input is unavailable"
+                )
+                return
+            }
+            self.converter = converter
+            input.installTap(onBus: 0, bufferSize: 1024, format: inputFormat, block: handler)
+            tapInstalled = true
+            engine.prepare()
+            do {
+                try engine.start()
+            } catch {
+                if tapInstalled {
+                    input.removeTap(onBus: 0)
+                    tapInstalled = false
+                }
+                startupError = AOSVoiceTransportFailure(
+                    code: "MICROPHONE_UNAVAILABLE",
+                    message: "microphone input is unavailable"
+                )
+            }
+        }
+        if let startupError { throw startupError }
+    }
+
+    private func enqueueInput(_ input: AVAudioPCMBuffer, at time: AVAudioTime) {
+        let timestamp = inputGate.observe(time)
+        guard let copy = aosCopyPCMBuffer(input) else { return }
+        queue.async { [weak self] in
+            guard let self, self.inputGate.acceptsInput(timestamp) else { return }
+            if let receiveInput = self.receiveInput {
+                receiveInput(copy)
+            } else {
+                self.receive(copy)
+            }
         }
     }
 
-    private func finishLocked(
-        keepSegments: Bool,
-        event: String,
-        reason: String,
-        failureCode: String?
-    ) {
+    private func captureEngineIsHealthy() -> Bool {
+        if let inputEngineHealthy { return inputEngineHealthy() }
+        var healthy = false
+        aosRunOnMainSync {
+            healthy = engine.isRunning
+                && engine.inputNode.outputFormat(forBus: 0).channelCount > 0
+        }
+        return healthy
+    }
+
+    private func finishPending() {
         finishLock.lock()
-        guard !finished else {
+        guard !finished, let request = pendingFinish else {
             finishLock.unlock()
             return
         }
         finished = true
         finishRequested = true
+        pendingFinish = nil
         finishLock.unlock()
         meterTimer?.cancel()
         meterTimer = nil
         stopEngine()
 
-        if !keepSegments {
+        if !request.keepSegments {
             writer.cancel()
         } else {
             do {
@@ -592,17 +840,17 @@ final class AOSSegmentedMicrophoneCaptureSession: AOSMicrophoneCaptureLease {
             }
         }
 
-        if let failureCode {
-            emit(event, ["code": failureCode])
-        } else if keepSegments {
-            emit(event, [
-                "reason": reason,
+        if let failureCode = request.failureCode {
+            emit(request.event, ["code": failureCode])
+        } else if request.keepSegments {
+            emit(request.event, [
+                "reason": request.reason,
                 "duration_ms": writer.durationMilliseconds,
                 "bytes": writer.totalBytes,
                 "segments": writer.completedSegmentCount,
             ])
         } else {
-            emit(event, ["reason": reason])
+            emit(request.event, ["reason": request.reason])
         }
         terminal(token)
     }
@@ -618,6 +866,16 @@ final class AOSSegmentedMicrophoneCaptureSession: AOSMicrophoneCaptureLease {
     }
 
     private func stopEngine() {
+        inputGate.close()
+        finishLock.lock()
+        let shouldStop = engineOwned
+        engineOwned = false
+        finishLock.unlock()
+        guard shouldStop else { return }
+        if let stopInputEngine {
+            stopInputEngine()
+            return
+        }
         aosRunOnMainSync {
             if tapInstalled {
                 engine.inputNode.removeTap(onBus: 0)

--- a/src/daemon/unified.swift
+++ b/src/daemon/unified.swift
@@ -3355,15 +3355,22 @@ class UnifiedDaemon {
                 ?? aosVoiceSegmentDefaultDuration
             let maximumDuration = (json["max_duration_seconds"] as? NSNumber)?.doubleValue
                 ?? aosVoiceCaptureMaximumDuration
+            if let value = json["ready_cue"], !(value is String) {
+                sendVoiceTransportError(to: outbound, message: "ready cue must be a string", code: "INVALID_READY_CUE", envelopeActive: envelopeActive, envelopeRef: envelopeRef)
+                return
+            }
             do {
-                try voiceTransport.startSegmentedCapture(
+                let readyCue = try AOSCaptureReadyCue.parse(json["ready_cue"] as? String)
+                let beginCapture = try voiceTransport.prepareSegmentedCapture(
                     owner: connectionID,
                     directoryPath: directoryPath,
                     segmentDuration: segmentDuration,
                     maximumDuration: maximumDuration,
+                    readyCue: readyCue,
                     ref: envelopeRef
                 )
                 sendResponseJSON(to: outbound, ["status": "ok"], envelopeActive: envelopeActive, envelopeRef: envelopeRef)
+                beginCapture()
             } catch let failure as AOSVoiceTransportFailure {
                 sendVoiceTransportError(to: outbound, message: failure.message, code: failure.code, envelopeActive: envelopeActive, envelopeRef: envelopeRef)
             } catch {

--- a/src/daemon/voice-transport.swift
+++ b/src/daemon/voice-transport.swift
@@ -658,6 +658,7 @@ final class AOSVoiceTransport {
     }
 
     private let lock = NSLock()
+    private let captureStartupQueue = DispatchQueue(label: "aos.voice.capture-startup", qos: .userInitiated)
     private let emit: EventEmitter
     private let microphoneAuthorization: AOSMicrophoneAuthorizationProviding
     private var hotkey: HotkeyLease?
@@ -769,13 +770,14 @@ final class AOSVoiceTransport {
         }
     }
 
-    func startSegmentedCapture(
+    func prepareSegmentedCapture(
         owner: UUID,
         directoryPath: String,
         segmentDuration: TimeInterval,
         maximumDuration: TimeInterval,
+        readyCue: AOSCaptureReadyCue,
         ref: String?
-    ) throws {
+    ) throws -> () -> Void {
         lock.lock()
         guard capture == nil else {
             lock.unlock()
@@ -783,19 +785,19 @@ final class AOSVoiceTransport {
         }
         lock.unlock()
 
-        var authorization = microphoneAuthorization.status()
-        if authorization == .notDetermined {
-            authorization = microphoneAuthorization.request(timeout: 30).after
-        }
-        if let failure = authorization.failure {
-            throw AOSVoiceTransportFailure(code: failure.code, message: failure.message)
-        }
         let session = try AOSSegmentedMicrophoneCaptureSession(
             owner: owner,
             ref: ref,
             directoryPath: directoryPath,
             segmentDuration: segmentDuration,
             maximumDuration: maximumDuration,
+            readyCue: readyCue,
+            authorizeMicrophone: { [microphoneAuthorization] in
+                let current = microphoneAuthorization.status()
+                return current == .notDetermined
+                    ? microphoneAuthorization.request(timeout: 30).after
+                    : current
+            },
             authorizationState: { [microphoneAuthorization] in microphoneAuthorization.status() },
             emit: { [emit] event, data in emit(owner, event, data, ref) },
             terminal: { [weak self] token in self?.captureDidTerminate(token: token) }
@@ -810,11 +812,10 @@ final class AOSVoiceTransport {
         capture = session
         lock.unlock()
         outputToCancel?.cancel(reason: "barge_in")
-        do {
-            try session.start()
-        } catch {
-            captureDidTerminate(token: session.token)
-            throw error
+        return { [captureStartupQueue] in
+            captureStartupQueue.async {
+                try? session.start()
+            }
         }
     }
 

--- a/tests/help-contract.sh
+++ b/tests/help-contract.sh
@@ -326,6 +326,7 @@ assert "--source hotkey" in forms["listen-hotkey"]["usage"], forms["listen-hotke
 assert "--source microphone" in forms["listen-microphone"]["usage"], forms["listen-microphone"]
 assert "--segments <absolute-directory>" in forms["listen-microphone-segmented"]["usage"], forms["listen-microphone-segmented"]
 assert "--segment-duration 3s" in forms["listen-microphone-segmented"]["usage"], forms["listen-microphone-segmented"]
+assert "--ready-cue none|chime" in forms["listen-microphone-segmented"]["usage"], forms["listen-microphone-segmented"]
 assert "Control+Option+Space" in text, text
 api_doc = Path("docs/api/aos.md").read_text(encoding="utf-8")
 architecture = Path("ARCHITECTURE.md").read_text(encoding="utf-8")

--- a/tests/voice-external-parser.sh
+++ b/tests/voice-external-parser.sh
@@ -120,6 +120,26 @@ grep -q '"code":"INVALID_ARG"' "$STATE_ROOT/listen-microphone-segment-duration-i
   exit 1
 }
 
+if ./aos listen --source microphone --segments /private/tmp/segments --ready-cue voice --follow 2>"$STATE_ROOT/listen-microphone-ready-cue-invalid.err"; then
+  echo "FAIL: segmented microphone listen accepted an unknown ready cue" >&2
+  exit 1
+fi
+grep -q '"code":"INVALID_ARG"' "$STATE_ROOT/listen-microphone-ready-cue-invalid.err" || {
+  echo "FAIL: invalid ready cue did not use INVALID_ARG" >&2
+  cat "$STATE_ROOT/listen-microphone-ready-cue-invalid.err" >&2
+  exit 1
+}
+
+if ./aos listen --source microphone --output /private/tmp/capture.wav --ready-cue chime --follow 2>"$STATE_ROOT/listen-microphone-ready-cue-target-invalid.err"; then
+  echo "FAIL: single-file microphone listen accepted a segmented ready cue" >&2
+  exit 1
+fi
+grep -q '"code":"INVALID_ARG"' "$STATE_ROOT/listen-microphone-ready-cue-target-invalid.err" || {
+  echo "FAIL: misplaced ready cue did not use INVALID_ARG" >&2
+  cat "$STATE_ROOT/listen-microphone-ready-cue-target-invalid.err" >&2
+  exit 1
+}
+
 secret="voice-parser-secret"
 if printf '%s' "$secret" | ./aos say --follow --rate invalid 2>"$STATE_ROOT/say-follow-rate-invalid.err"; then
   echo "FAIL: say follow accepted invalid rate" >&2

--- a/tests/voice-follow-cli.test.mjs
+++ b/tests/voice-follow-cli.test.mjs
@@ -131,6 +131,34 @@ test('microphone duration parsing rejects schema-incompatible bounds before daem
   const segmentResult = await tooShortSegment.completed;
   assert.equal(segmentResult.code, 1);
   assert.match(segmentResult.stderr, /"code":"INVALID_ARG"/);
+
+  const invalidCue = launch('scripts/aos-tell-listen.mjs', [
+    'listen',
+    '--source',
+    'microphone',
+    '--segments',
+    path.join(stateRoot, 'cue-segments'),
+    '--ready-cue',
+    'voice',
+    '--follow',
+  ], stateRoot);
+  const invalidCueResult = await invalidCue.completed;
+  assert.equal(invalidCueResult.code, 1);
+  assert.match(invalidCueResult.stderr, /"code":"INVALID_ARG"/);
+
+  const misplacedCue = launch('scripts/aos-tell-listen.mjs', [
+    'listen',
+    '--source',
+    'microphone',
+    '--output',
+    path.join(stateRoot, 'capture.wav'),
+    '--ready-cue',
+    'chime',
+    '--follow',
+  ], stateRoot);
+  const misplacedCueResult = await misplacedCue.completed;
+  assert.equal(misplacedCueResult.code, 1);
+  assert.match(misplacedCueResult.stderr, /"code":"INVALID_ARG"/);
 });
 
 const startingDaemonSource = `#!/usr/bin/env node
@@ -402,6 +430,8 @@ test('segmented microphone follow publishes path-free checkpoints and finalizes 
     segmentsDirectory,
     '--segment-duration',
     '3s',
+    '--ready-cue',
+    'chime',
     '--follow',
   ], stateRoot);
   while (!captureSocket) await new Promise((resolve) => setTimeout(resolve, 10));
@@ -411,6 +441,7 @@ test('segmented microphone follow publishes path-free checkpoints and finalizes 
   assert.deepEqual(requests.map((item) => item.action), ['microphone_segmented', 'stop']);
   assert.equal(requests[0].data.segments_directory, segmentsDirectory);
   assert.equal(requests[0].data.segment_duration_seconds, 3);
+  assert.equal(requests[0].data.ready_cue, 'chime');
   assert.ok(!result.stdout.includes(segmentsDirectory));
   assert.ok(!result.stderr.includes(segmentsDirectory));
   assert.deepEqual(result.stdout.trim().split('\n').map(JSON.parse).map((item) => item.event), [

--- a/tests/voice-transport-native.sh
+++ b/tests/voice-transport-native.sh
@@ -353,6 +353,455 @@ struct VoiceTransportNativeTest {
             require(failure.code == "INVALID_SEGMENT_DURATION", "wrong segment duration error")
         }
 
+        let defaultReadyCue = try AOSCaptureReadyCue.parse(nil)
+        let chimeReadyCue = try AOSCaptureReadyCue.parse("chime")
+        require(defaultReadyCue == .none, "missing ready cue did not default to none")
+        require(chimeReadyCue == .chime, "chime ready cue was rejected")
+        do {
+            _ = try AOSCaptureReadyCue.parse("voice")
+            require(false, "unknown ready cue was accepted")
+        } catch let failure as AOSVoiceTransportFailure {
+            require(failure.code == "INVALID_READY_CUE", "wrong ready cue error")
+        }
+        let inputGate = AOSCaptureInputGate()
+        require(!inputGate.acceptsInput(hostTime: 100), "capture input gate started open")
+        _ = inputGate.observe(AVAudioTime(hostTime: 100))
+        require(inputGate.open(afterHostTime: 200), "host-time capture gate did not establish a boundary")
+        require(!inputGate.acceptsInput(hostTime: 199), "capture input gate accepted a cue-era buffer")
+        require(inputGate.acceptsInput(hostTime: 200), "capture input gate did not open at its timestamp boundary")
+        inputGate.close()
+        require(!inputGate.acceptsInput(hostTime: 201), "capture input gate did not close")
+        let sampleTimeGate = AOSCaptureInputGate()
+        _ = sampleTimeGate.observe(AVAudioTime(sampleTime: 100, atRate: 16_000))
+        require(sampleTimeGate.open(afterHostTime: 200), "sample-time capture gate did not establish a boundary")
+        require(
+            !sampleTimeGate.acceptsInput(AOSCaptureInputTimestamp(hostTime: nil, sampleTime: 100)),
+            "sample-time capture gate accepted a cue-era buffer"
+        )
+        require(
+            sampleTimeGate.acceptsInput(AOSCaptureInputTimestamp(hostTime: nil, sampleTime: 101)),
+            "sample-time capture gate dropped post-cue input"
+        )
+        let clocklessGate = AOSCaptureInputGate()
+        require(
+            !clocklessGate.open(afterHostTime: 200),
+            "capture gate admitted a cue without an observable input clock"
+        )
+        let noCueGate = AOSCaptureInputGate()
+        require(
+            noCueGate.open(afterHostTime: 200, requireCueExclusion: false),
+            "capture gate rejected a no-cue lease without a timestamp"
+        )
+        require(
+            noCueGate.acceptsInput(AOSCaptureInputTimestamp(hostTime: nil, sampleTime: nil)),
+            "no-cue capture gate rejected ordinary untimed input"
+        )
+        let readyCueBuffer = try aosMakeCaptureReadyCueBuffer()
+        require(readyCueBuffer.format.sampleRate == 48_000, "ready cue sample rate drifted")
+        require(readyCueBuffer.frameLength > 0, "ready cue buffer was empty")
+        let cueSamples = readyCueBuffer.floatChannelData![0]
+        var cuePeak: Float = 0
+        for index in 0..<Int(readyCueBuffer.frameLength) {
+            cuePeak = max(cuePeak, abs(cueSamples[index]))
+        }
+        require(cuePeak > 0.1 && cuePeak <= 0.18, "ready cue amplitude left its safe envelope")
+        require(abs(cueSamples[0]) < 0.001, "ready cue did not fade in")
+        require(abs(cueSamples[Int(readyCueBuffer.frameLength) - 1]) < 0.001, "ready cue did not fade out")
+
+        let preparedDisconnectTerminal = DispatchSemaphore(value: 0)
+        var preparedDisconnectEvents: [String] = []
+        let preparedDisconnectTransport = AOSVoiceTransport(
+            emit: { emittedOwner, event, _, ref in
+                require(emittedOwner == owner, "prepared capture event owner drifted")
+                require(ref == "prepared-disconnect", "prepared capture event ref drifted")
+                preparedDisconnectEvents.append(event)
+                if event == "capture_segmented_canceled" { preparedDisconnectTerminal.signal() }
+            },
+            microphoneAuthorization: authorizedMicrophone
+        )
+        let beginPreparedCapture = try preparedDisconnectTransport.prepareSegmentedCapture(
+            owner: owner,
+            directoryPath: segmentRoot.path,
+            segmentDuration: 0.5,
+            maximumDuration: 1,
+            readyCue: .chime,
+            ref: "prepared-disconnect"
+        )
+        preparedDisconnectTransport.connectionClosed(owner)
+        beginPreparedCapture()
+        require(
+            preparedDisconnectTerminal.wait(timeout: .now() + 1) == .success,
+            "connection cleanup did not cancel a prepared segmented capture"
+        )
+        require(
+            preparedDisconnectEvents == ["capture_segmented_canceled"],
+            "prepared owner disconnect emitted an unexpected lifecycle"
+        )
+        let namesAfterPreparedDisconnect = try FileManager.default.contentsOfDirectory(atPath: segmentRoot.path)
+        require(namesAfterPreparedDisconnect.isEmpty, "prepared owner disconnect left output")
+
+        let authorizationEntered = DispatchSemaphore(value: 0)
+        let releaseAuthorization = DispatchSemaphore(value: 0)
+        let authorizationStopDone = DispatchSemaphore(value: 0)
+        let authorizationStopTerminal = DispatchSemaphore(value: 0)
+        let authorizationStopLock = NSLock()
+        var authorizationStopFailure: String?
+        var authorizationStopEvents: [String] = []
+        let stoppedDuringAuthorization = try AOSSegmentedMicrophoneCaptureSession(
+            owner: owner,
+            ref: "stop-during-authorization",
+            directoryPath: segmentRoot.path,
+            segmentDuration: 0.5,
+            maximumDuration: 1,
+            readyCue: .chime,
+            playReadyCue: { _, _ in
+                throw AOSVoiceTransportFailure(code: "UNEXPECTED_CUE", message: "cue must not start after stop")
+            },
+            startInputEngine: { _ in
+                throw AOSVoiceTransportFailure(code: "UNEXPECTED_ENGINE", message: "engine must not start after stop")
+            },
+            authorizeMicrophone: {
+                authorizationEntered.signal()
+                _ = releaseAuthorization.wait(timeout: .now() + 2)
+                return .authorized
+            },
+            authorizationState: { .authorized },
+            emit: { event, _ in
+                authorizationStopLock.lock()
+                authorizationStopEvents.append(event)
+                authorizationStopLock.unlock()
+            },
+            terminal: { _ in authorizationStopTerminal.signal() }
+        )
+        DispatchQueue.global().async {
+            do {
+                try stoppedDuringAuthorization.start()
+            } catch let failure as AOSVoiceTransportFailure {
+                authorizationStopLock.lock()
+                authorizationStopFailure = failure.code
+                authorizationStopLock.unlock()
+            } catch {
+                authorizationStopLock.lock()
+                authorizationStopFailure = "UNEXPECTED"
+                authorizationStopLock.unlock()
+            }
+            authorizationStopDone.signal()
+        }
+        require(
+            authorizationEntered.wait(timeout: .now() + 1) == .success,
+            "microphone authorization did not block"
+        )
+        stoppedDuringAuthorization.finalize(reason: "signal")
+        require(
+            authorizationStopTerminal.wait(timeout: .now() + 1) == .success,
+            "stop during authorization did not terminate capture"
+        )
+        releaseAuthorization.signal()
+        require(
+            authorizationStopDone.wait(timeout: .now() + 1) == .success,
+            "stop during authorization did not release startup"
+        )
+        authorizationStopLock.lock()
+        let authorizationFailure = authorizationStopFailure
+        let authorizationLifecycle = authorizationStopEvents
+        authorizationStopLock.unlock()
+        require(
+            authorizationFailure == "CAPTURE_CANCELED",
+            "stop during authorization returned the wrong failure"
+        )
+        require(
+            authorizationLifecycle == ["capture_segmented_canceled"],
+            "stop during authorization emitted a false completion"
+        )
+
+        let cueEntered = DispatchSemaphore(value: 0)
+        let canceledStartupDone = DispatchSemaphore(value: 0)
+        let canceledStartupTerminal = DispatchSemaphore(value: 0)
+        let canceledStartupLock = NSLock()
+        var canceledStartupFailure: String?
+        var canceledStartupEvents: [String] = []
+        var canceledStartupStops = 0
+        let canceledDuringCue = try AOSSegmentedMicrophoneCaptureSession(
+            owner: owner,
+            ref: "cancel-during-cue",
+            directoryPath: segmentRoot.path,
+            segmentDuration: 0.5,
+            maximumDuration: 1,
+            readyCue: .chime,
+            playReadyCue: { _, isCanceled in
+                cueEntered.signal()
+                let deadline = Date().addingTimeInterval(2)
+                while !isCanceled(), Date() < deadline {
+                    Thread.sleep(forTimeInterval: 0.005)
+                }
+                guard isCanceled() else {
+                    throw AOSVoiceTransportFailure(code: "READY_CUE_UNAVAILABLE", message: "test cue timed out")
+                }
+                throw AOSVoiceTransportFailure(code: "CAPTURE_CANCELED", message: "capture canceled")
+            },
+            startInputEngine: { _ in },
+            inputEngineHealthy: { true },
+            stopInputEngine: {
+                canceledStartupLock.lock()
+                canceledStartupStops += 1
+                canceledStartupLock.unlock()
+            },
+            authorizationState: { .authorized },
+            emit: { event, _ in
+                canceledStartupLock.lock()
+                canceledStartupEvents.append(event)
+                canceledStartupLock.unlock()
+            },
+            terminal: { _ in canceledStartupTerminal.signal() }
+        )
+        DispatchQueue.global().async {
+            do {
+                try canceledDuringCue.start()
+            } catch let failure as AOSVoiceTransportFailure {
+                canceledStartupLock.lock()
+                canceledStartupFailure = failure.code
+                canceledStartupLock.unlock()
+            } catch {
+                canceledStartupLock.lock()
+                canceledStartupFailure = "UNEXPECTED"
+                canceledStartupLock.unlock()
+            }
+            canceledStartupDone.signal()
+        }
+        require(cueEntered.wait(timeout: .now() + 1) == .success, "blocking ready cue did not start")
+        canceledDuringCue.finalize(reason: "signal")
+        require(canceledStartupDone.wait(timeout: .now() + 1) == .success, "cue cancellation did not release startup")
+        require(canceledStartupTerminal.wait(timeout: .now() + 1) == .success, "cue cancellation did not terminate capture")
+        canceledStartupLock.lock()
+        let canceledFailure = canceledStartupFailure
+        let canceledEvents = canceledStartupEvents
+        let canceledStops = canceledStartupStops
+        canceledStartupLock.unlock()
+        require(canceledFailure == "CAPTURE_CANCELED", "cue stop returned the wrong failure")
+        require(!canceledEvents.contains("capture_segmented_started"), "cue stop emitted a false ready event")
+        require(canceledEvents == ["capture_segmented_canceled"], "cue stop emitted a false completion")
+        require(canceledStops == 1, "cue stop did not stop its input engine exactly once")
+        let namesAfterCueCancellation = try FileManager.default.contentsOfDirectory(atPath: segmentRoot.path)
+        require(namesAfterCueCancellation.isEmpty, "cue cancellation left output")
+
+        let armingEntered = DispatchSemaphore(value: 0)
+        let releaseArming = DispatchSemaphore(value: 0)
+        let armingDone = DispatchSemaphore(value: 0)
+        let armingTerminal = DispatchSemaphore(value: 0)
+        let armingLock = NSLock()
+        var armingFailure: String?
+        var armingEvents: [String] = []
+        var armingStops = 0
+        let canceledDuringArming = try AOSSegmentedMicrophoneCaptureSession(
+            owner: owner,
+            ref: "cancel-during-arming",
+            directoryPath: segmentRoot.path,
+            segmentDuration: 0.5,
+            maximumDuration: 1,
+            readyCue: .chime,
+            playReadyCue: { _, _ in
+                throw AOSVoiceTransportFailure(code: "UNEXPECTED_CUE", message: "cue must not start after cancellation")
+            },
+            startInputEngine: { _ in
+                armingEntered.signal()
+                _ = releaseArming.wait(timeout: .now() + 2)
+            },
+            inputEngineHealthy: { true },
+            stopInputEngine: {
+                armingLock.lock()
+                armingStops += 1
+                armingLock.unlock()
+            },
+            authorizationState: { .authorized },
+            emit: { event, _ in
+                armingLock.lock()
+                armingEvents.append(event)
+                armingLock.unlock()
+            },
+            terminal: { _ in armingTerminal.signal() }
+        )
+        DispatchQueue.global().async {
+            do {
+                try canceledDuringArming.start()
+            } catch let failure as AOSVoiceTransportFailure {
+                armingLock.lock()
+                armingFailure = failure.code
+                armingLock.unlock()
+            } catch {
+                armingLock.lock()
+                armingFailure = "UNEXPECTED"
+                armingLock.unlock()
+            }
+            armingDone.signal()
+        }
+        require(armingEntered.wait(timeout: .now() + 1) == .success, "input engine arming did not begin")
+        canceledDuringArming.cancel(reason: "owner_disconnect")
+        require(
+            armingTerminal.wait(timeout: .now() + .milliseconds(50)) == .timedOut,
+            "capture cleanup completed before input engine arming settled"
+        )
+        releaseArming.signal()
+        require(armingDone.wait(timeout: .now() + 1) == .success, "arming cancellation did not release startup")
+        require(armingTerminal.wait(timeout: .now() + 1) == .success, "arming cancellation did not terminate capture")
+        armingLock.lock()
+        let armingResult = armingFailure
+        let armingLifecycle = armingEvents
+        let armingStopCount = armingStops
+        armingLock.unlock()
+        require(armingResult == "CAPTURE_CANCELED", "arming cancellation returned the wrong failure")
+        require(armingLifecycle == ["capture_segmented_canceled"], "arming cancellation emitted an unexpected lifecycle")
+        require(armingStopCount == 1, "late-started input engine was not stopped exactly once")
+
+        let admissionFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 16_000,
+            channels: 1,
+            interleaved: false
+        )!
+        let admissionBuffer = AVAudioPCMBuffer(pcmFormat: admissionFormat, frameCapacity: 8)!
+        admissionBuffer.frameLength = 8
+        let admissionTerminal = DispatchSemaphore(value: 0)
+        let admissionInput = DispatchSemaphore(value: 0)
+        let admissionLock = NSLock()
+        var admissionHandler: AOSSegmentedMicrophoneCaptureSession.InputHandler?
+        var admissionOrder: [String] = []
+        let orderedAdmission = try AOSSegmentedMicrophoneCaptureSession(
+            owner: owner,
+            ref: "ordered-admission",
+            directoryPath: segmentRoot.path,
+            segmentDuration: 0.5,
+            maximumDuration: 1,
+            readyCue: .chime,
+            playReadyCue: { _, _ in
+                admissionHandler?(admissionBuffer, AVAudioTime(hostTime: 199))
+                return 200
+            },
+            startInputEngine: { handler in
+                admissionHandler = handler
+                handler(admissionBuffer, AVAudioTime(hostTime: 100))
+            },
+            inputEngineHealthy: { true },
+            stopInputEngine: {},
+            receiveInput: { _ in
+                admissionLock.lock()
+                admissionOrder.append("input")
+                admissionLock.unlock()
+                admissionInput.signal()
+            },
+            authorizationState: { .authorized },
+            emit: { event, _ in
+                guard event != "audio_frame" else { return }
+                admissionLock.lock()
+                admissionOrder.append(event)
+                admissionLock.unlock()
+            },
+            terminal: { _ in admissionTerminal.signal() }
+        )
+        try orderedAdmission.start()
+        admissionHandler?(admissionBuffer, AVAudioTime(hostTime: 201))
+        require(admissionInput.wait(timeout: .now() + 1) == .success, "post-cue input was not accepted")
+        admissionLock.lock()
+        let orderedLifecycle = admissionOrder
+        admissionLock.unlock()
+        require(
+            orderedLifecycle == ["capture_segmented_started", "input"],
+            "accepted input was not ordered after the capture-started event"
+        )
+        orderedAdmission.cancel(reason: "test_complete")
+        require(admissionTerminal.wait(timeout: .now() + 1) == .success, "ordered admission did not clean up")
+
+        let clockFailureTerminal = DispatchSemaphore(value: 0)
+        var clockFailureEvents: [String] = []
+        var clockFailureStops = 0
+        let clocklessAdmission = try AOSSegmentedMicrophoneCaptureSession(
+            owner: owner,
+            ref: "clockless-admission",
+            directoryPath: segmentRoot.path,
+            segmentDuration: 0.5,
+            maximumDuration: 1,
+            readyCue: .chime,
+            playReadyCue: { _, _ in 300 },
+            startInputEngine: { _ in },
+            inputEngineHealthy: { true },
+            stopInputEngine: { clockFailureStops += 1 },
+            authorizationState: { .authorized },
+            emit: { event, _ in clockFailureEvents.append(event) },
+            terminal: { _ in clockFailureTerminal.signal() }
+        )
+        do {
+            try clocklessAdmission.start()
+            require(false, "cue admission without an input clock was accepted")
+        } catch let failure as AOSVoiceTransportFailure {
+            require(failure.code == "CAPTURE_CLOCK_UNAVAILABLE", "clockless admission returned the wrong failure")
+        }
+        require(clockFailureTerminal.wait(timeout: .now() + 1) == .success, "clockless admission did not terminate")
+        require(clockFailureEvents == ["capture_segmented_failed"], "clockless admission emitted an unexpected lifecycle")
+        require(clockFailureStops == 1, "clockless admission did not stop its input engine")
+
+        var authorizationAfterCue = AOSMicrophoneAuthorizationState.authorized
+        var permissionLossEvents: [String] = []
+        var permissionLossStops = 0
+        let permissionLossTerminal = DispatchSemaphore(value: 0)
+        let permissionLostBeforeAdmission = try AOSSegmentedMicrophoneCaptureSession(
+            owner: owner,
+            ref: "permission-loss-before-admission",
+            directoryPath: segmentRoot.path,
+            segmentDuration: 0.5,
+            maximumDuration: 1,
+            readyCue: .chime,
+            playReadyCue: { _, _ in
+                authorizationAfterCue = .denied
+                return 300
+            },
+            startInputEngine: { _ in },
+            inputEngineHealthy: { true },
+            stopInputEngine: { permissionLossStops += 1 },
+            authorizationState: { authorizationAfterCue },
+            emit: { event, _ in permissionLossEvents.append(event) },
+            terminal: { _ in permissionLossTerminal.signal() }
+        )
+        do {
+            try permissionLostBeforeAdmission.start()
+            require(false, "permission loss before capture admission was accepted")
+        } catch let failure as AOSVoiceTransportFailure {
+            require(failure.code == "MICROPHONE_PERMISSION_LOST", "permission loss returned the wrong failure")
+        }
+        require(permissionLossTerminal.wait(timeout: .now() + 1) == .success, "permission loss did not terminate capture")
+        require(permissionLossEvents == ["capture_segmented_failed"], "permission loss emitted an unexpected lifecycle")
+        require(permissionLossStops == 1, "permission loss did not stop its input engine")
+        let namesAfterPermissionLoss = try FileManager.default.contentsOfDirectory(atPath: segmentRoot.path)
+        require(namesAfterPermissionLoss.isEmpty, "permission loss left output")
+
+        var hardwareLossEvents: [String] = []
+        var hardwareLossStops = 0
+        let hardwareLossTerminal = DispatchSemaphore(value: 0)
+        let hardwareLostBeforeAdmission = try AOSSegmentedMicrophoneCaptureSession(
+            owner: owner,
+            ref: "hardware-loss-before-admission",
+            directoryPath: segmentRoot.path,
+            segmentDuration: 0.5,
+            maximumDuration: 1,
+            readyCue: .chime,
+            playReadyCue: { _, _ in 400 },
+            startInputEngine: { _ in },
+            inputEngineHealthy: { false },
+            stopInputEngine: { hardwareLossStops += 1 },
+            authorizationState: { .authorized },
+            emit: { event, _ in hardwareLossEvents.append(event) },
+            terminal: { _ in hardwareLossTerminal.signal() }
+        )
+        do {
+            try hardwareLostBeforeAdmission.start()
+            require(false, "hardware loss before capture admission was accepted")
+        } catch let failure as AOSVoiceTransportFailure {
+            require(failure.code == "MICROPHONE_UNAVAILABLE", "hardware loss returned the wrong failure")
+        }
+        require(hardwareLossTerminal.wait(timeout: .now() + 1) == .success, "hardware loss did not terminate capture")
+        require(hardwareLossEvents == ["capture_segmented_failed"], "hardware loss emitted an unexpected lifecycle")
+        require(hardwareLossStops == 1, "hardware loss did not stop its input engine")
+        let namesAfterHardwareLoss = try FileManager.default.contentsOfDirectory(atPath: segmentRoot.path)
+        require(namesAfterHardwareLoss.isEmpty, "hardware loss left output")
+
         let preStartCancelCompleted = DispatchSemaphore(value: 0)
         let canceledBeforeStart = try AOSSegmentedMicrophoneCaptureSession(
             owner: owner,
@@ -417,6 +866,7 @@ SWIFT
 
 swiftc -parse-as-library \
     "$ROOT/src/daemon/microphone-authorization.swift" \
+    "$ROOT/src/daemon/capture-ready-cue.swift" \
     "$ROOT/src/daemon/segmented-microphone-capture.swift" \
     "$ROOT/src/daemon/audio-playback.swift" \
     "$ROOT/src/daemon/voice-transport.swift" \


### PR DESCRIPTION
## Summary

- add an opt-in `--ready-cue chime` to segmented microphone follow
- arm microphone input with a closed gate, play a bounded nonverbal cue, then emit `capture_segmented_started` only after cue audio is excluded
- keep owner disconnect, Stop, cancellation, permission loss, hardware loss, and clock failure fail-closed during asynchronous startup
- preserve existing no-cue behavior and redact all audio/text/path content

## Validation

- native voice transport contracts: passed
- voice follow CLI: 16/16
- daemon voice schemas: 8/8
- full Swift typecheck: passed with existing unrelated warnings
- generated command manifests: clean
- `git diff --check`: passed
- strict read-only review: no P0/P1/P2 findings

No `./aos` execution, binary build, daemon operation, TCC change, signing action, or runtime acceptance was performed.
